### PR TITLE
Use Yojson for --info output

### DIFF
--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -1,55 +1,46 @@
 open Core_kernel
 open Ast
 open Middle
+open Yojson.Basic
 
-let rec sized_basetype_dims t =
+let rec unsized_basetype_json t =
+  let base_type_dims type_ dim : t =
+    `Assoc [("type", `String type_); ("dimensions", `Int dim)] in
   match t with
-  | SizedType.SInt -> ("int", 0)
-  | SReal -> ("real", 0)
-  | SComplex -> ("complex", 0)
-  | SVector _ | SRowVector _ -> ("real", 1)
-  | SComplexVector _ | SComplexRowVector _ -> ("complex", 1)
-  | SMatrix _ -> ("real", 2)
-  | SComplexMatrix _ -> ("complex", 2)
-  | SArray (t, _) ->
-      let bt, n = sized_basetype_dims t in
-      (bt, n + 1)
-
-let rec unsized_basetype_dims t =
-  match t with
-  | UnsizedType.UInt -> ("int", 0)
-  | UReal -> ("real", 0)
-  | UComplex -> ("complex", 0)
-  | UVector | URowVector -> ("real", 1)
-  | UComplexVector | UComplexRowVector -> ("complex", 1)
-  | UMatrix -> ("real", 2)
-  | UComplexMatrix -> ("complex", 2)
-  | UArray t ->
-      let bt, n = unsized_basetype_dims t in
-      (bt, n + 1)
+  | UnsizedType.UInt -> base_type_dims "int" 0
+  | UReal -> base_type_dims "real" 0
+  | UComplex -> base_type_dims "complex" 0
+  | UVector | URowVector -> base_type_dims "real" 1
+  | UComplexVector | UComplexRowVector -> base_type_dims "complex" 1
+  | UMatrix -> base_type_dims "real" 2
+  | UComplexMatrix -> base_type_dims "complex" 2
+  | UArray t' -> (
+    match unsized_basetype_json t' with
+    | `Assoc (ty :: ("dimensions", `Int dim) :: x) ->
+        `Assoc (ty :: ("dimensions", `Int (dim + 1)) :: x)
+    | _ ->
+        Common.FatalError.fatal_error_msg
+          [%message "Failed to produce info for type " (t : UnsizedType.t)] )
   | UMathLibraryFunction | UFun _ -> assert false
 
 let basetype_dims t =
   match t with
-  | Type.Sized t -> sized_basetype_dims t
-  | Type.Unsized t -> unsized_basetype_dims t
+  | Type.Sized t -> SizedType.to_unsized t |> unsized_basetype_json
+  | Type.Unsized t -> unsized_basetype_json t
 
-let get_var_decl {stmts; _} =
-  List.fold_right ~init:[]
-    ~f:(fun stmt acc ->
-      match stmt.Ast.stmt with
-      | Ast.VarDecl decl ->
-          let t, n = basetype_dims decl.decl_type in
-          (decl.identifier.name, t, n) :: acc
-      | _ -> acc )
-    stmts
+let get_var_decl {stmts; _} : t =
+  `Assoc
+    (List.fold_right ~init:[]
+       ~f:(fun stmt acc ->
+         match stmt.Ast.stmt with
+         | Ast.VarDecl decl ->
+             let type_info = basetype_dims decl.decl_type in
+             (decl.identifier.name, type_info) :: acc
+         | _ -> acc )
+       stmts )
 
-let block_info name ppf block =
-  let var_info ppf (name, t, n) =
-    Fmt.pf ppf "\"%s\": { \"type\": \"%s\", \"dimensions\": %d}" name t n in
-  let vars_info = Fmt.list ~sep:Fmt.comma var_info in
-  Fmt.pf ppf "\"%s\": { @[<v 0>%a @]}" name vars_info
-    (Option.value_map block ~default:[] ~f:get_var_decl)
+let block_info_json name block : t =
+  `Assoc [(name, Option.value_map block ~default:(`Assoc []) ~f:get_var_decl)]
 
 let rec get_function_calls_expr (funs, distrs) expr =
   let acc =
@@ -82,7 +73,7 @@ let rec get_function_calls_stmt ud_dists (funs, distrs) stmt =
     (fun acc _ -> acc)
     acc stmt.stmt
 
-let function_calls ppf p =
+let function_calls_json p =
   let map f list_op =
     Option.value_map ~default:[]
       ~f:(fun {stmts; _} -> List.concat_map ~f stmts)
@@ -97,22 +88,23 @@ let function_calls ppf p =
       (get_function_calls_stmt ud_dists)
       (String.Set.empty, String.Set.empty)
       p in
-  Fmt.pf ppf "\"functions\": [ @[<v 0>%a @]],@,"
-    (Fmt.list ~sep:Fmt.comma (fun ppf s -> Fmt.pf ppf "\"%s\"" s))
-    (Set.to_list funs) ;
-  Fmt.pf ppf "\"distributions\": [ @[<v 0>%a @]]"
-    (Fmt.list ~sep:Fmt.comma (fun ppf s -> Fmt.pf ppf "\"%s\"" s))
-    (Set.to_list distrs)
+  let set_to_List s =
+    `List (Set.to_list s |> List.map ~f:(fun str -> `String str)) in
+  `Assoc [("functions", set_to_List funs); ("distributions", set_to_List distrs)]
 
-let includes ppf () =
-  Fmt.pf ppf "\"included_files\": [ @[<v 0>%a @]]"
-    Fmt.(list ~sep:comma (fun ppf s -> Fmt.pf ppf "\"%s\"" s))
-    (List.rev !Preprocessor.included_files)
+let includes_json () =
+  `Assoc
+    [ ( "included_files"
+      , `List
+          ( List.rev !Preprocessor.included_files
+          |> List.map ~f:(fun str -> `String str) ) ) ]
 
-let info ast =
-  Fmt.str "{ @[<v 0>%a,@,%a,@,%a,@,%a,@,%a,@,%a @]}@." (block_info "inputs")
-    ast.datablock (block_info "parameters") ast.parametersblock
-    (block_info "transformed parameters")
-    ast.transformedparametersblock
-    (block_info "generated quantities")
-    ast.generatedquantitiesblock function_calls ast includes ()
+let info_json ast =
+  List.fold ~f:Util.combine ~init:(`Assoc [])
+    [ block_info_json "inputs" ast.datablock
+    ; block_info_json "parameters" ast.parametersblock
+    ; block_info_json "transformed parameters" ast.transformedparametersblock
+    ; block_info_json "generated quantities" ast.generatedquantitiesblock
+    ; function_calls_json ast; includes_json () ]
+
+let info ast = pretty_to_string (info_json ast)

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,7 +1,7 @@
 (library
  (name frontend)
  (public_name stanc.frontend)
- (libraries core_kernel re menhirLib fmt middle common)
+ (libraries core_kernel re menhirLib fmt middle common yojson)
  (inline_tests)
  (preprocess
   (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))

--- a/test/integration/cli-args/info/info.expected
+++ b/test/integration/cli-args/info/info.expected
@@ -1,35 +1,37 @@
   $ ../../../../../install/default/bin/stanc --include-paths=.,includes --info  info.stan
-{ "inputs": { "a": { "type": "int", "dimensions": 0},
-              "b": { "type": "real", "dimensions": 0},
-              "c": { "type": "real", "dimensions": 1},
-              "d": { "type": "real", "dimensions": 1},
-              "e": { "type": "real", "dimensions": 2},
-              "f": { "type": "int", "dimensions": 1},
-              "g": { "type": "real", "dimensions": 1},
-              "h": { "type": "real", "dimensions": 2},
-              "i": { "type": "real", "dimensions": 3},
-              "j": { "type": "int", "dimensions": 3} },
-  "parameters": { "l": { "type": "real", "dimensions": 1},
-                  "m": { "type": "real", "dimensions": 1},
-                  "n": { "type": "real", "dimensions": 1},
-                  "o": { "type": "real", "dimensions": 1},
-                  "p": { "type": "real", "dimensions": 2},
-                  "q": { "type": "real", "dimensions": 2},
-                  "r": { "type": "real", "dimensions": 2},
-                  "s": { "type": "real", "dimensions": 2},
-                  "y": { "type": "real", "dimensions": 0} },
-  "transformed parameters": { "t": { "type": "real", "dimensions": 2} },
-  "generated quantities": { "u": { "type": "real", "dimensions": 0} },
-  "functions": [ "log",
-                 "reduce_sum",
-                 "sin",
-                 "square" ],
-  "distributions": [ "dirichlet_lupdf",
-                     "normal_lccdf",
-                     "normal_lcdf",
-                     "normal_lpdf",
-                     "std_normal_lupdf" ],
-  "included_files": [ "./included.stan",
-                      "includes/recursive.stan",
-                      "includes/another_include.stan" ] }
-
+{
+  "inputs": {
+    "a": { "type": "int", "dimensions": 0 },
+    "b": { "type": "real", "dimensions": 0 },
+    "c": { "type": "real", "dimensions": 1 },
+    "d": { "type": "real", "dimensions": 1 },
+    "e": { "type": "real", "dimensions": 2 },
+    "f": { "type": "int", "dimensions": 1 },
+    "g": { "type": "real", "dimensions": 1 },
+    "h": { "type": "real", "dimensions": 2 },
+    "i": { "type": "real", "dimensions": 3 },
+    "j": { "type": "int", "dimensions": 3 }
+  },
+  "parameters": {
+    "l": { "type": "real", "dimensions": 1 },
+    "m": { "type": "real", "dimensions": 1 },
+    "n": { "type": "real", "dimensions": 1 },
+    "o": { "type": "real", "dimensions": 1 },
+    "p": { "type": "real", "dimensions": 2 },
+    "q": { "type": "real", "dimensions": 2 },
+    "r": { "type": "real", "dimensions": 2 },
+    "s": { "type": "real", "dimensions": 2 },
+    "y": { "type": "real", "dimensions": 0 }
+  },
+  "transformed parameters": { "t": { "type": "real", "dimensions": 2 } },
+  "generated quantities": { "u": { "type": "real", "dimensions": 0 } },
+  "functions": [ "log", "reduce_sum", "sin", "square" ],
+  "distributions": [
+    "dirichlet_lupdf", "normal_lccdf", "normal_lcdf", "normal_lpdf",
+    "std_normal_lupdf"
+  ],
+  "included_files": [
+    "./included.stan", "includes/recursive.stan",
+    "includes/another_include.stan"
+  ]
+}

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -156,31 +156,36 @@ Syntax error in 'string', line 8, column 0 to column 5, parsing error:
 Expected "generated quantities {" or end of file after end of model block.
 
 $ node info.js
-{ "inputs": { "a": { "type": "int", "dimensions": 0},
-              "b": { "type": "real", "dimensions": 0},
-              "c": { "type": "real", "dimensions": 1},
-              "d": { "type": "real", "dimensions": 1},
-              "e": { "type": "real", "dimensions": 2},
-              "f": { "type": "int", "dimensions": 1},
-              "g": { "type": "real", "dimensions": 1},
-              "h": { "type": "real", "dimensions": 2},
-              "i": { "type": "real", "dimensions": 3},
-              "j": { "type": "int", "dimensions": 3} },
-  "parameters": { "l": { "type": "real", "dimensions": 1},
-                  "m": { "type": "real", "dimensions": 1},
-                  "n": { "type": "real", "dimensions": 1},
-                  "o": { "type": "real", "dimensions": 1},
-                  "p": { "type": "real", "dimensions": 2},
-                  "q": { "type": "real", "dimensions": 2},
-                  "r": { "type": "real", "dimensions": 2},
-                  "s": { "type": "real", "dimensions": 2},
-                  "y": { "type": "real", "dimensions": 0} },
-  "transformed parameters": {  },
-  "generated quantities": {  },
-  "functions": [  ],
-  "distributions": [  ],
-  "included_files": [  ] }
-
+{
+  "inputs": {
+    "a": { "type": "int", "dimensions": 0 },
+    "b": { "type": "real", "dimensions": 0 },
+    "c": { "type": "real", "dimensions": 1 },
+    "d": { "type": "real", "dimensions": 1 },
+    "e": { "type": "real", "dimensions": 2 },
+    "f": { "type": "int", "dimensions": 1 },
+    "g": { "type": "real", "dimensions": 1 },
+    "h": { "type": "real", "dimensions": 2 },
+    "i": { "type": "real", "dimensions": 3 },
+    "j": { "type": "int", "dimensions": 3 }
+  },
+  "parameters": {
+    "l": { "type": "real", "dimensions": 1 },
+    "m": { "type": "real", "dimensions": 1 },
+    "n": { "type": "real", "dimensions": 1 },
+    "o": { "type": "real", "dimensions": 1 },
+    "p": { "type": "real", "dimensions": 2 },
+    "q": { "type": "real", "dimensions": 2 },
+    "r": { "type": "real", "dimensions": 2 },
+    "s": { "type": "real", "dimensions": 2 },
+    "y": { "type": "real", "dimensions": 0 }
+  },
+  "transformed parameters": {},
+  "generated quantities": {},
+  "functions": [],
+  "distributions": [],
+  "included_files": []
+}
 $ node math_sigs.js
 
 $ node optimization.js


### PR DESCRIPTION
This is similar to what we do in code generation, and will make writing the types of tuples much easier (e.g #820). The contents of the output are identical.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

The `--info` command now uses the Yojson library for it's output.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
