### PR TITLE
Revert "Add get_param_names overload with flag arguments"

### DIFF
--- a/test/integration/cli-args/filename_good.expected
+++ b/test/integration/cli-args/filename_good.expected
@@ -156,41 +156,9 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1549,23 +1549,6 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha_v", "beta", "cuts", "sigma",
-      "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1577,30 +1560,6 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
       std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
       std::vector<size_t>{static_cast<size_t>(n)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(k)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1371,27 +1371,6 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"cmat", "cvec", "crowvec", "z", "mat",
-      "vec", "rowvec", "r"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_c_matrix", "tp_c_vector",
-        "tp_c_rowvector", "tp_c", "carray"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1415,45 +1394,6 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
                           static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                             static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                            static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -2717,26 +2657,6 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"gq_c_matrix", "gq_c_vector",
-        "gq_c_rowvector", "gq_c", "carray"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -2751,32 +2671,6 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
                           static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                             static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                            static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -4733,27 +4627,6 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"cvmat", "cvvec", "cvrowvec", "zv",
-      "vmat", "vvec", "vrowvec", "v"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_c_matrix", "tp_c_vector",
-        "tp_c_rowvector", "tp_c", "carray"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -4777,45 +4650,6 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
                           static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                             static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                            static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5603,41 +5437,9 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -8155,32 +7957,6 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_r", "p_complex", "p_complex_array",
-      "p_complex_array_2d"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_r", "tp_complex",
-        "tp_complex_array", "tp_complex_array_2d"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"gq_i", "gq_r", "gq_complex",
-        "gq_complex_array", "gq_complex_array_2d", "z", "y", "i_arr",
-        "i_arr_1", "zi", "yi", "x"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -8203,47 +7979,6 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(3),
-                          static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(3),
-                            static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(3),
-                            static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(0)},
-        std::vector<size_t>{static_cast<size_t>(1)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-        }};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -8776,25 +8511,6 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"z", "zs", "x", "zx"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -8806,30 +8522,6 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
                           static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2),
-                            static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -9536,41 +9228,9 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -263,51 +263,11 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "tau", "theta_tilde"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"theta"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(J)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(J)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -655,41 +615,9 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"bar"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -1702,30 +1630,6 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"explicit", "float", "friend", "goto",
-      "inline", "long", "mutable", "namespace", "new", "noexcept", "not",
-      "not_eq", "nullptr", "operator", "or"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"throw", "try", "typeid", "typename",
-        "union", "unsigned", "using", "virtual", "volatile", "wchar_t",
-        "xor", "xor_eq", "fvar", "STAN_MAJOR", "STAN_MINOR", "STAN_PATCH",
-        "STAN_MATH_MAJOR", "STAN_MATH_MINOR", "STAN_MATH_PATCH"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -1741,38 +1645,6 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -2271,51 +2143,11 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "tau", "theta_tilde"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"theta"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(J)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(J)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -2727,25 +2559,6 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"xx"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y", "w", "td_arr33"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -2754,30 +2567,6 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(3)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -10941,43 +10730,6 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_real", "p_upper", "p_lower",
-      "offset_multiplier", "no_offset_multiplier", "offset_no_multiplier",
-      "p_real_1d_ar", "p_real_3d_ar", "p_vec", "p_1d_vec", "p_3d_vec",
-      "p_row_vec", "p_1d_row_vec", "p_3d_row_vec", "p_mat", "p_ar_mat",
-      "p_simplex", "p_1d_simplex", "p_3d_simplex", "p_cfcov_54",
-      "p_cfcov_33", "p_cfcov_33_ar", "x_p", "y_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_real_1d_ar", "tp_real_3d_ar",
-        "tp_vec", "tp_1d_vec", "tp_3d_vec", "tp_row_vec", "tp_1d_row_vec",
-        "tp_3d_row_vec", "tp_mat", "tp_ar_mat", "tp_simplex",
-        "tp_1d_simplex", "tp_3d_simplex", "tp_cfcov_54", "tp_cfcov_33",
-        "tp_cfcov_33_ar", "theta_p", "tp_real"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"gq_r1", "gq_r2", "gq_real_1d_ar",
-        "gq_real_3d_ar", "gq_vec", "gq_1d_vec", "gq_3d_vec", "gq_row_vec",
-        "gq_1d_row_vec", "gq_3d_row_vec", "gq_ar_mat", "gq_simplex",
-        "gq_1d_simplex", "gq_3d_simplex", "gq_cfcov_54", "gq_cfcov_33",
-        "gq_cfcov_33_ar", "indices", "indexing_mat", "idx_res1", "idx_res2",
-        "idx_res3", "idx_res11", "idx_res21", "idx_res31", "idx_res4",
-        "idx_res5"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -11071,118 +10823,6 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
                           static_cast<size_t>(3)},
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(4)},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(5)},
-      std::vector<size_t>{static_cast<size_t>(5)},
-      std::vector<size_t>{static_cast<size_t>(5)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                          static_cast<size_t>(K)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                          static_cast<size_t>(K), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                          static_cast<size_t>(K), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(4)},
-      std::vector<size_t>{static_cast<size_t>(4), static_cast<size_t>(5),
-                          static_cast<size_t>(2), static_cast<size_t>(3)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                          static_cast<size_t>(K), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(4)},
-      std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
-      std::vector<size_t>{static_cast<size_t>(K), static_cast<size_t>(3),
-                          static_cast<size_t>(3)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(4), static_cast<size_t>(5),
-                            static_cast<size_t>(2), static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(K), static_cast<size_t>(3),
-                            static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-        }};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(4), static_cast<size_t>(5),
-                            static_cast<size_t>(2), static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M),
-                            static_cast<size_t>(K), static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(K), static_cast<size_t>(3),
-                            static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(3),
-                            static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3),
-                            static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(3),
-                            static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3),
-                            static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3),
-                            static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(3),
-                            static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3),
-                            static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -14172,32 +13812,6 @@ const
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y0_p", "theta_p", "x_p", "x_p_v",
-      "shared_params_p", "job_params_p", "x_r"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"abc1_p", "abc2_p", "abc3_p",
-        "y_hat_tp1", "y_hat_tp2", "y_hat_tp3", "theta_p_as", "x_v", "y_v",
-        "y_p"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"y_hat", "y_1d", "z_1d", "abc1_gq",
-        "abc2_gq", "y_hat_gq", "yy_hat_gq", "theta_dbl"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -14221,50 +13835,6 @@ const
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(3)},
       std::vector<size_t>{static_cast<size_t>(3)},
       std::vector<size_t>{static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(1)},
-      std::vector<size_t>{static_cast<size_t>(1)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(3)},
-      std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(3)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(T), static_cast<size_t>(2)},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(3)},
-        std::vector<size_t>{static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -19022,28 +18592,6 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"r", "ra", "v"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"zg"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -19051,32 +18599,6 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -19753,26 +19275,6 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha", "beta", "gamma", "delta",
-      "z_init", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -19780,29 +19282,6 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       }, std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -21455,23 +20934,6 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha_v", "beta", "cuts", "sigma",
-      "alpha", "phi", "X_p", "beta_m", "X_rv_p"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -21483,30 +20945,6 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
       std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
       std::vector<size_t>{static_cast<size_t>(n)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(k)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -22361,43 +21799,10 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y", "z"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -22801,22 +22206,6 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"L_Omega", "z1"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -22827,29 +22216,6 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
                                                                    static_cast<size_t>(2)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(NS)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(nt)
-                                                                   ,
-                                                                   static_cast<size_t>(2)
-                                                                   ,
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(NS)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -23200,41 +22566,9 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -23628,53 +22962,12 @@ ident_functor__::operator()(const std::complex<T0__>& x,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"z", "zi", "zs", "x"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(4)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(4)}, std::vector<size_t>{
-        }};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -24463,53 +23756,12 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"gamma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"z_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(times)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(times)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -25097,22 +24349,6 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y1", "y2", "y3"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -25120,26 +24356,6 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
                                                                    },
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(N)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -27446,23 +26662,6 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a8", "a7", "a6", "a5", "a4", "a3",
-      "a2", "a1", "y8", "y7", "y6", "y5", "y4", "y3", "y2", "y1"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -27496,52 +26695,6 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(N)
-                                                                   ,
-                                                                   static_cast<size_t>(N)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -31809,29 +30962,6 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y1", "y2", "y3", "y4", "y5", "y6",
-      "y7", "y8", "y9", "y10", "y11", "y12", "y17"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"t1", "t1a", "t2", "t3", "t4", "t5",
-        "t6", "t7", "t8", "t9", "t10", "t11", "t12", "tg1", "tg2", "tg3",
-        "tg4", "tg5", "tg6", "tg7", "tg8", "tg9", "tg10", "tg11", "tg12",
-        "tgs"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -31862,53 +30992,6 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(N)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
-                          static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -33144,33 +32227,6 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"e", "pi", "log2", "log10", "sqrt2",
-      "not_a_number", "positive_infinity", "negative_infinity",
-      "machine_precision", "inv_logit", "logit", "num_elements", "pow",
-      "add", "sub", "multiply", "binomial_coefficient_log",
-      "read_constrain_lb", "read", "validate_non_negative_index", "length",
-      "validate_positive_index", "profile_map", "assign", "rvalue",
-      "stan_print", "model_base_crtp", "index_uni",
-      "bernoulli_logit_glm_lpmf", "reduce_sum", "segment", "ode_bdf",
-      "ode_bdf_tol"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"mu", "called", "result"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -33188,39 +32244,6 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{static_cast<size_t>(1), static_cast<size_t>(4)},
       std::vector<size_t>{static_cast<size_t>(result_1dim__)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(4)},
-      std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(1), static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(result_1dim__)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -33840,41 +32863,9 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -34230,41 +33221,9 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"x"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -36357,29 +35316,6 @@ class transform_model final : public model_base_crtp<transform_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_1", "p_2", "p_3", "p_4", "p_5",
-      "p_6", "p_7", "p_8", "p_9", "p_10", "pv_1", "pv_2", "pv_3", "pr_1",
-      "pr_2", "pr_3", "pm_1", "pm_2"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_1", "tp_2", "tp_3", "tp_4", "tp_5",
-        "tp_6", "tp_7", "tp_8", "tp_9", "tp_10", "tpv_1", "tpv_2", "tpv_3",
-        "tpr_1", "tpr_2", "tpr_3", "tpm_1", "tpm_2"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -36428,70 +35364,6 @@ class transform_model final : public model_base_crtp<transform_model> {
       std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
       std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
                           static_cast<size_t>(k)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(k)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                          static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                          static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                          static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-      std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                          static_cast<size_t>(k)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                            static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                            static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                            static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(m), static_cast<size_t>(k)},
-        std::vector<size_t>{static_cast<size_t>(n), static_cast<size_t>(m),
-                            static_cast<size_t>(k)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -37502,43 +36374,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"m", "y"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -37893,41 +36732,9 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"x"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -38284,41 +37091,9 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"x"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -38690,43 +37465,10 @@ class variable_named_context_model final : public model_base_crtp<variable_named
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -407,41 +407,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -878,25 +846,6 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "b", "r", "zp"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"c", "d", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -907,32 +856,6 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)},
-        std::vector<size_t>{static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -583,53 +583,12 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y", "y0", "t0", "times"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
       }, std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(M), static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M), static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -1554,25 +1513,6 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y", "y2"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -1580,29 +1520,6 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       },
       std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)},
       std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)},
-        std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7195,26 +7195,6 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_real", "p_real_array", "p_matrix",
-      "p_vector", "p_row_vector", "y_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"transformed_param_real"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -7224,31 +7204,6 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       std::vector<size_t>{static_cast<size_t>(d_int)},
       std::vector<size_t>{static_cast<size_t>(d_int)}, std::vector<size_t>{
       }, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(d_int)},
-      std::vector<size_t>{static_cast<size_t>(d_int),
-                          static_cast<size_t>(d_int)},
-      std::vector<size_t>{static_cast<size_t>(d_int)},
-      std::vector<size_t>{static_cast<size_t>(d_int)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -7957,26 +7912,6 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_real", "p_real_array", "p_matrix",
-      "p_vector", "p_row_vector", "y_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"transformed_param_real"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -7986,31 +7921,6 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       std::vector<size_t>{static_cast<size_t>(d_int)},
       std::vector<size_t>{static_cast<size_t>(d_int)}, std::vector<size_t>{
       }, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(d_int)},
-      std::vector<size_t>{static_cast<size_t>(d_int),
-                          static_cast<size_t>(d_int)},
-      std::vector<size_t>{static_cast<size_t>(d_int)},
-      std::vector<size_t>{static_cast<size_t>(d_int)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -330,43 +330,10 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"rho", "alpha", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1639,26 +1639,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"X_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
-        "X_tp5", "X_tp6", "X_tp7"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1673,36 +1653,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -2554,53 +2504,12 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       },
       std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4336,25 +4245,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_p", "beta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -4365,32 +4255,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(max_age)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5496,25 +5360,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"sigma", "sigma_age", "sigma_edu",
-      "sigma_state", "sigma_region", "sigma_age_edu", "b_0", "b_female",
-      "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
-      "b_age_edu", "b_hat"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -5528,32 +5373,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       std::vector<size_t>{static_cast<size_t>(n_age),
                           static_cast<size_t>(n_edu)},
       std::vector<size_t>{static_cast<size_t>(n_state)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_age)},
-      std::vector<size_t>{static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_region)},
-      std::vector<size_t>{static_cast<size_t>(n_age),
-                          static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_state)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5996,41 +5815,9 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -6381,41 +6168,9 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -6884,22 +6639,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "sigma", "theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -6907,26 +6646,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                                                                    },
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -7352,45 +7071,11 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "theta", "tau"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -8484,26 +8169,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "b", "c", "d", "e", "beta",
-      "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -8516,35 +8181,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(n_age)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_age_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_state)},
-      std::vector<size_t>{static_cast<size_t>(n_region_full)},
-      std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -9317,29 +8953,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"tau_phi", "phi_std_raw"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma_phi", "phi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"beta0", "beta1", "tau_theta",
-        "sigma_theta", "theta", "theta_std", "x", "y"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -9350,35 +8963,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(phi_std_raw_1dim__)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -11094,29 +10678,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
-      "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi", "mu"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -11129,37 +10690,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)},
       std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(nind)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -14427,29 +13957,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "psi", "beta",
-      "epsilon", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "b", "nu", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2", "Nsuper", "N", "B", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -14470,45 +13977,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       std::vector<size_t>{static_cast<size_t>(n_occasions)},
       std::vector<size_t>{static_cast<size_t>(M),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_occasions)},
-      std::vector<size_t>{static_cast<size_t>(M)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M),
-                             static_cast<size_t>(phi_2dim__)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -15675,25 +15143,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"pi", "theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"log_Pr_z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -15702,30 +15151,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       std::vector<size_t>{static_cast<size_t>(J), static_cast<size_t>(K),
                           static_cast<size_t>(K)},
       std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(K)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(J), static_cast<size_t>(K),
-                          static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -16365,26 +15790,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
-      "tau_phi", "theta_std", "phi_std_raw"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma_phi", "phi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -16392,29 +15797,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       }, std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
       }, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -18163,25 +17545,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_p", "beta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -18192,32 +17555,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(max_age)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -18772,41 +18109,9 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -19368,27 +18673,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_single_ret_vec",
-      "p_multi_ret_vec"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_single_ret_vec",
-        "tp_multi_ret_vec"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -19397,30 +18681,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       std::vector<size_t>{static_cast<size_t>(5)},
       std::vector<size_t>{static_cast<size_t>(5)},
       std::vector<size_t>{static_cast<size_t>(5)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(5)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(5)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(5)},
-        std::vector<size_t>{static_cast<size_t>(5)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -19851,41 +19111,9 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -20298,52 +19526,12 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"R", "out"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(N)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -23589,30 +22777,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "gamma",
-      "epsilon", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2", "psi", "b", "Nsuper", "N",
-        "B", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23633,45 +22797,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       std::vector<size_t>{static_cast<size_t>(n_occasions)},
       std::vector<size_t>{static_cast<size_t>(M),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_occasions)},
-      std::vector<size_t>{static_cast<size_t>(epsilon_1dim__)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M),
-                             static_cast<size_t>(phi_2dim__)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -24158,41 +23283,9 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24533,41 +23626,9 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"x"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24927,45 +23988,11 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(J)
                                                                    }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(J)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -26539,25 +25566,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -26568,32 +25576,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -27138,56 +26120,11 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"lbaz", "lbar"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -28012,29 +26949,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
-      "beta_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"logit_psi", "logit_p"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"occ_fs", "psi_con", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -28043,34 +26957,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       std::vector<size_t>{static_cast<size_t>(R), static_cast<size_t>(T)},
       std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(R)},
       std::vector<size_t>{static_cast<size_t>(R)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(R)},
-        std::vector<size_t>{static_cast<size_t>(R), static_cast<size_t>(T)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(R)},
-        std::vector<size_t>{static_cast<size_t>(R)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -28890,26 +27776,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
-      "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"a1", "a2", "y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -28919,32 +27785,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(J)},
-      std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(J)},
-        std::vector<size_t>{static_cast<size_t>(J)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -30140,23 +28980,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"theta", "phi", "x_matrix",
-      "x_vector", "x_cov"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -30164,26 +28987,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -30602,41 +29405,9 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -31321,26 +30092,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
-      "sigma_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -31349,30 +30100,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(n_pair)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -34531,22 +33258,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"m2", "m3"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -34555,27 +33266,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                                                                    static_cast<size_t>(10)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -35457,26 +34147,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha0", "alpha1", "alpha2",
-      "alpha12", "tau", "b"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -35484,28 +34154,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       }, std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -35988,53 +34636,12 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"no_init", "init_from_param",
-        "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -36644,47 +35251,9 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"x"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -301,26 +301,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"X_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
-        "X_tp5", "X_tp6", "X_tp7"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -335,36 +315,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -1135,53 +1085,12 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       },
       std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -1605,25 +1514,6 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"X_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"X_tp1", "X_tp2"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1633,31 +1523,6 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
                                                                    },
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -2616,25 +2481,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_p", "beta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -2645,32 +2491,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(max_age)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -3633,25 +3453,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"sigma", "sigma_age", "sigma_edu",
-      "sigma_state", "sigma_region", "sigma_age_edu", "b_0", "b_female",
-      "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
-      "b_age_edu", "b_hat"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -3665,32 +3466,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       std::vector<size_t>{static_cast<size_t>(n_age),
                           static_cast<size_t>(n_edu)},
       std::vector<size_t>{static_cast<size_t>(n_state)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_age)},
-      std::vector<size_t>{static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_region)},
-      std::vector<size_t>{static_cast<size_t>(n_age),
-                          static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_state)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4130,41 +3905,9 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4510,41 +4253,9 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4969,22 +4680,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "sigma", "theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -4992,26 +4687,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                                                                    },
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5429,45 +5104,11 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "theta", "tau"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -6385,26 +6026,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "b", "c", "d", "e", "beta",
-      "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -6417,35 +6038,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(n_age)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_age_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_state)},
-      std::vector<size_t>{static_cast<size_t>(n_region_full)},
-      std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -7145,29 +6737,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"tau_phi", "phi_std_raw"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma_phi", "phi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"beta0", "beta1", "tau_theta",
-        "sigma_theta", "theta", "theta_std", "x", "y"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -7178,35 +6747,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(phi_std_raw_1dim__)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -8180,29 +7720,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
-      "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi", "mu"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -8215,37 +7732,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)},
       std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(nind)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -9778,29 +9264,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "psi", "beta",
-      "epsilon", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "b", "nu", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2", "Nsuper", "N", "B", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -9821,45 +9284,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       std::vector<size_t>{static_cast<size_t>(n_occasions)},
       std::vector<size_t>{static_cast<size_t>(M),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_occasions)},
-      std::vector<size_t>{static_cast<size_t>(M)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M),
-                             static_cast<size_t>(phi_2dim__)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -10634,25 +10058,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"pi", "theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"log_Pr_z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -10661,30 +10066,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       std::vector<size_t>{static_cast<size_t>(J), static_cast<size_t>(K),
                           static_cast<size_t>(K)},
       std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(K)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(J), static_cast<size_t>(K),
-                          static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -11288,26 +10669,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
-      "tau_phi", "theta_std", "phi_std_raw"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma_phi", "phi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -11315,29 +10676,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       }, std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
       }, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -12284,25 +11622,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_p", "beta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -12313,32 +11632,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(max_age)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -12811,41 +12104,9 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -13271,41 +12532,9 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -13770,27 +12999,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_single_ret_vec",
-      "p_multi_ret_vec"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_single_ret_vec",
-        "tp_multi_ret_vec"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -13799,30 +13007,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       std::vector<size_t>{static_cast<size_t>(5)},
       std::vector<size_t>{static_cast<size_t>(5)},
       std::vector<size_t>{static_cast<size_t>(5)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(5)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(5)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(5)},
-        std::vector<size_t>{static_cast<size_t>(5)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -14242,41 +13426,9 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -14663,52 +13815,12 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"R", "out"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(N)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -16164,30 +15276,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "gamma",
-      "epsilon", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2", "psi", "b", "Nsuper", "N",
-        "B", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -16208,45 +15296,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       std::vector<size_t>{static_cast<size_t>(n_occasions)},
       std::vector<size_t>{static_cast<size_t>(M),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_occasions)},
-      std::vector<size_t>{static_cast<size_t>(epsilon_1dim__)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M),
-                             static_cast<size_t>(phi_2dim__)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -16730,41 +15779,9 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -17102,41 +16119,9 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"x"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -17489,45 +16474,11 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(J)
                                                                    }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(J)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -18365,25 +17316,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -18394,32 +17326,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -18924,56 +17830,11 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"lbaz", "lbar"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -19624,29 +18485,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
-      "beta_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"logit_psi", "logit_p"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"occ_fs", "psi_con", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -19655,34 +18493,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       std::vector<size_t>{static_cast<size_t>(R), static_cast<size_t>(T)},
       std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(R)},
       std::vector<size_t>{static_cast<size_t>(R)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(R)},
-        std::vector<size_t>{static_cast<size_t>(R), static_cast<size_t>(T)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(R)},
-        std::vector<size_t>{static_cast<size_t>(R)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -20397,26 +19207,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
-      "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"a1", "a2", "y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -20426,32 +19216,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(J)},
-      std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(J)},
-        std::vector<size_t>{static_cast<size_t>(J)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -21410,23 +20174,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"theta", "phi", "x_matrix",
-      "x_vector", "x_cov"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -21434,26 +20181,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -21863,41 +20590,9 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -22488,26 +21183,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
-      "sigma_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -22516,30 +21191,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(n_pair)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -23047,22 +21698,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"m2", "m3"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -23071,27 +21706,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                                                                    static_cast<size_t>(10)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -23709,26 +22323,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha0", "alpha1", "alpha2",
-      "alpha12", "tau", "b"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23736,28 +22330,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       }, std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24168,49 +22740,10 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"param"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"local"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(5)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(5)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24610,53 +23143,12 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"no_init", "init_from_param",
-        "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -25018,47 +23510,9 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"x"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -292,26 +292,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"X_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
-        "X_tp5", "X_tp6", "X_tp7"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -326,36 +306,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -1124,53 +1074,12 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "gamma", "xi", "delta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       },
       std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N_t), static_cast<size_t>(4)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -2214,25 +2123,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_p", "beta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -2243,32 +2133,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(max_age)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -3213,25 +3077,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"sigma", "sigma_age", "sigma_edu",
-      "sigma_state", "sigma_region", "sigma_age_edu", "b_0", "b_female",
-      "b_black", "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
-      "b_age_edu", "b_hat"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -3245,32 +3090,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       std::vector<size_t>{static_cast<size_t>(n_age),
                           static_cast<size_t>(n_edu)},
       std::vector<size_t>{static_cast<size_t>(n_state)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_age)},
-      std::vector<size_t>{static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_region)},
-      std::vector<size_t>{static_cast<size_t>(n_age),
-                          static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_state)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -3710,41 +3529,9 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4090,41 +3877,9 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4544,22 +4299,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "sigma", "theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -4567,26 +4306,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                                                                    },
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(2)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5002,45 +4721,11 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu", "theta", "tau"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5943,26 +5628,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "b", "c", "d", "e", "beta",
-      "sigma_a", "sigma_b", "sigma_c", "sigma_d", "sigma_e"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -5975,35 +5640,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(n_age)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(n_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_age_edu)},
-      std::vector<size_t>{static_cast<size_t>(n_state)},
-      std::vector<size_t>{static_cast<size_t>(n_region_full)},
-      std::vector<size_t>{static_cast<size_t>(5)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -6705,29 +6341,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"tau_phi", "phi_std_raw"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma_phi", "phi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"beta0", "beta1", "tau_theta",
-        "sigma_theta", "theta", "theta_std", "x", "y"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -6738,35 +6351,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(phi_std_raw_1dim__)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -7851,29 +7435,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "epsilon",
-      "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi", "mu"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -7886,37 +7447,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)},
       std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(nind)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -9836,29 +9366,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "psi", "beta",
-      "epsilon", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "b", "nu", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2", "Nsuper", "N", "B", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -9879,45 +9386,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       std::vector<size_t>{static_cast<size_t>(n_occasions)},
       std::vector<size_t>{static_cast<size_t>(M),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_occasions)},
-      std::vector<size_t>{static_cast<size_t>(M)}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M),
-                             static_cast<size_t>(phi_2dim__)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -10682,25 +10150,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"pi", "theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"log_Pr_z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -10709,30 +10158,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       std::vector<size_t>{static_cast<size_t>(J), static_cast<size_t>(K),
                           static_cast<size_t>(K)},
       std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(K)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(J), static_cast<size_t>(K),
-                          static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -11338,26 +10763,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta0", "beta1", "tau_theta",
-      "tau_phi", "theta_std", "phi_std_raw"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma_phi", "phi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -11365,29 +10770,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       }, std::vector<size_t>{static_cast<size_t>(N)},
       std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
       }, std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -12444,25 +11826,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_p", "beta"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -12473,32 +11836,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(max_age)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -13012,41 +12349,9 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -13565,27 +12870,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"p_single_ret_vec",
-      "p_multi_ret_vec"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_single_ret_vec",
-        "tp_multi_ret_vec"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -13594,30 +12878,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       std::vector<size_t>{static_cast<size_t>(5)},
       std::vector<size_t>{static_cast<size_t>(5)},
       std::vector<size_t>{static_cast<size_t>(5)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(5)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(5)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(5)},
-        std::vector<size_t>{static_cast<size_t>(5)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -14038,41 +13298,9 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -14491,52 +13719,12 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"R", "out"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(N)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -16413,30 +15601,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p", "gamma",
-      "epsilon", "sigma"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"sigma2", "psi", "b", "Nsuper", "N",
-        "B", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -16457,45 +15621,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       std::vector<size_t>{static_cast<size_t>(n_occasions)},
       std::vector<size_t>{static_cast<size_t>(M),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(n_occasions)},
-      std::vector<size_t>{static_cast<size_t>(epsilon_1dim__)},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(M),
-                             static_cast<size_t>(phi_2dim__)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(n_occasions)},
-        std::vector<size_t>{static_cast<size_t>(M),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -16979,41 +16104,9 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -17350,41 +16443,9 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"x"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -17735,45 +16796,11 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"theta"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
                                                                    static_cast<size_t>(J)
                                                                    }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(J)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -18725,25 +17752,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mean_phi", "mean_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "p", "chi"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -18754,32 +17762,6 @@ last_capture_functor__::operator()(const std::vector<int>& y_i,
                           static_cast<size_t>(n_occ_minus_1)},
       std::vector<size_t>{static_cast<size_t>(nind),
                           static_cast<size_t>(n_occasions)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(nind),
-                             static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occ_minus_1)},
-        std::vector<size_t>{static_cast<size_t>(nind),
-                            static_cast<size_t>(n_occasions)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -19323,56 +18305,11 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"mu"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"lbaz", "lbar"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -20016,29 +18953,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha_occ", "beta_occ", "alpha_p",
-      "beta_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"logit_psi", "logit_p"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"occ_fs", "psi_con", "z"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -20047,34 +18961,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       std::vector<size_t>{static_cast<size_t>(R), static_cast<size_t>(T)},
       std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(R)},
       std::vector<size_t>{static_cast<size_t>(R)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(R)},
-        std::vector<size_t>{static_cast<size_t>(R), static_cast<size_t>(T)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(R)},
-        std::vector<size_t>{static_cast<size_t>(R)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     
@@ -20785,26 +19671,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"beta", "eta1", "eta2", "mu_a1",
-      "mu_a2", "sigma_a1", "sigma_a2", "sigma_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"a1", "a2", "y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -20814,32 +19680,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }, std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(J)},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(J)},
-      std::vector<size_t>{static_cast<size_t>(J)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(J)},
-        std::vector<size_t>{static_cast<size_t>(J)},
-        std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -21764,23 +20604,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"theta", "phi", "x_matrix",
-      "x_vector", "x_cov"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -21788,26 +20611,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2)},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(3), static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2)},
-      std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(2)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -22442,26 +21245,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"a", "beta", "mu_a", "sigma_a",
-      "sigma_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"y_hat"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -22470,30 +21253,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(N)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(n_pair)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(N)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -22992,22 +21751,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"m2", "m3"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -23016,27 +21759,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                                                                    static_cast<size_t>(10)
                                                                    },
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -23651,26 +22373,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha0", "alpha1", "alpha2",
-      "alpha12", "tau", "b"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"sigma"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -23678,28 +22380,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       }, std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(I), static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24110,49 +22790,10 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"param"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"local"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(5)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(2), static_cast<size_t>(5)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24549,53 +23190,12 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"no_init", "init_from_param",
-        "dependent_no_init", "used_on_lhs", "no_init_if", "for_loop_var"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
       }, std::vector<size_t>{}, std::vector<size_t>{},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-        }, std::vector<size_t>{}, std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -24957,47 +23557,9 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::string> temp {"x"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
     
     } // get_dims() 
     

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -184,25 +184,6 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"A_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"A_complex_tp"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -212,31 +193,6 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
                                                                    },
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10),
                           static_cast<size_t>(2)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)
-                             , static_cast<size_t>(2)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -1805,31 +1761,6 @@ class constraints_model final : public model_base_crtp<constraints_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"high_low_est", "b", "h", "ar", "ma",
-      "phi_beta", "sigma2", "Intercept", "mean_price", "sigma_price",
-      "theta", "upper_test", "lower_upper_test", "row_vec_lower_upper_test",
-      "offset_mult_test", "ordered_test", "unit_vec_test",
-      "pos_ordered_test", "corr_matrix_test", "cov_matrix_test",
-      "chol_fac_cov_test", "chol_fac_corr_test"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"phi", "sigma", "prices", "prices_diff",
-        "mu", "err", "h_i_mean", "h_i_sigma", "h_sigma"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -1860,51 +1791,6 @@ class constraints_model final : public model_base_crtp<constraints_model> {
       std::vector<size_t>{static_cast<size_t>(Nr)},
       std::vector<size_t>{static_cast<size_t>(Nr)},
       std::vector<size_t>{static_cast<size_t>(Nr)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(N)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(K)},
-      std::vector<size_t>{static_cast<size_t>(Nr)},
-      std::vector<size_t>{static_cast<size_t>(2)}, std::vector<size_t>{
-      }, std::vector<size_t>{}, std::vector<size_t>{}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)}, std::vector<size_t>{
-      }, std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(K), static_cast<size_t>(K)},
-      std::vector<size_t>{static_cast<size_t>(K), static_cast<size_t>(K)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{}, std::vector<size_t>{static_cast<size_t>(N)},
-        std::vector<size_t>{static_cast<size_t>(Nr)},
-        std::vector<size_t>{static_cast<size_t>(Nr)},
-        std::vector<size_t>{static_cast<size_t>(Nr)},
-        std::vector<size_t>{static_cast<size_t>(Nr)},
-        std::vector<size_t>{static_cast<size_t>(Nr)},
-        std::vector<size_t>{static_cast<size_t>(Nr)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -2648,26 +2534,6 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"X_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"X_tp1", "X_tp2", "X_tp3", "X_tp4",
-        "X_tp5", "X_tp6", "X_tp7"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -2682,36 +2548,6 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   }};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -4383,36 +4219,6 @@ udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha", "p_soa_vec_v", "p_soa_mat",
-      "p_soa_arr_vec_v", "p_soa_mat_uni_col_idx", "p_soa_vec_uni_idx",
-      "p_soa_loop_mat_uni_col_idx", "p_soa_lhs_loop_mul",
-      "p_soa_rhs_loop_mul", "p_soa_used_with_aos_in_excluded_fun",
-      "p_soa_loop_mat_multi_uni_uni_idx", "p_aos_vec_v_assign_to_aos",
-      "p_aos_vec_v_tp_fails_func", "p_aos_loop_vec_v_uni_idx",
-      "p_aos_fail_assign_from_top_idx", "p_aos_loop_mat_uni_uni_idx",
-      "p_aos_mat", "p_aos_mat_pass_func_outer_single_indexed1",
-      "p_aos_mat_pass_func_outer_single_indexed2",
-      "p_aos_mat_fail_uni_uni_idx1", "p_aos_mat_fail_uni_uni_idx2"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_real_from_aos", "tp_aos_vec_v",
-        "tp_soa_single_idx_uninit", "tp_aos_fail_func_vec_v",
-        "tp_aos_fail_assign_from_top_idx"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
@@ -4440,49 +4246,6 @@ udf_fun_functor__::operator()(const T0__& A, std::ostream* pstream__)  const
       std::vector<size_t>{static_cast<size_t>(M)},
       std::vector<size_t>{static_cast<size_t>(M)},
       std::vector<size_t>{static_cast<size_t>(M)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)},
-      std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(M)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(M)},
-        std::vector<size_t>{static_cast<size_t>(M)},
-        std::vector<size_t>{static_cast<size_t>(M)},
-        std::vector<size_t>{static_cast<size_t>(M)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5251,43 +5014,10 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"alpha", "p_aos_loop_single_idx"};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{},
-      std::vector<size_t>{static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -5825,26 +5555,6 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"soa_x", "aos_x", "aos_y"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_real_from_soa",
-        "tp_matrix_aos_from_mix", "tp_matrix_from_udf_reduced_soa"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -5857,33 +5567,6 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
       std::vector<size_t>{},
       std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(5)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)},
-      std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -6486,26 +6169,6 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"row_soa", "udf_input_aos"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"user_func_aos", "empty_user_func_aos",
-        "inner_empty_user_func_aos", "int_aos_mul_aos", "mul_two_aos"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -6519,35 +6182,6 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
-        std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -7096,25 +6730,6 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"aos_p", "soa_p"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_real_from_soa"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -7124,30 +6739,6 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
                                                                    },
       std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)},
       std::vector<size_t>{}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(10)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(10), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp {std::vector<size_t>{}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     
@@ -7652,25 +7243,6 @@ const
     
     } // get_param_names() 
     
-  inline void get_param_names(std::vector<std::string>& names__,
-                              const bool emit_transformed_parameters__ = true,
-                              const bool emit_generated_quantities__ = true) const {
-    
-    names__ = std::vector<std::string>{"first_pass_soa_x", "aos_x"};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::string> temp {"tp_matrix_aos"};
-      names__.reserve(names__.size() + temp.size());
-      names__.insert(names__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
-    
-    } // get_param_names() 
-    
   inline void get_dims(std::vector<std::vector<size_t>>& dimss__) const {
     
     dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
@@ -7680,31 +7252,6 @@ const
                                                                    },
       std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)},
       std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)}};
-    
-    } // get_dims() 
-    
-  inline void get_dims(std::vector<std::vector<size_t>>& dimss__,
-                       const bool emit_transformed_parameters__ = true,
-                       const bool emit_generated_quantities__ = true) const {
-    
-    dimss__ = std::vector<std::vector<size_t>>{std::vector<size_t>{
-                                                                   static_cast<size_t>(5)
-                                                                   ,
-                                                                   static_cast<size_t>(10)
-                                                                   },
-      std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)}};
-    
-    if (emit_transformed_parameters__) {
-      std::vector<std::vector<size_t>> temp
-        {std::vector<size_t>{static_cast<size_t>(5), static_cast<size_t>(10)}};
-      dimss__.reserve(dimss__.size() + temp.size());
-      dimss__.insert(dimss__.end(), temp.begin(), temp.end());
-      
-    }
-    
-    if (emit_generated_quantities__) {
-      
-    }
     
     } // get_dims() 
     


### PR DESCRIPTION
Reverts stan-dev/stanc3#1241

This PR broke Stan tests. Until we have a plan to do all the changes required we should revert