### PR TITLE
Show source code context with errors in Javascript

### DIFF
--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -22,46 +22,49 @@ type t =
   | Syntax_error of syntax_error
   | Semantic_error of Semantic_error.t
 
-let pp_context_with_message ppf (msg, loc) =
-  Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string)
-    (Middle.Location.context_to_string loc)
-    msg
+let pp_context_with_message ?code ppf (msg, loc) =
+  let context =
+    match code with
+    | Some s -> Middle.Location.context_to_string (`String s) loc
+    | None -> Middle.Location.context_to_string `File loc in
+  Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string) context msg
 
-let pp_semantic_error ?printed_filename ppf err =
+let pp_semantic_error ?printed_filename ?code ppf err =
   let loc_span = Semantic_error.location err in
   Fmt.pf ppf "Semantic error in %s:@;%a"
     (Middle.Location_span.to_string ?printed_filename loc_span)
-    pp_context_with_message
+    (pp_context_with_message ?code)
     (Fmt.str "%a@." Semantic_error.pp err, loc_span.begin_loc)
 
 (** A syntax error message used when handling a SyntaxError *)
-let pp_syntax_error ?printed_filename ppf = function
+let pp_syntax_error ?printed_filename ?code ppf = function
   | Parsing (message, loc_span) ->
       Fmt.pf ppf "Syntax error in %s, parsing error:@,%a"
         (Middle.Location_span.to_string ?printed_filename loc_span)
-        pp_context_with_message
+        (pp_context_with_message ?code)
         (message, loc_span.begin_loc)
   | Lexing loc ->
       Fmt.pf ppf "Syntax error in %s, lexing error:@,%a@."
         (Middle.Location.to_string ?printed_filename
            {loc with col_num= loc.col_num - 1} )
-        pp_context_with_message
+        (pp_context_with_message ?code)
         ("Invalid character found.", loc)
   | UnexpectedEOF loc ->
       Fmt.pf ppf "Syntax error in %s, lexing error:@,%a@."
         (Middle.Location.to_string ?printed_filename
            {loc with col_num= loc.col_num - 1} )
-        pp_context_with_message
+        (pp_context_with_message ?code)
         ("Unexpected end of input", loc)
   | Include (message, loc) ->
       Fmt.pf ppf "Syntax error in %s, include error:@,%a@."
         (Middle.Location.to_string loc ?printed_filename)
-        pp_context_with_message (message, loc)
+        (pp_context_with_message ?code)
+        (message, loc)
 
-let pp ?printed_filename ppf = function
+let pp ?printed_filename ?code ppf = function
   | FileNotFound f ->
       Fmt.pf ppf "Error: file '%s' not found or cannot be opened@." f
-  | Syntax_error e -> pp_syntax_error ?printed_filename ppf e
-  | Semantic_error e -> pp_semantic_error ?printed_filename ppf e
+  | Syntax_error e -> pp_syntax_error ?printed_filename ?code ppf e
+  | Semantic_error e -> pp_semantic_error ?printed_filename ?code ppf e
 
-let to_string = Fmt.str "%a" (pp ?printed_filename:None)
+let to_string = Fmt.str "%a" (pp ?printed_filename:None ?code:None)

--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -23,11 +23,14 @@ type t =
   | Semantic_error of Semantic_error.t
 
 let pp_context_with_message ?code ppf (msg, loc) =
-  let context =
+  let open Middle.Location in
+  let context_callback =
     match code with
-    | Some s -> Middle.Location.context_to_string (`String s) loc
-    | None -> Middle.Location.context_to_string `File loc in
-  Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string) context msg
+    | Some s -> fun () -> String.split_lines s
+    | None -> fun () -> In_channel.read_lines loc.filename in
+  Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string)
+    (context_to_string context_callback loc)
+    msg
 
 let pp_semantic_error ?printed_filename ?code ppf err =
   let loc_span = Semantic_error.location err in

--- a/src/frontend/Errors.mli
+++ b/src/frontend/Errors.mli
@@ -19,13 +19,22 @@ type t =
   | Syntax_error of syntax_error
   | Semantic_error of Semantic_error.t
 
-val pp : ?printed_filename:string -> t Fmt.t
-val to_string : t -> string
+val pp : ?printed_filename:string -> ?code:string -> t Fmt.t
+(** Pretty-printer for error type [t]. Replace occurances of
+  filename from locations with [printed_filename], if supplied.
+  If [code] is supplied, read context from that string. Otherwise,
+  it will attempt to open the original file.
+ *)
 
-val pp_syntax_error :
-  ?printed_filename:string -> Format.formatter -> syntax_error -> unit
-(** A syntax error message used when handling a SyntaxError *)
+val to_string : t -> string
+(** Format an error [t] as a string. Should only be used in testing!
+  For user facing code, prefer [pp]
+  *)
 
 val pp_semantic_error :
-  ?printed_filename:string -> Format.formatter -> Semantic_error.t -> unit
+     ?printed_filename:string
+  -> ?code:string
+  -> Format.formatter
+  -> Semantic_error.t
+  -> unit
 (** A semantic error message used when handling a SemanticError *)

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -1,5 +1,14 @@
 $ node allow-undefined.js
-Semantic error in 'string', line 3, column 8 to column 11: 
+Semantic error in 'string', line 3, column 8 to column 11:
+   -------------------------------------------------
+     1:  
+     2:  functions {
+     3:      int foo(real a);
+                 ^
+     4:  }
+     5:  transformed data {
+   -------------------------------------------------
+
 Function is declared without specifying a definition.
 
 $ node auto-format.js
@@ -26,7 +35,15 @@ model {
 }
 
 $ node basic.js
-Semantic error in 'string', line 6, column 4 to column 5: 
+Semantic error in 'string', line 6, column 4 to column 5:
+   -------------------------------------------------
+     4:  }
+     5:  model {
+     6:      z ~ std_normal();
+             ^
+     7:  }
+   -------------------------------------------------
+
 Identifier 'z' not in scope.
 
 $ node canonical.js
@@ -70,10 +87,26 @@ dim(p) = (4, 3)
 $ node debug.js
 
 $ node filename.js
-Semantic error in 'good_filename', line 6, column 4 to column 5: 
+Semantic error in 'good_filename', line 6, column 4 to column 5:
+   -------------------------------------------------
+     4:  }
+     5:  model {
+     6:      z ~ std_normal();
+             ^
+     7:  }
+   -------------------------------------------------
+
 Identifier 'z' not in scope.
 
-Semantic error in 'string', line 6, column 4 to column 5: 
+Semantic error in 'string', line 6, column 4 to column 5:
+   -------------------------------------------------
+     4:  }
+     5:  model {
+     6:      z ~ std_normal();
+             ^
+     7:  }
+   -------------------------------------------------
+
 Identifier 'z' not in scope.
 
 $ node functions-only.js
@@ -153,6 +186,15 @@ real test_lpdf(real a, real b) {
 }
 $ node good_after_bad.js
 Syntax error in 'string', line 8, column 0 to column 5, parsing error:
+   -------------------------------------------------
+     6:      y ~ std_normal();
+     7:  }
+     8:  model {
+         ^
+     9:      y ~ std_normal();
+    10:  }
+   -------------------------------------------------
+
 Expected "generated quantities {" or end of file after end of model block.
 
 $ node info.js
@@ -189,7 +231,16 @@ $ node info.js
 $ node math_sigs.js
 
 $ node optimization.js
-Semantic error in 'string', line 3, column 8 to column 11: 
+Semantic error in 'string', line 3, column 8 to column 11:
+   -------------------------------------------------
+     1:  
+     2:  functions {
+     3:      int foo(real a);
+                 ^
+     4:  }
+     5:  
+   -------------------------------------------------
+
 Function is declared without specifying a definition.
 
 $ node pedantic.js


### PR DESCRIPTION
This refactors some of the error printing code to isolated the file-reading from the logic which creates an error.

As a bonus this allows us to pass in the code string from the JS compiler to also format an error.

So, something which currently looks like
```
Semantic error in 'string', line 3, column 8 to column 11: 
Function is declared without specifying a definition.
```
Would now look like 
```
Semantic error in 'string', line 3, column 8 to column 11:
   -------------------------------------------------
     1:  
     2:  functions {
     3:      int foo(real a);
                 ^
     4:  }
     5:  transformed data {
   -------------------------------------------------

Function is declared without specifying a definition.
```

This example is taken from the test output of the stancjs integration tests.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

The javascript interface (stancjs) now generates errors which look more like stanc3's by pointing out where in the supplied code the error occurred. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
