### PR TITLE
Fix return type of indexing operations on complex containers

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -373,21 +373,24 @@ let is_multiindex i =
 
 let inferred_unsizedtype_of_indexed ~loc ut indices =
   let rec aux type_ idcs =
+    let vec, rowvec, scalar =
+      if UnsizedType.is_complex_type type_ then
+        UnsizedType.(UComplexVector, UComplexRowVector, UComplex)
+      else (UVector, URowVector, UReal) in
     match (type_, idcs) with
     | _, [] -> type_
     | UnsizedType.UArray type_, `Single :: tl -> aux type_ tl
     | UArray type_, `Multi :: tl -> aux type_ tl |> UnsizedType.UArray
     | (UVector | URowVector | UComplexRowVector | UComplexVector), [`Single]
      |(UMatrix | UComplexMatrix), [`Single; `Single] ->
-        UnsizedType.UReal
+        scalar
     | ( ( UVector | URowVector | UMatrix | UComplexVector | UComplexMatrix
         | UComplexRowVector )
       , [`Multi] )
      |(UMatrix | UComplexMatrix), [`Multi; `Multi] ->
         type_
-    | (UMatrix | UComplexMatrix), ([`Single] | [`Single; `Multi]) ->
-        UnsizedType.URowVector
-    | (UMatrix | UComplexMatrix), [`Multi; `Single] -> UnsizedType.UVector
+    | (UMatrix | UComplexMatrix), ([`Single] | [`Single; `Multi]) -> rowvec
+    | (UMatrix | UComplexMatrix), [`Multi; `Single] -> vec
     | (UMatrix | UComplexMatrix), _ :: _ :: _ :: _
      |(UVector | URowVector | UComplexRowVector | UComplexVector), _ :: _ :: _
      |(UInt | UReal | UComplex | UFun _ | UMathLibraryFunction), _ :: _ ->

--- a/test/integration/bad/complex_mat_bad.stan
+++ b/test/integration/bad/complex_mat_bad.stan
@@ -1,0 +1,9 @@
+data {
+   int N;
+   complex_matrix[N,N] Z;
+}
+
+model {
+  real x = Z[1,1];
+  target += x;
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -330,6 +330,18 @@ Semantic error in 'cdf-sample.stan', line 5, column 2 to column 23:
    -------------------------------------------------
 
 CDF and CCDF functions may not be used with sampling notation. Use target += normal_cdf_log(...) instead.
+  $ ../../../../install/default/bin/stanc complex_mat_bad.stan
+Semantic error in 'complex_mat_bad.stan', line 7, column 2 to column 18:
+   -------------------------------------------------
+     5:  
+     6:  model {
+     7:    real x = Z[1,1];
+           ^
+     8:    target += x;
+     9:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to assignment operator =: lhs has type real and rhs has type complex
   $ ../../../../install/default/bin/stanc conditional_condition_bad_1.stan
 Semantic error in 'conditional_condition_bad_1.stan', line 6, column 6 to column 7:
    -------------------------------------------------


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Fix indexing of a complex container to return the correct type

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
