### PR TITLE
Allow driver code to set printed argument list in generated hpp

### DIFF
--- a/src/stan_math_backend/Stan_math_code_gen.ml
+++ b/src/stan_math_backend/Stan_math_code_gen.ml
@@ -26,17 +26,8 @@ open Function_gen
 
 let standalone_functions = ref false
 
-let stanc_args_to_print =
-  let sans_model_and_hpp_paths x =
-    not
-      String.(
-        is_suffix ~suffix:".stan" x
-        && not (is_prefix ~prefix:"--filename-in-msg" x)
-        || is_prefix ~prefix:"--o" x) in
-  (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
-  Array.to_list Sys.argv |> List.tl_exn
-  |> List.filter ~f:sans_model_and_hpp_paths
-  |> String.concat ~sep:" "
+(* set by drivers *)
+let stanc_args_to_print = ref ""
 
 (** Print name of model function.
   @param prog_name Name of the Stan program.
@@ -622,7 +613,7 @@ let pp_model ppf ({Program.prog_name; _} as p) =
     return std::vector<std::string>{"stanc_version = %s", "stancflags = %s"};
   }
   |}
-    "%%NAME%%3 %%VERSION%%" stanc_args_to_print ;
+    "%%NAME%%3 %%VERSION%%" !stanc_args_to_print ;
   pf ppf "@ %a@]@]@ };" pp_model_public p
 
 let usings =

--- a/src/stan_math_backend/Stan_math_code_gen.mli
+++ b/src/stan_math_backend/Stan_math_code_gen.mli
@@ -3,6 +3,11 @@ val model_prefix : string
     Currently "model_"
   *)
 
+val stanc_args_to_print : string ref
+(** A string containing the arguments used to produce this .hpp
+    Set by the drivers 
+*)
+
 val standalone_functions : bool ref
 (** Flag to generate just function code, used in RStan *)
 

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -359,6 +359,18 @@ let main () =
       Format.std_formatter () ;
     exit 0 ) ;
   if !model_file = "" then model_file_err () ;
+  let stanc_args_to_print =
+    let sans_model_and_hpp_paths x =
+      not
+        String.(
+          is_suffix ~suffix:".stan" x
+          && not (is_prefix ~prefix:"--filename-in-msg" x)
+          || is_prefix ~prefix:"--o" x) in
+    (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
+    Array.to_list Sys.argv |> List.tl_exn
+    |> List.filter ~f:sans_model_and_hpp_paths
+    |> String.concat ~sep:" " in
+  Stan_math_code_gen.stanc_args_to_print := stanc_args_to_print ;
   (* if we only have functions, always compile as standalone *)
   if String.is_suffix !model_file ~suffix:".stanfunctions" then (
     Stan_math_code_gen.standalone_functions := true ;

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -189,7 +189,8 @@ let stan2cpp_wrapped name code (flags : Js.string_array Js.t Js.opt) =
     |> Option.map ~f:Array.to_list
     |> Option.value ~default:[]
     |> List.filter ~f:sans_model_and_hpp_paths
-    |> String.concat ~sep:", " in
+    |> List.map ~f:(fun o -> "--" ^ o)
+    |> String.concat ~sep:" " in
   Stan_math_code_gen.stanc_args_to_print := stanc_args_to_print ;
   let result, warnings, pedantic_mode_warnings =
     stan2cpp (Js.to_string name) (Js.to_string code) is_flag_set flag_val in

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -177,6 +177,20 @@ let stan2cpp_wrapped name code (flags : Js.string_array Js.t Js.opt) =
       Array.find flags ~f:(String.is_prefix ~prefix)
       >>= String.chop_prefix ~prefix) in
   let printed_filename = flag_val "filename-in-msg" in
+  let stanc_args_to_print =
+    let sans_model_and_hpp_paths x =
+      not
+        String.(
+          is_suffix ~suffix:".stan" x
+          && not (is_prefix ~prefix:"filename-in-msg" x)
+          || is_prefix ~prefix:"o=" x) in
+    (* Ignore the "--o" arg, the stan file and the binary name (bin/stanc). *)
+    flags
+    |> Option.map ~f:Array.to_list
+    |> Option.value ~default:[]
+    |> List.filter ~f:sans_model_and_hpp_paths
+    |> String.concat ~sep:", " in
+  Stan_math_code_gen.stanc_args_to_print := stanc_args_to_print ;
   let result, warnings, pedantic_mode_warnings =
     stan2cpp (Js.to_string name) (Js.to_string code) is_flag_set flag_val in
   let warnings =

--- a/test/stancjs/optimization.js
+++ b/test/stancjs/optimization.js
@@ -104,4 +104,4 @@ var ind = opencl_test.result.search("matrix_cl<int> y_opencl__");
 console.assert(ind > -1, "ERROR: No OpenCL code found with the use-opencl flag!")
 
 // test that the stanc flags are placed in the model correctly
-console.log(opencl_test.result.match(/stancflags = .*"/)[0])
+console.log(opencl_test.result.match(/"stancflags = .*"/)[0])

--- a/test/stancjs/optimization.js
+++ b/test/stancjs/optimization.js
@@ -103,3 +103,5 @@ utils.print_error(opencl_test)
 var ind = opencl_test.result.search("matrix_cl<int> y_opencl__");
 console.assert(ind > -1, "ERROR: No OpenCL code found with the use-opencl flag!")
 
+// test that the stanc flags are placed in the model correctly
+console.log(opencl_test.result.match(/stancflags = .*"/)[0])

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -243,6 +243,7 @@ Semantic error in 'string', line 3, column 8 to column 11:
 
 Function is declared without specifying a definition.
 
+stancflags = --use-opencl --allow-undefined"
 $ node pedantic.js
 ["Warning in 'string', line 7, column 17: Argument 10000 suggests there may be\n    parameters that are not unit scale; consider rescaling with a multiplier\n    (see manual section 22.12).","Warning: The parameter k was declared but was not used in the density\n    calculation."]
 []

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -243,7 +243,7 @@ Semantic error in 'string', line 3, column 8 to column 11:
 
 Function is declared without specifying a definition.
 
-stancflags = --use-opencl --allow-undefined"
+"stancflags = --use-opencl --allow-undefined"
 $ node pedantic.js
 ["Warning in 'string', line 7, column 17: Argument 10000 suggests there may be\n    parameters that are not unit scale; consider rescaling with a multiplier\n    (see manual section 22.12).","Warning: The parameter k was declared but was not used in the density\n    calculation."]
 []


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

The generated `model_compile_info` will now feature arguments  passed in from stancjs


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
