### PR TITLE
Fix dune tests in ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,15 +195,12 @@ pipeline {
                         }
                     }
                     steps {
-                        dir("${env.WORKSPACE}/dune-tests"){
-                            unstash "Stanc3Setup"
-                            runShell("""
-                                eval \$(opam env)
-                                dune runtest
-                            """)
-                        }
+                        unstash "Stanc3Setup"
+                        runShell("""
+                            eval \$(opam env)
+                            dune runtest
+                        """)
                     }
-                    post { always { runShell("rm -rf ${env.WORKSPACE}/dune-tests/*") }}
                 }
                 stage("stancjs tests") {
                     agent {
@@ -214,15 +211,12 @@ pipeline {
                         }
                     }
                     steps {
-                        dir("${env.WORKSPACE}/stancjs-tests"){
-                            unstash "Stanc3Setup"
-                            runShell("""
-                                eval \$(opam env)
-                                dune build @runjstest
-                            """)
-                        }
+                        unstash "Stanc3Setup"
+                        runShell("""
+                            eval \$(opam env)
+                            dune build @runjstest
+                        """)
                     }
-                    post { always { runShell("rm -rf ${env.WORKSPACE}/stancjs-tests/*") }}
                 }
             }
         }
@@ -999,7 +993,10 @@ pipeline {
     }
     post {
        always {
-          script {utils.mailBuildResults()}
+          script {
+            runShell("rm -rf ${env.WORKSPACE}/*")
+            utils.mailBuildResults()
+          }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -994,7 +994,6 @@ pipeline {
     post {
        always {
           script {
-            runShell("rm -rf ${env.WORKSPACE}/*")
             utils.mailBuildResults()
           }
         }


### PR DESCRIPTION
Don't run ocaml tests in isolated directories, cleanup at the end of the pipeline

#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

There seems to be an issue with dune running from a child directory inside stanc3.
Before, we aimed for running each step with it's own source code isolated but since we were puttin stanc3 inside stanc3, example {path}/{stanc3 source code}/dune-tests/{stanc3 source code for this step} dune is running into an error
```
Entering directory '/tmp/stanc3'
Error: Too many opam files for package "stanc":
- dune-tests/stanc3/stanc.opam
- stanc.opam
```

This PR will execute the tests from the root of the working directory, therefore not running into this edge case.


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
