### PR TITLE
Github Actions: Build backwards-compatible Mac executables

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,10 +25,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Download older SDK
+        if: matrix.os == 'macos'
+        run: |
+          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.11.sdk.tar.xz
+          tar -xvf MacOSX10.11.sdk.tar.xz
+          sudo mv MacOSX10.11.sdk /Library/Developer/CommandLineTools/SDKs
+
+          echo "MACOSX_DEPLOYMENT_TARGET=10.11" >> $GITHUB_ENV
+          echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX10.11.sdk/" >> $GITHUB_ENV
+
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          cache-prefix: v3
+
       - run: bash -x scripts/install_build_deps.sh
 
       - name: Build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -561,18 +561,14 @@ pipeline {
 
         stage('Build binaries') {
             parallel {
-                // Builds on Flatiron macOS - recent macOS version
-                stage("Build & test Mac OS X binary - develop") {
+                stage("Build & test Mac OS X binary") {
                     when {
                         beforeAgent true
-                        allOf {
-                            expression { !skipRebuildingBinaries }
-                            anyOf { branch 'develop'; changeRequest() }
-                        }
+                        expression { !skipRebuildingBinaries }
                     }
                     agent { label 'osx' }
                     steps {
-                        dir("${env.WORKSPACE}/osx-develop"){
+                        dir("${env.WORKSPACE}/osx"){
                             unstash "Stanc3Setup"
                             runShell("""
                                 export PATH=/Users/jenkins/brew/bin:\$PATH
@@ -586,34 +582,7 @@ pipeline {
                             stash name:'mac-exe', includes:'bin/*'
                         }
                     }
-                    post { always { runShell("rm -rf ${env.WORKSPACE}/osx-develop/*") }}
-                }
-
-                // Builds on gelman macOS - version 10.11.6
-                stage("Build & test Mac OS X binary - release") {
-                    when {
-                        beforeAgent true
-                        allOf {
-                            expression { !skipRebuildingBinaries }
-                            anyOf { buildingTag(); branch 'master' }
-                        }
-                    }
-                    agent { label 'gg-osx' }
-                    steps {
-                        dir("${env.WORKSPACE}/osx-release"){
-                            unstash "Stanc3Setup"
-                            runShell("""
-                                opam switch 4.12.0
-                                eval \$(opam env --switch=4.12.0)
-                                opam update || true
-                                bash -x scripts/install_build_deps.sh
-                                dune build @install --root=.
-                            """)
-                            sh "mkdir -p bin && mv `find _build -name stanc.exe` bin/mac-stanc"
-                            stash name:'mac-exe', includes:'bin/*'
-                         }
-                    }
-                    post { always { runShell("rm -rf ${env.WORKSPACE}/osx-release/*") }}
+                    post { always { runShell("rm -rf ${env.WORKSPACE}/osx/*") }}
                 }
 
                 stage("Build stanc.js") {


### PR DESCRIPTION
This PR sets up our Github Actions run to use an older version of the MacOS SDK, allowing the built binaries to be used on older versions than the system which built them. 

Hopefully we will soon be able to do the same thing as part of the Flatiron Jenkins build, but even without it this removes the need for the gelman mac instances, since we could use this during releases if necessary. 

See sample run [here](https://github.com/WardBrian/stanc3/actions/runs/3154503248)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
