### PR TITLE
Expose cumulative sum for integers and complex types

### DIFF
--- a/src/common/Helpers.ml
+++ b/src/common/Helpers.ml
@@ -18,11 +18,6 @@ let lub_mem_pat lst =
   let any_soa = List.exists ~f:find_soa lst in
   match any_soa with true -> SoA | false -> AoS
 
-let option_or_else ~if_none x = Option.first_some x if_none
-let on_snd f (x, y) = (x, f y)
-let on_fst f (x, y) = (f x, y)
-let curry f x y = f (x, y)
-let uncurry f (x, y) = f x y
 let pp_builtin_syntax = Fmt.(string |> styled `Yellow)
 let pp_keyword = Fmt.(string |> styled `Blue)
 let pp_angle_brackets pp_v ppf v = Fmt.pf ppf "@[<1><%a>@]" pp_v v

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1089,6 +1089,8 @@ let () =
   add_unqualified ("csr_extract_v", ReturnType (UArray UInt), [UMatrix], AoS) ;
   add_unqualified ("csr_extract_u", ReturnType (UArray UInt), [UMatrix], AoS) ;
   add_unqualified
+    ("cumulative_sum", ReturnType (UArray UInt), [UArray UInt], AoS) ;
+  add_unqualified
     ("cumulative_sum", ReturnType (UArray UReal), [UArray UReal], AoS) ;
   add_unqualified ("cumulative_sum", ReturnType UVector, [UVector], SoA) ;
   add_unqualified ("cumulative_sum", ReturnType URowVector, [URowVector], SoA) ;

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1094,6 +1094,12 @@ let () =
     ("cumulative_sum", ReturnType (UArray UReal), [UArray UReal], AoS) ;
   add_unqualified ("cumulative_sum", ReturnType UVector, [UVector], SoA) ;
   add_unqualified ("cumulative_sum", ReturnType URowVector, [URowVector], SoA) ;
+  add_unqualified
+    ("cumulative_sum", ReturnType (UArray UComplex), [UArray UComplex], AoS) ;
+  add_unqualified
+    ("cumulative_sum", ReturnType UComplexVector, [UComplexVector], AoS) ;
+  add_unqualified
+    ("cumulative_sum", ReturnType UComplexRowVector, [UComplexRowVector], AoS) ;
   add_unqualified ("determinant", ReturnType UReal, [UMatrix], SoA) ;
   add_unqualified ("diag_matrix", ReturnType UMatrix, [UVector], AoS) ;
   add_unqualified

--- a/test/integration/good/function-signatures/math/matrix/cumulative_sum.stan
+++ b/test/integration/good/function-signatures/math/matrix/cumulative_sum.stan
@@ -10,7 +10,7 @@ transformed data {
   array[d_int] real transformed_data_real_array;
   vector[d_int] transformed_data_vector;
   row_vector[d_int] transformed_data_row_vector;
-  
+
   transformed_data_real_array = cumulative_sum(d_real_array);
   transformed_data_vector = cumulative_sum(d_vector);
   transformed_data_row_vector = cumulative_sum(d_row_vector);
@@ -27,7 +27,7 @@ transformed parameters {
   array[d_int] real transformed_param_real_array;
   vector[d_int] transformed_param_vector;
   row_vector[d_int] transformed_param_row_vector;
-  
+
   transformed_param_real_array = cumulative_sum(d_real_array);
   transformed_param_vector = cumulative_sum(d_vector);
   transformed_param_row_vector = cumulative_sum(d_row_vector);

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -3762,6 +3762,7 @@ Display all Stan math signatures exposed in the language
   csr_to_dense_matrix(int, int, vector, array[] int, array[] int) => matrix
   cumulative_sum(vector) => vector
   cumulative_sum(row_vector) => row_vector
+  cumulative_sum(array[] int) => array[] int
   cumulative_sum(array[] real) => array[] real
   determinant(matrix) => real
   diag_matrix(vector) => matrix

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -3762,8 +3762,11 @@ Display all Stan math signatures exposed in the language
   csr_to_dense_matrix(int, int, vector, array[] int, array[] int) => matrix
   cumulative_sum(vector) => vector
   cumulative_sum(row_vector) => row_vector
+  cumulative_sum(complex_vector) => complex_vector
+  cumulative_sum(complex_row_vector) => complex_row_vector
   cumulative_sum(array[] int) => array[] int
   cumulative_sum(array[] real) => array[] real
+  cumulative_sum(array[] complex) => array[] complex
   determinant(matrix) => real
   diag_matrix(vector) => matrix
   diag_matrix(complex_vector) => complex_matrix


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: https://github.com/stan-dev/docs/pull/517

## Release notes

Expose an overload for `cumulative_sum` which takes and returns an array of integers.

Expose overloads for `cumulative_sum` which work for complex arrays and vectors. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
