### PR TITLE
Collapse all require templates into a require_all

### DIFF
--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -5161,13 +5161,15 @@ static constexpr std::array<const char*, 428> locations_array__ =
  " (in 'complex_scalar.stan', line 33, column 45 to line 35, column 3)"};
 
 struct foo8_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
              std::ostream* pstream__) const;
 };
 struct foo1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::complex<T0__>& z, std::ostream* pstream__) const;
 };
@@ -5176,38 +5178,45 @@ struct foo4_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct foo6_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   operator()(const T0__& r, std::ostream* pstream__) const;
 };
 struct foo10_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
              std::ostream* pstream__) const;
 };
 struct foo2_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::complex<stan::promote_args_t<T0__>>
   operator()(const T0__& r, std::ostream* pstream__) const;
 };
 struct foo9_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   operator()(const T0__& r, std::ostream* pstream__) const;
 };
 struct foo3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::complex<stan::promote_args_t<T0__>>
   operator()(const std::complex<T0__>& z, std::ostream* pstream__) const;
 };
 struct foo7_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   operator()(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) const;
 };
 struct foo5_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) const;
 };
@@ -5230,7 +5239,8 @@ std::complex<double> foo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo1(const std::complex<T0__>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5246,7 +5256,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::complex<stan::promote_args_t<T0__>>
   foo2(const T0__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5262,7 +5273,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::complex<stan::promote_args_t<T0__>>
   foo3(const std::complex<T0__>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5293,7 +5305,8 @@ std::vector<std::complex<double>> foo4(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo5(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5309,7 +5322,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   foo6(const T0__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5326,7 +5340,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::complex<stan::promote_args_t<T0__>>>
   foo7(const std::vector<std::complex<T0__>>& z, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5342,7 +5357,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo8(const std::vector<std::vector<std::complex<T0__>>>& z,
        std::ostream* pstream__) {
@@ -5359,7 +5375,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   foo9(const T0__& r, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5381,7 +5398,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
   foo10(const std::vector<std::vector<std::complex<T0__>>>& z,
         std::ostream* pstream__) {
@@ -5398,7 +5416,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
                            std::ostream* pstream__)  const
@@ -5406,7 +5424,7 @@ foo8_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z
   return foo8(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo1_functor__::operator()(const std::complex<T0__>& z,
                            std::ostream* pstream__)  const
@@ -5420,14 +5438,14 @@ foo4_functor__::operator()(std::ostream* pstream__)  const
   return foo4(pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<std::complex<stan::promote_args_t<T0__>>>
 foo6_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo6(r, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
 foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& z,
                             std::ostream* pstream__)  const
@@ -5435,21 +5453,21 @@ foo10_functor__::operator()(const std::vector<std::vector<std::complex<T0__>>>& 
   return foo10(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::complex<stan::promote_args_t<T0__>>
 foo2_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo2(r, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<std::vector<std::complex<stan::promote_args_t<T0__>>>>
 foo9_functor__::operator()(const T0__& r, std::ostream* pstream__)  const
 {
   return foo9(r, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::complex<stan::promote_args_t<T0__>>
 foo3_functor__::operator()(const std::complex<T0__>& z,
                            std::ostream* pstream__)  const
@@ -5457,7 +5475,7 @@ foo3_functor__::operator()(const std::complex<T0__>& z,
   return foo3(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<std::complex<stan::promote_args_t<T0__>>>
 foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
                            std::ostream* pstream__)  const
@@ -5465,7 +5483,7 @@ foo7_functor__::operator()(const std::vector<std::complex<T0__>>& z,
   return foo7(z, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo5_functor__::operator()(const std::vector<std::complex<T0__>>& z,
                            std::ostream* pstream__)  const
@@ -7875,45 +7893,51 @@ static constexpr std::array<const char*, 31> locations_array__ =
  " (in 'user_function_templating.stan', line 23, column 38 to line 25, column 3)"};
 
 struct foo_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T0__>, -1, -1>>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& A,
              std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<Eigen::Matrix<std::complex<stan::promote_args_t<T0__>>, -1, -1>>
   operator()(const std::vector<Eigen::Matrix<std::complex<T0__>, -1, -1>>& Z,
              std::ostream* pstream__) const;
-  template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_row_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, 1, -1>
   operator()(const T0__& A, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
-            stan::require_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_row_vector<T0__>,
+                                stan::is_vt_complex<T0__>>* = nullptr>
   Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, 1, -1>
   operator()(const T0__& Z, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& A, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_complex<T0__>>* = nullptr>
   Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, -1, 1>
   operator()(const T0__& Z, std::ostream* pstream__) const;
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   operator()(const T0__& A, std::ostream* pstream__) const;
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_complex<T0__>>* = nullptr>
   Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, -1, -1>
   operator()(const T0__& Z, std::ostream* pstream__) const;
 };
 
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_complex<T0__>>* = nullptr>
   Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, -1, -1>
   foo(const T0__& Z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -7931,8 +7955,8 @@ template <typename T0__,
     }
     }
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   foo(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -7951,8 +7975,9 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_complex<T0__>>* = nullptr>
   Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, -1, 1>
   foo(const T0__& Z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -7969,8 +7994,9 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   foo(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -7989,8 +8015,9 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
-          stan::require_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_row_vector<T0__>,
+                              stan::is_vt_complex<T0__>>* = nullptr>
   Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, 1, -1>
   foo(const T0__& Z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -8007,8 +8034,9 @@ template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_row_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, 1, -1>
   foo(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -8027,7 +8055,8 @@ template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<Eigen::Matrix<std::complex<stan::promote_args_t<T0__>>, -1, -1>>
   foo(const std::vector<Eigen::Matrix<std::complex<T0__>, -1, -1>>& Z,
       std::ostream* pstream__) {
@@ -8044,7 +8073,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T0__>, -1, -1>>
   foo(const std::vector<Eigen::Matrix<T0__, -1, -1>>& A,
       std::ostream* pstream__) {
@@ -8063,7 +8093,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<Eigen::Matrix<stan::promote_args_t<T0__>, -1, -1>>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& A,
                           std::ostream* pstream__)  const
@@ -8071,7 +8101,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& A,
   return foo(A, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<Eigen::Matrix<std::complex<stan::promote_args_t<T0__>>, -1, -1>>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<std::complex<T0__>, -1, -1>>& Z,
                           std::ostream* pstream__)  const
@@ -8079,48 +8109,54 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<std::complex<T0__>, -1
   return foo(Z, pstream__);
 }
 
-template <typename T0__, stan::require_row_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_row_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, 1, -1>
 foo_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
 {
   return foo(A, pstream__);
 }
 
-template <typename T0__, stan::require_row_vector_t<T0__>*,
-          stan::require_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_row_vector<T0__>,
+                              stan::is_vt_complex<T0__>>*>
 Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, 1, -1>
 foo_functor__::operator()(const T0__& Z, std::ostream* pstream__)  const
 {
   return foo(Z, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 foo_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
 {
   return foo(A, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_complex<T0__>>*>
 Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, -1, 1>
 foo_functor__::operator()(const T0__& Z, std::ostream* pstream__)  const
 {
   return foo(Z, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
 foo_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
 {
   return foo(A, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_complex<T0__>>*>
 Eigen::Matrix<std::complex<stan::promote_args_t<stan::base_type_t<T0__>>>, -1, -1>
 foo_functor__::operator()(const T0__& Z, std::ostream* pstream__)  const
 {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -866,8 +866,9 @@ static constexpr std::array<const char*, 75> locations_array__ =
  " (in 'cpp-reserved-words.stan', line 14, column 17 to column 19)"};
 
 struct _stan_asm_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   void
   operator()(const T0__& _stan_class, std::ostream* pstream__) const;
 };
@@ -896,7 +897,8 @@ struct _stan_alignof_functor__ {
   operator()(const int& _stan_char, std::ostream* pstream__) const;
 };
 struct _stan_and_eq_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) const;
 };
@@ -960,7 +962,8 @@ void _stan_and(const int& _stan_STAN_MAJOR, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   _stan_and_eq(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -974,8 +977,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr> void
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr> void
   _stan_asm(const T0__& _stan_class_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
     int current_statement__ = 0; 
@@ -1094,8 +1098,9 @@ void _stan_char32_t(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 void
 _stan_asm_functor__::operator()(const T0__& _stan_class,
                                 std::ostream* pstream__)  const
@@ -1139,7 +1144,7 @@ _stan_alignof_functor__::operator()(const int& _stan_char,
   return _stan_alignof(_stan_char, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 _stan_and_eq_functor__::operator()(const T0__& _stan_STAN_MINOR,
                                    std::ostream* pstream__)  const
@@ -3584,12 +3589,12 @@ struct foo_five_args_lp_functor__ {
   template <bool propto__, typename T0__, typename T1__, typename T2__,
             typename T3__, typename T4__, typename T5__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
   operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
              const T4__& x5, const T5__& x6, T_lp__& lp__,
@@ -3598,17 +3603,18 @@ struct foo_five_args_lp_functor__ {
 struct f5_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>>
@@ -3624,14 +3630,15 @@ struct f5_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lcdf_functor__ {
-  template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <typename T1__,
+            stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct covsqrt2corsqrt_functor__ {
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   operator()(const T0__& mat, const int& invert, std::ostream* pstream__) const;
 };
@@ -3642,7 +3649,7 @@ struct foo_1_functor__ {
 struct unit_normal_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -3658,17 +3665,18 @@ struct vecfoo_functor__ {
 struct f6_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>>>
@@ -3685,11 +3693,12 @@ struct f6_functor__ {
 };
 struct foo_five_args_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr>
+            typename T4__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
   operator()(const T0__& x1, const T1__& x2, const T2__& x3, const T3__& x4,
              const T4__& x5, std::ostream* pstream__) const;
@@ -3701,17 +3710,18 @@ struct foo_2_functor__ {
 struct f3_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<int>>
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -3725,24 +3735,26 @@ struct f3_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>
@@ -3760,17 +3772,18 @@ struct f7_functor__ {
 struct f11_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>>
@@ -3788,17 +3801,18 @@ struct f11_functor__ {
 struct f12_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>>>
@@ -3815,9 +3829,9 @@ struct f12_functor__ {
 };
 struct sho_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<double>& x,
@@ -3825,8 +3839,8 @@ struct sho_functor__ {
 };
 struct foo_bar2_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
 };
@@ -3836,52 +3850,54 @@ struct matfoo_functor__ {
 };
 struct algebra_system_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
              const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct foo_rng_functor__ {
   template <typename T0__, typename T1__, typename RNG,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& mu, const T1__& sigma, RNG& base_rng__,
              std::ostream* pstream__) const;
 };
 struct relative_diff_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   operator()(const T0__& x, const T1__& y, const T2__& max_, const T3__& min_,
              std::ostream* pstream__) const;
 };
 struct vecmubar_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   operator()(const T0__& mu, std::ostream* pstream__) const;
 };
 struct f0_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   void
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -3896,16 +3912,16 @@ struct f0_functor__ {
 };
 struct foo_lpmf_functor__ {
   template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct foo_5_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<double>& data_r, const std::vector<int>& data_i,
@@ -3914,17 +3930,18 @@ struct foo_5_functor__ {
 struct f4_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>
@@ -3942,17 +3959,18 @@ struct f4_functor__ {
 struct f10_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>, -1, -1>
@@ -3970,17 +3988,18 @@ struct f10_functor__ {
 struct f2_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<int>
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -3996,17 +4015,18 @@ struct f2_functor__ {
 struct f9_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>>>
@@ -4024,17 +4044,18 @@ struct f9_functor__ {
 struct f8_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                        stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                             T10__, T11__>>, -1, 1>>
@@ -4050,25 +4071,28 @@ struct f8_functor__ {
              std::ostream* pstream__) const;
 };
 struct foo_lccdf_functor__ {
-  template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+  template <typename T1__,
+            stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& y, const T1__& lambda, std::ostream* pstream__) const;
 };
 struct vecmufoo_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   operator()(const T0__& mu, std::ostream* pstream__) const;
 };
 struct foo_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
 };
 struct foo_3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__>>
   operator()(const T0__& t, const int& n, std::ostream* pstream__) const;
 };
@@ -4078,34 +4102,36 @@ struct foo_6_functor__ {
 };
 struct binomialf_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& phi, const T1__& theta,
              const std::vector<double>& x_r, const std::vector<int>& x_i,
              std::ostream* pstream__) const;
 };
 struct foo_bar1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
             typename T7__, typename T8__, typename T9__, typename T10__,
-            typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_stan_scalar_t<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T8__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-            stan::require_not_vt_complex<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr>
+            typename T11__,
+            stan::require_all_t<stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_stan_scalar<T7__>,
+                                stan::is_stan_scalar<T8__>,
+                                stan::is_eigen_matrix_dynamic<T9__>,
+                                stan::is_vt_not_complex<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>>* = nullptr>
   int
   operator()(const int& a1, const std::vector<int>& a2,
              const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -4144,17 +4170,17 @@ int foo(const int& n, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,
       const std::vector<int>& x_int, std::ostream* pstream__) ; 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
   std::vector<stan::promote_args_t<T0__, T1__, T2__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<double>& x,
@@ -4198,7 +4224,8 @@ double foo_bar0(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo_bar1(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -4215,8 +4242,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -4233,7 +4260,7 @@ template <typename T0__, typename T1__,
     }
     }
 template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   foo_lpmf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -4247,7 +4274,8 @@ template <bool propto__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   foo_lcdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -4263,7 +4291,8 @@ template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
+template <typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   foo_lccdf(const int& y, const T1__& lambda, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -4280,8 +4309,8 @@ template <typename T1__, stan::require_stan_scalar_t<T1__>* = nullptr>
     }
     }
 template <typename T0__, typename T1__, typename RNG,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_rng(const T0__& mu, const T1__& sigma, RNG& base_rng__,
           std::ostream* pstream__) {
@@ -4299,8 +4328,8 @@ template <typename T0__, typename T1__, typename RNG,
     }
     }
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
                  std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -4567,7 +4596,8 @@ int foo_2(const int& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__>>
   foo_3(const T0__& t, const int& n, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -4584,7 +4614,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo_lp(const T0__& x, T_lp__& lp__, T_lp_accum__& lp_accum__,
          std::ostream* pstream__) {
@@ -4599,7 +4630,8 @@ template <bool propto__, typename T0__, typename T_lp__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   foo_4(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -4618,10 +4650,10 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr> void
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   relative_diff(const T0__& x, const T1__& y, const T2__& max_,
                 const T3__& min_, std::ostream* pstream__) {
@@ -4669,10 +4701,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, 1>
   foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
         const std::vector<double>& data_r, const std::vector<int>& data_i,
@@ -4695,11 +4727,12 @@ template <typename T0__, typename T1__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr>
+          typename T4__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
   foo_five_args(const T0__& x1, const T1__& x2, const T2__& x3,
                 const T3__& x4, const T4__& x5, std::ostream* pstream__) {
@@ -4720,12 +4753,12 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
 template <bool propto__, typename T0__, typename T1__, typename T2__,
           typename T3__, typename T4__, typename T5__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
   foo_five_args_lp(const T0__& x1, const T1__& x2, const T2__& x3,
                    const T3__& x4, const T4__& x5, const T5__& x6,
@@ -4745,8 +4778,8 @@ template <bool propto__, typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   covsqrt2corsqrt(const T0__& mat_arg__, const int& invert,
                   std::ostream* pstream__) {
@@ -4787,17 +4820,18 @@ template <typename T0__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr> void
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr> void
   f0(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
@@ -4832,17 +4866,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr> int
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr> int
   f1(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
@@ -4874,17 +4909,19 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr> std::vector<int>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
+  std::vector<int>
   f2(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
      const std::vector<T4__>& a5, const std::vector<std::vector<T5__>>& a6,
@@ -4916,17 +4953,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<int>>
   f3(const int& a1, const std::vector<int>& a2,
      const std::vector<std::vector<int>>& a3, const T3__& a4,
@@ -4959,17 +4997,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>
@@ -5004,17 +5043,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>>
@@ -5049,17 +5089,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>>>
@@ -5094,17 +5135,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>
@@ -5139,17 +5181,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>
@@ -5184,17 +5227,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>>
@@ -5229,17 +5273,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>
@@ -5275,17 +5320,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>
@@ -5321,17 +5367,18 @@ template <typename T3__, typename T4__, typename T5__, typename T6__,
     }
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_stan_scalar_t<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T8__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T9__>* = nullptr,
-          stan::require_not_vt_complex<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>* = nullptr>
   std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>>
@@ -5427,7 +5474,8 @@ Eigen::Matrix<double, -1, 1> vecfoo(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   vecmufoo(const T0__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5448,7 +5496,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
   vecmubar(const T0__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -5472,11 +5521,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   algebra_system(const T0__& x_arg__, const T1__& y_arg__,
                  const std::vector<T2__>& dat,
@@ -5511,10 +5560,10 @@ template <typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, 1>
   binomialf(const T0__& phi_arg__, const T1__& theta_arg__,
             const std::vector<double>& x_r, const std::vector<int>& x_i,
@@ -5543,12 +5592,13 @@ template <typename T0__, typename T1__,
     }
 template <bool propto__, typename T0__, typename T1__, typename T2__,
           typename T3__, typename T4__, typename T5__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__, T4__, stan::promote_args_t<T5__>>
 foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
                                        const T2__& x3, const T3__& x4,
@@ -5563,17 +5613,18 @@ foo_five_args_lp_functor__::operator()(const T0__& x1, const T1__& x2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>>
@@ -5592,7 +5643,7 @@ f5_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f5(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T1__, stan::require_stan_scalar_t<T1__>*>
+template <typename T1__, stan::require_all_t<stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T1__>
 foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
                                std::ostream* pstream__)  const
@@ -5600,8 +5651,9 @@ foo_lcdf_functor__::operator()(const int& y, const T1__& lambda,
   return foo_lcdf(y, lambda, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
 covsqrt2corsqrt_functor__::operator()(const T0__& mat, const int& invert,
                                       std::ostream* pstream__)  const
@@ -5615,7 +5667,8 @@ int foo_1_functor__::operator()(const int& a, std::ostream* pstream__)  const
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 unit_normal_lp_functor__::operator()(const T0__& u, T_lp__& lp__,
                                      T_lp_accum__& lp_accum__,
@@ -5637,17 +5690,18 @@ vecfoo_functor__::operator()(std::ostream* pstream__)  const
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<std::vector<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>>>
@@ -5667,11 +5721,12 @@ f6_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          typename T4__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*>
+          typename T4__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__, T4__>
 foo_five_args_functor__::operator()(const T0__& x1, const T1__& x2,
                                     const T2__& x3, const T3__& x4,
@@ -5688,17 +5743,18 @@ int foo_2_functor__::operator()(const int& a, std::ostream* pstream__)  const
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<std::vector<int>>
 f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -5715,7 +5771,7 @@ f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f3(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void foo_4_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
 {
@@ -5724,17 +5780,18 @@ const
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>
@@ -5755,17 +5812,18 @@ f7_functor__::operator()(const int& a1, const std::vector<int>& a2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>
@@ -5786,17 +5844,18 @@ f11_functor__::operator()(const int& a1, const std::vector<int>& a2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>>>
@@ -5816,9 +5875,9 @@ f12_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__>>
 sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                           const std::vector<T2__>& theta,
@@ -5829,8 +5888,9 @@ sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
   return sho(t, y, theta, x, x_int, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 foo_bar2_functor__::operator()(const T0__& x, const T1__& y,
                                std::ostream* pstream__)  const
@@ -5845,11 +5905,11 @@ matfoo_functor__::operator()(std::ostream* pstream__)  const
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
 algebra_system_functor__::operator()(const T0__& x, const T1__& y,
                                      const std::vector<T2__>& dat,
@@ -5860,8 +5920,8 @@ algebra_system_functor__::operator()(const T0__& x, const T1__& y,
 }
 
 template <typename T0__, typename T1__, typename RNG,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 foo_rng_functor__::operator()(const T0__& mu, const T1__& sigma,
                               RNG& base_rng__, std::ostream* pstream__) 
@@ -5871,10 +5931,10 @@ const
 }
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__>
 relative_diff_functor__::operator()(const T0__& x, const T1__& y,
                                     const T2__& max_, const T3__& min_,
@@ -5883,7 +5943,7 @@ relative_diff_functor__::operator()(const T0__& x, const T1__& y,
   return relative_diff(x, y, max_, min_, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmubar_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
 const
@@ -5893,17 +5953,18 @@ const
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 void
 f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -5920,7 +5981,8 @@ f0_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f0(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
+template <bool propto__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T1__>
 foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
                                std::ostream* pstream__)  const
@@ -5928,10 +5990,11 @@ foo_lpmf_functor__::operator()(const int& y, const T1__& lambda,
   return foo_lpmf<propto__>(y, lambda, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, 1>
 foo_5_functor__::operator()(const T0__& shared_params,
                             const T1__& job_params,
@@ -5944,17 +6007,18 @@ foo_5_functor__::operator()(const T0__& shared_params,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>
@@ -5975,17 +6039,18 @@ f4_functor__::operator()(const int& a1, const std::vector<int>& a2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, -1>
@@ -6006,17 +6071,18 @@ f10_functor__::operator()(const int& a1, const std::vector<int>& a2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<int>
 f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -6035,17 +6101,18 @@ f2_functor__::operator()(const int& a1, const std::vector<int>& a2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>>
@@ -6066,17 +6133,18 @@ f9_functor__::operator()(const int& a1, const std::vector<int>& a2,
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 std::vector<Eigen::Matrix<stan::promote_args_t<T3__, T4__, T5__, stan::base_type_t<T6__>, T7__,
                      stan::promote_args_t<T8__, stan::base_type_t<T9__>,
                                           T10__, T11__>>, -1, 1>>
@@ -6095,7 +6163,7 @@ f8_functor__::operator()(const int& a1, const std::vector<int>& a2,
   return f8(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, pstream__);
 }
 
-template <typename T1__, stan::require_stan_scalar_t<T1__>*>
+template <typename T1__, stan::require_all_t<stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T1__>
 foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
                                 std::ostream* pstream__)  const
@@ -6103,7 +6171,7 @@ foo_lccdf_functor__::operator()(const int& y, const T1__& lambda,
   return foo_lccdf(y, lambda, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__>, -1, 1>
 vecmufoo_functor__::operator()(const T0__& mu, std::ostream* pstream__) 
 const
@@ -6112,7 +6180,8 @@ const
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
                              T_lp_accum__& lp_accum__,
@@ -6121,7 +6190,7 @@ foo_lp_functor__::operator()(const T0__& x, T_lp__& lp__,
   return foo_lp<propto__>(x, lp__, lp_accum__, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::vector<stan::promote_args_t<T0__>>
 foo_3_functor__::operator()(const T0__& t, const int& n,
                             std::ostream* pstream__)  const
@@ -6134,10 +6203,11 @@ void foo_6_functor__::operator()(std::ostream* pstream__)  const
   return foo_6(pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, 1>
 binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
                                 const std::vector<double>& x_r,
@@ -6147,7 +6217,7 @@ binomialf_functor__::operator()(const T0__& phi, const T1__& theta,
   return binomialf(phi, theta, x_r, x_i, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_bar1_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
@@ -6156,17 +6226,18 @@ foo_bar1_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 
 template <typename T3__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T8__, typename T9__, typename T10__,
-          typename T11__, stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_stan_scalar_t<T7__>*,
-          stan::require_stan_scalar_t<T8__>*,
-          stan::require_eigen_matrix_dynamic_t<T9__>*,
-          stan::require_not_vt_complex<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*>
+          typename T11__,
+          stan::require_all_t<stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_stan_scalar<T7__>,
+                              stan::is_stan_scalar<T8__>,
+                              stan::is_eigen_matrix_dynamic<T9__>,
+                              stan::is_vt_not_complex<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>>*>
 int
 f1_functor__::operator()(const int& a1, const std::vector<int>& a2,
                          const std::vector<std::vector<int>>& a3,
@@ -12373,10 +12444,10 @@ static constexpr std::array<const char*, 158> locations_array__ =
 
 struct sho_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x,
@@ -12384,21 +12455,21 @@ struct sho_functor__ {
 };
 struct algebra_system_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& x, const T1__& y, const std::vector<T2__>& dat,
              const std::vector<int>& dat_int, std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   operator()(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
              const std::vector<T3__>& x_r, const std::vector<int>& x_i,
@@ -12406,11 +12477,11 @@ struct integrand_functor__ {
 };
 struct foo_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -12418,27 +12489,28 @@ struct foo_functor__ {
 };
 struct goo_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& shared_params, const T1__& job_params,
              const std::vector<T2__>& data_r, const std::vector<int>& data_i,
              std::ostream* pstream__) const;
 };
 struct map_rectfake_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   sho(const T0__& t, const std::vector<T1__>& y,
       const std::vector<T2__>& theta, const std::vector<T3__>& x,
@@ -12469,10 +12541,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T1__, T2__, T3__>
   integrand(const T0__& x, const T1__& xc, const std::vector<T2__>& theta,
             const std::vector<T3__>& x_r, const std::vector<int>& x_i,
@@ -12491,11 +12563,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -12518,11 +12590,11 @@ template <typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
       const std::vector<T2__>& data_r, const std::vector<int>& data_i,
@@ -12544,7 +12616,8 @@ template <typename T0__, typename T1__, typename T2__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   map_rectfake(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -12561,11 +12634,11 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
   algebra_system(const T0__& x_arg__, const T1__& y_arg__,
                  const std::vector<T2__>& dat,
@@ -12600,10 +12673,10 @@ template <typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                           const std::vector<T2__>& theta,
@@ -12615,11 +12688,11 @@ sho_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
 algebra_system_functor__::operator()(const T0__& x, const T1__& y,
                                      const std::vector<T2__>& dat,
@@ -12630,10 +12703,10 @@ algebra_system_functor__::operator()(const T0__& x, const T1__& y,
 }
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T1__, T2__, T3__>
 integrand_functor__::operator()(const T0__& x, const T1__& xc,
                                 const std::vector<T2__>& theta,
@@ -12645,11 +12718,11 @@ integrand_functor__::operator()(const T0__& x, const T1__& xc,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
 foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
                           const std::vector<T2__>& data_r,
@@ -12660,11 +12733,11 @@ foo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>, T2__>, -1, 1>
 goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
                           const std::vector<T2__>& data_r,
@@ -12674,7 +12747,7 @@ goo_functor__::operator()(const T0__& shared_params, const T1__& job_params,
   return goo(shared_params, job_params, data_r, data_i, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 map_rectfake_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -14921,12 +14994,12 @@ static constexpr std::array<const char*, 630> locations_array__ =
 
 struct f_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_col_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                        stan::base_type_t<T3__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a, const T3__& b,
@@ -14934,12 +15007,12 @@ struct f_functor__ {
 };
 struct f_odefunctor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_col_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                        stan::base_type_t<T3__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
@@ -14947,12 +15020,12 @@ struct f_odefunctor__ {
 };
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_col_vector_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                      stan::base_type_t<T3__>>, -1, 1>
   f(const T0__& t, const T1__& z_arg__, const T2__& a, const T3__& b_arg__,
@@ -14975,12 +15048,12 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_col_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                      stan::base_type_t<T3__>>, -1, 1>
 f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
@@ -14990,12 +15063,12 @@ f_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
 }
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_col_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                      stan::base_type_t<T3__>>, -1, 1>
 f_odefunctor__::operator()(const T0__& t, const T1__& z,
@@ -18782,10 +18855,10 @@ static constexpr std::array<const char*, 35> locations_array__ =
 
 struct dz_dt_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& z,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -18793,10 +18866,10 @@ struct dz_dt_functor__ {
 };
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   dz_dt(const T0__& t, const std::vector<T1__>& z,
         const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -18839,10 +18912,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 dz_dt_functor__::operator()(const T0__& t, const std::vector<T1__>& z,
                             const std::vector<T2__>& theta,
@@ -21159,46 +21232,55 @@ static constexpr std::array<const char*, 39> locations_array__ =
 struct foo_functor__ {
   double
   operator()(const std::vector<int>& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
              std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
              std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
              std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& p, std::ostream* pstream__) const;
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   stan::promote_args_t<stan::base_type_t<T0__>>
   operator()(const T0__& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   stan::promote_args_t<stan::base_type_t<T0__>>
   operator()(const T0__& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_row_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   stan::promote_args_t<stan::base_type_t<T0__>>
   operator()(const T0__& p, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& p, std::ostream* pstream__) const;
   double
   operator()(const int& p, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   stan::promote_args_t<stan::base_type_t<T0__>>
   foo(const T0__& p_arg__, std::ostream* pstream__) ; 
 double foo(const int& p, std::ostream* pstream__) ; 
@@ -21216,7 +21298,8 @@ double foo(const int& p, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__> foo(const T0__& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -21231,8 +21314,9 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_row_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   stan::promote_args_t<stan::base_type_t<T0__>>
   foo(const T0__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -21249,8 +21333,9 @@ template <typename T0__, stan::require_row_vector_t<T0__>* = nullptr,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
   stan::promote_args_t<stan::base_type_t<T0__>>
   foo(const T0__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -21268,8 +21353,8 @@ template <typename T0__, stan::require_col_vector_t<T0__>*,
     }
     }
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   stan::promote_args_t<stan::base_type_t<T0__>>
   foo(const T0__& p_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -21286,7 +21371,8 @@ template <typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo(const std::vector<T0__>& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -21302,7 +21388,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
       std::ostream* pstream__) {
@@ -21320,7 +21407,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
       std::ostream* pstream__) {
@@ -21338,7 +21426,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
       std::ostream* pstream__) {
@@ -21356,7 +21445,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo(const std::vector<std::vector<T0__>>& p, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -21394,7 +21484,7 @@ const
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<std::vector<T0__>>& p,
                           std::ostream* pstream__)  const
@@ -21402,7 +21492,7 @@ foo_functor__::operator()(const std::vector<std::vector<T0__>>& p,
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
                           std::ostream* pstream__)  const
@@ -21410,7 +21500,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& p,
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
                           std::ostream* pstream__)  const
@@ -21418,7 +21508,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& p,
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
                           std::ostream* pstream__)  const
@@ -21426,7 +21516,7 @@ foo_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& p,
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<T0__>& p, std::ostream* pstream__) 
 const
@@ -21434,31 +21524,34 @@ const
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 stan::promote_args_t<stan::base_type_t<T0__>>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 stan::promote_args_t<stan::base_type_t<T0__>>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_row_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_row_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 stan::promote_args_t<stan::base_type_t<T0__>>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
   return foo(p, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const T0__& p, std::ostream* pstream__)  const
 {
@@ -22643,17 +22736,20 @@ static constexpr std::array<const char*, 9> locations_array__ =
  " (in 'promotion.stan', line 6, column 28 to line 8, column 4)"};
 
 struct foo_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& zs, std::ostream* pstream__) const;
 };
 struct ident_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::complex<stan::promote_args_t<T0__>>
   operator()(const std::complex<T0__>& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   std::complex<stan::promote_args_t<T0__>>
   ident(const std::complex<T0__>& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -22669,7 +22765,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo(const std::vector<T0__>& zs, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -22685,7 +22782,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_functor__::operator()(const std::vector<T0__>& zs,
                           std::ostream* pstream__)  const
@@ -22693,7 +22790,7 @@ foo_functor__::operator()(const std::vector<T0__>& zs,
   return foo(zs, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 std::complex<stan::promote_args_t<T0__>>
 ident_functor__::operator()(const std::complex<T0__>& x,
                             std::ostream* pstream__)  const
@@ -23070,50 +23167,54 @@ static constexpr std::array<const char*, 26> locations_array__ =
 
 template <bool propto__>
   struct foo_lpdf_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct h_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<T3__>& a) const;
 };
 struct g_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct h_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<T3__>& a,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g(const std::vector<T0__>& y_slice, const int& start, const int& end,
     std::ostream* pstream__) {
@@ -23137,8 +23238,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h(const std::vector<T0__>& y_slice, const int& start, const int& end,
     const std::vector<T3__>& a, std::ostream* pstream__) {
@@ -23164,7 +23265,7 @@ template <typename T0__, typename T3__,
     }
     }
 template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo_lpdf(const std::vector<T0__>& y_slice, const int& start,
            const int& end, std::ostream* pstream__) {
@@ -23180,7 +23281,7 @@ template <bool propto__, typename T0__,
     }
     }
 template <bool propto__>
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
                                            const int& start, const int& end,
@@ -23189,7 +23290,8 @@ foo_lpdf_rsfunctor__<propto__>::operator()(const std::vector<T0__>& y_slice,
   return foo_lpdf<propto__>(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__, typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
                                const int& start, const int& end,
@@ -23198,7 +23300,7 @@ foo_lpdf_functor__::operator()(const std::vector<T0__>& y_slice,
   return foo_lpdf<propto__>(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                         const int& end, std::ostream* pstream__)  const
@@ -23206,8 +23308,9 @@ g_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__,
@@ -23216,7 +23319,7 @@ h_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return h(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__)  const
@@ -23224,8 +23327,9 @@ g_rsfunctor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                         const int& end, const std::vector<T3__>& a,
@@ -23823,15 +23927,16 @@ static constexpr std::array<const char*, 180> locations_array__ =
  " (in 'reduce_sum_m2.stan', line 113, column 65 to line 121, column 3)"};
 
 struct g6_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h6_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -23839,8 +23944,8 @@ struct h6_functor__ {
 };
 struct h6_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
@@ -23848,8 +23953,8 @@ struct h6_rsfunctor__ {
 };
 struct h8_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -23857,8 +23962,8 @@ struct h8_functor__ {
 };
 struct h7_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -23866,8 +23971,8 @@ struct h7_functor__ {
 };
 struct h8_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
@@ -23875,149 +23980,164 @@ struct h8_rsfunctor__ {
 };
 struct h2_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
              std::ostream* pstream__) const;
 };
 struct g8_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h2_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, 1>>& a) const;
 };
 struct g1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h5_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__, const std::vector<std::vector<T3__>>& a) const;
 };
 struct g1_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct h1_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<T3__>& a, std::ostream* pstream__) const;
 };
 struct g7_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g5_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g5_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h4_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
              const std::vector<Eigen::Matrix<T3__, -1, -1>>& a) const;
 };
 struct g4_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g7_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h5_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) const;
 };
 struct g8_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct h3_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
@@ -24025,8 +24145,8 @@ struct h3_rsfunctor__ {
 };
 struct h7_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__,
@@ -24034,16 +24154,16 @@ struct h7_rsfunctor__ {
 };
 struct h1_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              std::ostream* pstream__, const std::vector<T3__>& a) const;
 };
 struct h3_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -24051,15 +24171,16 @@ struct h3_functor__ {
 };
 struct h4_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y, const int& start, const int& end,
              const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
              std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      std::ostream* pstream__) {
@@ -24076,7 +24197,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -24104,7 +24226,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -24132,7 +24255,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -24161,7 +24285,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
      const int& end, std::ostream* pstream__) {
@@ -24197,7 +24322,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -24234,7 +24360,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -24271,7 +24398,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   g8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -24309,8 +24437,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h1(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<T3__>& a, std::ostream* pstream__) {
@@ -24330,8 +24458,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h2(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -24361,8 +24489,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h3(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -24392,8 +24520,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h4(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -24424,8 +24552,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h5(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
@@ -24461,8 +24589,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h6(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -24500,8 +24628,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h7(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -24539,8 +24667,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   h8(const std::vector<T0__>& y, const int& start, const int& end,
      const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -24577,7 +24705,7 @@ template <typename T0__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                          const int& start, const int& end,
@@ -24586,8 +24714,9 @@ g6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1
   return g6(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -24597,8 +24726,9 @@ h6_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h6(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h6_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24608,8 +24738,9 @@ const
   return h6(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -24619,8 +24750,9 @@ h8_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h8(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -24630,8 +24762,9 @@ h7_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h7(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h8_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24641,8 +24774,9 @@ const
   return h8(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -24652,7 +24786,7 @@ h2_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h2(y, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -24661,8 +24795,9 @@ g8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -
   return g8(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h2_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24672,7 +24807,7 @@ const
   return h2(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
@@ -24680,7 +24815,7 @@ g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g1(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                          const int& start, const int& end,
@@ -24689,7 +24824,7 @@ g2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
   return g2(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                            const int& start, const int& end,
@@ -24698,7 +24833,7 @@ g2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slic
   return g2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -24707,8 +24842,9 @@ g3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slic
   return g3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24717,7 +24853,7 @@ h5_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
   return h5(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -24726,8 +24862,9 @@ g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end, const std::vector<T3__>& a,
@@ -24736,7 +24873,7 @@ h1_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h1(y, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -24745,7 +24882,7 @@ g7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1
   return g7(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                          const int& start, const int& end,
@@ -24754,7 +24891,7 @@ g5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return g5(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                            const int& start, const int& end,
@@ -24763,7 +24900,7 @@ g5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return g5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                            const int& start, const int& end,
@@ -24772,7 +24909,7 @@ g6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return g6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -24781,8 +24918,9 @@ g4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice
   return g4(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h4_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24792,7 +24930,7 @@ const
   return h4(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -24801,7 +24939,7 @@ g4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_sli
   return g4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -24810,8 +24948,9 @@ g7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, 
   return g7(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -24821,7 +24960,7 @@ h5_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h5(y, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -24830,7 +24969,7 @@ g8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return g8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -24839,8 +24978,9 @@ g3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
   return g3(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h3_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24850,8 +24990,9 @@ const
   return h3(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h7_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24861,8 +25002,9 @@ const
   return h7(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
                            const int& end, std::ostream* pstream__,
@@ -24871,8 +25013,9 @@ h1_rsfunctor__::operator()(const std::vector<T0__>& y, const int& start,
   return h1(y, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -24882,8 +25025,9 @@ h3_functor__::operator()(const std::vector<T0__>& y, const int& start,
   return h3(y, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 h4_functor__::operator()(const std::vector<T0__>& y, const int& start,
                          const int& end,
@@ -26616,7 +26760,8 @@ static constexpr std::array<const char*, 342> locations_array__ =
  " (in 'reduce_sum_m3.stan', line 86, column 11 to line 149, column 3)"};
 
 struct f1a_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
@@ -26626,23 +26771,23 @@ struct s_rsfunctor__ {
             typename T7__, typename T9__, typename T10__, typename T11__,
             typename T12__, typename T14__, typename T15__, typename T16__,
             typename T17__, typename T19__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_not_vt_complex<T5__>* = nullptr,
-            stan::require_row_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_not_vt_complex<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr,
-            stan::require_stan_scalar_t<T12__>* = nullptr,
-            stan::require_stan_scalar_t<T14__>* = nullptr,
-            stan::require_stan_scalar_t<T15__>* = nullptr,
-            stan::require_stan_scalar_t<T16__>* = nullptr,
-            stan::require_stan_scalar_t<T17__>* = nullptr,
-            stan::require_stan_scalar_t<T19__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_col_vector<T5__>,
+                                stan::is_vt_not_complex<T5__>,
+                                stan::is_row_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_eigen_matrix_dynamic<T7__>,
+                                stan::is_vt_not_complex<T7__>,
+                                stan::is_stan_scalar<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>,
+                                stan::is_stan_scalar<T12__>,
+                                stan::is_stan_scalar<T14__>,
+                                stan::is_stan_scalar<T15__>,
+                                stan::is_stan_scalar<T16__>,
+                                stan::is_stan_scalar<T17__>,
+                                stan::is_stan_scalar<T19__>>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::base_type_t<T5__>,
                        stan::base_type_t<T6__>, stan::base_type_t<T7__>,
                        stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -26664,51 +26809,55 @@ struct s_rsfunctor__ {
              const std::vector<std::vector<std::vector<T19__>>>& q) const;
 };
 struct f4_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g12_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a) const;
 };
 struct f5_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct f8_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g8_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
              std::ostream* pstream__) const;
 };
 struct f1a_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g10_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -26720,31 +26869,32 @@ struct r_functor__ {
 };
 struct g1_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
 };
 struct g2_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
 };
 struct f6_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g12_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
@@ -26752,33 +26902,37 @@ struct g12_functor__ {
              std::ostream* pstream__) const;
 };
 struct f2_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f3_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f6_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f12_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g9_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -26786,8 +26940,8 @@ struct g9_rsfunctor__ {
 };
 struct g11_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
@@ -26795,27 +26949,30 @@ struct g11_functor__ {
              std::ostream* pstream__) const;
 };
 struct f3_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f1_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g11_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -26823,8 +26980,8 @@ struct g11_rsfunctor__ {
 };
 struct g9_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<std::vector<T3__>>& a,
@@ -26832,18 +26989,18 @@ struct g9_functor__ {
 };
 struct g4_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
 };
 struct g4_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -26854,16 +27011,17 @@ struct f11_functor__ {
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct f12_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_row_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_row_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
@@ -26875,15 +27033,16 @@ struct f11_rsfunctor__ {
 };
 struct g6_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
              std::ostream* pstream__) const;
 };
 struct f7_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
@@ -26894,16 +27053,17 @@ struct f9_rsfunctor__ {
              std::ostream* pstream__) const;
 };
 struct f4_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g2_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const T3__& a, std::ostream* pstream__) const;
@@ -26918,23 +27078,23 @@ struct s_functor__ {
             typename T7__, typename T9__, typename T10__, typename T11__,
             typename T12__, typename T14__, typename T15__, typename T16__,
             typename T17__, typename T19__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_not_vt_complex<T5__>* = nullptr,
-            stan::require_row_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_not_vt_complex<T7__>* = nullptr,
-            stan::require_stan_scalar_t<T9__>* = nullptr,
-            stan::require_stan_scalar_t<T10__>* = nullptr,
-            stan::require_stan_scalar_t<T11__>* = nullptr,
-            stan::require_stan_scalar_t<T12__>* = nullptr,
-            stan::require_stan_scalar_t<T14__>* = nullptr,
-            stan::require_stan_scalar_t<T15__>* = nullptr,
-            stan::require_stan_scalar_t<T16__>* = nullptr,
-            stan::require_stan_scalar_t<T17__>* = nullptr,
-            stan::require_stan_scalar_t<T19__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_col_vector<T5__>,
+                                stan::is_vt_not_complex<T5__>,
+                                stan::is_row_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_eigen_matrix_dynamic<T7__>,
+                                stan::is_vt_not_complex<T7__>,
+                                stan::is_stan_scalar<T9__>,
+                                stan::is_stan_scalar<T10__>,
+                                stan::is_stan_scalar<T11__>,
+                                stan::is_stan_scalar<T12__>,
+                                stan::is_stan_scalar<T14__>,
+                                stan::is_stan_scalar<T15__>,
+                                stan::is_stan_scalar<T16__>,
+                                stan::is_stan_scalar<T17__>,
+                                stan::is_stan_scalar<T19__>>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::base_type_t<T5__>,
                        stan::base_type_t<T6__>, stan::base_type_t<T7__>,
                        stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -26957,16 +27117,17 @@ struct s_functor__ {
              std::ostream* pstream__) const;
 };
 struct f2_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g3_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_row_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_row_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
@@ -26977,23 +27138,24 @@ struct f9_functor__ {
              std::ostream* pstream__) const;
 };
 struct f8_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
              const int& start, const int& end, std::ostream* pstream__) const;
 };
 struct g1_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__, const T3__& a) const;
 };
 struct g7_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -27001,8 +27163,8 @@ struct g7_functor__ {
 };
 struct g5_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, const std::vector<T3__>& a,
@@ -27010,23 +27172,24 @@ struct g5_functor__ {
 };
 struct g5_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
              const std::vector<T3__>& a) const;
 };
 struct f5_rsfunctor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<std::vector<T0__>>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g6_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -27034,8 +27197,8 @@ struct g6_rsfunctor__ {
 };
 struct g7_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -27043,8 +27206,8 @@ struct g7_rsfunctor__ {
 };
 struct g8_rsfunctor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__,
@@ -27056,15 +27219,16 @@ struct f10_rsfunctor__ {
              const int& end, std::ostream* pstream__) const;
 };
 struct f1_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end, std::ostream* pstream__) const;
 };
 struct g10_functor__ {
   template <typename T0__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   operator()(const std::vector<T0__>& y_slice, const int& start,
              const int& end,
@@ -27072,7 +27236,8 @@ struct g10_functor__ {
              std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      std::ostream* pstream__) {
@@ -27089,7 +27254,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f1a(const std::vector<T0__>& y_slice, const int& start, const int& end,
       std::ostream* pstream__) {
@@ -27106,7 +27272,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f2(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -27123,7 +27290,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f3(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -27140,7 +27308,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f4(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -27157,7 +27326,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f5(const std::vector<std::vector<T0__>>& y_slice, const int& start,
      const int& end, std::ostream* pstream__) {
@@ -27174,7 +27344,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f6(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -27191,7 +27362,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f7(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -27208,7 +27380,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f8(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
      const int& start, const int& end, std::ostream* pstream__) {
@@ -27273,7 +27446,8 @@ double
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   f12(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
       const int& start, const int& end, std::ostream* pstream__) {
@@ -27291,8 +27465,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g1(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a, std::ostream* pstream__) {
@@ -27310,9 +27484,9 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   g2(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -27332,9 +27506,9 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_row_vector_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_row_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   g3(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -27354,9 +27528,9 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   stan::promote_args_t<T0__, stan::base_type_t<T3__>>
   g4(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const T3__& a_arg__, std::ostream* pstream__) {
@@ -27376,8 +27550,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g5(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<T3__>& a, std::ostream* pstream__) {
@@ -27395,8 +27569,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g6(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, 1>>& a,
@@ -27415,8 +27589,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g7(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, 1, -1>>& a,
@@ -27435,8 +27609,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g8(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<Eigen::Matrix<T3__, -1, -1>>& a,
@@ -27455,8 +27629,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g9(const std::vector<T0__>& y_slice, const int& start, const int& end,
      const std::vector<std::vector<T3__>>& a, std::ostream* pstream__) {
@@ -27474,8 +27648,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g10(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, -1, 1>>>& a,
@@ -27494,8 +27668,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g11(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, 1, -1>>>& a,
@@ -27514,8 +27688,8 @@ template <typename T0__, typename T3__,
     }
     }
 template <typename T0__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   stan::promote_args_t<T0__, T3__>
   g12(const std::vector<T0__>& y_slice, const int& start, const int& end,
       const std::vector<std::vector<Eigen::Matrix<T3__, -1, -1>>>& a,
@@ -27537,23 +27711,23 @@ template <typename T0__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T9__, typename T10__, typename T11__,
           typename T12__, typename T14__, typename T15__, typename T16__,
           typename T17__, typename T19__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_not_vt_complex<T5__>* = nullptr,
-          stan::require_row_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-          stan::require_not_vt_complex<T7__>* = nullptr,
-          stan::require_stan_scalar_t<T9__>* = nullptr,
-          stan::require_stan_scalar_t<T10__>* = nullptr,
-          stan::require_stan_scalar_t<T11__>* = nullptr,
-          stan::require_stan_scalar_t<T12__>* = nullptr,
-          stan::require_stan_scalar_t<T14__>* = nullptr,
-          stan::require_stan_scalar_t<T15__>* = nullptr,
-          stan::require_stan_scalar_t<T16__>* = nullptr,
-          stan::require_stan_scalar_t<T17__>* = nullptr,
-          stan::require_stan_scalar_t<T19__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_row_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>,
+                              stan::is_stan_scalar<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>,
+                              stan::is_stan_scalar<T12__>,
+                              stan::is_stan_scalar<T14__>,
+                              stan::is_stan_scalar<T15__>,
+                              stan::is_stan_scalar<T16__>,
+                              stan::is_stan_scalar<T17__>,
+                              stan::is_stan_scalar<T19__>>* = nullptr>
   stan::promote_args_t<T0__, T4__, stan::base_type_t<T5__>,
                      stan::base_type_t<T6__>, stan::base_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -27903,7 +28077,7 @@ double r(std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -27915,23 +28089,24 @@ f1a_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
 template <typename T0__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T9__, typename T10__, typename T11__,
           typename T12__, typename T14__, typename T15__, typename T16__,
-          typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_not_vt_complex<T5__>*,
-          stan::require_row_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_not_vt_complex<T7__>*,
-          stan::require_stan_scalar_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*,
-          stan::require_stan_scalar_t<T12__>*,
-          stan::require_stan_scalar_t<T14__>*,
-          stan::require_stan_scalar_t<T15__>*,
-          stan::require_stan_scalar_t<T16__>*,
-          stan::require_stan_scalar_t<T17__>*,
-          stan::require_stan_scalar_t<T19__>*>
+          typename T17__, typename T19__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_row_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>,
+                              stan::is_stan_scalar<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>,
+                              stan::is_stan_scalar<T12__>,
+                              stan::is_stan_scalar<T14__>,
+                              stan::is_stan_scalar<T15__>,
+                              stan::is_stan_scalar<T16__>,
+                              stan::is_stan_scalar<T17__>,
+                              stan::is_stan_scalar<T19__>>*>
 stan::promote_args_t<T0__, T4__, stan::base_type_t<T5__>,
                      stan::base_type_t<T6__>, stan::base_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -27959,7 +28134,7 @@ const
            m, n, o, p, q, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -27968,8 +28143,9 @@ f4_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_sli
   return f4(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g12_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -27980,7 +28156,7 @@ const
   return g12(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                          const int& start, const int& end,
@@ -27989,7 +28165,7 @@ f5_functor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return f5(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -27998,8 +28174,9 @@ f8_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return f8(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -28009,7 +28186,7 @@ g8_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g8(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end, std::ostream* pstream__)  const
@@ -28017,8 +28194,9 @@ f1a_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return f1a(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g10_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -28034,8 +28212,9 @@ double r_functor__::operator()(std::ostream* pstream__)  const
   return r(pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -28044,9 +28223,10 @@ g1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g1(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 stan::promote_args_t<T0__, stan::base_type_t<T3__>>
 g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28055,7 +28235,7 @@ g2_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g2(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                            const int& start, const int& end,
@@ -28064,8 +28244,9 @@ f6_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1,
   return f6(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
@@ -28075,7 +28256,7 @@ g12_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g12(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                            const int& start, const int& end,
@@ -28084,7 +28265,7 @@ f2_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slic
   return f2(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                            const int& start, const int& end,
@@ -28093,7 +28274,7 @@ f3_rsfunctor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slic
   return f3(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1>>>& y_slice,
                          const int& start, const int& end,
@@ -28102,7 +28283,7 @@ f6_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, 1
   return f6(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
                             const int& start, const int& end,
@@ -28111,8 +28292,9 @@ f12_rsfunctor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y
   return f12(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28122,8 +28304,9 @@ g9_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g9(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
@@ -28133,7 +28316,7 @@ g11_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g11(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -28142,7 +28325,7 @@ f3_functor__::operator()(const std::vector<Eigen::Matrix<T0__, 1, -1>>& y_slice,
   return f3(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28151,7 +28334,7 @@ f1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return f1(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -28160,8 +28343,9 @@ f7_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1
   return f7(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g11_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                             const int& start, const int& end,
@@ -28172,8 +28356,9 @@ const
   return g11(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -28183,9 +28368,10 @@ g9_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g9(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 stan::promote_args_t<T0__, stan::base_type_t<T3__>>
 g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -28194,9 +28380,10 @@ g4_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g4(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 stan::promote_args_t<T0__, stan::base_type_t<T3__>>
 g4_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28213,7 +28400,7 @@ f11_functor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_sl
   return f11(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_slice,
                           const int& start, const int& end,
@@ -28222,9 +28409,10 @@ f12_functor__::operator()(const std::vector<std::vector<std::vector<T0__>>>& y_s
   return f12(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_row_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_row_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 stan::promote_args_t<T0__, stan::base_type_t<T3__>>
 g3_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -28241,8 +28429,9 @@ f11_rsfunctor__::operator()(const std::vector<std::vector<std::vector<int>>>& y_
   return f11(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -28252,7 +28441,7 @@ g6_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g6(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f7_rsfunctor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, 1, -1>>>& y_slice,
                            const int& start, const int& end,
@@ -28268,7 +28457,7 @@ f9_rsfunctor__::operator()(const std::vector<int>& y_slice, const int& start,
   return f9(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice,
                          const int& start, const int& end,
@@ -28277,9 +28466,10 @@ f4_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, -1>>& y_slice
   return f4(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 stan::promote_args_t<T0__, stan::base_type_t<T3__>>
 g2_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const T3__& a,
@@ -28299,23 +28489,24 @@ f10_functor__::operator()(const std::vector<std::vector<int>>& y_slice,
 template <typename T0__, typename T4__, typename T5__, typename T6__,
           typename T7__, typename T9__, typename T10__, typename T11__,
           typename T12__, typename T14__, typename T15__, typename T16__,
-          typename T17__, typename T19__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_not_vt_complex<T5__>*,
-          stan::require_row_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_not_vt_complex<T7__>*,
-          stan::require_stan_scalar_t<T9__>*,
-          stan::require_stan_scalar_t<T10__>*,
-          stan::require_stan_scalar_t<T11__>*,
-          stan::require_stan_scalar_t<T12__>*,
-          stan::require_stan_scalar_t<T14__>*,
-          stan::require_stan_scalar_t<T15__>*,
-          stan::require_stan_scalar_t<T16__>*,
-          stan::require_stan_scalar_t<T17__>*,
-          stan::require_stan_scalar_t<T19__>*>
+          typename T17__, typename T19__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_row_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>,
+                              stan::is_stan_scalar<T9__>,
+                              stan::is_stan_scalar<T10__>,
+                              stan::is_stan_scalar<T11__>,
+                              stan::is_stan_scalar<T12__>,
+                              stan::is_stan_scalar<T14__>,
+                              stan::is_stan_scalar<T15__>,
+                              stan::is_stan_scalar<T16__>,
+                              stan::is_stan_scalar<T17__>,
+                              stan::is_stan_scalar<T19__>>*>
 stan::promote_args_t<T0__, T4__, stan::base_type_t<T5__>,
                      stan::base_type_t<T6__>, stan::base_type_t<T7__>,
                      stan::promote_args_t<T9__, T10__, T11__, T12__, T14__,
@@ -28342,7 +28533,7 @@ s_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
            p, q, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
                          const int& start, const int& end,
@@ -28351,9 +28542,10 @@ f2_functor__::operator()(const std::vector<Eigen::Matrix<T0__, -1, 1>>& y_slice,
   return f2(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_row_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_row_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 stan::promote_args_t<T0__, stan::base_type_t<T3__>>
 g3_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28369,7 +28561,7 @@ f9_functor__::operator()(const std::vector<int>& y_slice, const int& start,
   return f9(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -1>>>& y_slice,
                          const int& start, const int& end,
@@ -28378,8 +28570,9 @@ f8_functor__::operator()(const std::vector<std::vector<Eigen::Matrix<T0__, -1, -
   return f8(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28388,8 +28581,9 @@ g1_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g1(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end,
@@ -28399,8 +28593,9 @@ g7_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g7(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, const std::vector<T3__>& a,
@@ -28409,8 +28604,9 @@ g5_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return g5(y_slice, start, end, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28420,7 +28616,7 @@ g5_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
   return g5(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
                            const int& start, const int& end,
@@ -28429,8 +28625,9 @@ f5_rsfunctor__::operator()(const std::vector<std::vector<T0__>>& y_slice,
   return f5(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g6_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28441,8 +28638,9 @@ const
   return g6(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g7_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28453,8 +28651,9 @@ const
   return g7(y_slice, start + 1, end + 1, a, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g8_rsfunctor__::operator()(const std::vector<T0__>& y_slice,
                            const int& start, const int& end,
@@ -28473,7 +28672,7 @@ f10_rsfunctor__::operator()(const std::vector<std::vector<int>>& y_slice,
   return f10(y_slice, start + 1, end + 1, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                          const int& end, std::ostream* pstream__)  const
@@ -28481,8 +28680,9 @@ f1_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
   return f1(y_slice, start, end, pstream__);
 }
 
-template <typename T0__, typename T3__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T3__>*>
+template <typename T0__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T3__>>*>
 stan::promote_args_t<T0__, T3__>
 g10_functor__::operator()(const std::vector<T0__>& y_slice, const int& start,
                           const int& end,
@@ -30507,30 +30707,30 @@ static constexpr std::array<const char*, 52> locations_array__ =
 
 struct rhs_odefunctor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& alpha) const;
 };
 struct rhs_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& alpha,
              std::ostream* pstream__) const;
 };
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   rhs(const T0__& t, const T1__& y_arg__, const T2__& alpha,
       std::ostream* pstream__) {
@@ -30555,10 +30755,10 @@ template <typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
 rhs_odefunctor__::operator()(const T0__& t, const T1__& y,
                              std::ostream* pstream__, const T2__& alpha) 
@@ -30568,10 +30768,10 @@ const
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
 rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
                           std::ostream* pstream__)  const
@@ -31560,20 +31760,20 @@ struct foo1_lpmf_functor__ {
 };
 struct foo2_lpdf_functor__ {
   template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, std::ostream* pstream__) const;
 };
 struct foo3_lpdf_functor__ {
   template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, std::ostream* pstream__) const;
 };
 struct foo5_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -31620,7 +31820,7 @@ template <bool propto__, typename T_lp__, typename T_lp_accum__> double
     }
     }
 template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo2_lpdf(const T0__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -31635,7 +31835,7 @@ template <bool propto__, typename T0__,
     }
     }
 template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo3_lpdf(const T0__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -31650,7 +31850,8 @@ template <bool propto__, typename T0__,
     }
     }
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   foo5_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
@@ -31688,7 +31889,8 @@ foo1_lpmf_functor__::operator()(const int& y, std::ostream* pstream__)  const
   return foo1_lpmf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__, typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo2_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
 const
@@ -31696,7 +31898,8 @@ const
   return foo2_lpdf<propto__>(y, pstream__);
 }
 
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__, typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo3_lpdf_functor__::operator()(const T0__& y, std::ostream* pstream__) 
 const
@@ -31705,7 +31908,8 @@ const
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 foo5_lp_functor__::operator()(const T0__& y, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -35537,12 +35741,14 @@ static constexpr std::array<const char*, 5> locations_array__ =
  " (in 'udf_tilde_stmt_conflict.stan', line 2, column 22 to line 4, column 3)"};
 
 struct normal_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& a, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__> normal(const T0__& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -35557,7 +35763,7 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 normal_functor__::operator()(const T0__& a, std::ostream* pstream__)  const
 {
@@ -35886,15 +36092,15 @@ static constexpr std::array<const char*, 5> locations_array__ =
 
 struct lb_constrain_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& y, std::ostream* pstream__) const;
 };
 
 template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   lb_constrain(const T0__& x, const T1__& y, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -35910,8 +36116,9 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 lb_constrain_functor__::operator()(const T0__& x, const T1__& y,
                                    std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -26,14 +26,15 @@ static constexpr std::array<const char*, 13> locations_array__ =
 
 struct foo1_functor__ {
   template <typename T0__, typename T2__, typename T3__, typename T4__,
-            typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_col_vector_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_row_vector_t<T5__>* = nullptr,
-            stan::require_not_vt_complex<T5__>* = nullptr>
+            typename T5__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_col_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_row_vector<T5__>,
+                                stan::is_vt_not_complex<T5__>>* = nullptr>
   stan::promote_args_t<T0__, T2__, stan::base_type_t<T3__>,
                        stan::base_type_t<T4__>, stan::base_type_t<T5__>>
   operator()(const T0__& a, const int& b, const std::vector<T2__>& c,
@@ -42,10 +43,10 @@ struct foo1_functor__ {
 };
 struct foo2_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, T1__, T2__>, -1, 1>
   operator()(const T0__& a, const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
              const std::vector<Eigen::Matrix<T2__, 1, -1>>& c,
@@ -53,32 +54,33 @@ struct foo2_functor__ {
 };
 struct foo3_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct add_udf_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 
 template <typename T0__, typename T2__, typename T3__, typename T4__,
-          typename T5__, stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_col_vector_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_row_vector_t<T5__>* = nullptr,
-          stan::require_not_vt_complex<T5__>* = nullptr>
+          typename T5__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_row_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>>* = nullptr>
   stan::promote_args_t<T0__, T2__, stan::base_type_t<T3__>,
                      stan::base_type_t<T4__>, stan::base_type_t<T5__>>
   foo1(const T0__& a, const int& b, const std::vector<T2__>& c,
@@ -104,10 +106,10 @@ template <typename T0__, typename T2__, typename T3__, typename T4__,
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, T1__, T2__>, -1, 1>
   foo2(const T0__& a_arg__,
        const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
@@ -129,10 +131,10 @@ template <typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   foo3(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -153,10 +155,10 @@ template <typename T0__, typename T1__,
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   add_udf(const T0__& a_arg__, const T1__& b_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -177,14 +179,15 @@ template <typename T0__, typename T1__,
     }
     }
 template <typename T0__, typename T2__, typename T3__, typename T4__,
-          typename T5__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_col_vector_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_row_vector_t<T5__>*,
-          stan::require_not_vt_complex<T5__>*>
+          typename T5__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_col_vector<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_row_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>>*>
 stan::promote_args_t<T0__, T2__, stan::base_type_t<T3__>,
                      stan::base_type_t<T4__>, stan::base_type_t<T5__>>
 foo1_functor__::operator()(const T0__& a, const int& b,
@@ -196,10 +199,10 @@ foo1_functor__::operator()(const T0__& a, const int& b,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, T1__, T2__>, -1, 1>
 foo2_functor__::operator()(const T0__& a,
                            const std::vector<Eigen::Matrix<T1__, -1, -1>>& b,
@@ -209,10 +212,11 @@ foo2_functor__::operator()(const T0__& a,
   return foo2(a, b, c, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 foo3_functor__::operator()(const T0__& a, const T1__& b,
                            std::ostream* pstream__)  const
@@ -221,10 +225,10 @@ foo3_functor__::operator()(const T0__& a, const T1__& b,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 add_udf_functor__::operator()(const T0__& a, const T1__& b,
                               std::ostream* pstream__)  const

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -49,65 +49,65 @@ static constexpr std::array<const char*, 36> locations_array__ =
 
 struct f_2_arg_functor__ {
   template <typename T0__, typename T1__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const int& b, const T3__& a,
              std::ostream* pstream__) const;
 };
 struct f_0_arg_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_1_arg_functor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a,
              std::ostream* pstream__) const;
 };
 struct f_1_arg_odefunctor__ {
   template <typename T0__, typename T1__, typename T2__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a) const;
 };
 struct f_0_arg_odefunctor__ {
   template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_odefunctor__ {
   template <typename T0__, typename T1__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const int& b, const T3__& a) const;
 };
 
 template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
   f_0_arg(const T0__& t, const T1__& z_arg__, std::ostream* pstream__) {
     using local_scalar_t__ =
@@ -126,10 +126,10 @@ template <typename T0__, typename T1__,
     }
     }
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   f_1_arg(const T0__& t, const T1__& z_arg__, const T2__& a,
           std::ostream* pstream__) {
@@ -149,10 +149,10 @@ template <typename T0__, typename T1__, typename T2__,
     }
     }
 template <typename T0__, typename T1__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
   f_2_arg(const T0__& t, const T1__& z_arg__, const int& b, const T3__& a,
           std::ostream* pstream__) {
@@ -172,10 +172,10 @@ template <typename T0__, typename T1__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
 f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
                               const T3__& a, std::ostream* pstream__)  const
@@ -183,9 +183,10 @@ f_2_arg_functor__::operator()(const T0__& t, const T1__& z, const int& b,
   return f_2_arg(t, z, b, a, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
 f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
                               std::ostream* pstream__)  const
@@ -194,10 +195,10 @@ f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
 f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
                               std::ostream* pstream__)  const
@@ -206,10 +207,10 @@ f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
 }
 
 template <typename T0__, typename T1__, typename T2__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
 f_1_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__, const T2__& a) 
@@ -218,9 +219,10 @@ const
   return f_1_arg(t, z, a, pstream__);
 }
 
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
 f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__)  const
@@ -229,10 +231,10 @@ f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
 }
 
 template <typename T0__, typename T1__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
 f_2_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
                                  std::ostream* pstream__, const int& b,
@@ -855,14 +857,14 @@ static constexpr std::array<const char*, 55> locations_array__ =
 struct simple_SIR_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
@@ -870,14 +872,14 @@ struct simple_SIR_functor__ {
              const int& unused, std::ostream* pstream__) const;
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& beta, const T3__& kappa,
@@ -887,14 +889,14 @@ struct simple_SIR_functor__ {
 struct simple_SIR_odefunctor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
@@ -902,14 +904,14 @@ struct simple_SIR_odefunctor__ {
              const T5__& xi, const T6__& delta, const int& unused) const;
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             typename T4__, typename T5__, typename T6__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_col_vector_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr,
-            stan::require_stan_scalar_t<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_stan_scalar_t<T6__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>,
+                                stan::is_stan_scalar<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
   operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
@@ -919,14 +921,14 @@ struct simple_SIR_odefunctor__ {
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
           typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_stan_scalar_t<T6__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
   simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
@@ -974,14 +976,14 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
           typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_col_vector_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr,
-          stan::require_stan_scalar_t<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_stan_scalar_t<T6__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
   simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta,
@@ -1034,14 +1036,14 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
           typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
@@ -1055,14 +1057,14 @@ simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
           typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_functor__::operator()(const T0__& t, const T1__& y,
@@ -1076,14 +1078,14 @@ const
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
           typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
@@ -1098,14 +1100,14 @@ const
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
           typename T4__, typename T5__, typename T6__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_col_vector_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*,
-          stan::require_stan_scalar_t<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_stan_scalar_t<T6__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>,
+                              stan::is_stan_scalar<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
 simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -37,14 +37,15 @@ struct int_only_multiplication_functor__ {
   operator()(const int& a, const int& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -54,36 +55,40 @@ struct int_array_fun_functor__ {
   operator()(const std::vector<int>& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
   template <typename T0__, typename RNG,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   my_log1p_exp(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -99,7 +104,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -129,8 +135,9 @@ double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -171,7 +178,8 @@ int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   test_lgamma(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -188,8 +196,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -204,7 +212,7 @@ template <bool propto__, typename T0__, typename T_lp__,
     }
     }
 template <typename T0__, typename RNG,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -221,8 +229,8 @@ template <typename T0__, typename RNG,
     }
     }
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -243,7 +251,7 @@ int_only_multiplication_functor__::operator()(const int& a, const int& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -252,7 +260,8 @@ const
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -268,7 +277,7 @@ int_array_fun_functor__::operator()(const std::vector<int>& a,
   return int_array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 array_fun_functor__::operator()(const std::vector<T0__>& a,
                                 std::ostream* pstream__)  const
@@ -276,7 +285,7 @@ array_fun_functor__::operator()(const std::vector<T0__>& a,
   return array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -284,8 +293,9 @@ const
   return my_log1p_exp(x, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const T0__& x,
                                          std::ostream* pstream__)  const
@@ -294,8 +304,8 @@ my_vector_mul_by_5_functor__::operator()(const T0__& x,
 }
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
                                 std::ostream* pstream__)  const
@@ -303,7 +313,8 @@ test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, typename RNG,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -423,14 +434,15 @@ struct int_only_multiplication_functor__ {
   operator()(const int& a, const int& b, std::ostream* pstream__) const;
 };
 struct test_lgamma_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
              std::ostream* pstream__) const;
@@ -440,36 +452,40 @@ struct int_array_fun_functor__ {
   operator()(const std::vector<int>& a, std::ostream* pstream__) const;
 };
 struct array_fun_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const std::vector<T0__>& a, std::ostream* pstream__) const;
 };
 struct my_log1p_exp_functor__ {
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct my_vector_mul_by_5_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct test_lpdf_functor__ {
   template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& a, const T1__& b, std::ostream* pstream__) const;
 };
 struct test_rng_functor__ {
   template <typename T0__, typename RNG,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& a, RNG& base_rng__, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   my_log1p_exp(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -485,7 +501,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   array_fun(const std::vector<T0__>& a, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -515,8 +532,9 @@ double int_array_fun(const std::vector<int>& a, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   my_vector_mul_by_5(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -557,7 +575,8 @@ int
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   test_lgamma(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -574,8 +593,8 @@ template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
     }
     }
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__,
           std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -590,7 +609,7 @@ template <bool propto__, typename T0__, typename T_lp__,
     }
     }
 template <typename T0__, typename RNG,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   test_rng(const T0__& a, RNG& base_rng__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -607,8 +626,8 @@ template <typename T0__, typename RNG,
     }
     }
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -629,7 +648,7 @@ int_only_multiplication_functor__::operator()(const int& a, const int& b,
   return int_only_multiplication(a, b, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 test_lgamma_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -638,7 +657,8 @@ const
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 test_lp_functor__::operator()(const T0__& a, T_lp__& lp__,
                               T_lp_accum__& lp_accum__,
@@ -654,7 +674,7 @@ int_array_fun_functor__::operator()(const std::vector<int>& a,
   return int_array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 array_fun_functor__::operator()(const std::vector<T0__>& a,
                                 std::ostream* pstream__)  const
@@ -662,7 +682,7 @@ array_fun_functor__::operator()(const std::vector<T0__>& a,
   return array_fun(a, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 my_log1p_exp_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -670,8 +690,9 @@ const
   return my_log1p_exp(x, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 my_vector_mul_by_5_functor__::operator()(const T0__& x,
                                          std::ostream* pstream__)  const
@@ -680,8 +701,8 @@ my_vector_mul_by_5_functor__::operator()(const T0__& x,
 }
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
                                 std::ostream* pstream__)  const
@@ -689,7 +710,8 @@ test_lpdf_functor__::operator()(const T0__& a, const T1__& b,
   return test_lpdf<propto__>(a, b, pstream__);
 }
 
-template <typename T0__, typename RNG, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, typename RNG,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 test_rng_functor__::operator()(const T0__& a, RNG& base_rng__,
                                std::ostream* pstream__)  const
@@ -796,10 +818,10 @@ static constexpr std::array<const char*, 11> locations_array__ =
 
 struct integrand_ode_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& r, const std::vector<T1__>& f,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -810,14 +832,16 @@ struct ode_integrate_functor__ {
   operator()(std::ostream* pstream__) const;
 };
 struct integrand_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   integrand(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -835,10 +859,10 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   integrand_ode(const T0__& r, const std::vector<T1__>& f,
                 const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -888,10 +912,10 @@ double ode_integrate(std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 integrand_ode_functor__::operator()(const T0__& r,
                                     const std::vector<T1__>& f,
@@ -908,8 +932,9 @@ double ode_integrate_functor__::operator()(std::ostream* pstream__)  const
   return ode_integrate(pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 integrand_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2015,10 +2015,10 @@ static constexpr std::array<const char*, 35> locations_array__ =
 
 struct simple_SIR_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -2026,10 +2026,10 @@ struct simple_SIR_functor__ {
 };
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -2085,10 +2085,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -2789,10 +2789,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -2879,10 +2879,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -3046,10 +3046,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -9230,10 +9230,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -9320,10 +9320,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -9487,10 +9487,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -10990,10 +10990,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -11005,15 +11005,15 @@ struct js_super_lp_functor__ {
   template <bool propto__, typename T3__, typename T4__, typename T5__,
             typename T6__, typename T7__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_not_vt_complex<T7__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_eigen_matrix_dynamic<T7__>,
+                                stan::is_vt_not_complex<T7__>>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11099,10 +11099,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -11267,15 +11267,15 @@ template <typename T0__, typename T1__,
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T7__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-          stan::require_not_vt_complex<T7__>* = nullptr> void
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>>* = nullptr> void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
               const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
@@ -11840,10 +11840,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -11860,15 +11860,16 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_not_vt_complex<T7__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>>*>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -15879,10 +15880,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -15969,10 +15970,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -16136,10 +16137,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -17681,14 +17682,14 @@ static constexpr std::array<const char*, 144> locations_array__ =
 struct jolly_seber_lp_functor__ {
   template <bool propto__, typename T3__, typename T4__, typename T5__,
             typename T6__, typename T_lp__, typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_not_vt_complex<T5__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_col_vector<T5__>,
+                                stan::is_vt_not_complex<T5__>,
+                                stan::is_eigen_matrix_dynamic<T6__>,
+                                stan::is_vt_not_complex<T6__>>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -17701,8 +17702,9 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& gamma, std::ostream* pstream__) const;
 };
@@ -17712,10 +17714,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -17797,10 +17799,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -17964,14 +17966,14 @@ template <typename T0__, typename T1__,
     }
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_not_vt_complex<T5__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr> void
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_eigen_matrix_dynamic<T6__>,
+                              stan::is_vt_not_complex<T6__>>* = nullptr> void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
                  const T3__& p_arg__, const T4__& phi_arg__,
@@ -18521,8 +18523,9 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -18587,14 +18590,14 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
     }
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_not_vt_complex<T5__>*,
-          stan::require_eigen_matrix_dynamic_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_eigen_matrix_dynamic<T6__>,
+                              stan::is_vt_not_complex<T6__>>*>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -18615,8 +18618,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
@@ -18632,10 +18636,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -21926,10 +21930,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -22016,10 +22020,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -22183,10 +22187,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -23447,27 +23451,27 @@ static constexpr std::array<const char*, 13> locations_array__ =
 
 struct baz_lpdf_functor__ {
   template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
   template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -23485,7 +23489,7 @@ template <bool propto__, typename T0__, typename T1__,
     }
     }
 template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -23503,7 +23507,7 @@ template <bool propto__, typename T1__,
     }
     }
 template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -23520,14 +23524,16 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__, typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
+template <bool propto__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -23536,8 +23542,8 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
 }
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -25773,15 +25779,15 @@ struct rfun_lp_functor__ {
 struct nrfun_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -25858,7 +25864,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -26874,12 +26881,14 @@ static constexpr std::array<const char*, 6> locations_array__ =
 struct dumb_functor__ {
   double
   operator()(const int& x, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__> dumb(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -26920,7 +26929,7 @@ const
   return dumb(x, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -679,10 +679,10 @@ static constexpr std::array<const char*, 37> locations_array__ =
 
 struct simple_SIR_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -690,10 +690,10 @@ struct simple_SIR_functor__ {
 };
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -744,10 +744,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -1831,10 +1831,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -1892,10 +1892,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -1966,10 +1966,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -7075,10 +7075,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -7136,10 +7136,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -7214,10 +7214,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -8149,10 +8149,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -8164,15 +8164,15 @@ struct js_super_lp_functor__ {
   template <bool propto__, typename T3__, typename T4__, typename T5__,
             typename T6__, typename T7__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_not_vt_complex<T7__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_eigen_matrix_dynamic<T7__>,
+                                stan::is_vt_not_complex<T7__>>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -8229,10 +8229,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -8303,15 +8303,15 @@ template <typename T0__, typename T1__,
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T7__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-          stan::require_not_vt_complex<T7__>* = nullptr> void
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>>* = nullptr> void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
               const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
@@ -8563,10 +8563,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -8583,15 +8583,16 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_not_vt_complex<T7__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>>*>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -10985,10 +10986,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -11046,10 +11047,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -11120,10 +11121,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -12046,14 +12047,14 @@ static constexpr std::array<const char*, 158> locations_array__ =
 struct jolly_seber_lp_functor__ {
   template <bool propto__, typename T3__, typename T4__, typename T5__,
             typename T6__, typename T_lp__, typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_not_vt_complex<T5__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_col_vector<T5__>,
+                                stan::is_vt_not_complex<T5__>,
+                                stan::is_eigen_matrix_dynamic<T6__>,
+                                stan::is_vt_not_complex<T6__>>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -12066,8 +12067,9 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& gamma, std::ostream* pstream__) const;
 };
@@ -12077,10 +12079,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -12133,10 +12135,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -12206,14 +12208,14 @@ template <typename T0__, typename T1__,
     }
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_not_vt_complex<T5__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr> void
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_eigen_matrix_dynamic<T6__>,
+                              stan::is_vt_not_complex<T6__>>* = nullptr> void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
                  const T3__& p_arg__, const T4__& phi_arg__,
@@ -12456,8 +12458,9 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -12501,14 +12504,14 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
     }
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_not_vt_complex<T5__>*,
-          stan::require_eigen_matrix_dynamic_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_eigen_matrix_dynamic<T6__>,
+                              stan::is_vt_not_complex<T6__>>*>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -12529,8 +12532,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
@@ -12546,10 +12550,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -14603,10 +14607,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -14664,10 +14668,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -14738,10 +14742,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -15437,27 +15441,27 @@ static constexpr std::array<const char*, 14> locations_array__ =
 
 struct baz_lpdf_functor__ {
   template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
   template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -15472,7 +15476,7 @@ template <bool propto__, typename T0__, typename T1__,
     }
     }
 template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -15487,7 +15491,7 @@ template <bool propto__, typename T1__,
     }
     }
 template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -15501,14 +15505,16 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__, typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
+template <bool propto__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -15517,8 +15523,8 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
 }
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -17470,15 +17476,15 @@ struct rfun_lp_functor__ {
 struct nrfun_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -17545,7 +17551,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,
@@ -18266,12 +18273,14 @@ static constexpr std::array<const char*, 6> locations_array__ =
 struct dumb_functor__ {
   double
   operator()(const int& x, std::ostream* pstream__) const;
-  template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__> dumb(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
@@ -18306,7 +18315,7 @@ const
   return dumb(x, pstream__);
 }
 
-template <typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 dumb_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -670,10 +670,10 @@ static constexpr std::array<const char*, 37> locations_array__ =
 
 struct simple_SIR_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr,
-            stan::require_stan_scalar_t<T2__>* = nullptr,
-            stan::require_stan_scalar_t<T3__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>,
+                                stan::is_stan_scalar<T2__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   operator()(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -681,10 +681,10 @@ struct simple_SIR_functor__ {
 };
 
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr,
-          stan::require_stan_scalar_t<T2__>* = nullptr,
-          stan::require_stan_scalar_t<T3__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>* = nullptr>
   std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
   simple_SIR(const T0__& t, const std::vector<T1__>& y,
              const std::vector<T2__>& theta, const std::vector<T3__>& x_r,
@@ -735,10 +735,10 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
     }
     }
 template <typename T0__, typename T1__, typename T2__, typename T3__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*,
-          stan::require_stan_scalar_t<T2__>*,
-          stan::require_stan_scalar_t<T3__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>,
+                              stan::is_stan_scalar<T2__>,
+                              stan::is_stan_scalar<T3__>>*>
 std::vector<stan::promote_args_t<T0__, T1__, T2__, T3__>>
 simple_SIR_functor__::operator()(const T0__& t, const std::vector<T1__>& y,
                                  const std::vector<T2__>& theta,
@@ -1366,10 +1366,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -1427,10 +1427,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -1500,10 +1500,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -6567,10 +6567,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -6628,10 +6628,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -6701,10 +6701,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -7633,10 +7633,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -7648,15 +7648,15 @@ struct js_super_lp_functor__ {
   template <bool propto__, typename T3__, typename T4__, typename T5__,
             typename T6__, typename T7__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_stan_scalar_t<T5__>* = nullptr,
-            stan::require_col_vector_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-            stan::require_not_vt_complex<T7__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_stan_scalar<T5__>,
+                                stan::is_col_vector<T6__>,
+                                stan::is_vt_not_complex<T6__>,
+                                stan::is_eigen_matrix_dynamic<T7__>,
+                                stan::is_vt_not_complex<T7__>>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -7713,10 +7713,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -7785,15 +7785,15 @@ template <typename T0__, typename T1__,
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T7__, typename T_lp__,
           typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_stan_scalar_t<T5__>* = nullptr,
-          stan::require_col_vector_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T7__>* = nullptr,
-          stan::require_not_vt_complex<T7__>* = nullptr> void
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>>* = nullptr> void
   js_super_lp(const std::vector<std::vector<int>>& y,
               const std::vector<int>& first, const std::vector<int>& last,
               const T3__& p_arg__, const T4__& phi_arg__, const T5__& psi,
@@ -8041,10 +8041,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -8061,15 +8061,16 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
 
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T7__, typename T_lp__,
-          typename T_lp_accum__, stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_stan_scalar_t<T5__>*,
-          stan::require_col_vector_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*,
-          stan::require_eigen_matrix_dynamic_t<T7__>*,
-          stan::require_not_vt_complex<T7__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_stan_scalar<T5__>,
+                              stan::is_col_vector<T6__>,
+                              stan::is_vt_not_complex<T6__>,
+                              stan::is_eigen_matrix_dynamic<T7__>,
+                              stan::is_vt_not_complex<T7__>>*>
 void
 js_super_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                   const std::vector<int>& first,
@@ -10448,10 +10449,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -10509,10 +10510,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -10582,10 +10583,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -11504,14 +11505,14 @@ static constexpr std::array<const char*, 158> locations_array__ =
 struct jolly_seber_lp_functor__ {
   template <bool propto__, typename T3__, typename T4__, typename T5__,
             typename T6__, typename T_lp__, typename T_lp_accum__,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-            stan::require_not_vt_complex<T4__>* = nullptr,
-            stan::require_col_vector_t<T5__>* = nullptr,
-            stan::require_not_vt_complex<T5__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr,
-            stan::require_not_vt_complex<T6__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>,
+                                stan::is_eigen_matrix_dynamic<T4__>,
+                                stan::is_vt_not_complex<T4__>,
+                                stan::is_col_vector<T5__>,
+                                stan::is_vt_not_complex<T5__>,
+                                stan::is_eigen_matrix_dynamic<T6__>,
+                                stan::is_vt_not_complex<T6__>>* = nullptr>
   void
   operator()(const std::vector<std::vector<int>>& y,
              const std::vector<int>& first, const std::vector<int>& last,
@@ -11524,8 +11525,9 @@ struct last_capture_functor__ {
   operator()(const std::vector<int>& y_i, std::ostream* pstream__) const;
 };
 struct seq_cprob_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& gamma, std::ostream* pstream__) const;
 };
@@ -11535,10 +11537,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& p, const T1__& phi, std::ostream* pstream__) const;
 };
@@ -11591,10 +11593,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
   prob_uncaptured(const T0__& p_arg__, const T1__& phi_arg__,
                   std::ostream* pstream__) {
@@ -11662,14 +11664,14 @@ template <typename T0__, typename T1__,
     }
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T4__>* = nullptr,
-          stan::require_not_vt_complex<T4__>* = nullptr,
-          stan::require_col_vector_t<T5__>* = nullptr,
-          stan::require_not_vt_complex<T5__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T6__>* = nullptr,
-          stan::require_not_vt_complex<T6__>* = nullptr> void
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_eigen_matrix_dynamic<T6__>,
+                              stan::is_vt_not_complex<T6__>>* = nullptr> void
   jolly_seber_lp(const std::vector<std::vector<int>>& y,
                  const std::vector<int>& first, const std::vector<int>& last,
                  const T3__& p_arg__, const T4__& phi_arg__,
@@ -11908,8 +11910,9 @@ template <bool propto__, typename T3__, typename T4__, typename T5__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -11952,14 +11955,14 @@ template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
     }
 template <bool propto__, typename T3__, typename T4__, typename T5__,
           typename T6__, typename T_lp__, typename T_lp_accum__,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*,
-          stan::require_eigen_matrix_dynamic_t<T4__>*,
-          stan::require_not_vt_complex<T4__>*,
-          stan::require_col_vector_t<T5__>*,
-          stan::require_not_vt_complex<T5__>*,
-          stan::require_eigen_matrix_dynamic_t<T6__>*,
-          stan::require_not_vt_complex<T6__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>,
+                              stan::is_eigen_matrix_dynamic<T4__>,
+                              stan::is_vt_not_complex<T4__>,
+                              stan::is_col_vector<T5__>,
+                              stan::is_vt_not_complex<T5__>,
+                              stan::is_eigen_matrix_dynamic<T6__>,
+                              stan::is_vt_not_complex<T6__>>*>
 void
 jolly_seber_lp_functor__::operator()(const std::vector<std::vector<int>>& y,
                                      const std::vector<int>& first,
@@ -11980,8 +11983,9 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   return last_capture(y_i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 seq_cprob_functor__::operator()(const T0__& gamma, std::ostream* pstream__) 
 const
@@ -11997,10 +12001,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T0__, typename T1__,
-          stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>, stan::base_type_t<T1__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const T0__& p, const T1__& phi,
                                       std::ostream* pstream__)  const
@@ -14041,10 +14045,10 @@ struct first_capture_functor__ {
 };
 struct prob_uncaptured_functor__ {
   template <typename T2__, typename T3__,
-            stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-            stan::require_not_vt_complex<T2__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-            stan::require_not_vt_complex<T3__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   operator()(const int& nind, const int& n_occasions, const T2__& p,
              const T3__& phi, std::ostream* pstream__) const;
@@ -14102,10 +14106,10 @@ int last_capture(const std::vector<int>& y_i, std::ostream* pstream__) {
     }
     }
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>* = nullptr,
-          stan::require_not_vt_complex<T2__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T3__>* = nullptr,
-          stan::require_not_vt_complex<T3__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
   prob_uncaptured(const int& nind, const int& n_occasions,
                   const T2__& p_arg__, const T3__& phi_arg__,
@@ -14175,10 +14179,10 @@ first_capture_functor__::operator()(const std::vector<int>& y_i,
 }
 
 template <typename T2__, typename T3__,
-          stan::require_eigen_matrix_dynamic_t<T2__>*,
-          stan::require_not_vt_complex<T2__>*,
-          stan::require_eigen_matrix_dynamic_t<T3__>*,
-          stan::require_not_vt_complex<T3__>*>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T2__>,
+                              stan::is_vt_not_complex<T2__>,
+                              stan::is_eigen_matrix_dynamic<T3__>,
+                              stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T2__>, stan::base_type_t<T3__>>, -1, -1>
 prob_uncaptured_functor__::operator()(const int& nind,
                                       const int& n_occasions, const T2__& p,
@@ -14874,27 +14878,27 @@ static constexpr std::array<const char*, 14> locations_array__ =
 
 struct baz_lpdf_functor__ {
   template <bool propto__, typename T0__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 struct bar_lpmf_functor__ {
   template <bool propto__, typename T1__,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   operator()(const int& n, const T1__& mu, std::ostream* pstream__) const;
 };
 struct foo_lpdf_functor__ {
   template <bool propto__, typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_stan_scalar_t<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   operator()(const T0__& x, const T1__& mu, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T0__, T1__>
   foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__, T1__>;
@@ -14909,7 +14913,7 @@ template <bool propto__, typename T0__, typename T1__,
     }
     }
 template <bool propto__, typename T1__,
-          stan::require_stan_scalar_t<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T1__>>* = nullptr>
   stan::promote_args_t<T1__>
   bar_lpmf(const int& n, const T1__& mu, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T1__>;
@@ -14924,7 +14928,7 @@ template <bool propto__, typename T1__,
     }
     }
 template <bool propto__, typename T0__,
-          stan::require_stan_scalar_t<T0__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   stan::promote_args_t<T0__>
   baz_lpdf(const T0__& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -14938,14 +14942,16 @@ template <bool propto__, typename T0__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <bool propto__, typename T0__, stan::require_stan_scalar_t<T0__>*>
+template <bool propto__, typename T0__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 stan::promote_args_t<T0__>
 baz_lpdf_functor__::operator()(const T0__& x, std::ostream* pstream__)  const
 {
   return baz_lpdf<propto__>(x, pstream__);
 }
 
-template <bool propto__, typename T1__, stan::require_stan_scalar_t<T1__>*>
+template <bool propto__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T1__>
 bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -14954,8 +14960,8 @@ bar_lpmf_functor__::operator()(const int& n, const T1__& mu,
 }
 
 template <bool propto__, typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>*,
-          stan::require_stan_scalar_t<T1__>*>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_stan_scalar<T1__>>*>
 stan::promote_args_t<T0__, T1__>
 foo_lpdf_functor__::operator()(const T0__& x, const T1__& mu,
                                std::ostream* pstream__)  const
@@ -16859,15 +16865,15 @@ struct rfun_lp_functor__ {
 struct nrfun_lp_functor__ {
   template <bool propto__, typename T0__, typename T_lp__,
             typename T_lp_accum__,
-            stan::require_stan_scalar_t<T0__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
   operator()(const T0__& x, const int& y, T_lp__& lp__,
              T_lp_accum__& lp_accum__, std::ostream* pstream__) const;
 };
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>* = nullptr>
-  void
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
   nrfun_lp(const T0__& x, const int& y, T_lp__& lp__,
            T_lp_accum__& lp_accum__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
@@ -16934,7 +16940,8 @@ rfun_lp_functor__::operator()(T_lp__& lp__, T_lp_accum__& lp_accum__,
 }
 
 template <bool propto__, typename T0__, typename T_lp__,
-          typename T_lp_accum__, stan::require_stan_scalar_t<T0__>*>
+          typename T_lp_accum__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>>*>
 void
 nrfun_lp_functor__::operator()(const T0__& x, const int& y, T_lp__& lp__,
                                T_lp_accum__& lp_accum__,

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -2996,8 +2996,9 @@ struct mask_fun_functor__ {
   operator()(const int& i, std::ostream* pstream__) const;
 };
 struct udf_fun_functor__ {
-  template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+  template <typename T0__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   operator()(const T0__& A, std::ostream* pstream__) const;
 };
@@ -3016,8 +3017,9 @@ int mask_fun(const int& i, std::ostream* pstream__) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, stan::require_col_vector_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
   udf_fun(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -3040,8 +3042,9 @@ const
   return mask_fun(i, pstream__);
 }
 
-template <typename T0__, stan::require_col_vector_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_col_vector<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, 1>
 udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
 {
@@ -5221,23 +5224,23 @@ static constexpr std::array<const char*, 12> locations_array__ =
 
 struct okay_reduction_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   nono_func(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -5255,9 +5258,9 @@ template <typename T0__,
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, -1>
   okay_reduction(const T0__& sum_x, const T1__& y_arg__,
                  std::ostream* pstream__) {
@@ -5276,9 +5279,10 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, -1>
 okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
                                      std::ostream* pstream__)  const
@@ -5286,8 +5290,9 @@ okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
   return okay_reduction(sum_x, y, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
 nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const
@@ -5850,8 +5855,8 @@ struct empty_user_func_functor__ {
 };
 struct mat_ret_user_func_functor__ {
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   operator()(const T0__& A, std::ostream* pstream__) const;
 };
@@ -5874,8 +5879,8 @@ Eigen::Matrix<double, -1, -1> empty_user_func(std::ostream* pstream__) {
     }
     }
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   mat_ret_user_func(const T0__& A_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -5898,8 +5903,9 @@ empty_user_func_functor__::operator()(std::ostream* pstream__)  const
   return empty_user_func(pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
 mat_ret_user_func_functor__::operator()(const T0__& A,
                                         std::ostream* pstream__)  const
@@ -6972,23 +6978,23 @@ static constexpr std::array<const char*, 10> locations_array__ =
 
 struct okay_reduction_functor__ {
   template <typename T0__, typename T1__,
-            stan::require_stan_scalar_t<T0__>* = nullptr,
-            stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-            stan::require_not_vt_complex<T1__>* = nullptr>
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_eigen_matrix_dynamic<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, -1>
   operator()(const T0__& sum_x, const T1__& y, std::ostream* pstream__) const;
 };
 struct nono_func_functor__ {
   template <typename T0__,
-            stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-            stan::require_not_vt_complex<T0__>* = nullptr>
+            stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                                stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   operator()(const T0__& x, std::ostream* pstream__) const;
 };
 
 template <typename T0__,
-          stan::require_eigen_matrix_dynamic_t<T0__>* = nullptr,
-          stan::require_not_vt_complex<T0__>* = nullptr>
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
   nono_func(const T0__& x_arg__, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<stan::base_type_t<T0__>>;
@@ -7006,9 +7012,9 @@ template <typename T0__,
     }
     }
 template <typename T0__, typename T1__,
-          stan::require_stan_scalar_t<T0__>* = nullptr,
-          stan::require_eigen_matrix_dynamic_t<T1__>* = nullptr,
-          stan::require_not_vt_complex<T1__>* = nullptr>
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, -1>
   okay_reduction(const T0__& sum_x, const T1__& y_arg__,
                  std::ostream* pstream__) {
@@ -7027,9 +7033,10 @@ template <typename T0__, typename T1__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, stan::require_stan_scalar_t<T0__>*,
-          stan::require_eigen_matrix_dynamic_t<T1__>*,
-          stan::require_not_vt_complex<T1__>*>
+template <typename T0__, typename T1__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_eigen_matrix_dynamic<T1__>,
+                              stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, -1>
 okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
                                      std::ostream* pstream__)  const
@@ -7037,8 +7044,9 @@ okay_reduction_functor__::operator()(const T0__& sum_x, const T1__& y,
   return okay_reduction(sum_x, y, pstream__);
 }
 
-template <typename T0__, stan::require_eigen_matrix_dynamic_t<T0__>*,
-          stan::require_not_vt_complex<T0__>*>
+template <typename T0__,
+          stan::require_all_t<stan::is_eigen_matrix_dynamic<T0__>,
+                              stan::is_vt_not_complex<T0__>>*>
 Eigen::Matrix<stan::promote_args_t<stan::base_type_t<T0__>>, -1, -1>
 nono_func_functor__::operator()(const T0__& x, std::ostream* pstream__) 
 const


### PR DESCRIPTION
This requires https://github.com/stan-dev/math/pull/2694

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Improve compile times by accumulating all template requirements into a single `require_all_t` on user defined functions.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
