### PR TITLE
Expose complex Schur decomposition functions

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1064,6 +1064,20 @@ let () =
     ("columns_dot_self", ReturnType UComplexRowVector, [UComplexRowVector], AoS) ;
   add_unqualified
     ("columns_dot_self", ReturnType UComplexRowVector, [UComplexMatrix], AoS) ;
+  add_unqualified
+    ( "complex_schur_decompose_t"
+    , ReturnType UComplexMatrix
+    , [UComplexMatrix]
+    , AoS ) ;
+  add_unqualified
+    ("complex_schur_decompose_t", ReturnType UComplexMatrix, [UMatrix], AoS) ;
+  add_unqualified
+    ( "complex_schur_decompose_u"
+    , ReturnType UComplexMatrix
+    , [UComplexMatrix]
+    , AoS ) ;
+  add_unqualified
+    ("complex_schur_decompose_u", ReturnType UComplexMatrix, [UMatrix], AoS) ;
   add_unqualified ("conj", ReturnType UComplex, [UComplex], AoS) ;
   add_unqualified ("cos", ReturnType UComplex, [UComplex], AoS) ;
   add_unqualified ("cosh", ReturnType UComplex, [UComplex], AoS) ;

--- a/test/integration/good/function-signatures/math/matrix/complex_schur_decompose.stan
+++ b/test/integration/good/function-signatures/math/matrix/complex_schur_decompose.stan
@@ -1,0 +1,36 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_cmatrix;
+}
+transformed data {
+  complex_matrix[d_int, d_int] transformed_data_cmatrix;
+  transformed_data_cmatrix = complex_schur_decompose_t(d_matrix);
+  transformed_data_cmatrix = complex_schur_decompose_t(d_cmatrix);
+
+  transformed_data_cmatrix = complex_schur_decompose_u(d_matrix);
+  transformed_data_cmatrix = complex_schur_decompose_u(d_cmatrix);
+
+}
+parameters {
+  real y_p;
+
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_cmatrix;
+}
+transformed parameters {
+  complex_matrix[d_int, d_int] transformed_param_cmatrix;
+
+  transformed_param_cmatrix = complex_schur_decompose_t(d_matrix);
+  transformed_param_cmatrix = complex_schur_decompose_t(p_matrix);
+  transformed_param_cmatrix = complex_schur_decompose_t(d_cmatrix);
+  transformed_param_cmatrix = complex_schur_decompose_t(p_cmatrix);
+
+  transformed_param_cmatrix = complex_schur_decompose_u(d_matrix);
+  transformed_param_cmatrix = complex_schur_decompose_u(p_matrix);
+  transformed_param_cmatrix = complex_schur_decompose_u(d_cmatrix);
+  transformed_param_cmatrix = complex_schur_decompose_u(p_cmatrix);
+}
+model {
+  y_p ~ normal(0,1);
+}

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -3740,6 +3740,10 @@ Display all Stan math signatures exposed in the language
   columns_dot_self(complex_vector) => complex_row_vector
   columns_dot_self(complex_row_vector) => complex_row_vector
   columns_dot_self(complex_matrix) => complex_row_vector
+  complex_schur_decompose_t(matrix) => complex_matrix
+  complex_schur_decompose_t(complex_matrix) => complex_matrix
+  complex_schur_decompose_u(matrix) => complex_matrix
+  complex_schur_decompose_u(complex_matrix) => complex_matrix
   conj(complex) => complex
   cos(int) => real
   cos(real) => real


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: https://github.com/stan-dev/docs/pull/581
  
## Release notes

Added functions `complex_schur_decompose_t` and `complex_schur_decompose_u` implementing the complex-valued Schur decomposition for matrices. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
