### PR TITLE
Add get_param_names overload with flag arguments

### DIFF
--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -156,6 +156,22 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1549,6 +1549,23 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha_v", "beta", "cuts", "sigma",
+      "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1371,6 +1371,27 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"cmat", "cvec", "crowvec", "z", "mat",
+      "vec", "rowvec", "r"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_c_matrix", "tp_c_vector",
+        "tp_c_rowvector", "tp_c", "carray"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -2654,6 +2675,26 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     
     names__ = std::vector<std::string>{"gq_c_matrix", "gq_c_vector",
       "gq_c_rowvector", "gq_c", "carray"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"gq_c_matrix", "gq_c_vector",
+        "gq_c_rowvector", "gq_c", "carray"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -4627,6 +4668,27 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"cvmat", "cvvec", "cvrowvec", "zv",
+      "vmat", "vvec", "vrowvec", "v"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_c_matrix", "tp_c_vector",
+        "tp_c_rowvector", "tp_c", "carray"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -5434,6 +5496,22 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -7957,6 +8035,32 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_r", "p_complex", "p_complex_array",
+      "p_complex_array_2d"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_r", "tp_complex",
+        "tp_complex_array", "tp_complex_array_2d"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"gq_i", "gq_r", "gq_complex",
+        "gq_complex_array", "gq_complex_array_2d", "z", "y", "i_arr",
+        "i_arr_1", "zi", "yi", "x"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -8508,6 +8612,25 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"z", "zs", "x", "zx"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"z", "zs", "x", "zx"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -9225,6 +9348,22 @@ class user_function_templating_model final : public model_base_crtp<user_functio
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -263,6 +263,25 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "tau", "theta_tilde"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"theta"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -612,6 +631,22 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"bar"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"bar"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -1630,6 +1665,30 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"explicit", "float", "friend", "goto",
+      "inline", "long", "mutable", "namespace", "new", "noexcept", "not",
+      "not_eq", "nullptr", "operator", "or"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"throw", "try", "typeid", "typename",
+        "union", "unsigned", "using", "virtual", "volatile", "wchar_t",
+        "xor", "xor_eq", "fvar", "STAN_MAJOR", "STAN_MINOR", "STAN_PATCH",
+        "STAN_MATH_MAJOR", "STAN_MATH_MINOR", "STAN_MATH_PATCH"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -2143,6 +2202,25 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "tau", "theta_tilde"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"theta"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -2556,6 +2634,25 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"xx", "y", "w", "td_arr33"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"xx"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y", "w", "td_arr33"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -10730,6 +10827,43 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_real", "p_upper", "p_lower",
+      "offset_multiplier", "no_offset_multiplier", "offset_no_multiplier",
+      "p_real_1d_ar", "p_real_3d_ar", "p_vec", "p_1d_vec", "p_3d_vec",
+      "p_row_vec", "p_1d_row_vec", "p_3d_row_vec", "p_mat", "p_ar_mat",
+      "p_simplex", "p_1d_simplex", "p_3d_simplex", "p_cfcov_54",
+      "p_cfcov_33", "p_cfcov_33_ar", "x_p", "y_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_real_1d_ar", "tp_real_3d_ar",
+        "tp_vec", "tp_1d_vec", "tp_3d_vec", "tp_row_vec", "tp_1d_row_vec",
+        "tp_3d_row_vec", "tp_mat", "tp_ar_mat", "tp_simplex",
+        "tp_1d_simplex", "tp_3d_simplex", "tp_cfcov_54", "tp_cfcov_33",
+        "tp_cfcov_33_ar", "theta_p", "tp_real"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"gq_r1", "gq_r2", "gq_real_1d_ar",
+        "gq_real_3d_ar", "gq_vec", "gq_1d_vec", "gq_3d_vec", "gq_row_vec",
+        "gq_1d_row_vec", "gq_3d_row_vec", "gq_ar_mat", "gq_simplex",
+        "gq_1d_simplex", "gq_3d_simplex", "gq_cfcov_54", "gq_cfcov_33",
+        "gq_cfcov_33_ar", "indices", "indexing_mat", "idx_res1", "idx_res2",
+        "idx_res3", "idx_res11", "idx_res21", "idx_res31", "idx_res4",
+        "idx_res5"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -13809,6 +13943,32 @@ const
       "y_hat_tp1", "y_hat_tp2", "y_hat_tp3", "theta_p_as", "x_v", "y_v",
       "y_p", "y_hat", "y_1d", "z_1d", "abc1_gq", "abc2_gq", "y_hat_gq",
       "yy_hat_gq", "theta_dbl"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y0_p", "theta_p", "x_p", "x_p_v",
+      "shared_params_p", "job_params_p", "x_r"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"abc1_p", "abc2_p", "abc3_p",
+        "y_hat_tp1", "y_hat_tp2", "y_hat_tp3", "theta_p_as", "x_v", "y_v",
+        "y_p"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"y_hat", "y_1d", "z_1d", "abc1_gq",
+        "abc2_gq", "y_hat_gq", "yy_hat_gq", "theta_dbl"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -18592,6 +18752,28 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"r", "ra", "v"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"zg"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -19272,6 +19454,26 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     
     names__ = std::vector<std::string>{"alpha", "beta", "gamma", "delta",
       "z_init", "sigma", "z"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha", "beta", "gamma", "delta",
+      "z_init", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -20934,6 +21136,23 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha_v", "beta", "cuts", "sigma",
+      "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -21799,6 +22018,22 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y", "z"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -22206,6 +22441,22 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"L_Omega", "z1"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -22563,6 +22814,22 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -22959,6 +23226,25 @@ ident_functor__::operator()(const std::complex<T0__>& x,
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"z", "zi", "zs", "x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"z", "zi", "zs", "x"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -23756,6 +24042,25 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"gamma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"z_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -24346,6 +24651,22 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"y1", "y2", "y3"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y1", "y2", "y3"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -26659,6 +26980,23 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     
     names__ = std::vector<std::string>{"a8", "a7", "a6", "a5", "a4", "a3",
       "a2", "a1", "y8", "y7", "y6", "y5", "y4", "y3", "y2", "y1"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a8", "a7", "a6", "a5", "a4", "a3",
+      "a2", "a1", "y8", "y7", "y6", "y5", "y4", "y3", "y2", "y1"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -30962,6 +31300,29 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y1", "y2", "y3", "y4", "y5", "y6",
+      "y7", "y8", "y9", "y10", "y11", "y12", "y17"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"t1", "t1a", "t2", "t3", "t4", "t5",
+        "t6", "t7", "t8", "t9", "t10", "t11", "t12", "tg1", "tg2", "tg3",
+        "tg4", "tg5", "tg6", "tg7", "tg8", "tg9", "tg10", "tg11", "tg12",
+        "tgs"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -32227,6 +32588,33 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"e", "pi", "log2", "log10", "sqrt2",
+      "not_a_number", "positive_infinity", "negative_infinity",
+      "machine_precision", "inv_logit", "logit", "num_elements", "pow",
+      "add", "sub", "multiply", "binomial_coefficient_log",
+      "read_constrain_lb", "read", "validate_non_negative_index", "length",
+      "validate_positive_index", "profile_map", "assign", "rvalue",
+      "stan_print", "model_base_crtp", "index_uni",
+      "bernoulli_logit_glm_lpmf", "reduce_sum", "segment", "ode_bdf",
+      "ode_bdf_tol"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"mu", "called", "result"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -32863,6 +33251,22 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -33218,6 +33622,22 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"x"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -35316,6 +35736,29 @@ class transform_model final : public model_base_crtp<transform_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_1", "p_2", "p_3", "p_4", "p_5",
+      "p_6", "p_7", "p_8", "p_9", "p_10", "pv_1", "pv_2", "pv_3", "pr_1",
+      "pr_2", "pr_3", "pm_1", "pm_2"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_1", "tp_2", "tp_3", "tp_4", "tp_5",
+        "tp_6", "tp_7", "tp_8", "tp_9", "tp_10", "tpv_1", "tpv_2", "tpv_3",
+        "tpr_1", "tpr_2", "tpr_3", "tpm_1", "tpm_2"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -36374,6 +36817,22 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"m", "y"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -36729,6 +37188,22 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"x"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -37088,6 +37563,22 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"x"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -37462,6 +37953,22 @@ class variable_named_context_model final : public model_base_crtp<variable_named
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "sigma"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -407,6 +407,22 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -843,6 +859,25 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"a", "b", "r", "zp", "c", "d", "z"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "b", "r", "zp"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"c", "d", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -583,6 +583,25 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y", "y0", "t0", "times"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -1510,6 +1529,25 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
     
     names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta", "y",
       "y2"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y", "y2"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7195,6 +7195,26 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_real", "p_real_array", "p_matrix",
+      "p_vector", "p_row_vector", "y_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"transformed_param_real"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -7909,6 +7929,26 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     
     names__ = std::vector<std::string>{"p_real", "p_real_array", "p_matrix",
       "p_vector", "p_row_vector", "y_p", "transformed_param_real"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_real", "p_real_array", "p_matrix",
+      "p_vector", "p_row_vector", "y_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"transformed_param_real"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -330,6 +330,22 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"rho", "alpha", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1639,6 +1639,26 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"X_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
+        "X_tp5", "X_tp6", "X_tp7"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -2501,6 +2521,25 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta", "y"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -4245,6 +4284,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_p", "beta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -5360,6 +5418,25 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"sigma", "sigma_age", "sigma_edu",
+      "sigma_state", "sigma_region", "sigma_age_edu", "b_0", "b_female",
+      "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
+      "b_age_edu", "b_hat"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -5815,6 +5892,22 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -6165,6 +6258,22 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -6639,6 +6748,22 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "sigma", "theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -7068,6 +7193,22 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "theta", "tau"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "theta", "tau"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -8169,6 +8310,26 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "b", "c", "d", "e", "beta",
+      "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -8950,6 +9111,29 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     names__ = std::vector<std::string>{"tau_phi", "phi_std_raw", "sigma_phi",
       "phi", "beta0", "beta1", "tau_theta", "sigma_theta", "theta",
       "theta_std", "x", "y"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"tau_phi", "phi_std_raw"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma_phi", "phi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"beta0", "beta1", "tau_theta",
+        "sigma_theta", "theta", "theta_std", "x", "y"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -10675,6 +10859,29 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
       "sigma", "phi", "p", "chi", "mu", "sigma2"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
+      "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi", "mu"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -13957,6 +14164,29 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "psi", "beta",
+      "epsilon", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "b", "nu", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2", "Nsuper", "N", "B", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -15143,6 +15373,25 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"pi", "theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"log_Pr_z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -15787,6 +16036,26 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     
     names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
       "tau_phi", "theta_std", "phi_std_raw", "sigma_phi", "phi"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
+      "tau_phi", "theta_std", "phi_std_raw"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma_phi", "phi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -17545,6 +17814,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_p", "beta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -18106,6 +18394,22 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -18673,6 +18977,27 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_single_ret_vec",
+      "p_multi_ret_vec"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_single_ret_vec",
+        "tp_multi_ret_vec"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -19111,6 +19436,22 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
@@ -19523,6 +19864,25 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"R", "out"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"R", "out"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -22777,6 +23137,30 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "gamma",
+      "epsilon", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2", "psi", "b", "Nsuper", "N",
+        "B", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23283,6 +23667,22 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -23623,6 +24023,22 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"x"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -23985,6 +24401,22 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"theta"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -25566,6 +25998,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -26117,6 +26568,28 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "tp", "lbaz", "lbar"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"lbaz", "lbar"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -26949,6 +27422,29 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
+      "beta_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"logit_psi", "logit_p"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"occ_fs", "psi_con", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -27773,6 +28269,26 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     
     names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
       "mu_a2", "sigma_a1", "sigma_a2", "sigma_y", "a1", "a2", "y_hat"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
+      "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"a1", "a2", "y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -28980,6 +29496,23 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"theta", "phi", "x_matrix",
+      "x_vector", "x_cov"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -29402,6 +29935,22 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -30089,6 +30638,26 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     
     names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
       "sigma_y", "y_hat"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
+      "sigma_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -33258,6 +33827,22 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"m2", "m3"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -34147,6 +34732,26 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha0", "alpha1", "alpha2",
+      "alpha12", "tau", "b"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -34633,6 +35238,26 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     
     names__ = std::vector<std::string>{"y", "no_init", "init_from_param",
       "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"no_init", "init_from_param",
+        "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -35248,6 +35873,25 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"x"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -301,6 +301,26 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"X_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
+        "X_tp5", "X_tp6", "X_tp7"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1085,6 +1105,25 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -1511,6 +1550,25 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"X_p", "X_tp1", "X_tp2"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"X_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"X_tp1", "X_tp2"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -2478,6 +2536,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mean_p", "beta", "phi", "p", "chi"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_p", "beta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -3453,6 +3530,25 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"sigma", "sigma_age", "sigma_edu",
+      "sigma_state", "sigma_region", "sigma_age_edu", "b_0", "b_female",
+      "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
+      "b_age_edu", "b_hat"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -3905,6 +4001,22 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -4250,6 +4362,22 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -4680,6 +4808,22 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "sigma", "theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -5101,6 +5245,22 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "theta", "tau"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "theta", "tau"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -6026,6 +6186,26 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "b", "c", "d", "e", "beta",
+      "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -6734,6 +6914,29 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     names__ = std::vector<std::string>{"tau_phi", "phi_std_raw", "sigma_phi",
       "phi", "beta0", "beta1", "tau_theta", "sigma_theta", "theta",
       "theta_std", "x", "y"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"tau_phi", "phi_std_raw"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma_phi", "phi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"beta0", "beta1", "tau_theta",
+        "sigma_theta", "theta", "theta_std", "x", "y"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -7717,6 +7920,29 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
       "sigma", "phi", "p", "chi", "mu", "sigma2"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
+      "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi", "mu"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -9264,6 +9490,29 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "psi", "beta",
+      "epsilon", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "b", "nu", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2", "Nsuper", "N", "B", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -10058,6 +10307,25 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"pi", "theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"log_Pr_z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -10666,6 +10934,26 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     
     names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
       "tau_phi", "theta_std", "phi_std_raw", "sigma_phi", "phi"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
+      "tau_phi", "theta_std", "phi_std_raw"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma_phi", "phi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -11622,6 +11910,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_p", "beta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -12104,6 +12411,22 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -12529,6 +12852,22 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -12999,6 +13338,27 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_single_ret_vec",
+      "p_multi_ret_vec"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_single_ret_vec",
+        "tp_multi_ret_vec"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -13426,6 +13786,22 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
@@ -13812,6 +14188,25 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"R", "out"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"R", "out"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -15276,6 +15671,30 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "gamma",
+      "epsilon", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2", "psi", "b", "Nsuper", "N",
+        "B", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -15779,6 +16198,22 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -16116,6 +16551,22 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"x"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -16471,6 +16922,22 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"theta"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -17316,6 +17783,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -17827,6 +18313,28 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "tp", "lbaz", "lbar"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"lbaz", "lbar"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -18482,6 +18990,29 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
       "beta_p", "logit_psi", "logit_p", "occ_fs", "psi_con", "z"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
+      "beta_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"logit_psi", "logit_p"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"occ_fs", "psi_con", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -19204,6 +19735,26 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     
     names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
       "mu_a2", "sigma_a1", "sigma_a2", "sigma_y", "a1", "a2", "y_hat"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
+      "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"a1", "a2", "y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -20174,6 +20725,23 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"theta", "phi", "x_matrix",
+      "x_vector", "x_cov"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -20587,6 +21155,22 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -21183,6 +21767,26 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
+      "sigma_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -21695,6 +22299,22 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"m2", "m3"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"m2", "m3"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -22323,6 +22943,26 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha0", "alpha1", "alpha2",
+      "alpha12", "tau", "b"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -22740,6 +23380,25 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"param"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"local"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23143,6 +23802,26 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"no_init", "init_from_param",
+        "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23507,6 +24186,25 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"x"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -292,6 +292,26 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"X_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
+        "X_tp5", "X_tp6", "X_tp7"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1071,6 +1091,25 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta", "y"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -2123,6 +2162,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_p", "beta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -3077,6 +3135,25 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"sigma", "sigma_age", "sigma_edu",
+      "sigma_state", "sigma_region", "sigma_age_edu", "b_0", "b_female",
+      "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
+      "b_age_edu", "b_hat"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -3529,6 +3606,22 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -3874,6 +3967,22 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -4299,6 +4408,22 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "sigma", "theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -4718,6 +4843,22 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "theta", "tau"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu", "theta", "tau"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -5628,6 +5769,26 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "b", "c", "d", "e", "beta",
+      "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -6338,6 +6499,29 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     names__ = std::vector<std::string>{"tau_phi", "phi_std_raw", "sigma_phi",
       "phi", "beta0", "beta1", "tau_theta", "sigma_theta", "theta",
       "theta_std", "x", "y"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"tau_phi", "phi_std_raw"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma_phi", "phi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"beta0", "beta1", "tau_theta",
+        "sigma_theta", "theta", "theta_std", "x", "y"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -7432,6 +7616,29 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
       "sigma", "phi", "p", "chi", "mu", "sigma2"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
+      "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi", "mu"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -9366,6 +9573,29 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "psi", "beta",
+      "epsilon", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "b", "nu", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2", "Nsuper", "N", "B", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -10150,6 +10380,25 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"pi", "theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"log_Pr_z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -10760,6 +11009,26 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     
     names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
       "tau_phi", "theta_std", "phi_std_raw", "sigma_phi", "phi"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
+      "tau_phi", "theta_std", "phi_std_raw"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma_phi", "phi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -11826,6 +12095,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_p", "beta"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -12346,6 +12634,22 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -12870,6 +13174,27 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"p_single_ret_vec",
+      "p_multi_ret_vec"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_single_ret_vec",
+        "tp_multi_ret_vec"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -13298,6 +13623,22 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
@@ -13716,6 +14057,25 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"R", "out"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"R", "out"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -15601,6 +15961,30 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p", "gamma",
+      "epsilon", "sigma"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"sigma2", "psi", "b", "Nsuper", "N",
+        "B", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -16104,6 +16488,22 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
@@ -16440,6 +16840,22 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"x"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -16793,6 +17209,22 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"theta"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"theta"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -17752,6 +18184,25 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mean_phi", "mean_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "p", "chi"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -18302,6 +18753,28 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"mu", "tp", "lbaz", "lbar"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"mu"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"lbaz", "lbar"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -18950,6 +19423,29 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
       "beta_p", "logit_psi", "logit_p", "occ_fs", "psi_con", "z"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
+      "beta_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"logit_psi", "logit_p"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"occ_fs", "psi_con", "z"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     
@@ -19668,6 +20164,26 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     
     names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
       "mu_a2", "sigma_a1", "sigma_a2", "sigma_y", "a1", "a2", "y_hat"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
+      "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"a1", "a2", "y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -20604,6 +21120,23 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"theta", "phi", "x_matrix",
+      "x_vector", "x_cov"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -21245,6 +21778,26 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
+      "sigma_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"y_hat"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -21748,6 +22301,22 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"m2", "m3"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"m2", "m3"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -22373,6 +22942,26 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha0", "alpha1", "alpha2",
+      "alpha12", "tau", "b"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"sigma"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -22790,6 +23379,25 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"param"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"local"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23190,6 +23798,26 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"no_init", "init_from_param",
+        "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23554,6 +24182,25 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   inline void get_param_names(std::vector<std::string>& names__) const {
     
     names__ = std::vector<std::string>{"x"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      std::vector<std::string> temp {"x"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
     
     } // get_param_names() 
     

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -184,6 +184,25 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"A_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"A_complex_tp"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1761,6 +1780,31 @@ class constraints_model final : public model_base_crtp<constraints_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"high_low_est", "b", "h", "ar", "ma",
+      "phi_beta", "sigma2", "Intercept", "mean_price", "sigma_price",
+      "theta", "upper_test", "lower_upper_test", "row_vec_lower_upper_test",
+      "offset_mult_test", "ordered_test", "unit_vec_test",
+      "pos_ordered_test", "corr_matrix_test", "cov_matrix_test",
+      "chol_fac_cov_test", "chol_fac_corr_test"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"phi", "sigma", "prices", "prices_diff",
+        "mu", "err", "h_i_mean", "h_i_sigma", "h_sigma"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -2531,6 +2575,26 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
     
     names__ = std::vector<std::string>{"X_p", "X_tp1", "X_tp2", "X_tp3",
       "X_tp4", "X_tp5", "X_tp6", "X_tp7"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"X_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
+        "X_tp5", "X_tp6", "X_tp7"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -4219,6 +4283,36 @@ udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha", "p_soa_vec_v", "p_soa_mat",
+      "p_soa_arr_vec_v", "p_soa_mat_uni_col_idx", "p_soa_vec_uni_idx",
+      "p_soa_loop_mat_uni_col_idx", "p_soa_lhs_loop_mul",
+      "p_soa_rhs_loop_mul", "p_soa_used_with_aos_in_excluded_fun",
+      "p_soa_loop_mat_multi_uni_uni_idx", "p_aos_vec_v_assign_to_aos",
+      "p_aos_vec_v_tp_fails_func", "p_aos_loop_vec_v_uni_idx",
+      "p_aos_fail_assign_from_top_idx", "p_aos_loop_mat_uni_uni_idx",
+      "p_aos_mat", "p_aos_mat_pass_func_outer_single_indexed1",
+      "p_aos_mat_pass_func_outer_single_indexed2",
+      "p_aos_mat_fail_uni_uni_idx1", "p_aos_mat_fail_uni_uni_idx2"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_real_from_aos", "tp_aos_vec_v",
+        "tp_soa_single_idx_uninit", "tp_aos_fail_func_vec_v",
+        "tp_aos_fail_assign_from_top_idx"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -5014,6 +5108,22 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"alpha", "p_aos_loop_single_idx"};
+    
+    if (emit_transformed_parameters__) {
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -5552,6 +5662,26 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
     names__ = std::vector<std::string>{"soa_x", "aos_x", "aos_y",
       "tp_real_from_soa", "tp_matrix_aos_from_mix",
       "tp_matrix_from_udf_reduced_soa"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"soa_x", "aos_x", "aos_y"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_real_from_soa",
+        "tp_matrix_aos_from_mix", "tp_matrix_from_udf_reduced_soa"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     
@@ -6169,6 +6299,26 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"row_soa", "udf_input_aos"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"user_func_aos", "empty_user_func_aos",
+        "inner_empty_user_func_aos", "int_aos_mul_aos", "mul_two_aos"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -6730,6 +6880,25 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
     
     } // get_param_names() 
     
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"aos_p", "soa_p"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_real_from_soa"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
+    
+    } // get_param_names() 
+    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -7240,6 +7409,25 @@ const
     
     names__ = std::vector<std::string>{"first_pass_soa_x", "aos_x",
       "tp_matrix_aos"};
+    
+    } // get_param_names() 
+    
+  inline void get_param_names(std::vector<std::string>& names__,
+                              const bool emit_transformed_parameters__ = true,
+                              const bool emit_generated_quantities__ = true) const {
+    
+    names__ = std::vector<std::string>{"first_pass_soa_x", "aos_x"};
+    
+    if (emit_transformed_parameters__) {
+      std::vector<std::string> temp {"tp_matrix_aos"};
+      names__.reserve(names__.size() + temp.size());
+      names__.insert(names__.end(), temp.begin(), temp.end());
+      
+    }
+    
+    if (emit_generated_quantities__) {
+      
+    }
     
     } // get_param_names() 
     


### PR DESCRIPTION
This would be the first part of #1240. After this is merged, we can safely update Stan's model_base to require these arguments, then delete the original overload, _then_ fix the bug @SteveBronder noticed by setting the flags to false during initialization. 

While we are at it, would we want to make the same change to `get_dims`?

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Added a new version of the model method `get_param_names` which allows specifiying if the transformed parameters or generated quantities should be emitted. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
