### PR TITLE
Add print and reject to info functions output

### DIFF
--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -53,6 +53,8 @@ let rec get_function_calls_stmt ud_dists (funs, distrs) stmt =
   let acc =
     match stmt.stmt with
     | NRFunApp (StanLib _, f, _) -> (Set.add funs f.name, distrs)
+    | Print _ -> (Set.add funs "print", distrs)
+    | Reject _ -> (Set.add funs "reject", distrs)
     | Tilde {distribution; _} ->
         let possible_names =
           List.map ~f:(( ^ ) distribution.name) Utils.distribution_suffices

--- a/test/integration/cli-args/info/info.expected
+++ b/test/integration/cli-args/info/info.expected
@@ -26,7 +26,7 @@
   },
   "transformed parameters": { "t": { "type": "real", "dimensions": 2 } },
   "generated quantities": { "u": { "type": "real", "dimensions": 0 } },
-  "functions": [ "log", "reduce_sum", "sin", "square" ],
+  "functions": [ "log", "print", "reduce_sum", "reject", "sin", "square" ],
   "distributions": [
     "dirichlet_lupdf", "normal_lccdf", "normal_lcdf", "normal_lpdf",
     "std_normal_lupdf"

--- a/test/integration/cli-args/info/info.stan
+++ b/test/integration/cli-args/info/info.stan
@@ -57,6 +57,10 @@ model {
     target += std_normal_lupdf(y);
     target += reduce_sum(f_lpdf, g, 1);
     y ~ goo();
+    print("hello world");
+    if (0) {
+      reject("goodbye");
+    }
 }
 
 generated quantities {


### PR DESCRIPTION
This makes it so `print` and `reject` will now be listed as functions in `stanc --info`s output. The fact that these aren't technically functions but pseudo-compiler-builtins isn't something we really want to subject users to, IMO.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

`print` and `reject` will now be listed as functions in `stanc --info`s output.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
