### PR TITLE
expose log determinant spd

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1592,8 +1592,8 @@ let () =
   add_nullary "log10" ;
   add_unqualified ("log10", ReturnType UComplex, [UComplex], AoS) ;
   add_nullary "log2" ;
-  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], AoS) ;
-  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], SoS) ;
+  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], SoS) ;
   add_binary_vec "log_diff_exp" AoS ;
   add_binary_vec "log_falling_factorial" AoS ;
   add_binary_vec "log_inv_logit_diff" AoS ;

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1592,8 +1592,8 @@ let () =
   add_nullary "log10" ;
   add_unqualified ("log10", ReturnType UComplex, [UComplex], AoS) ;
   add_nullary "log2" ;
-  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], SoS) ;
-  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], SoS) ;
+  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], SoA) ;
+  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], SoA) ;
   add_binary_vec "log_diff_exp" AoS ;
   add_binary_vec "log_falling_factorial" AoS ;
   add_binary_vec "log_inv_logit_diff" AoS ;

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1593,7 +1593,7 @@ let () =
   add_unqualified ("log10", ReturnType UComplex, [UComplex], AoS) ;
   add_nullary "log2" ;
   add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], SoA) ;
-  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], SoA) ;
   add_binary_vec "log_diff_exp" AoS ;
   add_binary_vec "log_falling_factorial" AoS ;
   add_binary_vec "log_inv_logit_diff" AoS ;

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1592,7 +1592,8 @@ let () =
   add_nullary "log10" ;
   add_unqualified ("log10", ReturnType UComplex, [UComplex], AoS) ;
   add_nullary "log2" ;
-  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], SoA) ;
+  add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], AoS) ;
+  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], AoS) ;
   add_binary_vec "log_diff_exp" AoS ;
   add_binary_vec "log_falling_factorial" AoS ;
   add_binary_vec "log_inv_logit_diff" AoS ;

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1593,7 +1593,7 @@ let () =
   add_unqualified ("log10", ReturnType UComplex, [UComplex], AoS) ;
   add_nullary "log2" ;
   add_unqualified ("log_determinant", ReturnType UReal, [UMatrix], SoA) ;
-  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], SoA) ;
+  add_unqualified ("log_determinant_spd", ReturnType UReal, [UMatrix], AoS) ;
   add_binary_vec "log_diff_exp" AoS ;
   add_binary_vec "log_falling_factorial" AoS ;
   add_binary_vec "log_inv_logit_diff" AoS ;

--- a/test/integration/good/function-signatures/math/matrix/log_determinant_spd.stan
+++ b/test/integration/good/function-signatures/math/matrix/log_determinant_spd.stan
@@ -1,0 +1,23 @@
+data { 
+  int d_int;
+  matrix[d_int,d_int] d_matrix;
+}
+
+transformed data {
+  real transformed_data_real;
+
+  transformed_data_real = log_determinant_spd(d_matrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int,d_int] p_matrix;
+}
+transformed parameters {
+  real transformed_param_real;
+
+  transformed_param_real = log_determinant_spd(d_matrix);
+  transformed_param_real = log_determinant_spd(p_matrix);
+}
+model {  
+  y_p ~ normal(0,1);
+}

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -11969,6 +11969,7 @@ Display all Stan math signatures exposed in the language
   log2(array[,,,,,,] row_vector) => array[,,,,,,] row_vector
   log2(array[,,,,,,] matrix) => array[,,,,,,] matrix
   log_determinant(matrix) => real
+  log_determinant_spd(matrix) => real
   log_diff_exp(int, int) => real
   log_diff_exp(int, real) => real
   log_diff_exp(real, int) => real


### PR DESCRIPTION
#### Submission Checklist
- [x] Fixes https://github.com/stan-dev/math/issues/2679
- [ ] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: [<LINK>](https://github.com/stan-dev/docs/pull/520)

## Release notes

Added `log_determinant_spd` which is faster when the input matrix is known to be symmetric and positive definite.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
