### PR TITLE
Fix size of output vector in write_array

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -481,7 +481,7 @@ let pp_overloads ppf {Program.output_vars; _} =
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -495,13 +495,13 @@ let pp_overloads ppf {Program.output_vars; _} =
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = %a;
-      const size_t num_transformed = %a;
-      const size_t num_gen_quantities = %a;
+      const size_t num_transformed = emit_transformed_parameters * %a;
+      const size_t num_gen_quantities = emit_generated_quantities * %a;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -223,7 +223,7 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -237,13 +237,13 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1705,7 +1705,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1720,13 +1720,13 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((((((k + k) + k) + 1) + 1) + 1) + (n * k)) + (n * k)) + n);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1346,7 +1346,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1361,14 +1361,14 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((((((N * N) * 2) + (N * 2)) + (N * 2)) + 2) + (N * N)) + N) + N) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((((((N * N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2));
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2406,7 +2406,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2420,14 +2420,14 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((N * N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4036,7 +4036,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4051,14 +4051,14 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((((((N * N) * 2) + (N * 2)) + (N * 2)) + 2) + (N * N)) + N) + N) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((((((N * N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2));
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4665,7 +4665,7 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4679,13 +4679,13 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -7356,7 +7356,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7371,16 +7371,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 2) + (2 * 2)) + ((2 * 3) * 2));
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((1 + 2) + (2 * 2)) + ((2 * 3) * 2));
-      const size_t num_gen_quantities = 
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (((((((((((1 + 1) + 2) + (2 * 2)) + ((2 * 3) * 2)) + 2) + 2) + 0) + 1) + 2)
      + 2) + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -7797,7 +7797,7 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7811,14 +7811,14 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((((3 * 2) + ((2 * 2) * 2)) + 2) + (2 * 2));
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -8452,7 +8452,7 @@ class user_function_templating_model final : public model_base_crtp<user_functio
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -8466,13 +8466,13 @@ class user_function_templating_model final : public model_base_crtp<user_functio
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -353,7 +353,7 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -368,13 +368,13 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + 1) + J);
-      const size_t num_transformed = J;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * J;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -682,7 +682,7 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -696,13 +696,13 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -1777,7 +1777,7 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1793,15 +1793,15 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       const size_t num_params__ = 
   ((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)
      + 1) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)
           + 1) + 1) + 1) + 1) + 1) + 1) + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2233,7 +2233,7 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2248,13 +2248,13 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + 1) + J);
-      const size_t num_transformed = J;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * J;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2692,7 +2692,7 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2706,14 +2706,14 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 3;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((3 * 3) + (3 * 3)) + (3 * 3));
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -12160,7 +12160,7 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -12179,12 +12179,12 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
               (((N * M) * K) * N)) + (5 * 4)) + (((4 * 5) * 2) * 3)) + N) +
           (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 * 3)) +
       ((K * 3) * 3)) + 2) + 2);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((((((((((((((N + ((N * M) * K)) + N) + (N * N)) + (((N * M) * K) * N))
                 + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) +
             (((4 * 5) * 2) * 3)) + N) + (N * N)) + (((N * M) * K) * N)) +
         (5 * 4)) + (3 * 3)) + ((K * 3) * 3)) + 2) + 1);
-      const size_t num_gen_quantities = 
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((((((((((((((((((((((1 + 1) + N) + ((N * M) * K)) + N) + (N * N)) +
                         (((N * M) * K) * N)) + N) + (N * N)) +
                      (((N * M) * K) * N)) + (((4 * 5) * 2) * 3)) + N) +
@@ -12194,9 +12194,9 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
       ((3 * 3) * 3)) + (3 * 4)) + (2 * 2));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -14098,7 +14098,7 @@ const
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -14113,15 +14113,15 @@ const
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((((2 + 1) + 1) + 2) + 3) + (3 * 3)) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((((((1 + 1) + 1) + 3) + 3) + 3) + 2) + 2) + 2) + 2);
-      const size_t num_gen_quantities = 
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((((T * 2) + 1) + 1) + 1) + 1) + 3) + 3) + 2);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -18718,7 +18718,7 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -18733,14 +18733,15 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + N) + N);
-      const size_t num_transformed = (N * N);
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (N * N);
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (N * N);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -19389,7 +19390,7 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -19404,14 +19405,14 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + 2) + 2);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (N * 2);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -21089,7 +21090,7 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -21104,13 +21105,13 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((((((k + k) + k) + 1) + 1) + 1) + (n * k)) + (n * k)) + n);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -21868,7 +21869,7 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -21883,13 +21884,13 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22309,7 +22310,7 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22324,13 +22325,13 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((nt * 2) * 2) + NS);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22631,7 +22632,7 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22645,13 +22646,13 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -23047,7 +23048,7 @@ ident_functor__::operator()(const std::complex<T0__>& x,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -23061,14 +23062,14 @@ ident_functor__::operator()(const std::complex<T0__>& x,
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (((1 + 2) + 4) + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -23654,7 +23655,7 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -23669,13 +23670,13 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((N + N) + N);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -26318,7 +26319,7 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -26336,13 +26337,13 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
                 (N * N)) + ((N * N) * N)) + (N * N)) + (N * N)) + N) +
            (((N * N) * N) * N)) + ((N * N) * N)) + ((N * N) * N)) + (N * N))
        + ((N * N) * N)) + (N * N)) + (N * N)) + N);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -30555,7 +30556,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -30572,16 +30573,16 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
   ((((((((((((N + (N * N)) + (N * N)) + ((N * N) * N)) + (N * N)) +
            ((N * N) * N)) + ((N * N) * N)) + (((N * N) * N) * N)) + 1) + N) +
       N) + (N * N)) + ((N * N) * N));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
                    1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1)
        + 1) + 1) + 1) + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -31624,7 +31625,7 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -31642,14 +31643,14 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
                            1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
                  1) + 1) + 5) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 4) +
      1) + 1);
-      const size_t num_transformed = ((1 + (1 * 4)) +
-                                                     result_1dim__);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((1 + (1 * 4)) + result_1dim__);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -32133,7 +32134,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -32147,13 +32148,13 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -32491,7 +32492,7 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -32505,13 +32506,13 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -35185,7 +35186,7 @@ class transform_model final : public model_base_crtp<transform_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -35202,16 +35203,16 @@ class transform_model final : public model_base_crtp<transform_model> {
   (((((((((((((((((k + k) + k) + k) + k) + k) + k) + k) + (m * k)) +
             ((n * m) * k)) + k) + (m * k)) + ((n * m) * k)) + k) + (m * k)) +
       ((n * m) * k)) + (m * k)) + ((n * m) * k));
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((((((((((((((k + k) + k) + k) + k) + k) + k) + k) + (m * k)) +
             ((n * m) * k)) + k) + (m * k)) + ((n * m) * k)) + k) + (m * k)) +
       ((n * m) * k)) + (m * k)) + ((n * m) * k));
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -35648,7 +35649,7 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -35663,13 +35664,13 @@ class truncate_model final : public model_base_crtp<truncate_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -36002,7 +36003,7 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -36016,13 +36017,13 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -36361,7 +36362,7 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -36375,13 +36376,13 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -473,7 +473,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -487,13 +487,13 @@ class simple_function_model final : public model_base_crtp<simple_function_model
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -967,7 +967,7 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -982,13 +982,14 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((2 + 2) + 1) + 2);
-      const size_t num_transformed = ((2 + 2) + 2);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((2 + 2) + 2);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -693,7 +693,7 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -708,13 +708,14 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + N) + 1) + N);
-      const size_t num_transformed = (M * N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (M * N);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -1625,7 +1626,7 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1640,14 +1641,14 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = ((N_t * 4) +
-                                                              (N_t * 4));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((N_t * 4) + (N_t * 4));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7319,7 +7319,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7334,13 +7334,13 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + d_int) + (d_int * d_int)) + d_int) + d_int) + 1);
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -8036,7 +8036,7 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -8051,13 +8051,13 @@ class restricted_model final : public model_base_crtp<restricted_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + d_int) + (d_int * d_int)) + d_int) + d_int) + 1);
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -403,7 +403,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -418,13 +418,13 @@ class simple_function_model final : public model_base_crtp<simple_function_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + 1) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1860,7 +1860,7 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1875,18 +1875,15 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (10 * 10);
-      const size_t num_transformed = (((((((10 * 10) +
-                                                         (10 * 10)) +
-                                                        (10 * 10)) +
-                                                       (10 * 10)) +
-                                                      (10 * 10)) + (10 * 10))
-                                                    + (10 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((((((10 * 10) + (10 * 10)) + (10 * 10)) + (10 * 10)) + (10 * 10)) +
+     (10 * 10)) + (10 * 10));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2601,7 +2598,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2616,13 +2613,14 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = (N_t * 4);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (N_t * 4);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4504,7 +4502,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4519,17 +4517,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + max_age);
-      const size_t num_transformed = (((nind *
-                                                          n_occ_minus_1) +
-                                                         (nind *
-                                                           n_occ_minus_1)) +
-                                                        (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -5641,7 +5636,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -5657,13 +5652,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       const size_t num_params__ = 
   (((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + n_age)
        + n_edu) + n_region) + (n_age * n_edu)) + n_state);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6006,7 +6001,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6020,13 +6015,13 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6359,7 +6354,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6373,13 +6368,13 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6855,7 +6850,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6870,13 +6865,13 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((2 + 2) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -7277,7 +7272,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7292,13 +7287,13 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + J) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -8447,7 +8442,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -8463,13 +8458,13 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       const size_t num_params__ = 
   ((((((((((n_age + n_edu) + n_age_edu) + n_state) + n_region_full) + 5) + 1)
        + 1) + 1) + 1) + 1);
-      const size_t num_transformed = N;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * N;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -9220,7 +9215,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -9235,14 +9230,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + phi_std_raw_1dim__);
-      const size_t num_transformed = (1 + N);
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (1 + N);
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (((((((1 + 1) + 1) + 1) + N) + N) + N) + N);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -11067,7 +11063,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -11082,21 +11078,15 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + nind) + 1);
-      const size_t num_transformed = ((((nind *
-                                                                    n_occ_minus_1)
-                                                                   +
-                                                                   (nind *
-                                                                    n_occ_minus_1))
-                                                                  +
-                                                                  (nind *
-                                                                    n_occasions))
-                                                                 + 1);
-      const size_t num_gen_quantities = 1;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions))
+    + 1);
+      const size_t num_gen_quantities = emit_generated_quantities * 1;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -14550,7 +14540,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -14565,21 +14555,16 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + n_occasions) + M) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((M * phi_2dim__) + (M * n_occasions)) + n_occasions) + n_occasions) +
     (M * n_occasions));
-      const size_t num_gen_quantities = ((((1 + 1) +
-                                                                    n_occasions)
-                                                                   +
-                                                                   n_occasions)
-                                                                  +
-                                                                  (M *
-                                                                    n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 
+  ((((1 + 1) + n_occasions) + n_occasions) + (M * n_occasions));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -15639,7 +15624,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -15654,14 +15639,14 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (K + ((J * K) * K));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (I * K);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -16271,7 +16256,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -16286,14 +16271,14 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + N) + N);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (1 + N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -18174,7 +18159,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -18189,17 +18174,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + max_age);
-      const size_t num_transformed = (((nind *
-                                                          n_occ_minus_1) +
-                                                         (nind *
-                                                           n_occ_minus_1)) +
-                                                        (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -18785,7 +18767,7 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -18800,13 +18782,14 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (5 + 5);
-      const size_t num_transformed = (5 + 5);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (5 + 5);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22283,7 +22266,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22298,16 +22281,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((1 + 1) + n_occasions) + epsilon_1dim__) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((M * phi_2dim__) + (M * n_occasions)) + (M * n_occasions));
-      const size_t num_gen_quantities = 
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((1 + 1) + n_occasions) + 1) + n_occasions) + n_occasions) +
     (M * n_occasions));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22640,7 +22623,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22654,13 +22637,13 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22983,7 +22966,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22997,13 +22980,13 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -23355,7 +23338,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -23369,13 +23352,13 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = J;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -25105,7 +25088,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -25120,15 +25103,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + 1);
-      const size_t num_transformed = (((nind * n_occ_minus_1) +
-                                                   (nind * n_occ_minus_1)) +
-                                                  (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -25602,7 +25584,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -25616,14 +25598,14 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (1 + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -26486,7 +26468,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -26501,14 +26483,15 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = (R + (R * T));
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (R + (R * T));
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((1 + R) + R);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -27317,7 +27300,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -27332,14 +27315,14 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((((1 + J) + J) + 1) + 1) + 1) + 1) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((J + J) + N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -28504,7 +28487,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -28519,13 +28502,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((1 + 1) + (3 * 2)) + 2) + (2 * 2));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -28880,7 +28863,7 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -28894,13 +28877,13 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -29605,7 +29588,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -29620,13 +29603,13 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((n_pair + 2) + 1) + 1) + 1);
-      const size_t num_transformed = N;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * N;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -32773,7 +32756,7 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -32788,13 +32771,13 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((10 * 10) + (10 * 10));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -33652,7 +33635,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -33667,13 +33650,13 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + 1) + (I * K));
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -34124,7 +34107,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -34138,14 +34121,14 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((1 + 1) + 1) + 1) + 1) + 1);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -34725,7 +34708,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -34739,13 +34722,13 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 1;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 1;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -522,7 +522,7 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -537,18 +537,15 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (10 * 10);
-      const size_t num_transformed = (((((((10 * 10) +
-                                                         (10 * 10)) +
-                                                        (10 * 10)) +
-                                                       (10 * 10)) +
-                                                      (10 * 10)) + (10 * 10))
-                                                    + (10 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((((((10 * 10) + (10 * 10)) + (10 * 10)) + (10 * 10)) + (10 * 10)) +
+     (10 * 10)) + (10 * 10));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -1182,7 +1179,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1197,13 +1194,14 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = (N_t * 4);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (N_t * 4);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -1641,7 +1639,7 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1656,13 +1654,14 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (10 * 10);
-      const size_t num_transformed = ((10 * 10) + (10 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((10 * 10) + (10 * 10));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2620,7 +2619,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2635,17 +2634,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + max_age);
-      const size_t num_transformed = (((nind *
-                                                          n_occ_minus_1) +
-                                                         (nind *
-                                                           n_occ_minus_1)) +
-                                                        (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -3614,7 +3610,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -3630,13 +3626,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       const size_t num_params__ = 
   (((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + n_age)
        + n_edu) + n_region) + (n_age * n_edu)) + n_state);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -3976,7 +3972,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -3990,13 +3986,13 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4324,7 +4320,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4338,13 +4334,13 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4776,7 +4772,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4791,13 +4787,13 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((2 + 2) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -5190,7 +5186,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -5205,13 +5201,13 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + J) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6184,7 +6180,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6200,13 +6196,13 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       const size_t num_params__ = 
   ((((((((((n_age + n_edu) + n_age_edu) + n_state) + n_region_full) + 5) + 1)
        + 1) + 1) + 1) + 1);
-      const size_t num_transformed = N;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * N;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6884,7 +6880,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6899,14 +6895,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + phi_std_raw_1dim__);
-      const size_t num_transformed = (1 + N);
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (1 + N);
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (((((((1 + 1) + 1) + 1) + N) + N) + N) + N);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -7870,7 +7867,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7885,21 +7882,15 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + nind) + 1);
-      const size_t num_transformed = ((((nind *
-                                                                    n_occ_minus_1)
-                                                                   +
-                                                                   (nind *
-                                                                    n_occ_minus_1))
-                                                                  +
-                                                                  (nind *
-                                                                    n_occasions))
-                                                                 + 1);
-      const size_t num_gen_quantities = 1;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions))
+    + 1);
+      const size_t num_gen_quantities = emit_generated_quantities * 1;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -9499,7 +9490,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -9514,21 +9505,16 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + n_occasions) + M) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((M * phi_2dim__) + (M * n_occasions)) + n_occasions) + n_occasions) +
     (M * n_occasions));
-      const size_t num_gen_quantities = ((((1 + 1) +
-                                                                    n_occasions)
-                                                                   +
-                                                                   n_occasions)
-                                                                  +
-                                                                  (M *
-                                                                    n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 
+  ((((1 + 1) + n_occasions) + n_occasions) + (M * n_occasions));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -10196,7 +10182,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -10211,14 +10197,14 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (K + ((J * K) * K));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (I * K);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -10792,7 +10778,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -10807,14 +10793,14 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + N) + N);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (1 + N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -11774,7 +11760,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -11789,17 +11775,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + max_age);
-      const size_t num_transformed = (((nind *
-                                                          n_occ_minus_1) +
-                                                         (nind *
-                                                           n_occ_minus_1)) +
-                                                        (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -12187,7 +12170,7 @@ class function_in_function_inline_model final : public model_base_crtp<function_
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -12201,13 +12184,13 @@ class function_in_function_inline_model final : public model_base_crtp<function_
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -12697,7 +12680,7 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -12712,13 +12695,14 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (5 + 5);
-      const size_t num_transformed = (5 + 5);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (5 + 5);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -14286,7 +14270,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -14301,16 +14285,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((1 + 1) + n_occasions) + epsilon_1dim__) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((M * phi_2dim__) + (M * n_occasions)) + (M * n_occasions));
-      const size_t num_gen_quantities = 
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((1 + 1) + n_occasions) + 1) + n_occasions) + n_occasions) +
     (M * n_occasions));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -14640,7 +14624,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -14654,13 +14638,13 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -14980,7 +14964,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -14994,13 +14978,13 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -15345,7 +15329,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -15359,13 +15343,13 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = J;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -16240,7 +16224,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -16255,15 +16239,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + 1);
-      const size_t num_transformed = (((nind * n_occ_minus_1) +
-                                                   (nind * n_occ_minus_1)) +
-                                                  (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -16697,7 +16680,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -16711,14 +16694,14 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (1 + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -17407,7 +17390,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -17422,14 +17405,15 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = (R + (R * T));
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (R + (R * T));
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((1 + R) + R);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -18133,7 +18117,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -18148,14 +18132,14 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((((1 + J) + J) + 1) + 1) + 1) + 1) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((J + J) + N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -19083,7 +19067,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -19098,13 +19082,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((1 + 1) + (3 * 2)) + 2) + (2 * 2));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -19450,7 +19434,7 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -19464,13 +19448,13 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -20081,7 +20065,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -20096,13 +20080,13 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((n_pair + 2) + 1) + 1) + 1);
-      const size_t num_transformed = N;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * N;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -20598,7 +20582,7 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -20613,13 +20597,13 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((10 * 10) + (10 * 10));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -21213,7 +21197,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -21228,13 +21212,13 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + 1) + (I * K));
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -21617,7 +21601,7 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -21631,14 +21615,14 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (2 * 5);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22016,7 +22000,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22030,14 +22014,14 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((1 + 1) + 1) + 1) + 1) + 1);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22369,7 +22353,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22383,13 +22367,13 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 1;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 1;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -513,7 +513,7 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -528,18 +528,15 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (10 * 10);
-      const size_t num_transformed = (((((((10 * 10) +
-                                                         (10 * 10)) +
-                                                        (10 * 10)) +
-                                                       (10 * 10)) +
-                                                      (10 * 10)) + (10 * 10))
-                                                    + (10 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((((((10 * 10) + (10 * 10)) + (10 * 10)) + (10 * 10)) + (10 * 10)) +
+     (10 * 10)) + (10 * 10));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -1171,7 +1168,7 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -1186,13 +1183,14 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = (N_t * 4);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (N_t * 4);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2319,7 +2317,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2334,17 +2332,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + max_age);
-      const size_t num_transformed = (((nind *
-                                                          n_occ_minus_1) +
-                                                         (nind *
-                                                           n_occ_minus_1)) +
-                                                        (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -3295,7 +3290,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -3311,13 +3306,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       const size_t num_params__ = 
   (((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) + n_age)
        + n_edu) + n_region) + (n_age * n_edu)) + n_state);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -3657,7 +3652,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -3671,13 +3666,13 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4005,7 +4000,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4019,13 +4014,13 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4452,7 +4447,7 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4467,13 +4462,13 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((2 + 2) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4864,7 +4859,7 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4879,13 +4874,13 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((1 + J) + 1);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -5843,7 +5838,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -5859,13 +5854,13 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       const size_t num_params__ = 
   ((((((((((n_age + n_edu) + n_age_edu) + n_state) + n_region_full) + 5) + 1)
        + 1) + 1) + 1) + 1);
-      const size_t num_transformed = N;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * N;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6545,7 +6540,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6560,14 +6555,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + phi_std_raw_1dim__);
-      const size_t num_transformed = (1 + N);
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (1 + N);
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (((((((1 + 1) + 1) + 1) + N) + N) + N) + N);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -7698,7 +7694,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7713,21 +7709,15 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + nind) + 1);
-      const size_t num_transformed = ((((nind *
-                                                                    n_occ_minus_1)
-                                                                   +
-                                                                   (nind *
-                                                                    n_occ_minus_1))
-                                                                  +
-                                                                  (nind *
-                                                                    n_occasions))
-                                                                 + 1);
-      const size_t num_gen_quantities = 1;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions))
+    + 1);
+      const size_t num_gen_quantities = emit_generated_quantities * 1;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -9770,7 +9760,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -9785,21 +9775,16 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + n_occasions) + M) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((M * phi_2dim__) + (M * n_occasions)) + n_occasions) + n_occasions) +
     (M * n_occasions));
-      const size_t num_gen_quantities = ((((1 + 1) +
-                                                                    n_occasions)
-                                                                   +
-                                                                   n_occasions)
-                                                                  +
-                                                                  (M *
-                                                                    n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 
+  ((((1 + 1) + n_occasions) + n_occasions) + (M * n_occasions));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -10457,7 +10442,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -10472,14 +10457,14 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (K + ((J * K) * K));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (I * K);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -11055,7 +11040,7 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -11070,14 +11055,14 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + N) + N);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (1 + N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -12203,7 +12188,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -12218,17 +12203,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + max_age);
-      const size_t num_transformed = (((nind *
-                                                          n_occ_minus_1) +
-                                                         (nind *
-                                                           n_occ_minus_1)) +
-                                                        (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -12771,7 +12753,7 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -12786,13 +12768,14 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (5 + 5);
-      const size_t num_transformed = (5 + 5);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (5 + 5);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -14837,7 +14820,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -14852,16 +14835,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((1 + 1) + n_occasions) + epsilon_1dim__) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((M * phi_2dim__) + (M * n_occasions)) + (M * n_occasions));
-      const size_t num_gen_quantities = 
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((((((1 + 1) + n_occasions) + 1) + n_occasions) + n_occasions) +
     (M * n_occasions));
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -15191,7 +15174,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -15205,13 +15188,13 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -15530,7 +15513,7 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -15544,13 +15527,13 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -15893,7 +15876,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -15907,13 +15890,13 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = J;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -16958,7 +16941,7 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -16973,15 +16956,14 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + 1);
-      const size_t num_transformed = (((nind * n_occ_minus_1) +
-                                                   (nind * n_occ_minus_1)) +
-                                                  (nind * n_occasions));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((nind * n_occ_minus_1) + (nind * n_occ_minus_1)) + (nind * n_occasions));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -17454,7 +17436,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -17468,14 +17450,14 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 
   (1 + 1);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -18157,7 +18139,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -18172,14 +18154,15 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((1 + 1) + 1) + 1);
-      const size_t num_transformed = (R + (R * T));
-      const size_t num_gen_quantities = 
+      const size_t num_transformed = emit_transformed_parameters * 
+  (R + (R * T));
+      const size_t num_gen_quantities = emit_generated_quantities * 
   ((1 + R) + R);
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -18879,7 +18862,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -18894,14 +18877,14 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((((1 + J) + J) + 1) + 1) + 1) + 1) + 1);
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((J + J) + N);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -19795,7 +19778,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -19810,13 +19793,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((1 + 1) + (3 * 2)) + 2) + (2 * 2));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -20425,7 +20408,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -20440,13 +20423,13 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((((n_pair + 2) + 1) + 1) + 1);
-      const size_t num_transformed = N;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * N;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -20933,7 +20916,7 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -20948,13 +20931,13 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((10 * 10) + (10 * 10));
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -21545,7 +21528,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -21560,13 +21543,13 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((((1 + 1) + 1) + 1) + 1) + (I * K));
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -21949,7 +21932,7 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -21963,14 +21946,14 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (2 * 5);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22345,7 +22328,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22359,14 +22342,14 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 1;
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   (((((1 + 1) + 1) + 1) + 1) + 1);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -22698,7 +22681,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -22712,13 +22695,13 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                             bool emit_generated_quantities = true,
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 0;
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 1;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 1;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -292,7 +292,7 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -307,13 +307,14 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (10 * 10);
-      const size_t num_transformed = ((10 * 10) * 2);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((10 * 10) * 2);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2124,7 +2125,7 @@ class constraints_model final : public model_base_crtp<constraints_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2141,18 +2142,14 @@ class constraints_model final : public model_base_crtp<constraints_model> {
   (((((((((((((((((((((N + K) + Nr) + 2) + 1) + 1) + 1) + 1) + N) + N) + 1) +
               N) + N) + N) + N) + N) + N) + N) + (N * N)) + (N * N)) +
      (K * K)) + (K * K));
-      const size_t num_transformed = ((((((((1 + 1)
-                                                                    + N) +
-                                                                    Nr) + Nr)
-                                                                    + Nr) +
-                                                                   Nr) + Nr)
-                                                                 + Nr);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  ((((((((1 + 1) + N) + Nr) + Nr) + Nr) + Nr) + Nr) + Nr);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -2757,7 +2754,7 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -2772,18 +2769,15 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (10 * 10);
-      const size_t num_transformed = (((((((10 * 10) +
-                                                         (10 * 10)) +
-                                                        (10 * 10)) +
-                                                       (10 * 10)) +
-                                                      (10 * 10)) + (10 * 10))
-                                                    + (10 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((((((10 * 10) + (10 * 10)) + (10 * 10)) + (10 * 10)) + (10 * 10)) +
+     (10 * 10)) + (10 * 10));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -4647,7 +4641,7 @@ udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -4664,14 +4658,14 @@ udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
   ((((((((((((((((((((1 + M) + (N * M)) + (10 * N)) + (N * M)) + N) +
                   (N * M)) + N) + N) + N) + (N * M)) + M) + M) + M) + M) +
          (N * M)) + (N * M)) + (N * M)) + (N * M)) + (N * M)) + (N * M));
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((((1 + M) + M) + M) + M);
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -5098,7 +5092,7 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -5113,13 +5107,13 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (1 + 10);
-      const size_t num_transformed = 0;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -5726,7 +5720,7 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -5741,14 +5735,14 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   (((5 * 10) + (5 * 10)) + (5 * 10));
-      const size_t num_transformed = 
+      const size_t num_transformed = emit_transformed_parameters * 
   ((1 + (5 * 10)) + (5 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6375,7 +6369,7 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6390,21 +6384,14 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((10 * 10) + (10 * 10));
-      const size_t num_transformed = (((((10 * 10)
-                                                                    +
-                                                                    (10 * 10))
-                                                                    +
-                                                                    (10 * 10))
-                                                                   +
-                                                                   (10 * 10))
-                                                                  +
-                                                                  (10 * 10));
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (((((10 * 10) + (10 * 10)) + (10 * 10)) + (10 * 10)) + (10 * 10));
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -6850,7 +6837,7 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -6865,13 +6852,13 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((10 * 10) + (10 * 10));
-      const size_t num_transformed = 1;
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 1;
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 
@@ -7380,7 +7367,7 @@ const
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
       std::vector<int> params_i;
-      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write, 
+      vars = Eigen::Matrix<double, Eigen::Dynamic, 1>::Constant(num_to_write,
         std::numeric_limits<double>::quiet_NaN());
       write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
@@ -7395,13 +7382,14 @@ const
                             std::ostream* pstream = nullptr) const {
       const size_t num_params__ = 
   ((5 * 10) + (5 * 10));
-      const size_t num_transformed = (5 * 10);
-      const size_t num_gen_quantities = 0;
+      const size_t num_transformed = emit_transformed_parameters * 
+  (5 * 10);
+      const size_t num_gen_quantities = emit_generated_quantities * 0;
       const size_t num_to_write = num_params__ + num_transformed +
         num_gen_quantities;
-      vars = std::vector<double>(num_to_write, 
-        std::numeric_limits<double>::quiet_NaN());        
-      write_array_impl(base_rng, params_r, params_i, vars, 
+      vars = std::vector<double>(num_to_write,
+        std::numeric_limits<double>::quiet_NaN());
+      write_array_impl(base_rng, params_r, params_i, vars,
         emit_transformed_parameters, emit_generated_quantities, pstream);
     }
 


### PR DESCRIPTION
Fixes the issue spotted in #1165 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made
    
## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
