### PR TITLE
Update nix files to use ocaml 4.12

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,16 @@
 with (import (builtins.fetchTarball {
-  name = "nixpkgs-19.09";
-  # Tarball of tagged release of Nixpkgs 19.09
-  url = "https://github.com/NixOS/nixpkgs/archive/19.09.tar.gz";
+  name = "nixpkgs-21.11";
+  # Tarball of tagged release of Nixpkgs 21.11
+  url = "https://github.com/NixOS/nixpkgs/archive/21.11.tar.gz";
   # Tarball hash obtained using `nix-prefetch-url --unpack <url>`
-  sha256 = "0mhqhq21y5vrr1f30qd2bvydv4bbbslvyzclhw0kdxmkgg3z4c92";
+  sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
 }) {});
 
 
 ocamlPackages.buildDunePackage rec {
   pname = "stanc";
-  version = "2.23.0";
-  
+  version = "2.29.0";
+
   # Only depend on necessary files to minimize rebuilds
   src = lib.sourceByRegex ./. [ "^src.*$" "^dune-project$" "^stanc\.opam$" ];
 
@@ -25,6 +25,7 @@ ocamlPackages.buildDunePackage rec {
   buildInputs = with ocamlPackages; [
     yojson
     menhir
+    menhirLib
     core_kernel
     ppx_jane
     ppx_deriving
@@ -37,7 +38,7 @@ ocamlPackages.buildDunePackage rec {
   meta = {
     homepage = https://github.com/stan-dev/stanc3;
     description = "The Stan transpiler (from Stan to C++ and beyond)";
-    license = stdenv.lib.licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ rybern ];
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,6 @@ with (import (builtins.fetchTarball {
   sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
 }) {});
 
-
 ocamlPackages.buildDunePackage rec {
   pname = "stanc";
   version = "2.29.0";
@@ -19,10 +18,16 @@ ocamlPackages.buildDunePackage rec {
 
   # Set to true and add the src regex "^test.*$" to run tests on every build
   doCheck = false;
+  # doCheck = true;
+
+  buildPhase = ''dune build -p stanc'';
 
   useDune2 = true;
 
   buildInputs = with ocamlPackages; [
+    stdenv
+    dune_2
+    ocaml
     yojson
     menhir
     menhirLib

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,11 @@
 let derivation = import ./default.nix; in
 
 with (import (builtins.fetchTarball {
-  name = "nixpkgs-19.09";
-  # Tarball of tagged release of Nixpkgs 19.09
-  url = "https://github.com/NixOS/nixpkgs/archive/19.09.tar.gz";
+  name = "nixpkgs-21.11";
+  # Tarball of tagged release of Nixpkgs 21.11
+  url = "https://github.com/NixOS/nixpkgs/archive/21.11.tar.gz";
   # Tarball hash obtained using `nix-prefetch-url --unpack <url>`
-  sha256 = "0mhqhq21y5vrr1f30qd2bvydv4bbbslvyzclhw0kdxmkgg3z4c92";
+  sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
 }) {});
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
This was never done following #1019. I briefly tested inside the nix-os docker containers to confirm that it now builds stanc again.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
