### PR TITLE
Fix reject() codegen for container types

### DIFF
--- a/src/stan_math_backend/Statement_gen.ml
+++ b/src/stan_math_backend/Statement_gen.ml
@@ -363,7 +363,8 @@ let rec pp_statement (ppf : Format.formatter) Stmt.Fixed.{pattern; meta} =
       pf ppf "if (pstream__) %a" pp_block (list ~sep:cut pp_arg, args)
   | NRFunApp (CompilerInternal FnReject, args) ->
       let err_strm = "errmsg_stream__" in
-      let add_to_string ppf e = pf ppf "%s << %a;" err_strm pp_expr e in
+      let add_to_string ppf e =
+        pf ppf "stan::math::stan_print(&%s, %a);" err_strm pp_expr e in
       pf ppf "std::stringstream %s;@," err_strm ;
       pf ppf "%a@," (list ~sep:cut add_to_string) args ;
       pf ppf "throw std::domain_error(%s.str());" err_strm

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -8857,7 +8857,7 @@ template <typename T0__,
     try {
       current_statement__ = 17;
       std::stringstream errmsg_stream__;
-      errmsg_stream__ << "called the wrong foo";
+      stan::math::stan_print(&errmsg_stream__, "called the wrong foo");
       throw std::domain_error(errmsg_stream__.str());
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8897,7 +8897,7 @@ template <typename T0__,
     try {
       current_statement__ = 21;
       std::stringstream errmsg_stream__;
-      errmsg_stream__ << "called the wrong foo";
+      stan::math::stan_print(&errmsg_stream__, "called the wrong foo");
       throw std::domain_error(errmsg_stream__.str());
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8937,7 +8937,7 @@ template <typename T0__,
     try {
       current_statement__ = 25;
       std::stringstream errmsg_stream__;
-      errmsg_stream__ << "called the wrong foo";
+      stan::math::stan_print(&errmsg_stream__, "called the wrong foo");
       throw std::domain_error(errmsg_stream__.str());
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8975,7 +8975,7 @@ template <typename T0__,
     try {
       current_statement__ = 29;
       std::stringstream errmsg_stream__;
-      errmsg_stream__ << "called the wrong foo";
+      stan::math::stan_print(&errmsg_stream__, "called the wrong foo");
       throw std::domain_error(errmsg_stream__.str());
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -3518,8 +3518,8 @@ static constexpr std::array<const char*, 787> locations_array__ =
  " (in 'mother.stan', line 182, column 36 to line 184, column 3)",
  " (in 'mother.stan', line 187, column 4 to column 24)",
  " (in 'mother.stan', line 186, column 22 to line 188, column 3)",
- " (in 'mother.stan', line 191, column 4 to column 42)",
- " (in 'mother.stan', line 190, column 21 to line 192, column 3)",
+ " (in 'mother.stan', line 191, column 4 to column 54)",
+ " (in 'mother.stan', line 190, column 29 to line 192, column 3)",
  " (in 'mother.stan', line 195, column 4 to column 18)",
  " (in 'mother.stan', line 196, column 4 to column 19)",
  " (in 'mother.stan', line 197, column 4 to column 26)",
@@ -3749,7 +3749,7 @@ struct foo_4_functor__ {
   template <typename T0__,
             stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
   void
-  operator()(const T0__& x, std::ostream* pstream__) const;
+  operator()(const std::vector<T0__>& x, std::ostream* pstream__) const;
 };
 struct f7_functor__ {
   template <typename T3__, typename T4__, typename T5__, typename T6__,
@@ -4643,7 +4643,7 @@ template <bool propto__, typename T0__, typename T_lp__,
     }
 template <typename T0__,
           stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr> void
-  foo_4(const T0__& x, std::ostream* pstream__) {
+  foo_4(const std::vector<T0__>& x, std::ostream* pstream__) {
     using local_scalar_t__ = stan::promote_args_t<T0__>;
     int current_statement__ = 0; 
     static constexpr bool propto__ = true;
@@ -4653,8 +4653,11 @@ template <typename T0__,
     try {
       current_statement__ = 710;
       std::stringstream errmsg_stream__;
-      errmsg_stream__ << "user-specified rejection";
-      errmsg_stream__ << x;
+      stan::math::stan_print(&errmsg_stream__, "user-specified rejection");
+      stan::math::stan_print(&errmsg_stream__, stan::model::rvalue(x, "x",
+                                                 stan::model::index_uni(1)));
+      stan::math::stan_print(&errmsg_stream__, "; ");
+      stan::math::stan_print(&errmsg_stream__, x);
       throw std::domain_error(errmsg_stream__.str());
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4685,24 +4688,24 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
       if (stan::math::logical_gt((abs_diff / avg_scale), max_)) {
         current_statement__ = 716;
         std::stringstream errmsg_stream__;
-        errmsg_stream__ << "user-specified rejection, difference above ";
-        errmsg_stream__ << max_;
-        errmsg_stream__ << " x:";
-        errmsg_stream__ << x;
-        errmsg_stream__ << " y:";
-        errmsg_stream__ << y;
+        stan::math::stan_print(&errmsg_stream__, "user-specified rejection, difference above ");
+        stan::math::stan_print(&errmsg_stream__, max_);
+        stan::math::stan_print(&errmsg_stream__, " x:");
+        stan::math::stan_print(&errmsg_stream__, x);
+        stan::math::stan_print(&errmsg_stream__, " y:");
+        stan::math::stan_print(&errmsg_stream__, y);
         throw std::domain_error(errmsg_stream__.str());
       } 
       current_statement__ = 719;
       if (stan::math::logical_lt((abs_diff / avg_scale), min_)) {
         current_statement__ = 718;
         std::stringstream errmsg_stream__;
-        errmsg_stream__ << "user-specified rejection, difference below ";
-        errmsg_stream__ << min_;
-        errmsg_stream__ << " x:";
-        errmsg_stream__ << x;
-        errmsg_stream__ << " y:";
-        errmsg_stream__ << y;
+        stan::math::stan_print(&errmsg_stream__, "user-specified rejection, difference below ");
+        stan::math::stan_print(&errmsg_stream__, min_);
+        stan::math::stan_print(&errmsg_stream__, " x:");
+        stan::math::stan_print(&errmsg_stream__, x);
+        stan::math::stan_print(&errmsg_stream__, " y:");
+        stan::math::stan_print(&errmsg_stream__, y);
         throw std::domain_error(errmsg_stream__.str());
       } 
       current_statement__ = 720;
@@ -5783,8 +5786,9 @@ f3_functor__::operator()(const int& a1, const std::vector<int>& a2,
 }
 
 template <typename T0__, stan::require_all_t<stan::is_stan_scalar<T0__>>*>
-void foo_4_functor__::operator()(const T0__& x, std::ostream* pstream__) 
-const
+void
+foo_4_functor__::operator()(const std::vector<T0__>& x,
+                            std::ostream* pstream__)  const
 {
   return foo_4(x, pstream__);
 }
@@ -10139,7 +10143,7 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
                 stan::model::index_uni(1)))) {
         current_statement__ = 137;
         std::stringstream errmsg_stream__;
-        errmsg_stream__ << "indexing test 1 failed";
+        stan::math::stan_print(&errmsg_stream__, "indexing test 1 failed");
         throw std::domain_error(errmsg_stream__.str());
       } 
       current_statement__ = 141;
@@ -10175,7 +10179,7 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
                 stan::model::index_uni(1)))) {
         current_statement__ = 143;
         std::stringstream errmsg_stream__;
-        errmsg_stream__ << "indexing test 2 failed";
+        stan::math::stan_print(&errmsg_stream__, "indexing test 2 failed");
         throw std::domain_error(errmsg_stream__.str());
       } 
       current_statement__ = 148;
@@ -10220,7 +10224,7 @@ int foo_functor__::operator()(const int& n, std::ostream* pstream__)  const
                 stan::model::index_uni(1)))) {
         current_statement__ = 150;
         std::stringstream errmsg_stream__;
-        errmsg_stream__ << "indexing test 3 failed";
+        stan::math::stan_print(&errmsg_stream__, "indexing test 3 failed");
         throw std::domain_error(errmsg_stream__.str());
       } 
       current_statement__ = 152;

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -1255,7 +1255,7 @@
        (meta <opaque>))))
     (fdloc <opaque>))
    ((fdrt ()) (fdname foo_4) (fdsuffix FnPlain)
-    (fdargs ((AutoDiffable x UReal)))
+    (fdargs ((AutoDiffable x (UArray UReal))))
     (fdbody
      (((pattern
         (Block
@@ -1263,8 +1263,22 @@
             (NRFunApp (CompilerInternal FnReject)
              (((pattern (Lit Str "user-specified rejection"))
                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta
+                   ((type_ (UArray UReal)) (loc <opaque>)
+                    (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Str "; "))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Var x))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta
+                ((type_ (UArray UReal)) (loc <opaque>)
+                 (adlevel AutoDiffable)))))))
            (meta <opaque>)))))
        (meta <opaque>))))
     (fdloc <opaque>))

--- a/test/integration/good/code-gen/mother.stan
+++ b/test/integration/good/code-gen/mother.stan
@@ -187,8 +187,8 @@ functions {
     return x + target();
   }
 
-  void foo_4(real x) {
-    reject("user-specified rejection", x);
+  void foo_4(array[] real x) {
+    reject("user-specified rejection", x[1], "; ", x);
   }
 
   real relative_diff(real x, real y, real max_, real min_) {

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -1273,7 +1273,7 @@
        (meta <opaque>))))
     (fdloc <opaque>))
    ((fdrt ()) (fdname foo_4) (fdsuffix FnPlain)
-    (fdargs ((AutoDiffable x UReal)))
+    (fdargs ((AutoDiffable x (UArray UReal))))
     (fdbody
      (((pattern
         (Block
@@ -1281,8 +1281,22 @@
             (NRFunApp (CompilerInternal FnReject)
              (((pattern (Lit Str "user-specified rejection"))
                (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
+              ((pattern
+                (Indexed
+                 ((pattern (Var x))
+                  (meta
+                   ((type_ (UArray UReal)) (loc <opaque>)
+                    (adlevel AutoDiffable))))
+                 ((Single
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              ((pattern (Lit Str "; "))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
               ((pattern (Var x))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta
+                ((type_ (UArray UReal)) (loc <opaque>)
+                 (adlevel AutoDiffable)))))))
            (meta <opaque>)))))
        (meta <opaque>))))
     (fdloc <opaque>))


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [X] OR, no user-facing changes were made

Typechecker thinks that `reject()` and `print()` have the essentially the same signature but codegen differences mean that
* `print(vector)` outputs a comma-separated list of elements while `reject(vector)` uses tabs instead of commas
* `reject(array)` fails to compile

This pull request changes `reject()` codegen to behave more like `print()`

## Release notes

Fix using `reject()` with container types.

## Copyright and Licensing

Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
