### PR TITLE
Add --debug-mem-patterns flag

### DIFF
--- a/src/analysis_and_optimization/Mem_pattern.ml
+++ b/src/analysis_and_optimization/Mem_pattern.ml
@@ -666,3 +666,32 @@ let rec modify_stmt_pattern
 and modify_stmt (Stmt.Fixed.{pattern; _} as stmt)
     (modifiable_set : string Set.Poly.t) =
   {stmt with pattern= modify_stmt_pattern pattern modifiable_set}
+
+let pp_mem_patterns ppf (Program.{log_prob; _} : Program.Typed.t) =
+  let pp_var ppf (name, stype) =
+    Fmt.pf ppf "%a %s: %a" UnsizedType.pp
+      (SizedType.to_unsized stype)
+      name Common.Helpers.pp_mem_pattern
+      (SizedType.get_mem_pattern stype) in
+  let mem_vars =
+    (* Collect all the sizedtypes which have a mem pattern *)
+    let find_decls =
+      let take_stmt acc = function
+        | Stmt.Fixed.
+            { pattern=
+                Decl
+                  { decl_id
+                  ; decl_type=
+                      Type.Sized
+                        SizedType.(
+                          ( SMatrix (_, _, _)
+                          | SVector (_, _)
+                          | SRowVector (_, _) ) as stype)
+                  ; _ }
+            ; _ } ->
+            (decl_id, stype) :: acc
+        | _ -> acc in
+      Mir_utils.fold_stmts ~take_expr:(fun acc _ -> acc) ~take_stmt ~init:[]
+    in
+    find_decls log_prob |> List.rev in
+  Fmt.(pf ppf "@[<v>%a@.@]" (list pp_var)) mem_vars

--- a/src/common/Helpers.ml
+++ b/src/common/Helpers.ml
@@ -13,6 +13,10 @@ open Core_kernel.Poly
  **)
 type mem_pattern = AoS | SoA [@@deriving sexp, compare, map, hash, fold]
 
+let pp_mem_pattern ppf = function
+  | AoS -> Fmt.string ppf "AoS"
+  | SoA -> Fmt.string ppf "SoA"
+
 let lub_mem_pat lst =
   let find_soa mem_pat = mem_pat = SoA in
   let any_soa = List.exists ~f:find_soa lst in

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -221,3 +221,10 @@ let modify_sizedtype_mem (mem_pattern : Common.Helpers.mem_pattern) st =
   match mem_pattern with
   | Common.Helpers.AoS -> demote_sizedtype_mem st
   | Common.Helpers.SoA -> promote_sizedtype_mem st
+
+let rec has_mem_pattern = function
+  | SInt | SReal | SComplex | SComplexVector _ | SComplexRowVector _
+   |SComplexMatrix _ ->
+      false
+  | SVector _ | SRowVector _ | SMatrix _ -> true
+  | SArray (t, _) -> has_mem_pattern t

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -94,7 +94,7 @@ let options =
       , Arg.Set dump_mem_pattern
       , " For debugging purposes: print a list of matrix variables and their \
          memory type, either AoS (array of structs) or the more efficient SoA \
-         (struct of arrays) Only has an effect when optimizations are turned \
+         (struct of arrays). Only has an effect when optimizations are turned \
          on." )
     ; ( "--debug-transformed-mir"
       , Arg.Set dump_tx_mir

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -28,6 +28,7 @@ let dump_tx_mir = ref false
 let dump_tx_mir_pretty = ref false
 let dump_opt_mir = ref false
 let dump_opt_mir_pretty = ref false
+let dump_mem_pattern = ref false
 let dump_stan_math_sigs = ref false
 let dump_stan_math_distributions = ref false
 let opt_lvl = ref Optimize.O0
@@ -89,6 +90,12 @@ let options =
       , Arg.Set dump_opt_mir_pretty
       , " For debugging purposes: pretty print the MIR after it's been \
          optimized. Only has an effect when optimizations are turned on." )
+    ; ( "--debug-mem-patterns"
+      , Arg.Set dump_mem_pattern
+      , " For debugging purposes: print a list of matrix variables and their \
+         memory type, either AoS (array of structs) or the more efficient SoA \
+         (struct of arrays) Only has an effect when optimizations are turned \
+         on." )
     ; ( "--debug-transformed-mir"
       , Arg.Set dump_tx_mir
       , " For debugging purposes: print the MIR after the backend has \
@@ -316,17 +323,18 @@ let use_file filename =
       Sexp.pp_hum Format.std_formatter [%sexp (tx_mir : Middle.Program.Typed.t)] ;
     if !dump_tx_mir_pretty then Program.Typed.pp Format.std_formatter tx_mir ;
     let opt_mir =
-      let opt =
-        let set_optims =
-          let base_optims = Optimize.level_optimizations !opt_lvl in
-          if !no_soa_opt then {base_optims with optimize_soa= false}
-          else if !soa_opt then {base_optims with optimize_soa= true}
-          else base_optims in
-        Optimize.optimization_suite ~settings:set_optims tx_mir in
-      if !dump_opt_mir then
-        Sexp.pp_hum Format.std_formatter [%sexp (opt : Middle.Program.Typed.t)] ;
-      if !dump_opt_mir_pretty then Program.Typed.pp Format.std_formatter opt ;
-      opt in
+      let set_optims =
+        let base_optims = Optimize.level_optimizations !opt_lvl in
+        if !no_soa_opt then {base_optims with optimize_soa= false}
+        else if !soa_opt then {base_optims with optimize_soa= true}
+        else base_optims in
+      Optimize.optimization_suite ~settings:set_optims tx_mir in
+    if !dump_mem_pattern then
+      Mem_pattern.pp_mem_patterns Format.std_formatter opt_mir ;
+    if !dump_opt_mir then
+      Sexp.pp_hum Format.std_formatter
+        [%sexp (opt_mir : Middle.Program.Typed.t)] ;
+    if !dump_opt_mir_pretty then Program.Typed.pp Format.std_formatter opt_mir ;
     if !output_file = "" then output_file := remove_dotstan !model_file ^ ".hpp" ;
     let cpp = Fmt.str "%a" Stan_math_code_gen.pp_prog opt_mir in
     Out_channel.write_all !output_file ~data:cpp ;

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -114,6 +114,11 @@ let stan2cpp model_name model_string is_flag_set flag_val =
         if is_flag_set "debug-optimized-mir-pretty" then
           r.return
             (Result.Ok (Fmt.str "%a" Program.Typed.pp opt_mir), warnings, []) ;
+        if is_flag_set "debug-mem-patterns" then
+          r.return
+            ( Result.Ok (Fmt.str "%a" Mem_pattern.pp_mem_patterns opt_mir)
+            , warnings
+            , [] ) ;
         if is_flag_set "debug-transformed-mir" then
           r.return
             ( Result.Ok

--- a/test/integration/cli-args/canonicalize/canonicalize.t
+++ b/test/integration/cli-args/canonicalize/canonicalize.t
@@ -12,6 +12,7 @@ Test that a nonsense argument is caught
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
     --debug-optimized-mir-pretty    For debugging purposes: pretty print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
+    --debug-mem-patterns            For debugging purposes: print a list of matrix variables and their memory type, either AoS (array of structs) or the more efficient SoA (struct of arrays). Only has an effect when optimizations are turned on.
     --debug-transformed-mir         For debugging purposes: print the MIR after the backend has transformed it.
     --debug-transformed-mir-pretty  For debugging purposes: pretty print the MIR after the backend has transformed it.
     --dump-stan-math-signatures     Dump out the list of supported type signatures for Stan Math backend.
@@ -57,6 +58,7 @@ Test capitalization - this should fail due to the lack of model_name, not the ca
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
     --debug-optimized-mir-pretty    For debugging purposes: pretty print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
+    --debug-mem-patterns            For debugging purposes: print a list of matrix variables and their memory type, either AoS (array of structs) or the more efficient SoA (struct of arrays). Only has an effect when optimizations are turned on.
     --debug-transformed-mir         For debugging purposes: print the MIR after the backend has transformed it.
     --debug-transformed-mir-pretty  For debugging purposes: pretty print the MIR after the backend has transformed it.
     --dump-stan-math-signatures     Dump out the list of supported type signatures for Stan Math backend.

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -10,6 +10,7 @@ Show help
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
     --debug-optimized-mir-pretty    For debugging purposes: pretty print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
+    --debug-mem-patterns            For debugging purposes: print a list of matrix variables and their memory type, either AoS (array of structs) or the more efficient SoA (struct of arrays). Only has an effect when optimizations are turned on.
     --debug-transformed-mir         For debugging purposes: print the MIR after the backend has transformed it.
     --debug-transformed-mir-pretty  For debugging purposes: pretty print the MIR after the backend has transformed it.
     --dump-stan-math-signatures     Dump out the list of supported type signatures for Stan Math backend.

--- a/test/integration/good/compiler-optimizations/mem_patterns/dune
+++ b/test/integration/good/compiler-optimizations/mem_patterns/dune
@@ -25,7 +25,7 @@
    %{targets}
    (run
     %{bin:run_bin_on_args}
-    "%{bin:stanc} -fsoa --debug-optimized-mir"
+    "%{bin:stanc} -fsoa --debug-optimized-mir --debug-mem-patterns"
     %{stanfiles}))))
 
 (rule

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -1,4 +1,5 @@
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir complex-fails.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns complex-fails.stan
+matrix A_p: AoS
 ((functions_block ()) (input_vars ())
  (prepare_data
   (((pattern
@@ -268,7 +269,31 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name complex_fails_model) (prog_path complex-fails.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir constraints.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns constraints.stan
+vector high_low_est: SoA
+vector b: SoA
+vector h: SoA
+vector ar: SoA
+vector mean_price: SoA
+vector sigma_price: SoA
+vector upper_test: SoA
+vector lower_upper_test: SoA
+row_vector row_vec_lower_upper_test: SoA
+vector offset_mult_test: SoA
+vector ordered_test: SoA
+vector unit_vec_test: SoA
+vector pos_ordered_test: SoA
+matrix corr_matrix_test: SoA
+matrix cov_matrix_test: SoA
+matrix chol_fac_cov_test: SoA
+matrix chol_fac_corr_test: SoA
+vector prices: SoA
+vector prices_diff: SoA
+vector mu: SoA
+vector err: SoA
+vector h_i_mean: SoA
+vector h_i_sigma: SoA
+vector h_sigma: SoA
 ((functions_block ())
  (input_vars
   ((N SInt) (K SInt)
@@ -5375,7 +5400,15 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name constraints_model) (prog_path constraints.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir deep_dependence.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns deep_dependence.stan
+matrix X_p: AoS
+matrix X_tp1: AoS
+matrix X_tp2: AoS
+matrix X_tp3: AoS
+matrix X_tp4: AoS
+matrix X_tp5: AoS
+matrix X_tp6: AoS
+matrix X_tp7: AoS
 ((functions_block ()) (input_vars ())
  (prepare_data
   (((pattern
@@ -6130,7 +6163,35 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name deep_dependence_model) (prog_path deep_dependence.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir indexing.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns indexing.stan
+vector p_soa_vec_v: SoA
+matrix p_soa_mat: SoA
+matrix p_soa_mat_uni_col_idx: SoA
+vector p_soa_vec_uni_idx: SoA
+matrix p_soa_loop_mat_uni_col_idx: SoA
+row_vector p_soa_lhs_loop_mul: SoA
+vector p_soa_rhs_loop_mul: SoA
+vector p_soa_used_with_aos_in_excluded_fun: SoA
+matrix p_soa_loop_mat_multi_uni_uni_idx: SoA
+vector p_aos_vec_v_assign_to_aos: AoS
+vector p_aos_vec_v_tp_fails_func: AoS
+vector p_aos_loop_vec_v_uni_idx: AoS
+vector p_aos_fail_assign_from_top_idx: AoS
+matrix p_aos_loop_mat_uni_uni_idx: AoS
+matrix p_aos_mat: AoS
+matrix p_aos_mat_pass_func_outer_single_indexed1: AoS
+matrix p_aos_mat_pass_func_outer_single_indexed2: AoS
+matrix p_aos_mat_fail_uni_uni_idx1: AoS
+matrix p_aos_mat_fail_uni_uni_idx2: AoS
+vector tp_aos_vec_v: AoS
+vector tp_soa_single_idx_uninit: SoA
+vector tp_aos_fail_func_vec_v: AoS
+vector tp_aos_fail_assign_from_top_idx: AoS
+vector tp_soa_used_with_aos_in_excluded_fun: SoA
+vector tp_soa_single_assign: SoA
+vector tp_soa_single_assign_from_soa: SoA
+vector tp_aos_loop_vec_v_uni_idx: AoS
+vector tp_aos_loop_vec_v_multi_uni_idx: AoS
 ((functions_block
   (((fdrt (UInt)) (fdname mask_fun) (fdsuffix FnPlain)
     (fdargs ((AutoDiffable i UInt)))
@@ -10888,7 +10949,10 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name indexing_model) (prog_path indexing.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir indexing2.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns indexing2.stan
+vector p_aos_loop_single_idx: AoS
+vector tp_soa_multi_idx_assign_in_loop: SoA
+vector tp_soa_single_idx_in_upfrom_idx: SoA
 ((functions_block ())
  (input_vars
   ((N SInt) (M SInt)
@@ -11296,7 +11360,12 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block Parameters) (out_trans Identity)))))
  (prog_name indexing2_model) (prog_path indexing2.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir reductions_allowed.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns reductions_allowed.stan
+matrix soa_x: SoA
+matrix aos_x: AoS
+matrix aos_y: AoS
+matrix tp_matrix_aos_from_mix: AoS
+matrix tp_matrix_from_udf_reduced_soa: AoS
 ((functions_block
   (((fdrt (UMatrix)) (fdname nono_func) (fdsuffix FnPlain)
     (fdargs ((AutoDiffable x UMatrix)))
@@ -12087,7 +12156,14 @@
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name reductions_allowed_model) (prog_path reductions_allowed.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir return_types_and_udfs_demotes.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns return_types_and_udfs_demotes.stan
+matrix row_soa: SoA
+matrix udf_input_aos: AoS
+matrix user_func_aos: AoS
+matrix empty_user_func_aos: AoS
+matrix inner_empty_user_func_aos: AoS
+matrix int_aos_mul_aos: AoS
+matrix mul_two_aos: AoS
 ((functions_block
   (((fdrt (UMatrix)) (fdname empty_user_func) (fdsuffix FnPlain) (fdargs ())
     (fdbody
@@ -12836,7 +12912,11 @@
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name return_types_and_udfs_demotes_model)
  (prog_path return_types_and_udfs_demotes.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir single_indexing.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns single_indexing.stan
+matrix aos_p: AoS
+matrix soa_p: SoA
+row_vector tp_row_vector_from_soa_loop: SoA
+matrix tp_matrix_from_soa_loop: SoA
 ((functions_block ()) (input_vars ())
  (prepare_data
   (((pattern
@@ -13399,7 +13479,10 @@
     ((out_unconstrained_st SReal) (out_constrained_st SReal)
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name single_indexing_model) (prog_path single_indexing.stan))
-  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir tp_reused.stan
+  $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns tp_reused.stan
+matrix first_pass_soa_x: AoS
+matrix aos_x: AoS
+matrix tp_matrix_aos: AoS
 ((functions_block
   (((fdrt (UMatrix)) (fdname nono_func) (fdsuffix FnPlain)
     (fdargs ((AutoDiffable x UMatrix)))

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -1,5 +1,5 @@
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns complex-fails.stan
-matrix A_p: AoS
+matrix[10, 10] A_p: AoS
 ((functions_block ()) (input_vars ())
  (prepare_data
   (((pattern
@@ -270,30 +270,30 @@ matrix A_p: AoS
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name complex_fails_model) (prog_path complex-fails.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns constraints.stan
-vector high_low_est: SoA
-vector b: SoA
-vector h: SoA
-vector ar: SoA
-vector mean_price: SoA
-vector sigma_price: SoA
-vector upper_test: SoA
-vector lower_upper_test: SoA
-row_vector row_vec_lower_upper_test: SoA
-vector offset_mult_test: SoA
-vector ordered_test: SoA
-vector unit_vec_test: SoA
-vector pos_ordered_test: SoA
-matrix corr_matrix_test: SoA
-matrix cov_matrix_test: SoA
-matrix chol_fac_cov_test: SoA
-matrix chol_fac_corr_test: SoA
-vector prices: SoA
-vector prices_diff: SoA
-vector mu: SoA
-vector err: SoA
-vector h_i_mean: SoA
-vector h_i_sigma: SoA
-vector h_sigma: SoA
+vector[N] high_low_est: SoA
+vector[K] b: SoA
+vector[Nr] h: SoA
+vector[2] ar: SoA
+vector[N] mean_price: SoA
+vector[N] sigma_price: SoA
+vector[N] upper_test: SoA
+vector[N] lower_upper_test: SoA
+row_vector[N] row_vec_lower_upper_test: SoA
+vector[N] offset_mult_test: SoA
+vector[N] ordered_test: SoA
+vector[N] unit_vec_test: SoA
+vector[N] pos_ordered_test: SoA
+matrix[N, N] corr_matrix_test: SoA
+matrix[N, N] cov_matrix_test: SoA
+matrix[K, K] chol_fac_cov_test: SoA
+matrix[K, K] chol_fac_corr_test: SoA
+vector[N] prices: SoA
+vector[Nr] prices_diff: SoA
+vector[Nr] mu: SoA
+vector[Nr] err: SoA
+vector[Nr] h_i_mean: SoA
+vector[Nr] h_i_sigma: SoA
+vector[Nr] h_sigma: SoA
 ((functions_block ())
  (input_vars
   ((N SInt) (K SInt)
@@ -5401,14 +5401,14 @@ vector h_sigma: SoA
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name constraints_model) (prog_path constraints.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns deep_dependence.stan
-matrix X_p: AoS
-matrix X_tp1: AoS
-matrix X_tp2: AoS
-matrix X_tp3: AoS
-matrix X_tp4: AoS
-matrix X_tp5: AoS
-matrix X_tp6: AoS
-matrix X_tp7: AoS
+matrix[10, 10] X_p: AoS
+matrix[10, 10] X_tp1: AoS
+matrix[10, 10] X_tp2: AoS
+matrix[10, 10] X_tp3: AoS
+matrix[10, 10] X_tp4: AoS
+matrix[10, 10] X_tp5: AoS
+matrix[10, 10] X_tp6: AoS
+matrix[10, 10] X_tp7: AoS
 ((functions_block ()) (input_vars ())
  (prepare_data
   (((pattern
@@ -6164,34 +6164,35 @@ matrix X_tp7: AoS
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name deep_dependence_model) (prog_path deep_dependence.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns indexing.stan
-vector p_soa_vec_v: SoA
-matrix p_soa_mat: SoA
-matrix p_soa_mat_uni_col_idx: SoA
-vector p_soa_vec_uni_idx: SoA
-matrix p_soa_loop_mat_uni_col_idx: SoA
-row_vector p_soa_lhs_loop_mul: SoA
-vector p_soa_rhs_loop_mul: SoA
-vector p_soa_used_with_aos_in_excluded_fun: SoA
-matrix p_soa_loop_mat_multi_uni_uni_idx: SoA
-vector p_aos_vec_v_assign_to_aos: AoS
-vector p_aos_vec_v_tp_fails_func: AoS
-vector p_aos_loop_vec_v_uni_idx: AoS
-vector p_aos_fail_assign_from_top_idx: AoS
-matrix p_aos_loop_mat_uni_uni_idx: AoS
-matrix p_aos_mat: AoS
-matrix p_aos_mat_pass_func_outer_single_indexed1: AoS
-matrix p_aos_mat_pass_func_outer_single_indexed2: AoS
-matrix p_aos_mat_fail_uni_uni_idx1: AoS
-matrix p_aos_mat_fail_uni_uni_idx2: AoS
-vector tp_aos_vec_v: AoS
-vector tp_soa_single_idx_uninit: SoA
-vector tp_aos_fail_func_vec_v: AoS
-vector tp_aos_fail_assign_from_top_idx: AoS
-vector tp_soa_used_with_aos_in_excluded_fun: SoA
-vector tp_soa_single_assign: SoA
-vector tp_soa_single_assign_from_soa: SoA
-vector tp_aos_loop_vec_v_uni_idx: AoS
-vector tp_aos_loop_vec_v_multi_uni_idx: AoS
+vector[M] p_soa_vec_v: SoA
+matrix[N, M] p_soa_mat: SoA
+array[vector[N], 10] p_soa_arr_vec_v: SoA
+matrix[N, M] p_soa_mat_uni_col_idx: SoA
+vector[N] p_soa_vec_uni_idx: SoA
+matrix[N, M] p_soa_loop_mat_uni_col_idx: SoA
+row_vector[N] p_soa_lhs_loop_mul: SoA
+vector[N] p_soa_rhs_loop_mul: SoA
+vector[N] p_soa_used_with_aos_in_excluded_fun: SoA
+matrix[N, M] p_soa_loop_mat_multi_uni_uni_idx: SoA
+vector[M] p_aos_vec_v_assign_to_aos: AoS
+vector[M] p_aos_vec_v_tp_fails_func: AoS
+vector[M] p_aos_loop_vec_v_uni_idx: AoS
+vector[M] p_aos_fail_assign_from_top_idx: AoS
+matrix[N, M] p_aos_loop_mat_uni_uni_idx: AoS
+matrix[N, M] p_aos_mat: AoS
+matrix[N, M] p_aos_mat_pass_func_outer_single_indexed1: AoS
+matrix[N, M] p_aos_mat_pass_func_outer_single_indexed2: AoS
+matrix[N, M] p_aos_mat_fail_uni_uni_idx1: AoS
+matrix[N, M] p_aos_mat_fail_uni_uni_idx2: AoS
+vector[M] tp_aos_vec_v: AoS
+vector[M] tp_soa_single_idx_uninit: SoA
+vector[M] tp_aos_fail_func_vec_v: AoS
+vector[M] tp_aos_fail_assign_from_top_idx: AoS
+vector[N] tp_soa_used_with_aos_in_excluded_fun: SoA
+vector[N] tp_soa_single_assign: SoA
+vector[N] tp_soa_single_assign_from_soa: SoA
+vector[N] tp_aos_loop_vec_v_uni_idx: AoS
+vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
 ((functions_block
   (((fdrt (UInt)) (fdname mask_fun) (fdsuffix FnPlain)
     (fdargs ((AutoDiffable i UInt)))
@@ -10950,9 +10951,9 @@ vector tp_aos_loop_vec_v_multi_uni_idx: AoS
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name indexing_model) (prog_path indexing.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns indexing2.stan
-vector p_aos_loop_single_idx: AoS
-vector tp_soa_multi_idx_assign_in_loop: SoA
-vector tp_soa_single_idx_in_upfrom_idx: SoA
+vector[10] p_aos_loop_single_idx: AoS
+vector[N] tp_soa_multi_idx_assign_in_loop: SoA
+vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
 ((functions_block ())
  (input_vars
   ((N SInt) (M SInt)
@@ -11361,11 +11362,11 @@ vector tp_soa_single_idx_in_upfrom_idx: SoA
      (out_block Parameters) (out_trans Identity)))))
  (prog_name indexing2_model) (prog_path indexing2.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns reductions_allowed.stan
-matrix soa_x: SoA
-matrix aos_x: AoS
-matrix aos_y: AoS
-matrix tp_matrix_aos_from_mix: AoS
-matrix tp_matrix_from_udf_reduced_soa: AoS
+matrix[5, 10] soa_x: SoA
+matrix[5, 10] aos_x: AoS
+matrix[5, 10] aos_y: AoS
+matrix[5, 10] tp_matrix_aos_from_mix: AoS
+matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
 ((functions_block
   (((fdrt (UMatrix)) (fdname nono_func) (fdsuffix FnPlain)
     (fdargs ((AutoDiffable x UMatrix)))
@@ -12157,13 +12158,13 @@ matrix tp_matrix_from_udf_reduced_soa: AoS
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name reductions_allowed_model) (prog_path reductions_allowed.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns return_types_and_udfs_demotes.stan
-matrix row_soa: SoA
-matrix udf_input_aos: AoS
-matrix user_func_aos: AoS
-matrix empty_user_func_aos: AoS
-matrix inner_empty_user_func_aos: AoS
-matrix int_aos_mul_aos: AoS
-matrix mul_two_aos: AoS
+matrix[10, 10] row_soa: SoA
+matrix[10, 10] udf_input_aos: AoS
+matrix[10, 10] user_func_aos: AoS
+matrix[10, 10] empty_user_func_aos: AoS
+matrix[10, 10] inner_empty_user_func_aos: AoS
+matrix[10, 10] int_aos_mul_aos: AoS
+matrix[10, 10] mul_two_aos: AoS
 ((functions_block
   (((fdrt (UMatrix)) (fdname empty_user_func) (fdsuffix FnPlain) (fdargs ())
     (fdbody
@@ -12913,10 +12914,10 @@ matrix mul_two_aos: AoS
  (prog_name return_types_and_udfs_demotes_model)
  (prog_path return_types_and_udfs_demotes.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns single_indexing.stan
-matrix aos_p: AoS
-matrix soa_p: SoA
-row_vector tp_row_vector_from_soa_loop: SoA
-matrix tp_matrix_from_soa_loop: SoA
+matrix[10, 10] aos_p: AoS
+matrix[10, 10] soa_p: SoA
+row_vector[10] tp_row_vector_from_soa_loop: SoA
+matrix[10, 10] tp_matrix_from_soa_loop: SoA
 ((functions_block ()) (input_vars ())
  (prepare_data
   (((pattern
@@ -13480,9 +13481,9 @@ matrix tp_matrix_from_soa_loop: SoA
      (out_block TransformedParameters) (out_trans Identity)))))
  (prog_name single_indexing_model) (prog_path single_indexing.stan))
   $ ../../../../../../install/default/bin/stanc -fsoa --debug-optimized-mir --debug-mem-patterns tp_reused.stan
-matrix first_pass_soa_x: AoS
-matrix aos_x: AoS
-matrix tp_matrix_aos: AoS
+matrix[5, 10] first_pass_soa_x: AoS
+matrix[5, 10] aos_x: AoS
+matrix[5, 10] tp_matrix_aos: AoS
 ((functions_block
   (((fdrt (UMatrix)) (fdname nono_func) (fdsuffix FnPlain)
     (fdargs ((AutoDiffable x UMatrix)))


### PR DESCRIPTION
Closes #1135 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Added `--debug-mem-patterns` flag, which will print out the memory type of variables (either Array of Structs or the more efficient Struct of Arrays pattern) when optimization is enabled. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
