### PR TITLE
Refactor: encapsulate variadic functions in typechecking

### DIFF
--- a/docs/exposing_new_functions.mld
+++ b/docs/exposing_new_functions.mld
@@ -130,8 +130,15 @@ For example, the following line defines the signature [add(real, matrix) => matr
 Functions such as the ODE integrators or [reduce_sum], which take in user-functions and a variable-length
 list of arguments, are {b NOT} added to this list.
 
-These are instead treated as special cases in the [Typechecker] module in the frontend folder. It
-it best to consult an existing example of how these are done before proceeding.
+"Nice" variadic functions are added to the hashtable [Stan_math_signatures.stan_math_variadic_signatures].
+This is probably sufficient for most variadic functions, e.g. all the ODE solvers and DAE solvers are done
+via this method.
+[reduce_sum] is not "nice", since it is both variadic and {e polymorphic}, requiring certain arguments to have the same
+(but {e not predetermined}) type. Therefore, [reduce_sum] is treated as special case in the [Typechecker]
+module in the frontend folder.
+
+Note that higher-order functions also usually require changes to the C++ code generation to work properly.
+It is best to consult an existing example of how these are done before proceeding.
 
 {1 Testing}
 

--- a/src/analysis_and_optimization/Memory_patterns.ml
+++ b/src/analysis_and_optimization/Memory_patterns.ml
@@ -113,9 +113,8 @@ let query_stan_math_mem_pattern_support (name : string)
     (args : (UnsizedType.autodifftype * UnsizedType.t) list) =
   let open Stan_math_signatures in
   match name with
+  | x when is_stan_math_variadic_function_name x -> false
   | x when is_reduce_sum_fn x -> false
-  | x when is_variadic_ode_fn x -> false
-  | x when is_variadic_dae_fn x -> false
   | _ ->
       let name =
         string_operator_to_stan_math_fns (Utils.stdlib_distribution_name name)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -26,7 +26,7 @@ module TypeError = struct
         * UnsizedType.t list
         * (UnsizedType.autodifftype * UnsizedType.t) list
         * SignatureMismatch.function_mismatch
-    | IllTypedVariadicDE of
+    | IllTypedVariadic of
         string
         * UnsizedType.t list
         * (UnsizedType.autodifftype * UnsizedType.t) list
@@ -131,7 +131,7 @@ module TypeError = struct
     | IllTypedReduceSumGeneric (name, arg_tys, expected_args, error) ->
         SignatureMismatch.pp_signature_mismatch ppf
           (name, arg_tys, ([((ReturnType UReal, expected_args), error)], false))
-    | IllTypedVariadicDE (name, arg_tys, args, error, return_type) ->
+    | IllTypedVariadic (name, arg_tys, args, error, return_type) ->
         SignatureMismatch.pp_signature_mismatch ppf
           ( name
           , arg_tys
@@ -550,25 +550,8 @@ let illtyped_reduce_sum_generic loc name arg_tys expected_args error =
     , TypeError.IllTypedReduceSumGeneric (name, arg_tys, expected_args, error)
     )
 
-let illtyped_variadic_ode loc name arg_tys args error =
-  TypeError
-    ( loc
-    , TypeError.IllTypedVariadicDE
-        ( name
-        , arg_tys
-        , args
-        , error
-        , Stan_math_signatures.variadic_ode_fun_return_type ) )
-
-let illtyped_variadic_dae loc name arg_tys args error =
-  TypeError
-    ( loc
-    , TypeError.IllTypedVariadicDE
-        ( name
-        , arg_tys
-        , args
-        , error
-        , Stan_math_signatures.variadic_dae_fun_return_type ) )
+let illtyped_variadic loc name arg_tys args fn_rt error =
+  TypeError (loc, TypeError.IllTypedVariadic (name, arg_tys, args, error, fn_rt))
 
 let ambiguous_function_promotion loc name arg_tys signatures =
   TypeError

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -58,14 +58,6 @@ val illtyped_reduce_sum_generic :
   -> SignatureMismatch.function_mismatch
   -> t
 
-val illtyped_variadic_ode :
-     Location_span.t
-  -> string
-  -> UnsizedType.t list
-  -> (UnsizedType.autodifftype * UnsizedType.t) list
-  -> SignatureMismatch.function_mismatch
-  -> t
-
 val ambiguous_function_promotion :
      Location_span.t
   -> string
@@ -74,11 +66,12 @@ val ambiguous_function_promotion :
      list
   -> t
 
-val illtyped_variadic_dae :
+val illtyped_variadic :
      Location_span.t
   -> string
   -> UnsizedType.t list
   -> (UnsizedType.autodifftype * UnsizedType.t) list
+  -> UnsizedType.t
   -> SignatureMismatch.function_mismatch
   -> t
 

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -122,8 +122,7 @@ let verify_name_fresh_udf loc tenv name =
     (* variadic functions are currently not in math sigs and aren't
        overloadable due to their separate typechecking *)
     Stan_math_signatures.is_reduce_sum_fn name
-    || Stan_math_signatures.is_variadic_ode_fn name
-    || Stan_math_signatures.is_variadic_dae_fn name
+    || Stan_math_signatures.is_stan_math_variadic_function_name name
   then Semantic_error.ident_is_stanmath_name loc name |> error
   else if Utils.is_unnormalized_distribution name then
     Semantic_error.udf_is_unnormalized_fn loc name |> error
@@ -194,10 +193,12 @@ let stan_math_return_type name arg_tys =
   match name with
   | x when Stan_math_signatures.is_reduce_sum_fn x ->
       Some (UnsizedType.ReturnType UReal)
-  | x when Stan_math_signatures.is_variadic_ode_fn x ->
-      Some (UnsizedType.ReturnType (UArray UVector))
-  | x when Stan_math_signatures.is_variadic_dae_fn x ->
-      Some (UnsizedType.ReturnType (UArray UVector))
+  | x when Stan_math_signatures.is_stan_math_variadic_function_name x ->
+      Some
+        (UnsizedType.ReturnType
+           (Hashtbl.find_exn Stan_math_signatures.stan_math_variadic_signatures
+              x )
+             .return_type )
   | _ ->
       SignatureMismatch.matching_stanlib_function name arg_tys
       |> match_to_rt_option
@@ -571,14 +572,16 @@ let make_function_variable cf loc id = function
 
 let rec check_fn ~is_cond_dist loc cf tenv id (tes : Ast.typed_expression list)
     =
-  if Stan_math_signatures.is_reduce_sum_fn id.name then
+  if Stan_math_signatures.is_stan_math_variadic_function_name id.name then
+    check_variadic ~is_cond_dist loc cf tenv id tes
+  else if Stan_math_signatures.is_reduce_sum_fn id.name then
     check_reduce_sum ~is_cond_dist loc cf tenv id tes
-  else if Stan_math_signatures.is_variadic_ode_fn id.name then
-    check_variadic_ode ~is_cond_dist loc cf tenv id tes
-  else if Stan_math_signatures.is_variadic_dae_fn id.name then
-    check_variadic_dae ~is_cond_dist loc cf tenv id tes
   else check_normal_fn ~is_cond_dist loc tenv id tes
 
+(** Reduce sum is a special case, even compared to the other
+    variadic functions, because it is polymorphic in the type of the
+    first argument. The first, fourth, and fifth arguments must agree,
+    which is too complicated to be captured declaratively. *)
 and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
   let basic_mismatch () =
     let mandatory_args =
@@ -635,33 +638,30 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
         |> error )
   | _ -> fail ()
 
-and check_variadic_ode ~is_cond_dist loc cf tenv id tes =
-  let optional_tol_mandatory_args =
-    if Stan_math_signatures.variadic_ode_adjoint_fn = id.name then
-      Stan_math_signatures.variadic_ode_adjoint_ctl_tol_arg_types
-    else if Stan_math_signatures.is_variadic_ode_nonadjoint_tol_fn id.name then
-      Stan_math_signatures.variadic_ode_tol_arg_types
-    else [] in
-  let mandatory_arg_types =
-    Stan_math_signatures.variadic_ode_mandatory_arg_types
-    @ optional_tol_mandatory_args in
+and check_variadic ~is_cond_dist loc cf tenv id tes =
+  let Stan_math_signatures.
+        { control_args
+        ; required_fn_args
+        ; required_fn_rt
+        ; allow_fn_lpdf
+        ; return_type } =
+    Hashtbl.find_exn Stan_math_signatures.stan_math_variadic_signatures id.name
+  in
   let fail () =
     let expected_args, err =
-      SignatureMismatch.check_variadic_args false mandatory_arg_types
-        Stan_math_signatures.variadic_ode_mandatory_fun_args
-        Stan_math_signatures.variadic_ode_fun_return_type (get_arg_types tes)
+      SignatureMismatch.check_variadic_args allow_fn_lpdf control_args
+        required_fn_args required_fn_rt (get_arg_types tes)
       |> Result.error |> Option.value_exn in
-    Semantic_error.illtyped_variadic_ode loc id.name
+    Semantic_error.illtyped_variadic loc id.name
       (List.map ~f:type_of_expr_typed tes)
-      expected_args err
+      expected_args required_fn_rt err
     |> error in
   let matching remaining_es Env.{type_= ftype; _} =
     let arg_types =
       (calculate_autodifftype cf Functions ftype, ftype)
       :: get_arg_types remaining_es in
-    SignatureMismatch.check_variadic_args false mandatory_arg_types
-      Stan_math_signatures.variadic_ode_mandatory_fun_args
-      Stan_math_signatures.variadic_ode_fun_return_type arg_types in
+    SignatureMismatch.check_variadic_args allow_fn_lpdf control_args
+      required_fn_args required_fn_rt arg_types in
   match tes with
   | {expr= Variable fname; _} :: remaining_es -> (
     match find_matching_first_order_fn tenv (matching remaining_es) fname with
@@ -671,61 +671,14 @@ and check_variadic_ode ~is_cond_dist loc cf tenv id tes =
           ~expr:
             (mk_fun_app ~is_cond_dist
                (StanLib FnPlain, id, Promotion.promote_list tes promotions) )
-          ~ad_level:(expr_ad_lub tes)
-          ~type_:Stan_math_signatures.variadic_ode_return_type ~loc
+          ~ad_level:(expr_ad_lub tes) ~type_:return_type ~loc
     | AmbiguousMatch ps ->
         Semantic_error.ambiguous_function_promotion loc fname.name None ps
         |> error
     | SignatureErrors (expected_args, err) ->
-        Semantic_error.illtyped_variadic_ode loc id.name
+        Semantic_error.illtyped_variadic loc id.name
           (List.map ~f:type_of_expr_typed tes)
-          expected_args err
-        |> error )
-  | _ -> fail ()
-
-and check_variadic_dae ~is_cond_dist loc cf tenv id tes =
-  let optional_tol_mandatory_args =
-    if Stan_math_signatures.is_variadic_dae_tol_fn id.name then
-      Stan_math_signatures.variadic_dae_tol_arg_types
-    else [] in
-  let mandatory_arg_types =
-    Stan_math_signatures.variadic_dae_mandatory_arg_types
-    @ optional_tol_mandatory_args in
-  let fail () =
-    let expected_args, err =
-      SignatureMismatch.check_variadic_args false mandatory_arg_types
-        Stan_math_signatures.variadic_dae_mandatory_fun_args
-        Stan_math_signatures.variadic_dae_fun_return_type (get_arg_types tes)
-      |> Result.error |> Option.value_exn in
-    Semantic_error.illtyped_variadic_dae loc id.name
-      (List.map ~f:type_of_expr_typed tes)
-      expected_args err
-    |> error in
-  let matching remaining_es Env.{type_= ftype; _} =
-    let arg_types =
-      (calculate_autodifftype cf Functions ftype, ftype)
-      :: get_arg_types remaining_es in
-    SignatureMismatch.check_variadic_args false mandatory_arg_types
-      Stan_math_signatures.variadic_dae_mandatory_fun_args
-      Stan_math_signatures.variadic_dae_fun_return_type arg_types in
-  match tes with
-  | {expr= Variable fname; _} :: remaining_es -> (
-    match find_matching_first_order_fn tenv (matching remaining_es) fname with
-    | SignatureMismatch.UniqueMatch (ftype, promotions) ->
-        let tes = make_function_variable cf loc fname ftype :: remaining_es in
-        mk_typed_expression
-          ~expr:
-            (mk_fun_app ~is_cond_dist
-               (StanLib FnPlain, id, Promotion.promote_list tes promotions) )
-          ~ad_level:(expr_ad_lub tes)
-          ~type_:Stan_math_signatures.variadic_dae_return_type ~loc
-    | AmbiguousMatch ps ->
-        Semantic_error.ambiguous_function_promotion loc fname.name None ps
-        |> error
-    | SignatureErrors (expected_args, err) ->
-        Semantic_error.illtyped_variadic_dae loc id.name
-          (List.map ~f:type_of_expr_typed tes)
-          expected_args err
+          expected_args required_fn_rt err
         |> error )
   | _ -> fail ()
 

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -90,6 +90,14 @@ type fkind =
 type fun_arg = UnsizedType.autodifftype * UnsizedType.t
 type signature = UnsizedType.returntype * fun_arg list * Mem_pattern.t
 
+type variadic_signature =
+  { return_type: UnsizedType.t
+  ; control_args: fun_arg list
+  ; allow_fn_lpdf: bool [@default false]
+  ; required_fn_rt: UnsizedType.t
+  ; required_fn_args: fun_arg list }
+[@@deriving create]
+
 let is_primitive = function
   | UnsizedType.UReal -> true
   | UInt -> true
@@ -102,6 +110,13 @@ let (stan_math_signatures : (string, signature list) Hashtbl.t) =
 (** All of the signatures that are added by hand, rather than the ones
     added "declaratively" *)
 let (manual_stan_math_signatures : (string, signature list) Hashtbl.t) =
+  String.Table.create ()
+
+(** The variadic signatures hash table
+
+    These functions cannot be overloaded.
+*)
+let (stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t) =
   String.Table.create ()
 
 (* XXX The correct word here isn't combination - what is it? *)
@@ -152,64 +167,6 @@ let rec real_to_complex = function
   | UArray t -> UArray (real_to_complex t)
   | x -> x
 
-let reduce_sum_allowed_dimensionalities = [1; 2; 3; 4; 5; 6; 7]
-
-let reduce_sum_slice_types =
-  let base_slice_type i =
-    [ bare_array_type (UnsizedType.UReal, i)
-    ; bare_array_type (UnsizedType.UInt, i)
-    ; bare_array_type (UnsizedType.UMatrix, i)
-    ; bare_array_type (UnsizedType.UVector, i)
-    ; bare_array_type (UnsizedType.URowVector, i) ] in
-  List.concat (List.map ~f:base_slice_type reduce_sum_allowed_dimensionalities)
-
-(* Variadic ODE *)
-let variadic_ode_adjoint_ctl_tol_arg_types =
-  [ (UnsizedType.DataOnly, UnsizedType.UReal)
-    (* real relative_tolerance_forward *)
-  ; (DataOnly, UVector) (* vector absolute_tolerance_forward *)
-  ; (DataOnly, UReal) (* real relative_tolerance_backward *)
-  ; (DataOnly, UVector) (* real absolute_tolerance_backward *)
-  ; (DataOnly, UReal) (* real relative_tolerance_quadrature *)
-  ; (DataOnly, UReal) (* real absolute_tolerance_quadrature *)
-  ; (DataOnly, UInt) (* int max_num_steps *)
-  ; (DataOnly, UInt) (* int num_steps_between_checkpoints *)
-  ; (DataOnly, UInt) (* int interpolation_polynomial *)
-  ; (DataOnly, UInt) (* int solver_forward *); (DataOnly, UInt)
-    (* int solver_backward *) ]
-
-let variadic_ode_tol_arg_types =
-  [ (UnsizedType.DataOnly, UnsizedType.UReal); (DataOnly, UReal)
-  ; (DataOnly, UInt) ]
-
-let variadic_ode_mandatory_arg_types =
-  [ (UnsizedType.AutoDiffable, UnsizedType.UVector); (AutoDiffable, UReal)
-  ; (AutoDiffable, UArray UReal) ]
-
-let variadic_ode_mandatory_fun_args =
-  [ (UnsizedType.AutoDiffable, UnsizedType.UReal)
-  ; (UnsizedType.AutoDiffable, UnsizedType.UVector) ]
-
-let variadic_ode_fun_return_type = UnsizedType.UVector
-let variadic_ode_return_type = UnsizedType.UArray UnsizedType.UVector
-
-let variadic_dae_tol_arg_types =
-  [ (UnsizedType.DataOnly, UnsizedType.UReal); (DataOnly, UReal)
-  ; (DataOnly, UInt) ]
-
-let variadic_dae_mandatory_arg_types =
-  [ (UnsizedType.AutoDiffable, UnsizedType.UVector); (* yy *)
-    (UnsizedType.AutoDiffable, UnsizedType.UVector); (* yp *)
-    (AutoDiffable, UReal); (AutoDiffable, UArray UReal) ]
-
-let variadic_dae_mandatory_fun_args =
-  [ (UnsizedType.AutoDiffable, UnsizedType.UReal)
-  ; (UnsizedType.AutoDiffable, UnsizedType.UVector)
-  ; (UnsizedType.AutoDiffable, UnsizedType.UVector) ]
-
-let variadic_dae_fun_return_type = UnsizedType.UVector
-let variadic_dae_return_type = UnsizedType.UArray UnsizedType.UVector
-
 let mk_declarative_sig (fnkinds, name, args, mem_pattern) =
   let sfxes = function
     | Lpmf -> ["_lpmf"]
@@ -258,31 +215,6 @@ let full_lpdf = [Lpdf; Rng; Ccdf; Cdf]
 let full_lpmf = [Lpmf; Rng; Ccdf; Cdf]
 let full_lpdf_depr = full_lpdf @ [Log]
 let full_lpmf_depr = full_lpmf @ [Log]
-let reduce_sum_functions = String.Set.of_list ["reduce_sum"; "reduce_sum_static"]
-let variadic_ode_adjoint_fn = "ode_adjoint_tol_ctl"
-
-let variadic_ode_nonadjoint_fns =
-  String.Set.of_list
-    [ "ode_bdf_tol"; "ode_rk45_tol"; "ode_adams_tol"; "ode_bdf"; "ode_rk45"
-    ; "ode_adams"; "ode_ckrk"; "ode_ckrk_tol" ]
-
-let ode_tolerances_suffix = "_tol"
-let is_reduce_sum_fn f = Set.mem reduce_sum_functions f
-let is_variadic_ode_nonadjoint_fn f = Set.mem variadic_ode_nonadjoint_fns f
-
-let is_variadic_ode_fn f =
-  Set.mem variadic_ode_nonadjoint_fns f || f = variadic_ode_adjoint_fn
-
-let is_variadic_ode_nonadjoint_tol_fn f =
-  is_variadic_ode_nonadjoint_fn f
-  && String.is_suffix f ~suffix:ode_tolerances_suffix
-
-let variadic_dae_fns = String.Set.of_list ["dae_tol"; "dae"]
-let dae_tolerances_suffix = "_tol"
-let is_variadic_dae_fn f = Set.mem variadic_dae_fns f
-
-let is_variadic_dae_tol_fn f =
-  is_variadic_dae_fn f && String.is_suffix f ~suffix:dae_tolerances_suffix
 
 let distributions =
   [ ( full_lpmf_depr
@@ -434,6 +366,9 @@ let declarative_fnsigs =
 let is_stan_math_function_name name =
   let name = Utils.stdlib_distribution_name name in
   Hashtbl.mem stan_math_signatures name
+
+let is_stan_math_variadic_function_name name =
+  Hashtbl.mem stan_math_variadic_signatures name
 
 let dist_name_suffix udf_names name =
   let is_udf_name s = List.exists ~f:(fun (n, _) -> n = s) udf_names in
@@ -2621,6 +2556,117 @@ let () =
   Hashtbl.iteri manual_stan_math_signatures ~f:(fun ~key ~data ->
       List.iter data ~f:(fun data ->
           Hashtbl.add_multi stan_math_signatures ~key ~data ) )
+
+(* variadics *)
+
+let reduce_sum_allowed_dimensionalities = [1; 2; 3; 4; 5; 6; 7]
+
+let reduce_sum_slice_types =
+  let base_slice_type i =
+    [ bare_array_type (UnsizedType.UReal, i)
+    ; bare_array_type (UnsizedType.UInt, i)
+    ; bare_array_type (UnsizedType.UMatrix, i)
+    ; bare_array_type (UnsizedType.UVector, i)
+    ; bare_array_type (UnsizedType.URowVector, i) ] in
+  List.concat (List.map ~f:base_slice_type reduce_sum_allowed_dimensionalities)
+
+(* Variadic ODE *)
+let variadic_ode_adjoint_ctl_tol_arg_types =
+  [ (UnsizedType.DataOnly, UnsizedType.UReal)
+    (* real relative_tolerance_forward *)
+  ; (DataOnly, UVector) (* vector absolute_tolerance_forward *)
+  ; (DataOnly, UReal) (* real relative_tolerance_backward *)
+  ; (DataOnly, UVector) (* real absolute_tolerance_backward *)
+  ; (DataOnly, UReal) (* real relative_tolerance_quadrature *)
+  ; (DataOnly, UReal) (* real absolute_tolerance_quadrature *)
+  ; (DataOnly, UInt) (* int max_num_steps *)
+  ; (DataOnly, UInt) (* int num_steps_between_checkpoints *)
+  ; (DataOnly, UInt) (* int interpolation_polynomial *)
+  ; (DataOnly, UInt) (* int solver_forward *); (DataOnly, UInt)
+    (* int solver_backward *) ]
+
+let variadic_ode_tol_arg_types =
+  [ (UnsizedType.DataOnly, UnsizedType.UReal); (DataOnly, UReal)
+  ; (DataOnly, UInt) ]
+
+let variadic_ode_mandatory_arg_types =
+  [ (UnsizedType.AutoDiffable, UnsizedType.UVector); (AutoDiffable, UReal)
+  ; (AutoDiffable, UArray UReal) ]
+
+let variadic_ode_mandatory_fun_args =
+  [ (UnsizedType.AutoDiffable, UnsizedType.UReal)
+  ; (UnsizedType.AutoDiffable, UnsizedType.UVector) ]
+
+let variadic_ode_fun_return_type = UnsizedType.UVector
+let variadic_ode_return_type = UnsizedType.UArray UnsizedType.UVector
+
+let variadic_dae_tol_arg_types =
+  [ (UnsizedType.DataOnly, UnsizedType.UReal); (DataOnly, UReal)
+  ; (DataOnly, UInt) ]
+
+let variadic_dae_mandatory_arg_types =
+  [ (UnsizedType.AutoDiffable, UnsizedType.UVector); (* yy *)
+    (UnsizedType.AutoDiffable, UnsizedType.UVector); (* yp *)
+    (AutoDiffable, UReal); (AutoDiffable, UArray UReal) ]
+
+let variadic_dae_mandatory_fun_args =
+  [ (UnsizedType.AutoDiffable, UnsizedType.UReal)
+  ; (UnsizedType.AutoDiffable, UnsizedType.UVector)
+  ; (UnsizedType.AutoDiffable, UnsizedType.UVector) ]
+
+let reduce_sum_functions = String.Set.of_list ["reduce_sum"; "reduce_sum_static"]
+let variadic_ode_adjoint_fn = "ode_adjoint_tol_ctl"
+
+let variadic_ode_nonadjoint_fns =
+  String.Set.of_list
+    [ "ode_bdf_tol"; "ode_rk45_tol"; "ode_adams_tol"; "ode_bdf"; "ode_rk45"
+    ; "ode_adams"; "ode_ckrk"; "ode_ckrk_tol" ]
+
+let ode_tolerances_suffix = "_tol"
+let is_reduce_sum_fn f = Set.mem reduce_sum_functions f
+
+let is_variadic_ode_fn f =
+  Set.mem variadic_ode_nonadjoint_fns f || f = variadic_ode_adjoint_fn
+
+let variadic_dae_fns = String.Set.of_list ["dae_tol"; "dae"]
+let dae_tolerances_suffix = "_tol"
+let is_variadic_dae_fn f = Set.mem variadic_dae_fns f
+let variadic_dae_fun_return_type = UnsizedType.UVector
+let variadic_dae_return_type = UnsizedType.UArray UnsizedType.UVector
+
+let add_variadic_fn name ~return_type ?control_args ?allow_fn_lpdf
+    ~required_fn_rt ?required_fn_args () =
+  Hashtbl.add_exn stan_math_variadic_signatures ~key:name
+    ~data:
+      (create_variadic_signature ~return_type ?control_args ?allow_fn_lpdf
+         ?required_fn_args ~required_fn_rt () )
+
+let () =
+  (* DAEs *)
+  add_variadic_fn "dae" ~return_type:variadic_dae_return_type
+    ~control_args:variadic_dae_mandatory_arg_types
+    ~required_fn_args:variadic_dae_mandatory_fun_args
+    ~required_fn_rt:variadic_dae_fun_return_type () ;
+  add_variadic_fn "dae_tol" ~return_type:variadic_dae_return_type
+    ~control_args:(variadic_dae_mandatory_arg_types @ variadic_dae_tol_arg_types)
+    ~required_fn_args:variadic_dae_mandatory_fun_args
+    ~required_fn_rt:variadic_dae_fun_return_type () ;
+  (* non-adjoint ODES - same for all *)
+  let add_ode name =
+    add_variadic_fn name ~return_type:variadic_ode_return_type
+      ~control_args:
+        ( if String.is_suffix name ~suffix:ode_tolerances_suffix then
+          variadic_ode_mandatory_arg_types @ variadic_ode_tol_arg_types
+        else variadic_ode_mandatory_arg_types )
+      ~required_fn_rt:variadic_ode_fun_return_type
+      ~required_fn_args:variadic_ode_mandatory_fun_args () in
+  Set.iter ~f:add_ode variadic_ode_nonadjoint_fns ;
+  (* Adjoint ODE function *)
+  add_variadic_fn variadic_ode_adjoint_fn ~return_type:variadic_ode_return_type
+    ~control_args:
+      (variadic_ode_mandatory_arg_types @ variadic_ode_adjoint_ctl_tol_arg_types)
+    ~required_fn_rt:variadic_ode_fun_return_type
+    ~required_fn_args:variadic_ode_mandatory_fun_args ()
 
 let%expect_test "dist name suffix" =
   dist_name_suffix [] "normal" |> print_endline ;

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -28,6 +28,11 @@ type variadic_signature =
   ; required_fn_args: fun_arg list }
 
 val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t
+(** Mapping from names to description of a variadic function.
+
+  Note that these function names cannot be overloaded, and usually require
+  customized code-gen in the backend.
+*)
 
 val is_stan_math_variadic_function_name : string -> bool
 (** Equivalent to [Hashtbl.mem stan_math_variadic_signatures s]*)

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -20,6 +20,18 @@ val stan_math_signatures : (string, signature list) Hashtbl.t
 val is_stan_math_function_name : string -> bool
 (** Equivalent to [Hashtbl.mem stan_math_signatures s]*)
 
+type variadic_signature =
+  { return_type: UnsizedType.t
+  ; control_args: fun_arg list
+  ; allow_fn_lpdf: bool
+  ; required_fn_rt: UnsizedType.t
+  ; required_fn_args: fun_arg list }
+
+val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t
+
+val is_stan_math_variadic_function_name : string -> bool
+(** Equivalent to [Hashtbl.mem stan_math_variadic_signatures s]*)
+
 (** Pretty printers *)
 
 val pp_math_sig : signature Fmt.t
@@ -54,32 +66,17 @@ val make_assignmentoperator_stan_math_signatures : Operator.t -> signature list
 
 (** Special functions for the variadic signatures exposed *)
 
-(* TODO: We should think of a better encapsulization for these,
-   this doesn't scale well.
-*)
-
 (* reduce_sum helpers *)
 val is_reduce_sum_fn : string -> bool
 val reduce_sum_slice_types : UnsizedType.t list
 
+(** These are only used in code-gen, typing is done via [stan_math_variadic_signatures] *)
+
 (* variadic ODE helpers *)
 val is_variadic_ode_fn : string -> bool
-val is_variadic_ode_nonadjoint_tol_fn : string -> bool
 val ode_tolerances_suffix : string
 val variadic_ode_adjoint_fn : string
-val variadic_ode_mandatory_arg_types : fun_arg list
-val variadic_ode_mandatory_fun_args : fun_arg list
-val variadic_ode_tol_arg_types : fun_arg list
-val variadic_ode_adjoint_ctl_tol_arg_types : fun_arg list
-val variadic_ode_fun_return_type : UnsizedType.t
-val variadic_ode_return_type : UnsizedType.t
 
 (* variadic DAE helpers *)
 val is_variadic_dae_fn : string -> bool
-val is_variadic_dae_tol_fn : string -> bool
 val dae_tolerances_suffix : string
-val variadic_dae_mandatory_arg_types : fun_arg list
-val variadic_dae_mandatory_fun_args : fun_arg list
-val variadic_dae_tol_arg_types : fun_arg list
-val variadic_dae_fun_return_type : UnsizedType.t
-val variadic_dae_return_type : UnsizedType.t


### PR DESCRIPTION
In anticipation of #576 and potential future variadic higher-order functions, I decided it was worth taking a good look at cleaning up the shared code between existing variadic functions. 

The DAE and ODE functions, and the future `solve_newton` etc are completely described by a few rules:

1. What type does the higher-order function itself return?
2. What arguments are for this function, rather than passed to the first argument (I named these the `control_args`)?
3. What return type do we require for the function passed in?
4. What, if any, arguments do we require for the function passed in?

This PR reorganizes the existing code around this to remove current duplication and prevent more going foward.

Note that the above are **not** sufficient to capture `reduce_sum`, since item 4 is actually dynamic depending on the first argument. So, for now at least, this is left as a special case. 

This would also let us try to print these as part of `--dump-stan-math-signatures` eventually, if we wanted to. 


Finally, I'd like to note that it would eventually be nice to also clean up the code gen for these higher-order functions, which is currently also very special cased due to the differing positions of arguments, different requirements for functors being generated, etc. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Replace this text with a short note on what will change if this pull request is merged. This will be included in the release notes.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
