### PR TITLE
Make log suffix explicit in declarative distribution signatures

### DIFF
--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -26,7 +26,7 @@ let deprecated_distributions =
               | Lpmf -> Some (name ^ "_log", name ^ "_lpmf")
               | Cdf -> Some (name ^ "_cdf_log", name ^ "_lcdf")
               | Ccdf -> Some (name ^ "_ccdf_log", name ^ "_lccdf")
-              | Rng | UnaryVectorized -> None ) ) ) )
+              | Rng | Log | UnaryVectorized -> None ) ) ) )
 
 let stan_lib_deprecations =
   Map.merge_skewed deprecated_distributions deprecated_functions

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -29,7 +29,7 @@ val pretty_print_all_math_distributions : unit Fmt.t
 
 type dimensionality
 
-type fkind = Lpmf | Lpdf | Rng | Cdf | Ccdf | UnaryVectorized
+type fkind = Lpmf | Lpdf | Log | Rng | Cdf | Ccdf | UnaryVectorized
 [@@deriving show {with_path= false}]
 
 val distributions :

--- a/test/integration/signatures/stan_math_distributions.t
+++ b/test/integration/signatures/stan_math_distributions.t
@@ -1,67 +1,67 @@
 Display all Stan math distributions exposed in the language
   $ stanc --dump-stan-math-distributions
-  beta_binomial: lpmf, rng, ccdf, cdf
-  beta: lpdf, rng, ccdf, cdf
-  beta_proportion: lpdf, ccdf, cdf
-  bernoulli: lpmf, rng, ccdf, cdf
-  bernoulli_logit: lpmf, rng
+  beta_binomial: lpmf, rng, ccdf, cdf, log (deprecated)
+  beta: lpdf, rng, ccdf, cdf, log (deprecated)
+  beta_proportion: lpdf, ccdf, cdf, log (deprecated)
+  bernoulli: lpmf, rng, ccdf, cdf, log (deprecated)
+  bernoulli_logit: lpmf, rng, log (deprecated)
   bernoulli_logit_glm: lpmf
-  binomial: lpmf, rng, ccdf, cdf
-  binomial_logit: lpmf
-  categorical: lpmf
-  categorical_logit: lpmf
+  binomial: lpmf, rng, ccdf, cdf, log (deprecated)
+  binomial_logit: lpmf, log (deprecated)
+  categorical: lpmf, log (deprecated)
+  categorical_logit: lpmf, log (deprecated)
   categorical_logit_glm: lpmf
-  cauchy: lpdf, rng, ccdf, cdf
-  chi_square: lpdf, rng, ccdf, cdf
-  dirichlet: lpdf
-  discrete_range: lpmf, rng, ccdf, cdf
-  double_exponential: lpdf, rng, ccdf, cdf
-  exp_mod_normal: lpdf, rng, ccdf, cdf
-  exponential: lpdf, rng, ccdf, cdf
-  frechet: lpdf, rng, ccdf, cdf
-  gamma: lpdf, rng, ccdf, cdf
-  gaussian_dlm_obs: lpdf
-  gumbel: lpdf, rng, ccdf, cdf
+  cauchy: lpdf, rng, ccdf, cdf, log (deprecated)
+  chi_square: lpdf, rng, ccdf, cdf, log (deprecated)
+  dirichlet: lpdf, log (deprecated)
+  discrete_range: lpmf, rng, ccdf, cdf, log (deprecated)
+  double_exponential: lpdf, rng, ccdf, cdf, log (deprecated)
+  exp_mod_normal: lpdf, rng, ccdf, cdf, log (deprecated)
+  exponential: lpdf, rng, ccdf, cdf, log (deprecated)
+  frechet: lpdf, rng, ccdf, cdf, log (deprecated)
+  gamma: lpdf, rng, ccdf, cdf, log (deprecated)
+  gaussian_dlm_obs: lpdf, log (deprecated)
+  gumbel: lpdf, rng, ccdf, cdf, log (deprecated)
   hmm_latent: rng
-  hypergeometric: lpmf, rng
-  inv_chi_square: lpdf, rng, ccdf, cdf
-  inv_gamma: lpdf, rng, ccdf, cdf
-  inv_wishart: lpdf
-  lkj_corr: lpdf
-  lkj_corr_cholesky: lpdf
-  logistic: lpdf, rng, ccdf, cdf
-  loglogistic: lpdf, rng, cdf
-  lognormal: lpdf, rng, ccdf, cdf
-  multi_gp: lpdf
-  multi_gp_cholesky: lpdf
-  multinomial: lpmf
-  multinomial_logit: lpmf
-  multi_normal: lpdf
-  multi_normal_cholesky: lpdf
-  multi_normal_prec: lpdf
-  multi_student_t: lpdf
-  neg_binomial: lpmf, rng, ccdf, cdf
-  neg_binomial_2: lpmf, rng, ccdf, cdf
-  neg_binomial_2_log: lpmf, rng
+  hypergeometric: lpmf, rng, log (deprecated)
+  inv_chi_square: lpdf, rng, ccdf, cdf, log (deprecated)
+  inv_gamma: lpdf, rng, ccdf, cdf, log (deprecated)
+  inv_wishart: lpdf, log (deprecated)
+  lkj_corr: lpdf, log (deprecated)
+  lkj_corr_cholesky: lpdf, log (deprecated)
+  logistic: lpdf, rng, ccdf, cdf, log (deprecated)
+  loglogistic: lpdf, rng, cdf, log (deprecated)
+  lognormal: lpdf, rng, ccdf, cdf, log (deprecated)
+  multi_gp: lpdf, log (deprecated)
+  multi_gp_cholesky: lpdf, log (deprecated)
+  multinomial: lpmf, log (deprecated)
+  multinomial_logit: lpmf, log (deprecated)
+  multi_normal: lpdf, log (deprecated)
+  multi_normal_cholesky: lpdf, log (deprecated)
+  multi_normal_prec: lpdf, log (deprecated)
+  multi_student_t: lpdf, log (deprecated)
+  neg_binomial: lpmf, rng, ccdf, cdf, log (deprecated)
+  neg_binomial_2: lpmf, rng, ccdf, cdf, log (deprecated)
+  neg_binomial_2_log: lpmf, rng, log (deprecated)
   neg_binomial_2_log_glm: lpmf
-  normal: lpdf, rng, ccdf, cdf
+  normal: lpdf, rng, ccdf, cdf, log (deprecated)
   normal_id_glm: lpdf
-  ordered_logistic: lpmf
+  ordered_logistic: lpmf, log (deprecated)
   ordered_logistic_glm: lpmf
-  ordered_probit: lpmf
-  pareto: lpdf, rng, ccdf, cdf
-  pareto_type_2: lpdf, rng, ccdf, cdf
-  poisson: lpmf, rng, ccdf, cdf
-  poisson_log: lpmf, rng
+  ordered_probit: lpmf, log (deprecated)
+  pareto: lpdf, rng, ccdf, cdf, log (deprecated)
+  pareto_type_2: lpdf, rng, ccdf, cdf, log (deprecated)
+  poisson: lpmf, rng, ccdf, cdf, log (deprecated)
+  poisson_log: lpmf, rng, log (deprecated)
   poisson_log_glm: lpmf
-  rayleigh: lpdf, rng, ccdf, cdf
-  scaled_inv_chi_square: lpdf, rng, ccdf, cdf
-  skew_normal: lpdf, rng, ccdf, cdf
-  skew_double_exponential: lpdf, rng, ccdf, cdf
-  student_t: lpdf, rng, ccdf, cdf
-  std_normal: lpdf, rng, ccdf, cdf
-  uniform: lpdf, rng, ccdf, cdf
-  von_mises: lpdf, rng, ccdf, cdf
-  weibull: lpdf, rng, ccdf, cdf
-  wiener: lpdf
-  wishart: lpdf
+  rayleigh: lpdf, rng, ccdf, cdf, log (deprecated)
+  scaled_inv_chi_square: lpdf, rng, ccdf, cdf, log (deprecated)
+  skew_normal: lpdf, rng, ccdf, cdf, log (deprecated)
+  skew_double_exponential: lpdf, rng, ccdf, cdf, log (deprecated)
+  student_t: lpdf, rng, ccdf, cdf, log (deprecated)
+  std_normal: lpdf, rng, ccdf, cdf, log (deprecated)
+  uniform: lpdf, rng, ccdf, cdf, log (deprecated)
+  von_mises: lpdf, rng, ccdf, cdf, log (deprecated)
+  weibull: lpdf, rng, ccdf, cdf, log (deprecated)
+  wiener: lpdf, log (deprecated)
+  wishart: lpdf, log (deprecated)


### PR DESCRIPTION
We currently assume whenever a function has a Lp[md]f signature, it must also have a _log, unless it is a GLM. This creates issues for things like #1188, which want to add new distributions but don't support the deprecated/soon to be removed _log suffix. This change makes it so that Log is explicitly listed as a function type for signatures, so in particular it does not always need to be present. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Allowed the adding of new distributions without requiring them to support deprecated suffixes. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
