### PR TITLE
Improve errors for function re-declaration or missing definition

### DIFF
--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -44,7 +44,7 @@ let add env key type_ kind = Map.add_multi env ~key ~data:{type_; kind}
 let set_raw env key data = Map.set env ~key ~data
 let find env key = Map.find_multi env key
 let mem env key = Map.mem env key
-let iter env f = Map.iter env ~f
+let iteri env f = Map.iteri env ~f:(fun ~key ~data -> f key data)
 
 module Distance = struct
   (**  Wagner–Fischer algorithm for edit distance

--- a/src/frontend/Environment.mli
+++ b/src/frontend/Environment.mli
@@ -50,7 +50,7 @@ val set_raw : t -> string -> info list -> t
 (** Overwrite the existing items bound to a name *)
 
 val mem : t -> string -> bool
-val iter : t -> (info list -> unit) -> unit
+val iteri : t -> (string -> info list -> unit) -> unit
 
 val nearest_ident : t -> string -> string option
 (** The nearest identifier by edit distance, capped at edit distance 3 (if one exists) *)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -677,7 +677,7 @@ let invalid_sampling_cdf_or_ccdf loc name =
 let invalid_sampling_no_such_dist loc name =
   StatementError (loc, StatementError.InvalidSamplingNoSuchDistribution name)
 
-let target_plusequals_outisde_model_or_logprob loc =
+let target_plusequals_outside_model_or_logprob loc =
   StatementError (loc, StatementError.TargetPlusEqualsOutsideModelOrLogProb)
 
 let invalid_truncation_cdf_or_ccdf loc =
@@ -695,7 +695,7 @@ let continue_outside_loop loc =
 let expression_return_outside_returning_fn loc =
   StatementError (loc, StatementError.ExpressionReturnOutsideReturningFn)
 
-let void_ouside_nonreturning_fn loc =
+let void_outside_nonreturning_fn loc =
   StatementError (loc, StatementError.VoidReturnOutsideNonReturningFn)
 
 let non_data_variable_size_decl loc =

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -364,7 +364,7 @@ module StatementError = struct
         string * UnsizedType.returntype * UnsizedType.returntype
     | FuncDeclRedefined of string * UnsizedType.t * bool
     | FunDeclExists of string
-    | FunDeclNoDefn
+    | FunDeclNoDefn of string * bool
     | FunDeclNeedsBlock
     | NonRealProbFunDef
     | ProbDensityNonRealVariate of UnsizedType.t option
@@ -442,14 +442,16 @@ module StatementError = struct
     | FuncDeclRedefined (name, ut, stan_math) ->
         Fmt.pf ppf "Function '%s' %s signature %a" name
           ( if stan_math then "is already declared in the Stan Math library with"
-          else "has already been declared to for" )
+          else "has already been declared for" )
           UnsizedType.pp ut
     | FunDeclExists name ->
         Fmt.pf ppf
           "Function '%s' has already been declared. A definition is expected."
           name
-    | FunDeclNoDefn ->
-        Fmt.pf ppf "Function is declared without specifying a definition."
+    | FunDeclNoDefn (name, redeclaration) ->
+        Fmt.pf ppf
+          "Function '%s' is %sdeclared without specifying a definition." name
+          (if redeclaration then "re-" else "")
     | FunDeclNeedsBlock ->
         Fmt.pf ppf "Function definitions must be wrapped in curly braces."
     | NonRealProbFunDef ->
@@ -715,7 +717,8 @@ let fn_decl_redefined loc name ~stan_math ut =
 let fn_decl_exists loc name =
   StatementError (loc, StatementError.FunDeclExists name)
 
-let fn_decl_without_def loc = StatementError (loc, StatementError.FunDeclNoDefn)
+let fn_decl_without_def loc name previous =
+  StatementError (loc, StatementError.FunDeclNoDefn (name, previous))
 
 let fn_decl_needs_block loc =
   StatementError (loc, StatementError.FunDeclNeedsBlock)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -364,7 +364,7 @@ module StatementError = struct
         string * UnsizedType.returntype * UnsizedType.returntype
     | FuncDeclRedefined of string * UnsizedType.t * bool
     | FunDeclExists of string
-    | FunDeclNoDefn of string * bool
+    | FunDeclNoDefn of string
     | FunDeclNeedsBlock
     | NonRealProbFunDef
     | ProbDensityNonRealVariate of UnsizedType.t option
@@ -448,10 +448,9 @@ module StatementError = struct
         Fmt.pf ppf
           "Function '%s' has already been declared. A definition is expected."
           name
-    | FunDeclNoDefn (name, redeclaration) ->
-        Fmt.pf ppf
-          "Function '%s' is %sdeclared without specifying a definition." name
-          (if redeclaration then "re-" else "")
+    | FunDeclNoDefn name ->
+        Fmt.pf ppf "Function '%s' is declared without specifying a definition."
+          name
     | FunDeclNeedsBlock ->
         Fmt.pf ppf "Function definitions must be wrapped in curly braces."
     | NonRealProbFunDef ->
@@ -717,8 +716,8 @@ let fn_decl_redefined loc name ~stan_math ut =
 let fn_decl_exists loc name =
   StatementError (loc, StatementError.FunDeclExists name)
 
-let fn_decl_without_def loc name previous =
-  StatementError (loc, StatementError.FunDeclNoDefn (name, previous))
+let fn_decl_without_def loc name =
+  StatementError (loc, StatementError.FunDeclNoDefn name)
 
 let fn_decl_needs_block loc =
   StatementError (loc, StatementError.FunDeclNeedsBlock)

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -124,13 +124,13 @@ val cannot_assign_to_multiindex : Location_span.t -> t
 val invalid_sampling_pdf_or_pmf : Location_span.t -> t
 val invalid_sampling_cdf_or_ccdf : Location_span.t -> string -> t
 val invalid_sampling_no_such_dist : Location_span.t -> string -> t
-val target_plusequals_outisde_model_or_logprob : Location_span.t -> t
+val target_plusequals_outside_model_or_logprob : Location_span.t -> t
 val invalid_truncation_cdf_or_ccdf : Location_span.t -> t
 val multivariate_truncation : Location_span.t -> t
 val break_outside_loop : Location_span.t -> t
 val continue_outside_loop : Location_span.t -> t
 val expression_return_outside_returning_fn : Location_span.t -> t
-val void_ouside_nonreturning_fn : Location_span.t -> t
+val void_outside_nonreturning_fn : Location_span.t -> t
 val non_data_variable_size_decl : Location_span.t -> t
 val non_int_bounds : Location_span.t -> t
 val complex_transform : Location_span.t -> t

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -147,7 +147,7 @@ val fn_decl_redefined :
   Location_span.t -> string -> stan_math:bool -> UnsizedType.t -> t
 
 val fn_decl_exists : Location_span.t -> string -> t
-val fn_decl_without_def : Location_span.t -> t
+val fn_decl_without_def : Location_span.t -> string -> bool -> t
 val fn_decl_needs_block : Location_span.t -> t
 val non_real_prob_fn_def : Location_span.t -> t
 val prob_density_non_real_variate : Location_span.t -> UnsizedType.t option -> t

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -147,7 +147,7 @@ val fn_decl_redefined :
   Location_span.t -> string -> stan_math:bool -> UnsizedType.t -> t
 
 val fn_decl_exists : Location_span.t -> string -> t
-val fn_decl_without_def : Location_span.t -> string -> bool -> t
+val fn_decl_without_def : Location_span.t -> string -> t
 val fn_decl_needs_block : Location_span.t -> t
 val non_real_prob_fn_def : Location_span.t -> t
 val prob_density_non_real_variate : Location_span.t -> UnsizedType.t option -> t

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -437,7 +437,7 @@ let verify_fn_target_plus_equals cf loc id =
     && not
          ( cf.in_lp_fun_def || cf.current_block = Model
          || cf.current_block = TParam )
-  then Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
+  then Semantic_error.target_plusequals_outside_model_or_logprob loc |> error
 
 (** Rng functions cannot be used in Tp or Model and only
     in function defs with the right suffix
@@ -864,7 +864,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
           ( cf.in_lp_fun_def || cf.current_block = Model
           || cf.current_block = TParam )
       then
-        Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
+        Semantic_error.target_plusequals_outside_model_or_logprob loc |> error
       else
         mk_typed_expression ~expr:GetLP
           ~ad_level:(calculate_autodifftype cf cf.current_block UReal)
@@ -876,7 +876,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
           ( cf.in_lp_fun_def || cf.current_block = Model
           || cf.current_block = TParam )
       then
-        Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
+        Semantic_error.target_plusequals_outside_model_or_logprob loc |> error
       else
         mk_typed_expression ~expr:GetTarget
           ~ad_level:(calculate_autodifftype cf cf.current_block UReal)
@@ -924,7 +924,7 @@ let verify_nrfn_target loc cf id =
     && not
          ( cf.in_lp_fun_def || cf.current_block = Model
          || cf.current_block = TParam )
-  then Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
+  then Semantic_error.target_plusequals_outside_model_or_logprob loc |> error
 
 let check_nrfn loc tenv id es =
   match Env.find tenv id.name with
@@ -1084,7 +1084,7 @@ let verify_target_pe_expr_type loc e =
 
 let verify_target_pe_usage loc cf =
   if cf.in_lp_fun_def || cf.current_block = Model then ()
-  else Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
+  else Semantic_error.target_plusequals_outside_model_or_logprob loc |> error
 
 let check_target_pe loc cf tenv e =
   let te = check_expression cf tenv e in
@@ -1117,7 +1117,7 @@ let verify_sampling_cdf_ccdf loc id =
 (* Target+= can only be used in model and functions with right suffix (same for tilde etc) *)
 let verify_valid_sampling_pos loc cf =
   if cf.in_lp_fun_def || cf.current_block = Model then ()
-  else Semantic_error.target_plusequals_outisde_model_or_logprob loc |> error
+  else Semantic_error.target_plusequals_outside_model_or_logprob loc |> error
 
 let verify_sampling_distribution loc tenv id arguments =
   let name = id.name in
@@ -1222,7 +1222,7 @@ let check_return loc cf tenv e =
 
 let check_returnvoid loc cf =
   if (not cf.in_fun_def) || cf.in_returning_fun_def then
-    Semantic_error.void_ouside_nonreturning_fn loc |> error
+    Semantic_error.void_outside_nonreturning_fn loc |> error
   else mk_typed_statement ~stmt:ReturnVoid ~return_type:(Complete Void) ~loc
 
 let check_printable cf tenv = function

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1575,7 +1575,7 @@ and get_fn_decl_or_defn loc tenv id arg_tys rt body =
   match body with
   | {stmt= Skip; _} ->
       if exists_matching_fn_declared tenv id arg_tys rt then
-        Semantic_error.fn_decl_without_def loc |> error
+        Semantic_error.fn_decl_without_def loc id.name true |> error
       else `UserDeclared id.id_loc
   | _ -> `UserDefined
 
@@ -1728,14 +1728,14 @@ let verify_fun_def_body_in_block = function
   | _ -> ()
 
 let verify_functions_have_defn tenv function_block_stmts_opt =
-  let error_on_undefined funs =
+  let error_on_undefined name funs =
     List.iter funs ~f:(fun f ->
         match f with
         | Env.{kind= `UserDeclared loc; _} ->
-            Semantic_error.fn_decl_without_def loc |> error
+            Semantic_error.fn_decl_without_def loc name false |> error
         | _ -> () ) in
   if !check_that_all_functions_have_definition then
-    Env.iter tenv error_on_undefined ;
+    Env.iteri tenv error_on_undefined ;
   match function_block_stmts_opt with
   | Some {stmts= []; _} | None -> ()
   | Some {stmts= ls; _} -> List.iter ~f:verify_fun_def_body_in_block ls

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1575,7 +1575,7 @@ and get_fn_decl_or_defn loc tenv id arg_tys rt body =
   match body with
   | {stmt= Skip; _} ->
       if exists_matching_fn_declared tenv id arg_tys rt then
-        Semantic_error.fn_decl_without_def loc id.name true |> error
+        Semantic_error.fn_decl_exists loc id.name |> error
       else `UserDeclared id.id_loc
   | _ -> `UserDefined
 
@@ -1732,7 +1732,7 @@ let verify_functions_have_defn tenv function_block_stmts_opt =
     List.iter (List.rev funs) ~f:(fun f ->
         match f with
         | Env.{kind= `UserDeclared loc; _} ->
-            Semantic_error.fn_decl_without_def loc name false |> error
+            Semantic_error.fn_decl_without_def loc name |> error
         | _ -> () ) in
   if !check_that_all_functions_have_definition then
     Env.iteri tenv error_on_undefined ;

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1729,7 +1729,7 @@ let verify_fun_def_body_in_block = function
 
 let verify_functions_have_defn tenv function_block_stmts_opt =
   let error_on_undefined name funs =
-    List.iter funs ~f:(fun f ->
+    List.iter (List.rev funs) ~f:(fun f ->
         match f with
         | Env.{kind= `UserDeclared loc; _} ->
             Semantic_error.fn_decl_without_def loc name false |> error

--- a/test/integration/bad/function-signatures/overloading/stanc.expected
+++ b/test/integration/bad/function-signatures/overloading/stanc.expected
@@ -221,7 +221,7 @@ Semantic error in 'redefinition.stan', line 6, column 3 to line 8, column 4:
      8:     }
    -------------------------------------------------
 
-Function 'foo' has already been declared to for signature (real) => int
+Function 'foo' has already been declared for signature (real) => int
   $ ../../../../../../install/default/bin/stanc returntype_issues.stan
 Semantic error in 'returntype_issues.stan', line 6, column 3 to line 8, column 4:
    -------------------------------------------------

--- a/test/integration/bad/functions-bad8.stan
+++ b/test/integration/bad/functions-bad8.stan
@@ -1,0 +1,4 @@
+functions {
+  void bar(int x);
+  void bar(int x);
+}

--- a/test/integration/bad/functions-bad9.stan
+++ b/test/integration/bad/functions-bad9.stan
@@ -1,0 +1,4 @@
+functions {
+  void bar(int x);
+  void bar(int x, real y);
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1109,7 +1109,7 @@ Semantic error in 'functions-bad1.stan', line 6, column 2 to column 20:
      8:  parameters {
    -------------------------------------------------
 
-Function 'flib' has already been declared to for signature (real) => real
+Function 'flib' has already been declared for signature (real) => real
   $ ../../../../install/default/bin/stanc functions-bad11.stan
 Semantic error in 'functions-bad11.stan', line 3, column 4 to column 20:
    -------------------------------------------------
@@ -1215,7 +1215,7 @@ Semantic error in 'functions-bad19.stan', line 4, column 2 to line 6, column 3:
      6:    }
    -------------------------------------------------
 
-Function 'my_fun3' has already been declared to for signature (real) => real
+Function 'my_fun3' has already been declared for signature (real) => real
   $ ../../../../install/default/bin/stanc functions-bad2.stan
 Semantic error in 'functions-bad2.stan', line 8, column 7 to column 13:
    -------------------------------------------------
@@ -1227,7 +1227,7 @@ Semantic error in 'functions-bad2.stan', line 8, column 7 to column 13:
     10:  }
    -------------------------------------------------
 
-Function is declared without specifying a definition.
+Function 'barfoo' is declared without specifying a definition.
   $ ../../../../install/default/bin/stanc functions-bad20.stan
 Semantic error in 'functions-bad20.stan', line 4, column 2 to line 6, column 3:
    -------------------------------------------------
@@ -1239,7 +1239,7 @@ Semantic error in 'functions-bad20.stan', line 4, column 2 to line 6, column 3:
      6:    }
    -------------------------------------------------
 
-Function 'my_fun3' has already been declared to for signature (data real) => real
+Function 'my_fun3' has already been declared for signature (data real) => real
   $ ../../../../install/default/bin/stanc functions-bad21.stan
 Semantic error in 'functions-bad21.stan', line 13, column 11 to column 21:
    -------------------------------------------------
@@ -1388,6 +1388,17 @@ Semantic error in 'functions-bad7.stan', line 14, column 6 to column 20:
    -------------------------------------------------
 
 Target can only be accessed in the model block or in definitions of functions with the suffix _lp.
+  $ ../../../../install/default/bin/stanc functions-bad8.stan
+Semantic error in 'functions-bad8.stan', line 3, column 2 to column 18:
+   -------------------------------------------------
+     1:  functions {
+     2:    void bar(int x);
+     3:    void bar(int x);
+           ^
+     4:  }
+   -------------------------------------------------
+
+Function 'bar' is re-declared without specifying a definition.
   $ ../../../../install/default/bin/stanc get-lp-target-data.stan
 Semantic error in 'get-lp-target-data.stan', line 2, column 19 to column 27:
    -------------------------------------------------
@@ -2037,7 +2048,7 @@ Semantic error in 'redefine-ccdf3.stan', line 5, column 2 to line 7, column 3:
      7:    }
    -------------------------------------------------
 
-Function 'foo_ccdf_log' has already been declared to for signature (int, real) => real
+Function 'foo_ccdf_log' has already been declared for signature (int, real) => real
   $ ../../../../install/default/bin/stanc redefine-cdf3.stan
 Semantic error in 'redefine-cdf3.stan', line 5, column 2 to line 7, column 3:
    -------------------------------------------------
@@ -2049,7 +2060,7 @@ Semantic error in 'redefine-cdf3.stan', line 5, column 2 to line 7, column 3:
      7:    }
    -------------------------------------------------
 
-Function 'foo_cdf_log' has already been declared to for signature (int, real) => real
+Function 'foo_cdf_log' has already been declared for signature (int, real) => real
   $ ../../../../install/default/bin/stanc redefine-prob3.stan
 Semantic error in 'redefine-prob3.stan', line 5, column 2 to line 7, column 3:
    -------------------------------------------------
@@ -2061,7 +2072,7 @@ Semantic error in 'redefine-prob3.stan', line 5, column 2 to line 7, column 3:
      7:    }
    -------------------------------------------------
 
-Function 'foo_lpmf' has already been declared to for signature (int) => real
+Function 'foo_lpmf' has already been declared for signature (int) => real
   $ ../../../../install/default/bin/stanc rng_loc1.stan
 Semantic error in 'rng_loc1.stan', line 3, column 11 to column 29:
    -------------------------------------------------

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1398,7 +1398,7 @@ Semantic error in 'functions-bad8.stan', line 3, column 2 to column 18:
      4:  }
    -------------------------------------------------
 
-Function 'bar' is re-declared without specifying a definition.
+Function 'bar' has already been declared. A definition is expected.
   $ ../../../../install/default/bin/stanc functions-bad9.stan
 Semantic error in 'functions-bad9.stan', line 2, column 7 to column 10:
    -------------------------------------------------

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1399,6 +1399,17 @@ Semantic error in 'functions-bad8.stan', line 3, column 2 to column 18:
    -------------------------------------------------
 
 Function 'bar' is re-declared without specifying a definition.
+  $ ../../../../install/default/bin/stanc functions-bad9.stan
+Semantic error in 'functions-bad9.stan', line 2, column 7 to column 10:
+   -------------------------------------------------
+     1:  functions {
+     2:    void bar(int x);
+                ^
+     3:    void bar(int x, real y);
+     4:  }
+   -------------------------------------------------
+
+Function 'bar' is declared without specifying a definition.
   $ ../../../../install/default/bin/stanc get-lp-target-data.stan
 Semantic error in 'get-lp-target-data.stan', line 2, column 19 to column 27:
    -------------------------------------------------

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -9,7 +9,7 @@ Semantic error in 'string', line 3, column 8 to column 11:
      5:  transformed data {
    -------------------------------------------------
 
-Function is declared without specifying a definition.
+Function 'foo' is declared without specifying a definition.
 
 $ node auto-format.js
 parameters {
@@ -241,7 +241,7 @@ Semantic error in 'string', line 3, column 8 to column 11:
      5:  
    -------------------------------------------------
 
-Function is declared without specifying a definition.
+Function 'foo' is declared without specifying a definition.
 
 "stancflags = --use-opencl --allow-undefined"
 $ node pedantic.js


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improved the error generated when a function is re-declared, or when a function is not given a definition. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
