### PR TITLE
Initialize complex types to NaN for both components

### DIFF
--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -66,15 +66,18 @@ let rec pp_initialize ppf (st, adtype) =
     | SComplex ->
         let scalar = local_scalar (SizedType.to_unsized st) adtype in
         pf ppf "std::complex<%s>(%s, %s)" scalar init_nan init_nan
-    | SVector (AoS, size)
-     |SRowVector (AoS, size)
-     |SComplexVector size
-     |SComplexRowVector size ->
+    | SVector (AoS, size) | SRowVector (AoS, size) ->
         pf ppf "@[<hov 2>%a::Constant(@,%a,@ %s)@]" pp_st (st, adtype) pp_expr
           size init_nan
-    | SMatrix (AoS, d1, d2) | SComplexMatrix (d1, d2) ->
+    | SComplexVector size | SComplexRowVector size ->
+        pf ppf "@[<hov 2>%a::Constant(@,%a,@ %a)@]" pp_st (st, adtype) pp_expr
+          size pp_initialize (SComplex, adtype)
+    | SMatrix (AoS, d1, d2) ->
         pf ppf "@[<hov 2>%a::Constant(@,%a,@ %a,@ %s)@]" pp_st (st, adtype)
           pp_expr d1 pp_expr d2 init_nan
+    | SComplexMatrix (d1, d2) ->
+        pf ppf "@[<hov 2>%a::Constant(@,%a,@ %a,@ %a)@]" pp_st (st, adtype)
+          pp_expr d1 pp_expr d2 pp_initialize (SComplex, adtype)
     | SVector (SoA, size) ->
         pf ppf "@[<hov 2>%a(@,%a)@]" pp_possibly_var_decl (adtype, ut, SoA)
           pp_initialize

--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -43,15 +43,18 @@ let rec pp_initialize ppf (st, adtype) =
     | SComplex ->
         let scalar = local_scalar (SizedType.to_unsized st) adtype in
         pf ppf "@[<hov 2>std::complex<%s>(%s,@ %s)@]" scalar init_nan init_nan
-    | SComplexVector size
-     |SComplexRowVector size
-     |SVector (_, size)
-     |SRowVector (_, size) ->
+    | SComplexVector size | SComplexRowVector size ->
+        pf ppf "@[<hov 2>%a::Constant(@,%a,@ %a)@]" pp_st (st, adtype) pp_expr
+          size pp_initialize (SComplex, adtype)
+    | SVector (_, size) | SRowVector (_, size) ->
         pf ppf "@[<hov 2>%a::Constant(@,%a,@ %s)@]" pp_st (st, adtype) pp_expr
           size init_nan
-    | SMatrix (_, d1, d2) | SComplexMatrix (d1, d2) ->
+    | SMatrix (_, d1, d2) ->
         pf ppf "@[<hov 2>%a::Constant(@,%a,@ %a,@ %s)@]" pp_st (st, adtype)
           pp_expr d1 pp_expr d2 init_nan
+    | SComplexMatrix (d1, d2) ->
+        pf ppf "@[<hov 2>%a::Constant(@,%a,@ %a,@ %a)@]" pp_st (st, adtype)
+          pp_expr d1 pp_expr d2 pp_initialize (SComplex, adtype)
     | SArray (t, d) ->
         pf ppf "@[<hov 2>%a(@,%a,@ @,%a)@]" pp_st (st, adtype) pp_expr d
           pp_initialize (t, adtype)

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -243,19 +243,19 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     try {
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> cmat =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-           N, DUMMY_VAR__);
+           N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 1;
       cmat = in__.template read<
                Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>>(N, N);
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> cvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 2;
       cvec = in__.template read<
                Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>>(N);
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> crowvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 3;
       crowvec = in__.template read<
                   Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>>(N);
@@ -280,7 +280,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       r = in__.template read<local_scalar_t__>();
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> tp_c_matrix =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-           N, DUMMY_VAR__);
+           N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 14;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, cmat),
         "assigning variable tp_c_matrix");
@@ -393,7 +393,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
         "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> tp_c_vector =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(crowvec),
         "assigning variable tp_c_vector");
@@ -496,7 +496,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
         "assigning variable tp_c_vector");
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> tp_c_rowvector =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvec),
         "assigning variable tp_c_rowvector");
@@ -1302,7 +1302,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       pos__ = 1;
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> cmat =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-           N, DUMMY_VAR__);
+           N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
           stan::model::assign(cmat, in__.read<local_scalar_t__>(),
@@ -1313,7 +1313,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       out__.write(cmat);
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> cvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         stan::model::assign(cvec, in__.read<local_scalar_t__>(),
           "assigning variable cvec", stan::model::index_uni(sym1__));
@@ -1321,7 +1321,7 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       out__.write(cvec);
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> crowvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         stan::model::assign(crowvec, in__.read<local_scalar_t__>(),
           "assigning variable crowvec", stan::model::index_uni(sym1__));
@@ -3381,19 +3381,19 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     try {
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> cvmat =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-           N, DUMMY_VAR__);
+           N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 1;
       cvmat = in__.template read<
                 Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>>(N, N);
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> cvvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 2;
       cvvec = in__.template read<
                 Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>>(N);
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> cvrowvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 3;
       cvrowvec = in__.template read<
                    Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>>(N);
@@ -3419,7 +3419,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       v = in__.template read<local_scalar_t__>();
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> tp_c_matrix =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-           N, DUMMY_VAR__);
+           N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 14;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, cvmat),
         "assigning variable tp_c_matrix");
@@ -3525,7 +3525,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> tp_c_vector =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(cvrowvec),
         "assigning variable tp_c_vector");
@@ -3624,7 +3624,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         "assigning variable tp_c_vector");
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> tp_c_rowvector =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvvec),
         "assigning variable tp_c_rowvector");
@@ -4558,7 +4558,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       pos__ = 1;
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> cvmat =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-           N, DUMMY_VAR__);
+           N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
           stan::model::assign(cvmat, in__.read<local_scalar_t__>(),
@@ -4569,7 +4569,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       out__.write(cvmat);
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> cvvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         stan::model::assign(cvvec, in__.read<local_scalar_t__>(),
           "assigning variable cvvec", stan::model::index_uni(sym1__));
@@ -4577,7 +4577,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       out__.write(cvvec);
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> cvrowvec =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         stan::model::assign(cvrowvec, in__.read<local_scalar_t__>(),
           "assigning variable cvrowvec", stan::model::index_uni(sym1__));
@@ -8374,14 +8374,14 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     try {
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> z =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(3,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 1;
       stan::model::assign(z, (Eigen::Matrix<std::complex<double>,-1,1>(3) <<
         stan::math::to_complex(3, 0), stan::math::to_complex(0, 4),
         stan::math::to_complex(4, 0)).finished(), "assigning variable z");
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> zs =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(2,
-           2, DUMMY_VAR__);
+           2, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 2;
       stan::model::assign(zs, stan::math::to_matrix(
         std::vector<Eigen::Matrix<std::complex<double>, 1, -1>>{
@@ -8398,7 +8398,7 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         2).finished(), "assigning variable x");
       Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> zx =
          Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(2,
-           DUMMY_VAR__);
+           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 4;
       stan::model::assign(zx, x, "assigning variable zx");
     } catch (const std::exception& e) {
@@ -9121,7 +9121,7 @@ class user_function_templating_model final : public model_base_crtp<user_functio
         stan::math::validate_non_negative_index("x", "N", N);
         Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> x =
            Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(N,
-             N, DUMMY_VAR__);
+             N, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
         current_statement__ = 4;
         stan::model::assign(x, foo(stan::model::deep_copy(x), pstream__),
           "assigning variable x");
@@ -9129,7 +9129,7 @@ class user_function_templating_model final : public model_base_crtp<user_functio
         stan::math::validate_non_negative_index("y", "N", N);
         Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1> y =
            Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>::Constant(N,
-             DUMMY_VAR__);
+             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
         current_statement__ = 7;
         stan::model::assign(y, foo(stan::model::deep_copy(y), pstream__),
           "assigning variable y");
@@ -9137,7 +9137,7 @@ class user_function_templating_model final : public model_base_crtp<user_functio
         stan::math::validate_non_negative_index("z", "N", N);
         Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1> z =
            Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>::Constant(N,
-             DUMMY_VAR__);
+             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
         current_statement__ = 10;
         stan::model::assign(z, foo(stan::model::deep_copy(z), pstream__),
           "assigning variable z");
@@ -9149,7 +9149,8 @@ class user_function_templating_model final : public model_base_crtp<user_functio
            std::vector<Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>>(
              2, 
              Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(
-               N, N, DUMMY_VAR__));
+               N, N,
+               std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
         current_statement__ = 13;
         stan::model::assign(w,
           foo(

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -759,19 +759,22 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     try {
       Eigen::Matrix<std::complex<double>, -1, -1> cmat =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 1;
       cmat = in__.template read<
                Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>>(N, N);
       Eigen::Matrix<std::complex<double>, -1, 1> cvec =
          Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 2;
       cvec = in__.template read<
                Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>>(N);
       Eigen::Matrix<std::complex<double>, 1, -1> crowvec =
          Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 3;
       crowvec = in__.template read<
                   Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>>(N);
@@ -800,13 +803,16 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       r = in__.template read<local_scalar_t__>();
       Eigen::Matrix<std::complex<double>, -1, -1> tp_c_matrix =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       Eigen::Matrix<std::complex<double>, -1, 1> tp_c_vector =
          Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       Eigen::Matrix<std::complex<double>, 1, -1> tp_c_rowvector =
          Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       std::complex<double> tp_c =
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
@@ -1917,7 +1923,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
             static_cast<size_t>(N), static_cast<size_t>(2)});
       cmat_data__ = 
         Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&cmat) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, -1>>(cmat_data__.data(), N, N);
         
       
@@ -1948,7 +1955,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
             static_cast<size_t>(2)});
       cvec_data__ = 
         Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&cvec) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, 1>>(cvec_data__.data(), N);
         
       
@@ -1975,7 +1983,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
             static_cast<size_t>(2)});
       crowvec_data__ = 
         Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&crowvec) Eigen::Map<Eigen::Matrix<std::complex<double>, 1, -1>>(crowvec_data__.data(), N);
         
       
@@ -2177,7 +2186,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       } 
       Eigen::Matrix<std::complex<double>, -1, -1> gq_c_matrix =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 2;
       stan::model::assign(gq_c_matrix, stan::math::multiply(cmat, cmat),
         "assigning variable gq_c_matrix");
@@ -2288,7 +2298,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         "assigning variable gq_c_matrix");
       Eigen::Matrix<std::complex<double>, -1, 1> gq_c_vector =
          Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 28;
       stan::model::assign(gq_c_vector, stan::math::transpose(crowvec),
         "assigning variable gq_c_vector");
@@ -2389,7 +2400,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         "assigning variable gq_c_vector");
       Eigen::Matrix<std::complex<double>, 1, -1> gq_c_rowvector =
          Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 52;
       stan::model::assign(gq_c_rowvector, stan::math::transpose(cvec),
         "assigning variable gq_c_rowvector");
@@ -3130,7 +3142,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
             static_cast<size_t>(N), static_cast<size_t>(2)});
       cmat_data__ = 
         Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&cmat) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, -1>>(cmat_data__.data(), N, N);
         
       
@@ -3161,7 +3174,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
             static_cast<size_t>(2)});
       cvec_data__ = 
         Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&cvec) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, 1>>(cvec_data__.data(), N);
         
       
@@ -3188,7 +3202,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
             static_cast<size_t>(2)});
       crowvec_data__ = 
         Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&crowvec) Eigen::Map<Eigen::Matrix<std::complex<double>, 1, -1>>(crowvec_data__.data(), N);
         
       
@@ -3941,19 +3956,22 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     try {
       Eigen::Matrix<std::complex<double>, -1, -1> cvmat =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 1;
       cvmat = in__.template read<
                 Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>>(N, N);
       Eigen::Matrix<std::complex<double>, -1, 1> cvvec =
          Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 2;
       cvvec = in__.template read<
                 Eigen::Matrix<std::complex<local_scalar_t__>, -1, 1>>(N);
       Eigen::Matrix<std::complex<double>, 1, -1> cvrowvec =
          Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 3;
       cvrowvec = in__.template read<
                    Eigen::Matrix<std::complex<local_scalar_t__>, 1, -1>>(N);
@@ -3983,13 +4001,16 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       v = in__.template read<local_scalar_t__>();
       Eigen::Matrix<std::complex<double>, -1, -1> tp_c_matrix =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       Eigen::Matrix<std::complex<double>, -1, 1> tp_c_vector =
          Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       Eigen::Matrix<std::complex<double>, 1, -1> tp_c_rowvector =
          Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       std::complex<double> tp_c =
          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
            std::numeric_limits<double>::quiet_NaN());
@@ -5059,7 +5080,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
             static_cast<size_t>(2)});
       z1_data__ = 
         Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&z1) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, 1>>(z1_data__.data(), N);
         
       
@@ -5086,7 +5108,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
             static_cast<size_t>(2)});
       z2_data__ = 
         Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&z2) Eigen::Map<Eigen::Matrix<std::complex<double>, 1, -1>>(z2_data__.data(), N);
         
       
@@ -5115,7 +5138,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
             static_cast<size_t>(N), static_cast<size_t>(2)});
       z3_data__ = 
         Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&z3) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, -1>>(z3_data__.data(), N, N);
         
       
@@ -5184,7 +5208,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
       z5 = 
         std::vector<Eigen::Matrix<std::complex<double>, -1, 1>>(M, 
           Eigen::Matrix<std::complex<double>, -1, 1>::Constant(N,
-            std::numeric_limits<double>::quiet_NaN()));
+            std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+              std::numeric_limits<double>::quiet_NaN())));
       
       
       {
@@ -5217,7 +5242,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
       z6 = 
         std::vector<Eigen::Matrix<std::complex<double>, 1, -1>>(M, 
           Eigen::Matrix<std::complex<double>, 1, -1>::Constant(N,
-            std::numeric_limits<double>::quiet_NaN()));
+            std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+              std::numeric_limits<double>::quiet_NaN())));
       
       
       {
@@ -5253,7 +5279,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
       z7 = 
         std::vector<Eigen::Matrix<std::complex<double>, -1, -1>>(M, 
           Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, N,
-            std::numeric_limits<double>::quiet_NaN()));
+            std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+              std::numeric_limits<double>::quiet_NaN())));
       
       
       {
@@ -5289,7 +5316,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
             static_cast<size_t>(M), static_cast<size_t>(2)});
       z8_data__ = 
         Eigen::Matrix<std::complex<double>, -1, -1>::Constant(N, M,
-          std::numeric_limits<double>::quiet_NaN());
+          std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN()));
       new (&z8) Eigen::Map<Eigen::Matrix<std::complex<double>, -1, -1>>(z8_data__.data(), N, M);
         
       
@@ -8407,16 +8435,19 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     try {
       Eigen::Matrix<std::complex<double>, -1, 1> z =
          Eigen::Matrix<std::complex<double>, -1, 1>::Constant(3,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       Eigen::Matrix<std::complex<double>, -1, -1> zs =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(2, 2,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       Eigen::Matrix<double, 1, -1> x =
          Eigen::Matrix<double, 1, -1>::Constant(2,
            std::numeric_limits<double>::quiet_NaN());
       Eigen::Matrix<std::complex<double>, 1, -1> zx =
          Eigen::Matrix<std::complex<double>, 1, -1>::Constant(2,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       if (stan::math::logical_negation((stan::math::primitive_value(
             emit_transformed_parameters__) || stan::math::primitive_value(
             emit_generated_quantities__)))) {

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -81,7 +81,7 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
               10);
       Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1> A_complex_tp =
          Eigen::Matrix<std::complex<local_scalar_t__>, -1, -1>::Constant(10,
-           10, DUMMY_VAR__);
+           10, std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 2;
       stan::model::assign(A_complex_tp, A_p,
         "assigning variable A_complex_tp");

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -125,7 +125,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
               10);
       Eigen::Matrix<std::complex<double>, -1, -1> A_complex_tp =
          Eigen::Matrix<std::complex<double>, -1, -1>::Constant(10, 10,
-           std::numeric_limits<double>::quiet_NaN());
+           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
+             std::numeric_limits<double>::quiet_NaN()));
       out__.write(A_p);
       if (stan::math::logical_negation((stan::math::primitive_value(
             emit_transformed_parameters__) || stan::math::primitive_value(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

This tweaks code gen slightly to initialize empty complex Eigen types to have `nan` for both the real and imaginary portions. 

Currently, the model:
```stan
transformed data {
   complex_vector[1] Z;
}

model {
   print(Z[1]);
}
```

prints `(nan, 0)`. This PR makes that `(nan, nan)`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
