### PR TITLE
Clean up MIR pretty printing code

### DIFF
--- a/src/common/Fixed.ml
+++ b/src/common/Fixed.ml
@@ -75,7 +75,7 @@ module Make (Pattern : Pattern.S) : S with module Pattern := Pattern = struct
   [@@deriving compare, map, fold, hash, sexp]
 
   let rec pp f ppf {pattern; meta} =
-    Fmt.pf ppf {|%a%a|} f meta (Pattern.pp (pp f)) pattern
+    Fmt.pf ppf "%a%a" f meta (Pattern.pp (pp f)) pattern
 
   include Foldable.Make (struct
     type nonrec 'a t = 'a t

--- a/src/common/Helpers.ml
+++ b/src/common/Helpers.ml
@@ -17,8 +17,3 @@ let lub_mem_pat lst =
   let find_soa mem_pat = mem_pat = SoA in
   let any_soa = List.exists ~f:find_soa lst in
   match any_soa with true -> SoA | false -> AoS
-
-let pp_builtin_syntax = Fmt.(string |> styled `Yellow)
-let pp_keyword = Fmt.(string |> styled `Blue)
-let pp_angle_brackets pp_v ppf v = Fmt.pf ppf "@[<1><%a>@]" pp_v v
-let pp_brackets_postfix pp_e ppf = Fmt.pf ppf {|%a[]|} pp_e

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -33,8 +33,7 @@ module Fixed = struct
             Fmt.(list pp_e ~sep:Fmt.comma)
             args
       | TernaryIf (pred, texpr, fexpr) ->
-          Fmt.pf ppf "(@[%a@ %a@ %a@ %a@ %a@])" pp_e pred pp_builtin_syntax "?"
-            pp_e texpr pp_builtin_syntax ":" pp_e fexpr
+          Fmt.pf ppf "(@[%a@ ?@ %a@ :@ %a@])" pp_e pred pp_e texpr pp_e fexpr
       | Indexed (expr, indices) ->
           Fmt.pf ppf "@[%a%a@]" pp_e expr
             ( if List.is_empty indices then fun _ _ -> ()

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -12,13 +12,12 @@ type 'a t =
 
 let pp pp_e ppf = function
   | All -> Fmt.char ppf ':'
-  | Single index -> pp_e ppf index
-  | Upfrom index -> Fmt.pf ppf {|%a:|} pp_e index
-  | Between (lower, upper) -> Fmt.pf ppf {|%a:%a|} pp_e lower pp_e upper
-  | MultiIndex index -> Fmt.pf ppf {|%a|} pp_e index
+  | Single index | MultiIndex index -> pp_e ppf index
+  | Upfrom index -> Fmt.pf ppf "%a:" pp_e index
+  | Between (lower, upper) -> Fmt.pf ppf "%a:%a" pp_e lower pp_e upper
 
 let pp_indexed pp_e ppf (ident, indices) =
-  Fmt.pf ppf {|@[%s%a@]|} ident
+  Fmt.pf ppf "@[%s%a@]" ident
     ( if List.is_empty indices then fun _ _ -> ()
     else Fmt.(list (pp pp_e) ~sep:comma |> brackets) )
     indices

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -20,22 +20,22 @@ let rec pp pp_e ppf = function
   | SInt -> Fmt.string ppf "int"
   | SReal -> Fmt.string ppf "real"
   | SComplex -> Fmt.string ppf "complex"
-  | SVector (_, expr) -> Fmt.pf ppf {|vector%a|} (Fmt.brackets pp_e) expr
-  | SRowVector (_, expr) -> Fmt.pf ppf {|row_vector%a|} (Fmt.brackets pp_e) expr
+  | SVector (_, expr) -> Fmt.pf ppf "vector%a" (Fmt.brackets pp_e) expr
+  | SRowVector (_, expr) -> Fmt.pf ppf "row_vector%a" (Fmt.brackets pp_e) expr
   | SComplexVector expr ->
-      Fmt.pf ppf {|complex_vector%a|} (Fmt.brackets pp_e) expr
+      Fmt.pf ppf "complex_vector%a" (Fmt.brackets pp_e) expr
   | SComplexRowVector expr ->
-      Fmt.pf ppf {|complex_row_vector%a|} (Fmt.brackets pp_e) expr
+      Fmt.pf ppf "complex_row_vector%a" (Fmt.brackets pp_e) expr
   | SMatrix (_, d1_expr, d2_expr) ->
-      Fmt.pf ppf {|matrix%a|}
+      Fmt.pf ppf "matrix%a"
         Fmt.(pair ~sep:comma pp_e pp_e |> brackets)
         (d1_expr, d2_expr)
   | SComplexMatrix (d1_expr, d2_expr) ->
-      Fmt.pf ppf {|complex_matrix%a|}
+      Fmt.pf ppf "complex_matrix%a"
         Fmt.(pair ~sep:comma pp_e pp_e |> brackets)
         (d1_expr, d2_expr)
   | SArray (st, expr) ->
-      Fmt.pf ppf {|array%a|}
+      Fmt.pf ppf "array%a"
         Fmt.(pair ~sep:comma (fun ppf st -> pp pp_e ppf st) pp_e |> brackets)
         (st, expr)
 

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -33,37 +33,32 @@ module Fixed = struct
 
     let pp pp_e pp_s ppf = function
       | Assignment ((assignee, _, idcs), rhs) ->
-          Fmt.pf ppf {|@[<h>%a =@ %a;@]|} (Index.pp_indexed pp_e)
-            (assignee, idcs) pp_e rhs
-      | TargetPE expr ->
-          Fmt.pf ppf {|@[<h>%a +=@ %a;@]|} pp_keyword "target" pp_e expr
+          Fmt.pf ppf "@[<h>%a =@ %a;@]" (Index.pp_indexed pp_e) (assignee, idcs)
+            pp_e rhs
+      | TargetPE expr -> Fmt.pf ppf "@[<h>target +=@ %a;@]" pp_e expr
       | NRFunApp (kind, args) ->
-          Fmt.pf ppf {|@[%a%a;@]|} (Fun_kind.pp pp_e) kind
+          Fmt.pf ppf "@[%a%a;@]" (Fun_kind.pp pp_e) kind
             Fmt.(list pp_e ~sep:comma |> parens)
             args
-      | Break -> pp_keyword ppf "break;"
-      | Continue -> pp_keyword ppf "continue;"
-      | Skip -> pp_keyword ppf ";"
-      | Return (Some expr) ->
-          Fmt.pf ppf {|%a %a;|} pp_keyword "return" pp_e expr
-      | Return _ -> pp_keyword ppf "return;"
+      | Break -> Fmt.string ppf "break;"
+      | Continue -> Fmt.string ppf "continue;"
+      | Skip -> Fmt.string ppf ";"
+      | Return (Some expr) -> Fmt.pf ppf "return %a;" pp_e expr
+      | Return _ -> Fmt.string ppf "return;"
       | IfElse (pred, s_true, Some s_false) ->
-          Fmt.pf ppf {|%a(%a) %a %a %a|} pp_builtin_syntax "if" pp_e pred pp_s
-            s_true pp_builtin_syntax "else" pp_s s_false
-      | IfElse (pred, s_true, _) ->
-          Fmt.pf ppf {|%a(%a) %a|} pp_builtin_syntax "if" pp_e pred pp_s s_true
-      | While (pred, stmt) ->
-          Fmt.pf ppf {|%a(%a) %a|} pp_builtin_syntax "while" pp_e pred pp_s stmt
+          Fmt.pf ppf "if(%a) %a else %a" pp_e pred pp_s s_true pp_s s_false
+      | IfElse (pred, s_true, _) -> Fmt.pf ppf "if(%a) %a" pp_e pred pp_s s_true
+      | While (pred, stmt) -> Fmt.pf ppf "while(%a) %a" pp_e pred pp_s stmt
       | For {loopvar; lower; upper; body} ->
-          Fmt.pf ppf {|%a(%s in %a:%a) %a|} pp_builtin_syntax "for" loopvar pp_e
-            lower pp_e upper pp_s body
+          Fmt.pf ppf "for(%s in %a:%a) %a" loopvar pp_e lower pp_e upper pp_s
+            body
       | Profile (_, stmts) ->
-          Fmt.pf ppf {|{@;<1 2>@[<v>%a@]@;}|} Fmt.(list pp_s ~sep:Fmt.cut) stmts
+          Fmt.pf ppf "{@;<1 2>@[<v>%a@]@;}" Fmt.(list pp_s ~sep:cut) stmts
       | Block stmts ->
-          Fmt.pf ppf {|{@;<1 2>@[<v>%a@]@;}|} Fmt.(list pp_s ~sep:Fmt.cut) stmts
-      | SList stmts -> Fmt.(list pp_s ~sep:Fmt.cut |> vbox) ppf stmts
+          Fmt.pf ppf "{@;<1 2>@[<v>%a@]@;}" Fmt.(list pp_s ~sep:cut) stmts
+      | SList stmts -> Fmt.(list pp_s ~sep:cut |> vbox) ppf stmts
       | Decl {decl_adtype; decl_id; decl_type; _} ->
-          Fmt.pf ppf {|%a%a %s;|} UnsizedType.pp_autodifftype decl_adtype
+          Fmt.pf ppf "%a%a %s;" UnsizedType.pp_autodifftype decl_adtype
             (Type.pp pp_e) decl_type decl_id
 
     include Foldable.Make2 (struct

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -2,7 +2,6 @@
 
 open Core_kernel
 open Core_kernel.Poly
-open Common.Helpers
 
 type t =
   | UInt
@@ -27,7 +26,7 @@ and autodifftype = DataOnly | AutoDiffable
 and returntype = Void | ReturnType of t [@@deriving compare, hash, sexp]
 
 let pp_autodifftype ppf = function
-  | DataOnly -> pp_keyword ppf "data "
+  | DataOnly -> Fmt.string ppf "data "
   | AutoDiffable -> ()
 
 let unsized_array_depth unsized_ty =
@@ -49,15 +48,15 @@ let rec unwind_array_type = function
   | ut -> (ut, 0)
 
 let rec pp ppf = function
-  | UInt -> pp_keyword ppf "int"
-  | UReal -> pp_keyword ppf "real"
-  | UComplex -> pp_keyword ppf "complex"
-  | UVector -> pp_keyword ppf "vector"
-  | URowVector -> pp_keyword ppf "row_vector"
-  | UMatrix -> pp_keyword ppf "matrix"
-  | UComplexVector -> pp_keyword ppf "complex_vector"
-  | UComplexRowVector -> pp_keyword ppf "complex_row_vector"
-  | UComplexMatrix -> pp_keyword ppf "complex_matrix"
+  | UInt -> Fmt.string ppf "int"
+  | UReal -> Fmt.string ppf "real"
+  | UComplex -> Fmt.string ppf "complex"
+  | UVector -> Fmt.string ppf "vector"
+  | URowVector -> Fmt.string ppf "row_vector"
+  | UMatrix -> Fmt.string ppf "matrix"
+  | UComplexVector -> Fmt.string ppf "complex_vector"
+  | UComplexRowVector -> Fmt.string ppf "complex_row_vector"
+  | UComplexMatrix -> Fmt.string ppf "complex_matrix"
   | UArray ut ->
       let ut2, d = unwind_array_type ut in
       let array_str = "[" ^ String.make d ',' ^ "]" in
@@ -66,8 +65,7 @@ let rec pp ppf = function
       Fmt.pf ppf {|@[<h>(%a) => %a@]|}
         Fmt.(list pp_fun_arg ~sep:comma)
         argtypes pp_returntype rt
-  | UMathLibraryFunction ->
-      (pp_angle_brackets Fmt.string) ppf "Stan Math function"
+  | UMathLibraryFunction -> Fmt.string ppf "<Stan Math function>"
 
 and pp_fun_arg ppf (ad_ty, unsized_ty) =
   match ad_ty with


### PR DESCRIPTION
The MIR pretty printing had a few oddities in it. It used quoted strings `{| ... |}` instead of normal string literals `" ... "` without needing to, and it would associate a color/style with keywords. We don't (and can't) really print things out in color, so that doesn't need to happen. 

#### Submission Checklist

- [x] Run unit tests
- Documentation

    - [x] OR, no user-facing changes were made

## Release notes

Cleaned up code for pretty printing the Middle Intermediate Representation (MIR)

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
