### PR TITLE
Do not let dune automatically guess root dir in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -568,7 +568,7 @@ pipeline {
                                 opam update || true
                                 bash -x scripts/install_build_deps.sh
                                 dune subst
-                                dune build @install
+                                dune build @install --root=.
                             """)
                             sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/mac-stanc"
                             stash name:'mac-exe', includes:'bin/*'
@@ -596,7 +596,7 @@ pipeline {
                                 opam update || true
                                 bash -x scripts/install_build_deps.sh
                                 dune subst
-                                dune build @install
+                                dune build @install --root=.
                             """)
                             sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/mac-stanc"
                             stash name:'mac-exe', includes:'bin/*'
@@ -626,7 +626,7 @@ pipeline {
                             runShell("""
                                 eval \$(opam env)
                                 dune subst
-                                dune build --profile release src/stancjs
+                                dune build --root=. --profile release src/stancjs
                             """)
                             sh "mkdir -p bin && mv `find _build -name stancjs.bc.js` bin/stanc.js"
                             sh "mv `find _build -name index.html` bin/load_stanc.html"
@@ -657,7 +657,7 @@ pipeline {
                             runShell("""
                                 eval \$(opam env)
                                 dune subst
-                                dune build @install --profile static
+                                dune build @install --profile static --root=.
                             """)
                             sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/linux-stanc"
                             stash name:'linux-exe', includes:'bin/*'
@@ -876,7 +876,7 @@ pipeline {
                             runShell("""
                                 eval \$(opam env)
                                 dune subst
-                                dune build -x windows
+                                dune build -x windows --root=.
                             """)
                             sh "mkdir -p bin && mv _build/default.windows/src/stanc/stanc.exe bin/windows-stanc"
                             stash name:'windows-exe', includes:'bin/*'

--- a/scripts/build_multiarch_stanc3.sh
+++ b/scripts/build_multiarch_stanc3.sh
@@ -25,4 +25,4 @@ SHA=$(skopeo inspect --raw docker://stanorg/stanc3:multiarch | jq '.manifests | 
 # Register QEMU translation binaries
 docker run --rm --privileged multiarch/qemu-user-static --reset
 
-docker run --privileged -v $(pwd):$(pwd):rw,z stanorg/stanc3:multiarch@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static && chmod -R 777 _build  && chmod -R 777 src && chmod -R 777 test"
+docker run --privileged -v $(pwd):$(pwd):rw,z stanorg/stanc3:multiarch@$SHA /bin/bash -c "cd $(pwd) && eval \$(opam env) && dune build @install --profile static --root=. && chmod -R 777 _build  && chmod -R 777 src && chmod -R 777 test"


### PR DESCRIPTION
Use --root when running in isolated directories to avoid dune automatically guessing the root directory in CI.

#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
