### PR TITLE
Pin core kernel to v0.14

### DIFF
--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-# Menhir is our parsing library and annoyingly its module name does not match
-# its library name, so we install it manually here.
-
 opam pin -y dune 2.8.4
+opam pin -y core_kernel v0.14.2
 
 opam install -y core_kernel.v0.14.2 menhir.20210929 ppx_deriving.5.2.1 fmt.0.8.8 yojson.1.7.0


### PR DESCRIPTION
Apparently installing a specific version is not enough to prevent a newer version from being installed, so we should just pin core to v0.14

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
