### PR TITLE
Refactor/variadic codegen cleanups

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -636,7 +636,7 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
 
 and check_variadic ~is_cond_dist loc cf tenv id tes =
   let Stan_math_signatures.
-        {control_args; required_fn_args; required_fn_rt; return_type} =
+        {control_args; required_fn_args; required_fn_rt; return_type; _} =
     Hashtbl.find_exn Stan_math_signatures.stan_math_variadic_signatures id.name
   in
   let matching remaining_es Env.{type_= ftype; _} =

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -636,7 +636,7 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
 
 and check_variadic ~is_cond_dist loc cf tenv id tes =
   let Stan_math_signatures.
-        {control_args; required_fn_args; required_fn_rt; return_type; _} =
+        {control_args; required_fn_args; required_fn_rt; return_type} =
     Hashtbl.find_exn Stan_math_signatures.stan_math_variadic_signatures id.name
   in
   let matching remaining_es Env.{type_= ftype; _} =

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -2634,7 +2634,6 @@ let is_variadic_ode_fn f =
   Set.mem variadic_ode_nonadjoint_fns f || f = variadic_ode_adjoint_fn
 
 let variadic_dae_fns = String.Set.of_list ["dae_tol"; "dae"]
-let dae_tolerances_suffix = "_tol"
 let is_variadic_dae_fn f = Set.mem variadic_dae_fns f
 let variadic_dae_fun_return_type = UnsizedType.UVector
 let variadic_dae_return_type = UnsizedType.UArray UnsizedType.UVector

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -94,9 +94,7 @@ type variadic_signature =
   { return_type: UnsizedType.t
   ; control_args: fun_arg list
   ; required_fn_rt: UnsizedType.t
-  ; required_fn_args: fun_arg list
-  ; hof_args_before_pstream: int
-  ; required_fn_args_before_pstream: int }
+  ; required_fn_args: fun_arg list }
 [@@deriving create]
 
 let is_primitive = function
@@ -2637,12 +2635,7 @@ let add_variadic_fn name ~return_type ?control_args ~required_fn_rt
   Hashtbl.add_exn stan_math_variadic_signatures ~key:name
     ~data:
       (create_variadic_signature ~return_type ?control_args ?required_fn_args
-         ~required_fn_rt
-         ~hof_args_before_pstream:
-           (Option.value_map ~f:List.length control_args ~default:0 + 1)
-         ~required_fn_args_before_pstream:
-           (Option.value_map ~f:List.length required_fn_args ~default:0)
-         () )
+         ~required_fn_rt () )
 
 let () =
   (* DAEs *)

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -95,8 +95,8 @@ type variadic_signature =
   ; control_args: fun_arg list
   ; required_fn_rt: UnsizedType.t
   ; required_fn_args: fun_arg list
-  ; hof_pstream_loc: int
-  ; required_fn_pstream_loc: int }
+  ; hof_args_before_pstream: int
+  ; required_fn_args_before_pstream: int }
 [@@deriving create]
 
 let is_primitive = function
@@ -2633,24 +2633,27 @@ let variadic_dae_fun_return_type = UnsizedType.UVector
 let variadic_dae_return_type = UnsizedType.UArray UnsizedType.UVector
 
 let add_variadic_fn name ~return_type ?control_args ~required_fn_rt
-    ?required_fn_args ~hof_pstream_loc ~required_fn_pstream_loc () =
+    ?required_fn_args () =
   Hashtbl.add_exn stan_math_variadic_signatures ~key:name
     ~data:
       (create_variadic_signature ~return_type ?control_args ?required_fn_args
-         ~required_fn_rt ~hof_pstream_loc ~required_fn_pstream_loc () )
+         ~required_fn_rt
+         ~hof_args_before_pstream:
+           (Option.value_map ~f:List.length control_args ~default:0 + 1)
+         ~required_fn_args_before_pstream:
+           (Option.value_map ~f:List.length required_fn_args ~default:0)
+         () )
 
 let () =
   (* DAEs *)
   add_variadic_fn "dae" ~return_type:variadic_dae_return_type
     ~control_args:variadic_dae_mandatory_arg_types
     ~required_fn_args:variadic_dae_mandatory_fun_args
-    ~required_fn_rt:variadic_dae_fun_return_type ~hof_pstream_loc:6
-    ~required_fn_pstream_loc:4 () ;
+    ~required_fn_rt:variadic_dae_fun_return_type () ;
   add_variadic_fn "dae_tol" ~return_type:variadic_dae_return_type
     ~control_args:(variadic_dae_mandatory_arg_types @ variadic_dae_tol_arg_types)
     ~required_fn_args:variadic_dae_mandatory_fun_args
-    ~required_fn_rt:variadic_dae_fun_return_type ~hof_pstream_loc:9
-    ~required_fn_pstream_loc:4 () ;
+    ~required_fn_rt:variadic_dae_fun_return_type () ;
   (* non-adjoint ODES - same for all *)
   let add_ode name =
     add_variadic_fn name ~return_type:variadic_ode_return_type
@@ -2659,18 +2662,14 @@ let () =
           variadic_ode_mandatory_arg_types @ variadic_ode_tol_arg_types
         else variadic_ode_mandatory_arg_types )
       ~required_fn_rt:variadic_ode_fun_return_type
-      ~required_fn_args:variadic_ode_mandatory_fun_args
-      ~hof_pstream_loc:
-        (if String.is_suffix name ~suffix:ode_tolerances_suffix then 8 else 5)
-      ~required_fn_pstream_loc:3 () in
+      ~required_fn_args:variadic_ode_mandatory_fun_args () in
   Set.iter ~f:add_ode variadic_ode_nonadjoint_fns ;
   (* Adjoint ODE function *)
   add_variadic_fn variadic_ode_adjoint_fn ~return_type:variadic_ode_return_type
     ~control_args:
       (variadic_ode_mandatory_arg_types @ variadic_ode_adjoint_ctl_tol_arg_types)
     ~required_fn_rt:variadic_ode_fun_return_type
-    ~required_fn_args:variadic_ode_mandatory_fun_args ~hof_pstream_loc:16
-    ~required_fn_pstream_loc:3 ()
+    ~required_fn_args:variadic_ode_mandatory_fun_args ()
 
 let%expect_test "dist name suffix" =
   dist_name_suffix [] "normal" |> print_endline ;

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -2629,12 +2629,6 @@ let variadic_ode_nonadjoint_fns =
 
 let ode_tolerances_suffix = "_tol"
 let is_reduce_sum_fn f = Set.mem reduce_sum_functions f
-
-let is_variadic_ode_fn f =
-  Set.mem variadic_ode_nonadjoint_fns f || f = variadic_ode_adjoint_fn
-
-let variadic_dae_fns = String.Set.of_list ["dae_tol"; "dae"]
-let is_variadic_dae_fn f = Set.mem variadic_dae_fns f
 let variadic_dae_fun_return_type = UnsizedType.UVector
 let variadic_dae_return_type = UnsizedType.UArray UnsizedType.UVector
 

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -85,8 +85,3 @@ val make_assignmentoperator_stan_math_signatures : Operator.t -> signature list
 (* reduce_sum helpers *)
 val is_reduce_sum_fn : string -> bool
 val reduce_sum_slice_types : UnsizedType.t list
-
-(** These are only used in code-gen, typing is done via [stan_math_variadic_signatures] *)
-
-val is_variadic_ode_fn : string -> bool
-val is_variadic_dae_fn : string -> bool

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -26,7 +26,17 @@ type variadic_signature =
   ; required_fn_rt: UnsizedType.t
   ; required_fn_args: fun_arg list
   ; hof_pstream_loc: int
-  ; required_fn_pstream_loc: int }
+        (** This specifies where the pstream* argument goes in the call to the variadic function,
+      usually after some required arguments and control args.contents
+
+      For example, for dae(), the arguments [f, yy0, yp0, t0, ts] all precede
+      the msgs argument, making msgs the 6th argument, so this number is 6.
+      *)
+  ; required_fn_pstream_loc: int
+        (** Similar to the above, but specifies where in the {e functor} we expect
+      pstream* to occur. For example, for a dae, this is the 4th argument,
+      so this number is 4 *)
+  }
 
 val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t
 (** Mapping from names to description of a variadic function.
@@ -78,11 +88,5 @@ val reduce_sum_slice_types : UnsizedType.t list
 
 (** These are only used in code-gen, typing is done via [stan_math_variadic_signatures] *)
 
-(* variadic ODE helpers *)
 val is_variadic_ode_fn : string -> bool
-val ode_tolerances_suffix : string
-val variadic_ode_adjoint_fn : string
-
-(* variadic DAE helpers *)
 val is_variadic_dae_fn : string -> bool
-val dae_tolerances_suffix : string

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -24,7 +24,9 @@ type variadic_signature =
   { return_type: UnsizedType.t
   ; control_args: fun_arg list
   ; required_fn_rt: UnsizedType.t
-  ; required_fn_args: fun_arg list }
+  ; required_fn_args: fun_arg list
+  ; hof_pstream_loc: int
+  ; required_fn_pstream_loc: int }
 
 val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t
 (** Mapping from names to description of a variadic function.

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -25,17 +25,26 @@ type variadic_signature =
   ; control_args: fun_arg list
   ; required_fn_rt: UnsizedType.t
   ; required_fn_args: fun_arg list
-  ; hof_pstream_loc: int
+  ; hof_args_before_pstream: int
         (** This specifies where the pstream* argument goes in the call to the variadic function,
       usually after some required arguments and control args.contents
 
       For example, for dae(), the arguments [f, yy0, yp0, t0, ts] all precede
-      the msgs argument, making msgs the 6th argument, so this number is 6.
+      the msgs argument, making msgs the 6th argument, so this number is 5.
+
+      In general, for existing functions this is [length(control_args) + 1].
+
+      Only used in C++ code generation, can be ignored elsewhere.
       *)
-  ; required_fn_pstream_loc: int
+  ; required_fn_args_before_pstream: int
         (** Similar to the above, but specifies where in the {e functor} we expect
       pstream* to occur. For example, for a dae, this is the 4th argument,
-      so this number is 4 *)
+      so this number is 3.
+
+      In general, for existing functions this is [length(required_fn_args)].
+
+      Only used in C++ code generation, can be ignored elsewhere.
+      *)
   }
 
 val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -24,28 +24,7 @@ type variadic_signature =
   { return_type: UnsizedType.t
   ; control_args: fun_arg list
   ; required_fn_rt: UnsizedType.t
-  ; required_fn_args: fun_arg list
-  ; hof_args_before_pstream: int
-        (** This specifies where the pstream* argument goes in the call to the variadic function,
-      usually after some required arguments and control args.contents
-
-      For example, for dae(), the arguments [f, yy0, yp0, t0, ts] all precede
-      the msgs argument, making msgs the 6th argument, so this number is 5.
-
-      In general, for existing functions this is [length(control_args) + 1].
-
-      Only used in C++ code generation, can be ignored elsewhere.
-      *)
-  ; required_fn_args_before_pstream: int
-        (** Similar to the above, but specifies where in the {e functor} we expect
-      pstream* to occur. For example, for a dae, this is the 4th argument,
-      so this number is 3.
-
-      In general, for existing functions this is [length(required_fn_args)].
-
-      Only used in C++ code generation, can be ignored elsewhere.
-      *)
-  }
+  ; required_fn_args: fun_arg list }
 
 val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t
 (** Mapping from names to description of a variadic function.

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -139,8 +139,8 @@ let variadic_functor_suffix x = sprintf "_variadic%d_functor__" x
 
 let functor_suffix_select hof =
   match Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures hof with
-  | Some {required_fn_args_before_pstream; _} ->
-      variadic_functor_suffix required_fn_args_before_pstream
+  | Some {required_fn_args; _} ->
+      variadic_functor_suffix (List.length required_fn_args)
   | None when Stan_math_signatures.is_reduce_sum_fn hof ->
       reduce_sum_functor_suffix
   | None -> functor_suffix
@@ -350,10 +350,11 @@ and gen_functionals fname suffix es mem_pattern =
             , grainsize :: container :: msgs :: tl )
         | _, _
           when Stan_math_signatures.is_stan_math_variadic_function_name fname ->
-            let Stan_math_signatures.{hof_args_before_pstream; _} =
+            let Stan_math_signatures.{control_args; _} =
               Hashtbl.find_exn
                 Stan_math_signatures.stan_math_variadic_signatures fname in
-            let hd, tl = List.split_n converted_es hof_args_before_pstream in
+            let hd, tl =
+              List.split_n converted_es (List.length control_args + 1) in
             (fname, hd @ (msgs :: tl))
         | ( "map_rect"
           , {pattern= FunApp ((UserDefined (f, _) | StanLib (f, _, _)), _); _}

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -135,12 +135,12 @@ let fn_renames =
 let map_rect_calls = Int.Table.create ()
 let functor_suffix = "_functor__"
 let reduce_sum_functor_suffix = "_rsfunctor__"
-let variadic_functor_suffix x = sprintf "_vari_%d_functor__" x
+let variadic_functor_suffix x = sprintf "_variadic%d_functor__" x
 
 let functor_suffix_select hof =
   match Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures hof with
-  | Some {required_fn_pstream_loc; _} ->
-      variadic_functor_suffix required_fn_pstream_loc
+  | Some {required_fn_args_before_pstream; _} ->
+      variadic_functor_suffix required_fn_args_before_pstream
   | None when Stan_math_signatures.is_reduce_sum_fn hof ->
       reduce_sum_functor_suffix
   | None -> functor_suffix
@@ -350,10 +350,10 @@ and gen_functionals fname suffix es mem_pattern =
             , grainsize :: container :: msgs :: tl )
         | _, _
           when Stan_math_signatures.is_stan_math_variadic_function_name fname ->
-            let Stan_math_signatures.{hof_pstream_loc; _} =
+            let Stan_math_signatures.{hof_args_before_pstream; _} =
               Hashtbl.find_exn
                 Stan_math_signatures.stan_math_variadic_signatures fname in
-            let hd, tl = List.split_n converted_es (hof_pstream_loc - 1) in
+            let hd, tl = List.split_n converted_es hof_args_before_pstream in
             (fname, hd @ (msgs :: tl))
         | ( "map_rect"
           , {pattern= FunApp ((UserDefined (f, _) | StanLib (f, _, _)), _); _}

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -135,17 +135,15 @@ let fn_renames =
 let map_rect_calls = Int.Table.create ()
 let functor_suffix = "_functor__"
 let reduce_sum_functor_suffix = "_rsfunctor__"
-let variadic_ode_functor_suffix = "_odefunctor__"
-let variadic_dae_functor_suffix = "_daefunctor__"
+let variadic_functor_suffix x = sprintf "_vari_%d_functor__" x
 
 let functor_suffix_select hof =
-  match hof with
-  | x when Stan_math_signatures.is_reduce_sum_fn x -> reduce_sum_functor_suffix
-  | x when Stan_math_signatures.is_variadic_ode_fn x ->
-      variadic_ode_functor_suffix
-  | x when Stan_math_signatures.is_variadic_dae_fn x ->
-      variadic_dae_functor_suffix
-  | _ -> functor_suffix
+  match Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures hof with
+  | Some {required_fn_pstream_loc; _} ->
+      variadic_functor_suffix required_fn_pstream_loc
+  | None when Stan_math_signatures.is_reduce_sum_fn hof ->
+      reduce_sum_functor_suffix
+  | None -> functor_suffix
 
 let constraint_to_string = function
   | Transformation.Ordered -> Some "ordered"
@@ -350,51 +348,13 @@ and gen_functionals fname suffix es mem_pattern =
               ^ reduce_sum_functor_suffix in
             ( Fmt.str "%s<%s%s>" fname normalized_dist_functor propto_template
             , grainsize :: container :: msgs :: tl )
-        | x, f :: y0 :: t0 :: ts :: rel_tol :: abs_tol :: max_steps :: tl
-          when Stan_math_signatures.is_variadic_ode_fn x
-               && String.is_suffix fname
-                    ~suffix:Stan_math_signatures.ode_tolerances_suffix
-               && not (Stan_math_signatures.variadic_ode_adjoint_fn = x) ->
-            ( fname
-            , f :: y0 :: t0 :: ts :: rel_tol :: abs_tol :: max_steps :: msgs
-              :: tl )
-        | x, f :: y0 :: t0 :: ts :: tl
-          when Stan_math_signatures.is_variadic_ode_fn x
-               && not (Stan_math_signatures.variadic_ode_adjoint_fn = x) ->
-            (fname, f :: y0 :: t0 :: ts :: msgs :: tl)
-        | ( x
-          , f
-            :: y0
-               :: t0
-                  :: ts
-                     :: rel_tol
-                        :: abs_tol
-                           :: rel_tol_b
-                              :: abs_tol_b
-                                 :: rel_tol_q
-                                    :: abs_tol_q
-                                       :: max_num_steps
-                                          :: num_checkpoints
-                                             :: interpolation_polynomial
-                                                :: solver_f :: solver_b :: tl )
-          when Stan_math_signatures.variadic_ode_adjoint_fn = x ->
-            ( fname
-            , f :: y0 :: t0 :: ts :: rel_tol :: abs_tol :: rel_tol_b
-              :: abs_tol_b :: rel_tol_q :: abs_tol_q :: max_num_steps
-              :: num_checkpoints :: interpolation_polynomial :: solver_f
-              :: solver_b :: msgs :: tl )
-        | ( x
-          , f :: yy0 :: yp0 :: t0 :: ts :: rel_tol :: abs_tol :: max_steps :: tl
-          )
-          when Stan_math_signatures.is_variadic_dae_fn x
-               && String.is_suffix fname
-                    ~suffix:Stan_math_signatures.dae_tolerances_suffix ->
-            ( fname
-            , f :: yy0 :: yp0 :: t0 :: ts :: rel_tol :: abs_tol :: max_steps
-              :: msgs :: tl )
-        | x, f :: yy0 :: yp0 :: t0 :: ts :: tl
-          when Stan_math_signatures.is_variadic_dae_fn x ->
-            (fname, f :: yy0 :: yp0 :: t0 :: ts :: msgs :: tl)
+        | _, _
+          when Stan_math_signatures.is_stan_math_variadic_function_name fname ->
+            let Stan_math_signatures.{hof_pstream_loc; _} =
+              Hashtbl.find_exn
+                Stan_math_signatures.stan_math_variadic_signatures fname in
+            let hd, tl = List.split_n converted_es (hof_pstream_loc - 1) in
+            (fname, hd @ (msgs :: tl))
         | ( "map_rect"
           , {pattern= FunApp ((UserDefined (f, _) | StanLib (f, _, _)), _); _}
             :: tl ) ->

--- a/src/stan_math_backend/Function_gen.ml
+++ b/src/stan_math_backend/Function_gen.ml
@@ -234,7 +234,7 @@ let gen_pp_sig fdargs fdrt extra_templates extra ppf (name, args, variadic) =
   let args, variadic_args =
     match variadic with
     | `ReduceSum -> List.split_n args 3
-    | `VariadicHOF x -> List.split_n args (x - 1)
+    | `VariadicHOF x -> List.split_n args x
     | `None -> (args, []) in
   let arg_strs =
     args

--- a/src/stan_math_backend/Function_gen.ml
+++ b/src/stan_math_backend/Function_gen.ml
@@ -402,10 +402,10 @@ let get_variadic_requirements (p : Program.Numbered.t) =
       match
         Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures x
       with
-      | Some {required_fn_args_before_pstream; _} ->
+      | Some {required_fn_args; _} ->
           Map.add_multi accum
             ~key:(Utils.stdlib_distribution_name f)
-            ~data:required_fn_args_before_pstream
+            ~data:(List.length required_fn_args)
       | _ -> Expr.Fixed.Pattern.fold find_functors_expr accum pattern )
     | _ -> Expr.Fixed.Pattern.fold find_functors_expr accum pattern in
   let rec find_functors_stmt accum stmt =

--- a/src/stan_math_backend/Function_gen.ml
+++ b/src/stan_math_backend/Function_gen.ml
@@ -402,10 +402,10 @@ let get_variadic_requirements (p : Program.Numbered.t) =
       match
         Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures x
       with
-      | Some {required_fn_pstream_loc; _} ->
+      | Some {required_fn_args_before_pstream; _} ->
           Map.add_multi accum
             ~key:(Utils.stdlib_distribution_name f)
-            ~data:required_fn_pstream_loc
+            ~data:required_fn_args_before_pstream
       | _ -> Expr.Fixed.Pattern.fold find_functors_expr accum pattern )
     | _ -> Expr.Fixed.Pattern.fold find_functors_expr accum pattern in
   let rec find_functors_stmt accum stmt =

--- a/src/stan_math_backend/Function_gen.ml
+++ b/src/stan_math_backend/Function_gen.ml
@@ -234,8 +234,7 @@ let gen_pp_sig fdargs fdrt extra_templates extra ppf (name, args, variadic) =
   let args, variadic_args =
     match variadic with
     | `ReduceSum -> List.split_n args 3
-    | `VariadicODE -> List.split_n args 2
-    | `VariadicDAE -> List.split_n args 3
+    | `VariadicHOF x -> List.split_n args (x - 1)
     | `None -> (args, []) in
   let arg_strs =
     args
@@ -296,8 +295,7 @@ let pp_fun_def ppf
           match variadic_fun_type with
           | `None -> functor_suffix
           | `ReduceSum -> reduce_sum_functor_suffix
-          | `VariadicODE -> variadic_ode_functor_suffix
-          | `VariadicDAE -> variadic_dae_functor_suffix in
+          | `VariadicHOF x -> variadic_functor_suffix x in
         let functor_name = fdname ^ suffix in
         let struct_template =
           match (fdsuffix, variadic_fun_type) with
@@ -344,11 +342,11 @@ let pp_fun_def ppf
       else if String.Set.mem funs_used_in_variadic_ode fdname then
         (* Produces the variadic ode functors that has the pstream argument
            as the third and not last argument *)
-        register_functor ([], fdargs, `VariadicODE)
+        register_functor ([], fdargs, `VariadicHOF 3)
       else if String.Set.mem funs_used_in_variadic_dae fdname then
         (* Produces the variadic DAE functors that has the pstream argument
            as the fourth and not last argument *)
-        register_functor ([], fdargs, `VariadicDAE)
+        register_functor ([], fdargs, `VariadicHOF 4)
 
 let pp_standalone_fun_def namespace_fun ppf
     Program.{fdname; fdsuffix; fdargs; fdbody; fdrt; _} =

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -15022,7 +15022,7 @@ struct f_functor__ {
   operator()(const T0__& t, const T1__& z, const T2__& a, const T3__& b,
              std::ostream* pstream__) const;
 };
-struct f_vari_3_functor__ {
+struct f_variadic2_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
                                 stan::is_col_vector<T1__>,
@@ -15032,7 +15032,7 @@ struct f_vari_3_functor__ {
                                 stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                        stan::base_type_t<T3__>>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& z,
              const T2__& a, const T3__& b) const;
 };
 
@@ -15088,9 +15088,9 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                      stan::base_type_t<T3__>>, -1, 1>
-f_vari_3_functor__::operator()(const T0__& t, const T1__& z,
-                               std::ostream* pstream__, const T2__& a,
-                               const T3__& b)  const
+f_variadic2_functor__::operator()(const T0__& t, std::ostream* pstream__,
+                                  const T1__& z, const T2__& a, const T3__& b) 
+const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -15204,51 +15204,51 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       
       current_statement__ = 610;
       stan::model::assign(zd,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 611;
       stan::model::assign(zd,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 612;
       stan::model::assign(zd,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 613;
       stan::model::assign(zd,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 614;
       stan::model::assign(zd,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 615;
       stan::model::assign(zd,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 616;
       stan::model::assign(zd,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable zd");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable zd");
       current_statement__ = 617;
       stan::model::assign(zd,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable zd");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable zd");
       current_statement__ = 618;
       stan::model::assign(zd,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, vd), "assigning variable zd");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 619;
       stan::model::assign(zd,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
-          rd, vd), "assigning variable zd");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, id, rad,
+          pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 620;
       stan::model::assign(zd,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, vd), "assigning variable zd");
       current_statement__ = 621;
       stan::model::assign(zd,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, id, rad, pstream__,
           rd, vd), "assigning variable zd");
       current_statement__ = 622;
       stan::math::validate_non_negative_index("ra", "N", N);
@@ -15303,796 +15303,796 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(N, DUMMY_VAR__));
       current_statement__ = 4;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 5;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 9;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 10;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 11;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 12;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 13;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 14;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 15;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 16;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 17;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 18;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 19;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 20;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 21;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 22;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 23;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 24;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 25;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 26;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 27;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 28;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 29;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 30;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 31;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 32;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 33;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 34;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 35;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 36;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 37;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 38;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 39;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 40;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 41;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 42;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 43;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 44;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 45;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 46;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 47;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 48;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 49;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 50;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 51;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 52;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 53;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 54;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 55;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 56;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 57;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 58;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 59;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 60;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 61;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 62;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 63;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 64;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 65;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 66;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 67;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 68;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 69;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 70;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 71;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 72;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 73;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 74;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 75;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 76;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 77;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 78;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 79;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 80;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 81;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 82;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 83;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 84;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 85;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 86;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 87;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 88;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 89;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 90;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 91;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 92;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 93;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 94;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 95;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 96;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 97;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 98;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 99;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 100;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 101;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 102;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 103;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
-          rd, vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, id, rad,
+          pstream__, rd, vd), "assigning variable z");
       current_statement__ = 104;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, vd), "assigning variable z");
       current_statement__ = 105;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, v), "assigning variable z");
       current_statement__ = 106;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          r, vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, r, vd), "assigning variable z");
       current_statement__ = 107;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          r, v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, r, v), "assigning variable z");
       current_statement__ = 108;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 109;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 110;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 111;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 112;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 113;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 114;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 115;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 116;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 117;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 118;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 119;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 120;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 121;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 122;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 123;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 124;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 125;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 126;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 127;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 128;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 129;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 130;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 131;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 132;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 133;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 134;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 135;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 136;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 137;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 138;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 139;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 140;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 141;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 142;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 143;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 144;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 145;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 146;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 147;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 148;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 149;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 150;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 151;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 152;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 153;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 154;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 155;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 156;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 157;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 158;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 159;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 160;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 161;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 162;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 163;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 164;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 165;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, rd,
           vd), "assigning variable z");
       current_statement__ = 166;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 167;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 168;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 169;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, id, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 170;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 171;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 172;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 173;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 174;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 175;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 176;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 177;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 178;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 179;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 180;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 181;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 182;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 183;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 184;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 185;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 186;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 187;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 188;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 189;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 190;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 191;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 192;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 193;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 194;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 195;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 196;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 197;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 198;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 199;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 200;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 201;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable z");
       {
         current_statement__ = 400;
         stan::math::validate_non_negative_index("zm", "N", N);
@@ -16103,796 +16103,796 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
              Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(N, DUMMY_VAR__));
         current_statement__ = 402;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 403;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 404;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 405;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 406;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 407;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 408;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 409;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 410;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 411;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 412;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 413;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 414;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 415;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 416;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 417;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 418;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 419;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 420;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 421;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 422;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 423;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 424;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 425;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 426;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 427;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 428;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 429;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 430;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 431;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 432;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 433;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 434;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 435;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, id, rad,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 436;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 437;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 438;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 439;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 440;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 441;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 442;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 443;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 444;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 445;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 446;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 447;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 448;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 449;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 450;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 451;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 452;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 453;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 454;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 455;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 456;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 457;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 458;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 459;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 460;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 461;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 462;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 463;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 464;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 465;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 466;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 467;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 468;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, id, rad,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 469;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 470;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 471;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 472;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
-            1e-6, 100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad,
+            1e-6, 1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 473;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 474;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
-            1e-6, 100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra,
+            1e-6, 1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 475;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
-            1e-6, 100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra,
+            1e-6, 1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 476;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
-            1e-6, 100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra,
+            1e-6, 1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 477;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 478;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
-            1e-6, 100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad,
+            1e-6, 1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 479;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
-            1e-6, 100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad,
+            1e-6, 1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 480;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
-            1e-6, 100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad,
+            1e-6, 1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 481;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 482;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 483;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 484;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 485;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
-            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad,
+            1e-6, 1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 486;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
-            1e-6, 100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad,
+            1e-6, 1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 487;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
-            1e-6, 100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad,
+            1e-6, 1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 488;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
-            1e-6, 100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad,
+            1e-6, 1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 489;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 490;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 491;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 492;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 493;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 494;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 495;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 496;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 497;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 498;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 499;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 500;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+          stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 501;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, id, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 502;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 503;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 504;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 505;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 506;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 507;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 508;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 509;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 510;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 511;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 512;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 513;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 514;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 515;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 516;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 517;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 518;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 519;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 520;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 521;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 522;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 523;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 524;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 525;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 526;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 527;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 528;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 529;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 530;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__,
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 531;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__,
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 532;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 533;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 534;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, id, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 535;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 536;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 537;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 538;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 539;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 540;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 541;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 542;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 543;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 544;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 545;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 546;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 547;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__,
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 548;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__,
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 549;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 550;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 551;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 552;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 553;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 554;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 555;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__,
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 556;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__,
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 557;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 558;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 559;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__,
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 560;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__,
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 561;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 562;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 563;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 564;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 565;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 566;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 567;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, id, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 568;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            rd, vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 569;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            rd, v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, rd, v), "assigning variable zm");
         current_statement__ = 570;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            r, vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, r, vd), "assigning variable zm");
         current_statement__ = 571;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
-            r, v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad,
+            pstream__, r, v), "assigning variable zm");
         current_statement__ = 572;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 573;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 574;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 575;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 576;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__,
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 577;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__,
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 578;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 579;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 580;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 581;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 582;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 583;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 584;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__,
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
             rd, vd), "assigning variable zm");
         current_statement__ = 585;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__,
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
             rd, v), "assigning variable zm");
         current_statement__ = 586;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 587;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 588;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 589;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 590;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 591;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 592;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 593;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 594;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 595;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 596;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 597;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 598;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 599;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 600;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(r, 0, 1));
       }
@@ -16954,796 +16954,796 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       } 
       current_statement__ = 4;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 5;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 9;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 10;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 11;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 12;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 13;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 14;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 15;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 16;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 17;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 18;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 19;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 20;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 21;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 22;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 23;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 24;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 25;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 26;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 27;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 28;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 29;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 30;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 31;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 32;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 33;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 34;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 35;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 36;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 37;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 38;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 39;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 40;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 41;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 42;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 43;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 44;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 45;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 46;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 47;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 48;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 49;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 50;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 51;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 52;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 53;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 54;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 55;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 56;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 57;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 58;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 59;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 60;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 61;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 62;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 63;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 64;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 65;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 66;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 67;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 68;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 69;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 70;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 71;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 72;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 73;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 74;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 75;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 76;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 77;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 78;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 79;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 80;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 81;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 82;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 83;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 84;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 85;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 86;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 87;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 88;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 89;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 90;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 91;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 92;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 93;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 94;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 95;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 96;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 97;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 98;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 99;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 100;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 101;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 102;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 103;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
-          rd, vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, id, rad,
+          pstream__, rd, vd), "assigning variable z");
       current_statement__ = 104;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, vd), "assigning variable z");
       current_statement__ = 105;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, v), "assigning variable z");
       current_statement__ = 106;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          r, vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, r, vd), "assigning variable z");
       current_statement__ = 107;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          r, v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, r, v), "assigning variable z");
       current_statement__ = 108;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 109;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 110;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 111;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 112;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 113;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 114;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 115;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 116;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 117;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 118;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 119;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 120;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 121;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 122;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 123;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 124;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 125;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 126;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 127;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 128;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 129;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 130;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 131;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 132;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 133;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 134;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 135;
       stan::model::assign(z,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 136;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 137;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 138;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 139;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 140;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 141;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 142;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 143;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 144;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 145;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 146;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 147;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 148;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 149;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 150;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 151;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 152;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 153;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 154;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 155;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 156;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 157;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 158;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 159;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 160;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 161;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 162;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 163;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 164;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 165;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, rd,
           vd), "assigning variable z");
       current_statement__ = 166;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 167;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 168;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 169;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, id, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 170;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, vd), "assigning variable z");
       current_statement__ = 171;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, v), "assigning variable z");
       current_statement__ = 172;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 173;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 174;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 175;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 176;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 177;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 178;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 179;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 180;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 181;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 182;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 183;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 184;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 185;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 186;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 187;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 188;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 189;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 190;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 191;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 192;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 193;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 194;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 195;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 196;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 197;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 198;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 199;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 200;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__, r,
           vd), "assigning variable z");
       current_statement__ = 201;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable z");
       if (emit_transformed_parameters__) {
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
           for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
@@ -17760,796 +17760,796 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
              std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 202;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 203;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 204;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 205;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 206;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 207;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 208;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 209;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 210;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 211;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 212;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 213;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 214;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 215;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 216;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 217;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 218;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 219;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 220;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 221;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 222;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 223;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 224;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 225;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 226;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 227;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 228;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 229;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 230;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 231;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 232;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 233;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 234;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 235;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 236;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 237;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 238;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 239;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 240;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 241;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 242;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 243;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 244;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 245;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 246;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 247;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 248;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 249;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 250;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 251;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 252;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 253;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 254;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 255;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 256;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 257;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 258;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 259;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 260;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 261;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 262;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 263;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 264;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 265;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 266;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 267;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 268;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, id, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 269;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 270;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 271;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 272;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 273;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 274;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 275;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 276;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, rd, ra, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 277;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 278;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 279;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 280;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 281;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 282;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 283;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 284;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 285;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 286;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 287;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 288;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, rad, 1e-6,
           1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 289;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 290;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 291;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 292;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 293;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 294;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 295;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 296;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 297;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 298;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 299;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 300;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_variadic2_functor__(), v, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 301;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, id, rad, pstream__,
           rd, vd), "assigning variable zg");
       current_statement__ = 302;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, vd), "assigning variable zg");
       current_statement__ = 303;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
           rd, v), "assigning variable zg");
       current_statement__ = 304;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 305;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 306;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 307;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 308;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 309;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 310;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 311;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 312;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 313;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 314;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 315;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 316;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 317;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 318;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 319;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 320;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 321;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 322;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 323;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 324;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 325;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 326;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 327;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 328;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 329;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 330;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 331;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 332;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__, r,
           vd), "assigning variable zg");
       current_statement__ = 333;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 334;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
-          rd, vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, id, rad,
+          pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 335;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 336;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          rd, v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, rd, v), "assigning variable zg");
       current_statement__ = 337;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          r, vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, r, vd), "assigning variable zg");
       current_statement__ = 338;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
-          r, v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, rad,
+          pstream__, r, v), "assigning variable zg");
       current_statement__ = 339;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
           rd, vd), "assigning variable zg");
       current_statement__ = 340;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
           rd, v), "assigning variable zg");
       current_statement__ = 341;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 342;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 343;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
           rd, vd), "assigning variable zg");
       current_statement__ = 344;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
           rd, v), "assigning variable zg");
       current_statement__ = 345;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 346;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 347;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 348;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 349;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 350;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), vd, r, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 351;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
           rd, vd), "assigning variable zg");
       current_statement__ = 352;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
           rd, v), "assigning variable zg");
       current_statement__ = 353;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 354;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 355;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 356;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 357;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 358;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, rd, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 359;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 360;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 361;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 362;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 363;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 364;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 365;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 366;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_variadic2_functor__(), v, r, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 367;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 368;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 369;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 370;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 371;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 372;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 373;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 374;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 375;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, rd, ra, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 376;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 377;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 378;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 379;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 380;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 381;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 382;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__, r,
           vd), "assigning variable zg");
       current_statement__ = 383;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 384;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 385;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 386;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 387;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 388;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 389;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 390;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__, r,
           vd), "assigning variable zg");
       current_statement__ = 391;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 392;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 393;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 394;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__, r,
           vd), "assigning variable zg");
       current_statement__ = 395;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 396;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, rd,
           vd), "assigning variable zg");
       current_statement__ = 397;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 398;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 399;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable zg");
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
           out__.write(zg[(sym2__ - 1)][(sym1__ - 1)]);
@@ -31530,6 +31530,16 @@ static constexpr std::array<const char*, 52> locations_array__ =
  " (in 'shadowing.stan', line 5, column 4 to column 14)",
  " (in 'shadowing.stan', line 2, column 43 to line 6, column 3)"};
 
+struct rhs_variadic2_functor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& y,
+             const T2__& alpha) const;
+};
 struct rhs_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
@@ -31539,16 +31549,6 @@ struct rhs_functor__ {
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& alpha,
              std::ostream* pstream__) const;
-};
-struct rhs_vari_3_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_stan_scalar<T0__>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>,
-                                stan::is_stan_scalar<T2__>>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
-             const T2__& alpha) const;
 };
 
 template <typename T0__, typename T1__, typename T2__,
@@ -31585,8 +31585,8 @@ template <typename T0__, typename T1__, typename T2__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
-                          std::ostream* pstream__)  const
+rhs_variadic2_functor__::operator()(const T0__& t, std::ostream* pstream__,
+                                    const T1__& y, const T2__& alpha)  const
 {
   return rhs(t, y, alpha, pstream__);
 }
@@ -31597,9 +31597,8 @@ template <typename T0__, typename T1__, typename T2__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-rhs_vari_3_functor__::operator()(const T0__& t, const T1__& y,
-                                 std::ostream* pstream__, const T2__& alpha) 
-const
+rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
+                          std::ostream* pstream__)  const
 {
   return rhs(t, y, alpha, pstream__);
 }
@@ -31829,7 +31828,7 @@ const
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(4, DUMMY_VAR__));
       current_statement__ = 35;
       stan::model::assign(called,
-        stan::math::ode_bdf(rhs_vari_3_functor__(), segment, 1.0,
+        stan::math::ode_bdf(rhs_variadic2_functor__(), segment, 1.0,
           std::vector<double>{3.0}, pstream__, 3.5),
         "assigning variable called");
       Eigen::Matrix<local_scalar_t__, -1, 1> result =
@@ -32064,7 +32063,7 @@ const
                stan::math::binomial_coefficient_log(3, 4)));
       current_statement__ = 35;
       stan::model::assign(called,
-        stan::math::ode_bdf(rhs_vari_3_functor__(), segment, 1.0,
+        stan::math::ode_bdf(rhs_variadic2_functor__(), segment, 1.0,
           std::vector<double>{3.0}, pstream__, 3.5),
         "assigning variable called");
       current_statement__ = 36;

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -15022,7 +15022,7 @@ struct f_functor__ {
   operator()(const T0__& t, const T1__& z, const T2__& a, const T3__& b,
              std::ostream* pstream__) const;
 };
-struct f_odefunctor__ {
+struct f_vari_3_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
                                 stan::is_col_vector<T1__>,
@@ -15088,9 +15088,9 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                      stan::base_type_t<T3__>>, -1, 1>
-f_odefunctor__::operator()(const T0__& t, const T1__& z,
-                           std::ostream* pstream__, const T2__& a,
-                           const T3__& b)  const
+f_vari_3_functor__::operator()(const T0__& t, const T1__& z,
+                               std::ostream* pstream__, const T2__& a,
+                               const T3__& b)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -15204,52 +15204,52 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       
       current_statement__ = 610;
       stan::model::assign(zd,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zd");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 611;
       stan::model::assign(zd,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zd");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 612;
       stan::model::assign(zd,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zd");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 613;
       stan::model::assign(zd,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zd");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 614;
       stan::model::assign(zd,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zd");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 615;
       stan::model::assign(zd,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zd");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zd");
       current_statement__ = 616;
       stan::model::assign(zd,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, vd),
-        "assigning variable zd");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          vd), "assigning variable zd");
       current_statement__ = 617;
       stan::model::assign(zd,
-        stan::math::ode_bdf(f_odefunctor__(), vd, id, rad, pstream__, rd, vd),
-        "assigning variable zd");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
+          vd), "assigning variable zd");
       current_statement__ = 618;
       stan::model::assign(zd,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable zd");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable zd");
       current_statement__ = 619;
       stan::model::assign(zd,
-        stan::math::ode_adams(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable zd");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable zd");
       current_statement__ = 620;
       stan::model::assign(zd,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable zd");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable zd");
       current_statement__ = 621;
       stan::model::assign(zd,
-        stan::math::ode_rk45(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable zd");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable zd");
       current_statement__ = 622;
       stan::math::validate_non_negative_index("ra", "N", N);
       current_statement__ = 623;
@@ -15303,795 +15303,795 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(N, DUMMY_VAR__));
       current_statement__ = 4;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 5;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 9;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 10;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 11;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 12;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 13;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 14;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 15;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 16;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 17;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 18;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 19;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 20;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 21;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 22;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 23;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 24;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 25;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 26;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 27;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 28;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 29;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 30;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 31;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 32;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 33;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 34;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 35;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 36;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 37;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 38;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 39;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 40;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 41;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 42;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 43;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 44;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 45;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 46;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 47;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 48;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 49;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 50;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 51;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 52;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 53;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 54;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 55;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 56;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 57;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 58;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 59;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 60;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 61;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 62;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 63;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 64;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 65;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 66;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 67;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 68;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 69;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 70;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 71;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 72;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 73;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 74;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 75;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 76;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 77;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 78;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 79;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 80;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 81;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 82;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 83;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 84;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 85;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 86;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 87;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 88;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 89;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 90;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 91;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 92;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 93;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 94;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 95;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 96;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 97;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 98;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 99;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 100;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 101;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 102;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 103;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 104;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 105;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 106;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 107;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 108;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 109;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 110;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 111;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 112;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 113;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 114;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 115;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 116;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 117;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 118;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 119;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 120;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 121;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 122;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 123;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 124;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 125;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 126;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 127;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 128;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 129;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 130;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 131;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 132;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 133;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 134;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 135;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 136;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, id, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 137;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 138;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 139;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 140;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 141;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 142;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 143;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 144;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 145;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 146;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 147;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 148;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 149;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 150;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 151;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 152;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 153;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 154;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 155;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 156;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 157;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 158;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 159;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 160;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 161;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 162;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 163;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 164;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 165;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 166;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd, v),
         "assigning variable z");
       current_statement__ = 167;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, vd),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, vd),
         "assigning variable z");
       current_statement__ = 168;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 169;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 170;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 171;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 172;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 173;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 174;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 175;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 176;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 177;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 178;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 179;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 180;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 181;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 182;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 183;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 184;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 185;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 186;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 187;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 188;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 189;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 190;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 191;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 192;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 193;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 194;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 195;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 196;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 197;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 198;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 199;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 200;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 201;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, v),
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
         "assigning variable z");
       {
         current_statement__ = 400;
@@ -16103,796 +16103,796 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
              Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(N, DUMMY_VAR__));
         current_statement__ = 402;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 403;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 404;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 405;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 406;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 407;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 408;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 409;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 410;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 411;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 412;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 413;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 414;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 415;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 416;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 417;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 418;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 419;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 420;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 421;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 422;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 423;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 424;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 425;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 426;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 427;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 428;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 429;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 430;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 431;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
             100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 432;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
             100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 433;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
             100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 434;
         stan::model::assign(zm,
-          stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+          stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
             100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 435;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 436;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 437;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 438;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 439;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 440;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 441;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 442;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 443;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 444;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 445;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 446;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 447;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 448;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 449;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 450;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 451;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 452;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 453;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 454;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 455;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 456;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 457;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 458;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 459;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 460;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 461;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 462;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 463;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 464;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 465;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 466;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 467;
         stan::model::assign(zm,
-          stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 468;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, id, rad, 1e-6,
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 469;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 470;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 471;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 472;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6,
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
             1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 473;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 474;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 475;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 476;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 477;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 478;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 479;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 480;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 481;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 482;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 483;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 484;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 485;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 486;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 487;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 488;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 489;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 490;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 491;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 492;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 493;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 494;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 495;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 496;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 497;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, vd), "assigning variable zm");
         current_statement__ = 498;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, rd, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, rd, v), "assigning variable zm");
         current_statement__ = 499;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, vd), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, vd), "assigning variable zm");
         current_statement__ = 500;
         stan::model::assign(zm,
-          stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
-            100, pstream__, r, v), "assigning variable zm");
+          stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6,
+            1e-6, 100, pstream__, r, v), "assigning variable zm");
         current_statement__ = 501;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, id, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 502;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 503;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 504;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 505;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 506;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 507;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 508;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 509;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 510;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 511;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 512;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 513;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 514;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 515;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 516;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 517;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 518;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 519;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 520;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 521;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 522;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 523;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 524;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 525;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 526;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 527;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 528;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 529;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 530;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 531;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 532;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 533;
         stan::model::assign(zm,
-          stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 534;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, id, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 535;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 536;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 537;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 538;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 539;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 540;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 541;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 542;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 543;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 544;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 545;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 546;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 547;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 548;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 549;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 550;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 551;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 552;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 553;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 554;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 555;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 556;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 557;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 558;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 559;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 560;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 561;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 562;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 563;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+            vd), "assigning variable zm");
         current_statement__ = 564;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+            v), "assigning variable zm");
         current_statement__ = 565;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 566;
         stan::model::assign(zm,
-          stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 567;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, id, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 568;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 569;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-            v), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 570;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            r, vd), "assigning variable zm");
         current_statement__ = 571;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__,
+            r, v), "assigning variable zm");
         current_statement__ = 572;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 573;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 574;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 575;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 576;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 577;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 578;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 579;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 580;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+            vd), "assigning variable zm");
         current_statement__ = 581;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+            v), "assigning variable zm");
         current_statement__ = 582;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 583;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 584;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd,
-            vd), "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__,
+            rd, vd), "assigning variable zm");
         current_statement__ = 585;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__,
+            rd, v), "assigning variable zm");
         current_statement__ = 586;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 587;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 588;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+            vd), "assigning variable zm");
         current_statement__ = 589;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+            v), "assigning variable zm");
         current_statement__ = 590;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 591;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 592;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+            vd), "assigning variable zm");
         current_statement__ = 593;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+            v), "assigning variable zm");
         current_statement__ = 594;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 595;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 596;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+            vd), "assigning variable zm");
         current_statement__ = 597;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+            v), "assigning variable zm");
         current_statement__ = 598;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r,
+            vd), "assigning variable zm");
         current_statement__ = 599;
         stan::model::assign(zm,
-          stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, v),
-          "assigning variable zm");
+          stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r,
+            v), "assigning variable zm");
         current_statement__ = 600;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(r, 0, 1));
       }
@@ -16954,795 +16954,795 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       } 
       current_statement__ = 4;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 5;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 9;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 10;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 11;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 12;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 13;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 14;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 15;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 16;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 17;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 18;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 19;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 20;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 21;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 22;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 23;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 24;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 25;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 26;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 27;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 28;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 29;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 30;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 31;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 32;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 33;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 34;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 35;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 36;
       stan::model::assign(z,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 37;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 38;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 39;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 40;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 41;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 42;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 43;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 44;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 45;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 46;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 47;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 48;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 49;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 50;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 51;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 52;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 53;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 54;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 55;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 56;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 57;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 58;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 59;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 60;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 61;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 62;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 63;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 64;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 65;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 66;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 67;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 68;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 69;
       stan::model::assign(z,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable z");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable z");
       current_statement__ = 70;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 71;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 72;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 73;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 74;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 75;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 76;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 77;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 78;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 79;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 80;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 81;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 82;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 83;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 84;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 85;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 86;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 87;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 88;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 89;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 90;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 91;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 92;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 93;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 94;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 95;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 96;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 97;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 98;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable z");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable z");
       current_statement__ = 99;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable z");
       current_statement__ = 100;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable z");
       current_statement__ = 101;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable z");
       current_statement__ = 102;
       stan::model::assign(z,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable z");
       current_statement__ = 103;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 104;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 105;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          v), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 106;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable z");
       current_statement__ = 107;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable z");
       current_statement__ = 108;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 109;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 110;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 111;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 112;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 113;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 114;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 115;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 116;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 117;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 118;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 119;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 120;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 121;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 122;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 123;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 124;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 125;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 126;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 127;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 128;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 129;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 130;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 131;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 132;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 133;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 134;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 135;
       stan::model::assign(z,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 136;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, id, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 137;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 138;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 139;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 140;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 141;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 142;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 143;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 144;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 145;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 146;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 147;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 148;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 149;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 150;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 151;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 152;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 153;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 154;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 155;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 156;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 157;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 158;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 159;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 160;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 161;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 162;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 163;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 164;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 165;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 166;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd, v),
         "assigning variable z");
       current_statement__ = 167;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, vd),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, vd),
         "assigning variable z");
       current_statement__ = 168;
       stan::model::assign(z,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
         "assigning variable z");
       current_statement__ = 169;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 170;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable z");
       current_statement__ = 171;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable z");
       current_statement__ = 172;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 173;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 174;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 175;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 176;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 177;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 178;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 179;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 180;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 181;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 182;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 183;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 184;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 185;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 186;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 187;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 188;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 189;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 190;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 191;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 192;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 193;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 194;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 195;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 196;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 197;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable z");
       current_statement__ = 198;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable z");
       current_statement__ = 199;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable z");
       current_statement__ = 200;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable z");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable z");
       current_statement__ = 201;
       stan::model::assign(z,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, v),
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
         "assigning variable z");
       if (emit_transformed_parameters__) {
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -17760,795 +17760,795 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
              std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 202;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 203;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 204;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 205;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 206;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 207;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 208;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 209;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 210;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 211;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 212;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 213;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 214;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 215;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 216;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 217;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 218;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 219;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 220;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 221;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 222;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 223;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 224;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 225;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 226;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 227;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 228;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 229;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 230;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 231;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 232;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 233;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 234;
       stan::model::assign(zg,
-        stan::math::ode_bdf_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable zg");
+        stan::math::ode_bdf_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 235;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 236;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 237;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 238;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 239;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 240;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 241;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 242;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 243;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 244;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 245;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 246;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 247;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 248;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 249;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 250;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 251;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), vd, r, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 252;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 253;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 254;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 255;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 256;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 257;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 258;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 259;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 260;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 261;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 262;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 263;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 264;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 265;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 266;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 267;
       stan::model::assign(zg,
-        stan::math::ode_adams_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6,
+        stan::math::ode_adams_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 268;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, id, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, id, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 269;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 270;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 271;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 272;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 273;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 274;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 275;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 276;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, rd, ra, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, rd, ra, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 277;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 278;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 279;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 280;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 281;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 282;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 283;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 284;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), vd, r, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), vd, r, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 285;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 286;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 287;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 288;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, rad, 1e-6, 1e-6,
-          100, pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, rad, 1e-6,
+          1e-6, 100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 289;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 290;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 291;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 292;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, rd, ra, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, rd, ra, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 293;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 294;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 295;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 296;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, rad, 1e-6, 1e-6,
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, rad, 1e-6, 1e-6,
           100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 297;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, vd), "assigning variable zg");
       current_statement__ = 298;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, rd, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, rd, v), "assigning variable zg");
       current_statement__ = 299;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, vd), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, vd), "assigning variable zg");
       current_statement__ = 300;
       stan::model::assign(zg,
-        stan::math::ode_rk45_tol(f_odefunctor__(), v, r, ra, 1e-6, 1e-6, 100,
-          pstream__, r, v), "assigning variable zg");
+        stan::math::ode_rk45_tol(f_vari_3_functor__(), v, r, ra, 1e-6, 1e-6,
+          100, pstream__, r, v), "assigning variable zg");
       current_statement__ = 301;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 302;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 303;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 304;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 305;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 306;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 307;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 308;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 309;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 310;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 311;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 312;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 313;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 314;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 315;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 316;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 317;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 318;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 319;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 320;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 321;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 322;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 323;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 324;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 325;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 326;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 327;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 328;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 329;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 330;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 331;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 332;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 333;
       stan::model::assign(zg,
-        stan::math::ode_rk45(f_odefunctor__(), v, r, ra, pstream__, r, v),
+        stan::math::ode_rk45(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
         "assigning variable zg");
       current_statement__ = 334;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, id, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, id, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 335;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 336;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, rd,
-          v), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 337;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          r, vd), "assigning variable zg");
       current_statement__ = 338;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, rad, pstream__,
+          r, v), "assigning variable zg");
       current_statement__ = 339;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 340;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 341;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 342;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 343;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 344;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 345;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 346;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 347;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 348;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 349;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 350;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), vd, r, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 351;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd,
-          vd), "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+          rd, vd), "assigning variable zg");
       current_statement__ = 352;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__,
+          rd, v), "assigning variable zg");
       current_statement__ = 353;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 354;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 355;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 356;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 357;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 358;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, rd, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 359;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 360;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 361;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 362;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 363;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 364;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 365;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 366;
       stan::model::assign(zg,
-        stan::math::ode_adams(f_odefunctor__(), v, r, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_adams(f_vari_3_functor__(), v, r, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 367;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, id, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, id, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 368;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 369;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 370;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 371;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 372;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 373;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 374;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 375;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, rd, ra, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, rd, ra, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 376;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 377;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 378;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 379;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 380;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 381;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 382;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 383;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), vd, r, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), vd, r, ra, pstream__, r, v),
         "assigning variable zg");
       current_statement__ = 384;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 385;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 386;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 387;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, rad, pstream__, r, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, rad, pstream__, r,
+          v), "assigning variable zg");
       current_statement__ = 388;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 389;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 390;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 391;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, rd, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, rd, ra, pstream__, r, v),
         "assigning variable zg");
       current_statement__ = 392;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 393;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, rd, v),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, rd,
+          v), "assigning variable zg");
       current_statement__ = 394;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r,
+          vd), "assigning variable zg");
       current_statement__ = 395;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, rad, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, rad, pstream__, r, v),
         "assigning variable zg");
       current_statement__ = 396;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, vd),
-        "assigning variable zg");
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd,
+          vd), "assigning variable zg");
       current_statement__ = 397;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, rd, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, rd, v),
         "assigning variable zg");
       current_statement__ = 398;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, vd),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, vd),
         "assigning variable zg");
       current_statement__ = 399;
       stan::model::assign(zg,
-        stan::math::ode_bdf(f_odefunctor__(), v, r, ra, pstream__, r, v),
+        stan::math::ode_bdf(f_vari_3_functor__(), v, r, ra, pstream__, r, v),
         "assigning variable zg");
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
@@ -31530,16 +31530,6 @@ static constexpr std::array<const char*, 52> locations_array__ =
  " (in 'shadowing.stan', line 5, column 4 to column 14)",
  " (in 'shadowing.stan', line 2, column 43 to line 6, column 3)"};
 
-struct rhs_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_stan_scalar<T0__>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>,
-                                stan::is_stan_scalar<T2__>>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
-             const T2__& alpha) const;
-};
 struct rhs_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
@@ -31549,6 +31539,16 @@ struct rhs_functor__ {
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& y, const T2__& alpha,
              std::ostream* pstream__) const;
+};
+struct rhs_vari_3_functor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
+  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
+             const T2__& alpha) const;
 };
 
 template <typename T0__, typename T1__, typename T2__,
@@ -31585,9 +31585,8 @@ template <typename T0__, typename T1__, typename T2__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-rhs_odefunctor__::operator()(const T0__& t, const T1__& y,
-                             std::ostream* pstream__, const T2__& alpha) 
-const
+rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
+                          std::ostream* pstream__)  const
 {
   return rhs(t, y, alpha, pstream__);
 }
@@ -31598,8 +31597,9 @@ template <typename T0__, typename T1__, typename T2__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
-                          std::ostream* pstream__)  const
+rhs_vari_3_functor__::operator()(const T0__& t, const T1__& y,
+                                 std::ostream* pstream__, const T2__& alpha) 
+const
 {
   return rhs(t, y, alpha, pstream__);
 }
@@ -31829,7 +31829,7 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(4, DUMMY_VAR__));
       current_statement__ = 35;
       stan::model::assign(called,
-        stan::math::ode_bdf(rhs_odefunctor__(), segment, 1.0,
+        stan::math::ode_bdf(rhs_vari_3_functor__(), segment, 1.0,
           std::vector<double>{3.0}, pstream__, 3.5),
         "assigning variable called");
       Eigen::Matrix<local_scalar_t__, -1, 1> result =
@@ -32064,7 +32064,7 @@ rhs_functor__::operator()(const T0__& t, const T1__& y, const T2__& alpha,
                stan::math::binomial_coefficient_log(3, 4)));
       current_statement__ = 35;
       stan::model::assign(called,
-        stan::math::ode_bdf(rhs_odefunctor__(), segment, 1.0,
+        stan::math::ode_bdf(rhs_vari_3_functor__(), segment, 1.0,
           std::vector<double>{3.0}, pstream__, 3.5),
         "assigning variable called");
       current_statement__ = 36;

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -15032,7 +15032,7 @@ struct f_variadic2_functor__ {
                                 stan::is_vt_not_complex<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                        stan::base_type_t<T3__>>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& z,
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a, const T3__& b) const;
 };
 
@@ -15088,9 +15088,9 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_vt_not_complex<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__,
                      stan::base_type_t<T3__>>, -1, 1>
-f_variadic2_functor__::operator()(const T0__& t, std::ostream* pstream__,
-                                  const T1__& z, const T2__& a, const T3__& b) 
-const
+f_variadic2_functor__::operator()(const T0__& t, const T1__& z,
+                                  std::ostream* pstream__, const T2__& a,
+                                  const T3__& b)  const
 {
   return f(t, z, a, b, pstream__);
 }
@@ -31537,7 +31537,7 @@ struct rhs_variadic2_functor__ {
                                 stan::is_vt_not_complex<T1__>,
                                 stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& y,
+  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& alpha) const;
 };
 struct rhs_functor__ {
@@ -31585,8 +31585,9 @@ template <typename T0__, typename T1__, typename T2__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-rhs_variadic2_functor__::operator()(const T0__& t, std::ostream* pstream__,
-                                    const T1__& y, const T2__& alpha)  const
+rhs_variadic2_functor__::operator()(const T0__& t, const T1__& y,
+                                    std::ostream* pstream__,
+                                    const T2__& alpha)  const
 {
   return rhs(t, y, alpha, pstream__);
 }

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -47,15 +47,13 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 9, column 4 to column 13)",
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
-struct f_1_arg_vari_3_functor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct f_0_arg_variadic2_functor__ {
+  template <typename T0__, typename T1__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
                                 stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>,
-                                stan::is_stan_scalar<T2__>>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
-             const T2__& a) const;
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& z) const;
 };
 struct f_2_arg_functor__ {
   template <typename T0__, typename T1__, typename T3__,
@@ -75,15 +73,25 @@ struct f_0_arg_functor__ {
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
-struct f_2_arg_vari_3_functor__ {
+struct f_2_arg_variadic2_functor__ {
   template <typename T0__, typename T1__, typename T3__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
                                 stan::is_col_vector<T1__>,
                                 stan::is_vt_not_complex<T1__>,
                                 stan::is_stan_scalar<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& z,
              const int& b, const T3__& a) const;
+};
+struct f_1_arg_variadic2_functor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& z,
+             const T2__& a) const;
 };
 struct f_1_arg_functor__ {
   template <typename T0__, typename T1__, typename T2__,
@@ -94,14 +102,6 @@ struct f_1_arg_functor__ {
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
   operator()(const T0__& t, const T1__& z, const T2__& a,
              std::ostream* pstream__) const;
-};
-struct f_0_arg_vari_3_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_all_t<stan::is_stan_scalar<T0__>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 
 template <typename T0__, typename T1__,
@@ -171,17 +171,16 @@ template <typename T0__, typename T1__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
-template <typename T0__, typename T1__, typename T2__,
+template <typename T0__, typename T1__,
           stan::require_all_t<stan::is_stan_scalar<T0__>,
                               stan::is_col_vector<T1__>,
-                              stan::is_vt_not_complex<T1__>,
-                              stan::is_stan_scalar<T2__>>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-f_1_arg_vari_3_functor__::operator()(const T0__& t, const T1__& z,
-                                     std::ostream* pstream__, const T2__& a) 
-const
+                              stan::is_vt_not_complex<T1__>>*>
+Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
+f_0_arg_variadic2_functor__::operator()(const T0__& t,
+                                        std::ostream* pstream__,
+                                        const T1__& z)  const
 {
-  return f_1_arg(t, z, a, pstream__);
+  return f_0_arg(t, z, pstream__);
 }
 
 template <typename T0__, typename T1__, typename T3__,
@@ -213,11 +212,25 @@ template <typename T0__, typename T1__, typename T3__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
-f_2_arg_vari_3_functor__::operator()(const T0__& t, const T1__& z,
-                                     std::ostream* pstream__, const int& b,
-                                     const T3__& a)  const
+f_2_arg_variadic2_functor__::operator()(const T0__& t,
+                                        std::ostream* pstream__,
+                                        const T1__& z, const int& b,
+                                        const T3__& a)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
+}
+
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
+Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
+f_1_arg_variadic2_functor__::operator()(const T0__& t,
+                                        std::ostream* pstream__,
+                                        const T1__& z, const T2__& a)  const
+{
+  return f_1_arg(t, z, a, pstream__);
 }
 
 template <typename T0__, typename T1__, typename T2__,
@@ -230,17 +243,6 @@ f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
                               std::ostream* pstream__)  const
 {
   return f_1_arg(t, z, a, pstream__);
-}
-
-template <typename T0__, typename T1__,
-          stan::require_all_t<stan::is_stan_scalar<T0__>,
-                              stan::is_col_vector<T1__>,
-                              stan::is_vt_not_complex<T1__>>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
-f_0_arg_vari_3_functor__::operator()(const T0__& t, const T1__& z,
-                                     std::ostream* pstream__)  const
-{
-  return f_0_arg(t, z, pstream__);
 }
 
 
@@ -419,22 +421,22 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(N, DUMMY_VAR__));
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_0_arg_vari_3_functor__(), y0, t0,
-          times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
+        stan::math::ode_adjoint_tol_ctl(f_0_arg_variadic2_functor__(), y0,
+          t0, times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__),
         "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_1_arg_vari_3_functor__(), y0, t0,
-          times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
+        stan::math::ode_adjoint_tol_ctl(f_1_arg_variadic2_functor__(), y0,
+          t0, times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, y),
         "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_2_arg_vari_3_functor__(), y0, t0,
-          times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
+        stan::math::ode_adjoint_tol_ctl(f_2_arg_variadic2_functor__(), y0,
+          t0, times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, i, y),
         "assigning variable z");
@@ -504,22 +506,22 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       } 
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_0_arg_vari_3_functor__(), y0, t0,
-          times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
+        stan::math::ode_adjoint_tol_ctl(f_0_arg_variadic2_functor__(), y0,
+          t0, times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__),
         "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_1_arg_vari_3_functor__(), y0, t0,
-          times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
+        stan::math::ode_adjoint_tol_ctl(f_1_arg_variadic2_functor__(), y0,
+          t0, times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, y),
         "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_2_arg_vari_3_functor__(), y0, t0,
-          times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
+        stan::math::ode_adjoint_tol_ctl(f_2_arg_variadic2_functor__(), y0,
+          t0, times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, i, y),
         "assigning variable z");
@@ -889,7 +891,7 @@ struct simple_SIR_functor__ {
              const T4__& gamma, const T5__& xi, const T6__& delta,
              std::ostream* pstream__) const;
 };
-struct simple_SIR_vari_3_functor__ {
+struct simple_SIR_variadic2_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             typename T4__, typename T5__, typename T6__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
@@ -902,7 +904,7 @@ struct simple_SIR_vari_3_functor__ {
                                 stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& y,
              const T2__& beta, const T3__& kappa, const T4__& gamma,
              const T5__& xi, const T6__& delta, const int& unused) const;
   template <typename T0__, typename T1__, typename T2__, typename T3__,
@@ -917,7 +919,7 @@ struct simple_SIR_vari_3_functor__ {
                                 stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
+  operator()(const T0__& t, std::ostream* pstream__, const T1__& y,
              const T2__& beta, const T3__& kappa, const T4__& gamma,
              const T5__& xi, const T6__& delta) const;
 };
@@ -1091,12 +1093,13 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_vari_3_functor__::operator()(const T0__& t, const T1__& y,
-                                        std::ostream* pstream__,
-                                        const T2__& beta, const T3__& kappa,
-                                        const T4__& gamma, const T5__& xi,
-                                        const T6__& delta, const int& unused) 
-const
+simple_SIR_variadic2_functor__::operator()(const T0__& t,
+                                           std::ostream* pstream__,
+                                           const T1__& y, const T2__& beta,
+                                           const T3__& kappa,
+                                           const T4__& gamma, const T5__& xi,
+                                           const T6__& delta,
+                                           const int& unused)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
 }
@@ -1113,11 +1116,12 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_vari_3_functor__::operator()(const T0__& t, const T1__& y,
-                                        std::ostream* pstream__,
-                                        const T2__& beta, const T3__& kappa,
-                                        const T4__& gamma, const T5__& xi,
-                                        const T6__& delta)  const
+simple_SIR_variadic2_functor__::operator()(const T0__& t,
+                                           std::ostream* pstream__,
+                                           const T1__& y, const T2__& beta,
+                                           const T3__& kappa,
+                                           const T4__& gamma, const T5__& xi,
+                                           const T6__& delta)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, pstream__);
 }
@@ -1294,7 +1298,7 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(4, DUMMY_VAR__));
       current_statement__ = 5;
       stan::model::assign(y,
-        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+        stan::math::ode_rk45_tol(simple_SIR_variadic2_functor__(), y0, t0, t,
           1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta),
         "assigning variable y");
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> y2 =
@@ -1302,7 +1306,7 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(4, DUMMY_VAR__));
       current_statement__ = 6;
       stan::model::assign(y2,
-        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+        stan::math::ode_rk45_tol(simple_SIR_variadic2_functor__(), y0, t0, t,
           1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta, unused),
         "assigning variable y2");
       current_statement__ = 5;
@@ -1442,12 +1446,12 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       } 
       current_statement__ = 5;
       stan::model::assign(y,
-        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+        stan::math::ode_rk45_tol(simple_SIR_variadic2_functor__(), y0, t0, t,
           1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta),
         "assigning variable y");
       current_statement__ = 6;
       stan::model::assign(y2,
-        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+        stan::math::ode_rk45_tol(simple_SIR_variadic2_functor__(), y0, t0, t,
           1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta, unused),
         "assigning variable y2");
       current_statement__ = 5;

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -53,7 +53,7 @@ struct f_0_arg_variadic2_functor__ {
                                 stan::is_col_vector<T1__>,
                                 stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& z) const;
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
 struct f_2_arg_functor__ {
   template <typename T0__, typename T1__, typename T3__,
@@ -80,7 +80,7 @@ struct f_2_arg_variadic2_functor__ {
                                 stan::is_vt_not_complex<T1__>,
                                 stan::is_stan_scalar<T3__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& z,
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const int& b, const T3__& a) const;
 };
 struct f_1_arg_variadic2_functor__ {
@@ -90,7 +90,7 @@ struct f_1_arg_variadic2_functor__ {
                                 stan::is_vt_not_complex<T1__>,
                                 stan::is_stan_scalar<T2__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& z,
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& a) const;
 };
 struct f_1_arg_functor__ {
@@ -176,9 +176,8 @@ template <typename T0__, typename T1__,
                               stan::is_col_vector<T1__>,
                               stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
-f_0_arg_variadic2_functor__::operator()(const T0__& t,
-                                        std::ostream* pstream__,
-                                        const T1__& z)  const
+f_0_arg_variadic2_functor__::operator()(const T0__& t, const T1__& z,
+                                        std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
 }
@@ -212,10 +211,9 @@ template <typename T0__, typename T1__, typename T3__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T3__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
-f_2_arg_variadic2_functor__::operator()(const T0__& t,
+f_2_arg_variadic2_functor__::operator()(const T0__& t, const T1__& z,
                                         std::ostream* pstream__,
-                                        const T1__& z, const int& b,
-                                        const T3__& a)  const
+                                        const int& b, const T3__& a)  const
 {
   return f_2_arg(t, z, b, a, pstream__);
 }
@@ -226,9 +224,9 @@ template <typename T0__, typename T1__, typename T2__,
                               stan::is_vt_not_complex<T1__>,
                               stan::is_stan_scalar<T2__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-f_1_arg_variadic2_functor__::operator()(const T0__& t,
+f_1_arg_variadic2_functor__::operator()(const T0__& t, const T1__& z,
                                         std::ostream* pstream__,
-                                        const T1__& z, const T2__& a)  const
+                                        const T2__& a)  const
 {
   return f_1_arg(t, z, a, pstream__);
 }
@@ -904,7 +902,7 @@ struct simple_SIR_variadic2_functor__ {
                                 stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& y,
+  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& beta, const T3__& kappa, const T4__& gamma,
              const T5__& xi, const T6__& delta, const int& unused) const;
   template <typename T0__, typename T1__, typename T2__, typename T3__,
@@ -919,7 +917,7 @@ struct simple_SIR_variadic2_functor__ {
                                 stan::is_stan_scalar<T6__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                        stan::promote_args_t<T5__, T6__>>, -1, 1>
-  operator()(const T0__& t, std::ostream* pstream__, const T1__& y,
+  operator()(const T0__& t, const T1__& y, std::ostream* pstream__,
              const T2__& beta, const T3__& kappa, const T4__& gamma,
              const T5__& xi, const T6__& delta) const;
 };
@@ -1093,9 +1091,9 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_variadic2_functor__::operator()(const T0__& t,
+simple_SIR_variadic2_functor__::operator()(const T0__& t, const T1__& y,
                                            std::ostream* pstream__,
-                                           const T1__& y, const T2__& beta,
+                                           const T2__& beta,
                                            const T3__& kappa,
                                            const T4__& gamma, const T5__& xi,
                                            const T6__& delta,
@@ -1116,9 +1114,9 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_variadic2_functor__::operator()(const T0__& t,
+simple_SIR_variadic2_functor__::operator()(const T0__& t, const T1__& y,
                                            std::ostream* pstream__,
-                                           const T1__& y, const T2__& beta,
+                                           const T2__& beta,
                                            const T3__& kappa,
                                            const T4__& gamma, const T5__& xi,
                                            const T6__& delta)  const

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -47,6 +47,16 @@ static constexpr std::array<const char*, 36> locations_array__ =
  " (in 'ode_adjoint_test_model.stan', line 9, column 4 to column 13)",
  " (in 'ode_adjoint_test_model.stan', line 8, column 50 to line 10, column 3)"};
 
+struct f_1_arg_vari_3_functor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T2__>>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
+             const T2__& a) const;
+};
 struct f_2_arg_functor__ {
   template <typename T0__, typename T1__, typename T3__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
@@ -65,6 +75,16 @@ struct f_0_arg_functor__ {
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
 };
+struct f_2_arg_vari_3_functor__ {
+  template <typename T0__, typename T1__, typename T3__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_stan_scalar<T3__>>* = nullptr>
+  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
+             const int& b, const T3__& a) const;
+};
 struct f_1_arg_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
@@ -75,33 +95,13 @@ struct f_1_arg_functor__ {
   operator()(const T0__& t, const T1__& z, const T2__& a,
              std::ostream* pstream__) const;
 };
-struct f_1_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_stan_scalar<T0__>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>,
-                                stan::is_stan_scalar<T2__>>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
-             const T2__& a) const;
-};
-struct f_0_arg_odefunctor__ {
+struct f_0_arg_vari_3_functor__ {
   template <typename T0__, typename T1__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
                                 stan::is_col_vector<T1__>,
                                 stan::is_vt_not_complex<T1__>>* = nullptr>
   Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const;
-};
-struct f_2_arg_odefunctor__ {
-  template <typename T0__, typename T1__, typename T3__,
-            stan::require_all_t<stan::is_stan_scalar<T0__>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>,
-                                stan::is_stan_scalar<T3__>>* = nullptr>
-  Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
-             const int& b, const T3__& a) const;
 };
 
 template <typename T0__, typename T1__,
@@ -171,6 +171,19 @@ template <typename T0__, typename T1__, typename T3__,
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
     }
+template <typename T0__, typename T1__, typename T2__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T2__>>*>
+Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
+f_1_arg_vari_3_functor__::operator()(const T0__& t, const T1__& z,
+                                     std::ostream* pstream__, const T2__& a) 
+const
+{
+  return f_1_arg(t, z, a, pstream__);
+}
+
 template <typename T0__, typename T1__, typename T3__,
           stan::require_all_t<stan::is_stan_scalar<T0__>,
                               stan::is_col_vector<T1__>,
@@ -194,6 +207,19 @@ f_0_arg_functor__::operator()(const T0__& t, const T1__& z,
   return f_0_arg(t, z, pstream__);
 }
 
+template <typename T0__, typename T1__, typename T3__,
+          stan::require_all_t<stan::is_stan_scalar<T0__>,
+                              stan::is_col_vector<T1__>,
+                              stan::is_vt_not_complex<T1__>,
+                              stan::is_stan_scalar<T3__>>*>
+Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
+f_2_arg_vari_3_functor__::operator()(const T0__& t, const T1__& z,
+                                     std::ostream* pstream__, const int& b,
+                                     const T3__& a)  const
+{
+  return f_2_arg(t, z, b, a, pstream__);
+}
+
 template <typename T0__, typename T1__, typename T2__,
           stan::require_all_t<stan::is_stan_scalar<T0__>,
                               stan::is_col_vector<T1__>,
@@ -206,41 +232,15 @@ f_1_arg_functor__::operator()(const T0__& t, const T1__& z, const T2__& a,
   return f_1_arg(t, z, a, pstream__);
 }
 
-template <typename T0__, typename T1__, typename T2__,
-          stan::require_all_t<stan::is_stan_scalar<T0__>,
-                              stan::is_col_vector<T1__>,
-                              stan::is_vt_not_complex<T1__>,
-                              stan::is_stan_scalar<T2__>>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__>, -1, 1>
-f_1_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
-                                 std::ostream* pstream__, const T2__& a) 
-const
-{
-  return f_1_arg(t, z, a, pstream__);
-}
-
 template <typename T0__, typename T1__,
           stan::require_all_t<stan::is_stan_scalar<T0__>,
                               stan::is_col_vector<T1__>,
                               stan::is_vt_not_complex<T1__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>>, -1, 1>
-f_0_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
-                                 std::ostream* pstream__)  const
+f_0_arg_vari_3_functor__::operator()(const T0__& t, const T1__& z,
+                                     std::ostream* pstream__)  const
 {
   return f_0_arg(t, z, pstream__);
-}
-
-template <typename T0__, typename T1__, typename T3__,
-          stan::require_all_t<stan::is_stan_scalar<T0__>,
-                              stan::is_col_vector<T1__>,
-                              stan::is_vt_not_complex<T1__>,
-                              stan::is_stan_scalar<T3__>>*>
-Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T3__>, -1, 1>
-f_2_arg_odefunctor__::operator()(const T0__& t, const T1__& z,
-                                 std::ostream* pstream__, const int& b,
-                                 const T3__& a)  const
-{
-  return f_2_arg(t, z, b, a, pstream__);
 }
 
 
@@ -419,21 +419,21 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(N, DUMMY_VAR__));
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_0_arg_odefunctor__(), y0, t0,
+        stan::math::ode_adjoint_tol_ctl(f_0_arg_vari_3_functor__(), y0, t0,
           times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__),
         "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_1_arg_odefunctor__(), y0, t0,
+        stan::math::ode_adjoint_tol_ctl(f_1_arg_vari_3_functor__(), y0, t0,
           times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, y),
         "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_2_arg_odefunctor__(), y0, t0,
+        stan::math::ode_adjoint_tol_ctl(f_2_arg_vari_3_functor__(), y0, t0,
           times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, i, y),
@@ -504,21 +504,21 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       } 
       current_statement__ = 6;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_0_arg_odefunctor__(), y0, t0,
+        stan::math::ode_adjoint_tol_ctl(f_0_arg_vari_3_functor__(), y0, t0,
           times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__),
         "assigning variable z");
       current_statement__ = 7;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_1_arg_odefunctor__(), y0, t0,
+        stan::math::ode_adjoint_tol_ctl(f_1_arg_vari_3_functor__(), y0, t0,
           times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, y),
         "assigning variable z");
       current_statement__ = 8;
       stan::model::assign(z,
-        stan::math::ode_adjoint_tol_ctl(f_2_arg_odefunctor__(), y0, t0,
+        stan::math::ode_adjoint_tol_ctl(f_2_arg_vari_3_functor__(), y0, t0,
           times, rel_tol_f, abs_tol_f, rel_tol_b, abs_tol_b, rel_tol_q,
           abs_tol_q, max_num_steps, num_checkpoints,
           interpolation_polynomial, solver_f, solver_b, pstream__, i, y),
@@ -889,7 +889,7 @@ struct simple_SIR_functor__ {
              const T4__& gamma, const T5__& xi, const T6__& delta,
              std::ostream* pstream__) const;
 };
-struct simple_SIR_odefunctor__ {
+struct simple_SIR_vari_3_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             typename T4__, typename T5__, typename T6__,
             stan::require_all_t<stan::is_stan_scalar<T0__>,
@@ -1091,11 +1091,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
-                                    std::ostream* pstream__,
-                                    const T2__& beta, const T3__& kappa,
-                                    const T4__& gamma, const T5__& xi,
-                                    const T6__& delta, const int& unused) 
+simple_SIR_vari_3_functor__::operator()(const T0__& t, const T1__& y,
+                                        std::ostream* pstream__,
+                                        const T2__& beta, const T3__& kappa,
+                                        const T4__& gamma, const T5__& xi,
+                                        const T6__& delta, const int& unused) 
 const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, unused, pstream__);
@@ -1113,11 +1113,11 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
                               stan::is_stan_scalar<T6__>>*>
 Eigen::Matrix<stan::promote_args_t<T0__, stan::base_type_t<T1__>, T2__, T3__, T4__,
                      stan::promote_args_t<T5__, T6__>>, -1, 1>
-simple_SIR_odefunctor__::operator()(const T0__& t, const T1__& y,
-                                    std::ostream* pstream__,
-                                    const T2__& beta, const T3__& kappa,
-                                    const T4__& gamma, const T5__& xi,
-                                    const T6__& delta)  const
+simple_SIR_vari_3_functor__::operator()(const T0__& t, const T1__& y,
+                                        std::ostream* pstream__,
+                                        const T2__& beta, const T3__& kappa,
+                                        const T4__& gamma, const T5__& xi,
+                                        const T6__& delta)  const
 {
   return simple_SIR(t, y, beta, kappa, gamma, xi, delta, pstream__);
 }
@@ -1294,16 +1294,16 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(4, DUMMY_VAR__));
       current_statement__ = 5;
       stan::model::assign(y,
-        stan::math::ode_rk45_tol(simple_SIR_odefunctor__(), y0, t0, t, 1e-6,
-          1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta),
+        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+          1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta),
         "assigning variable y");
       std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>> y2 =
          std::vector<Eigen::Matrix<local_scalar_t__, -1, 1>>(N_t, 
            Eigen::Matrix<local_scalar_t__, -1, 1>::Constant(4, DUMMY_VAR__));
       current_statement__ = 6;
       stan::model::assign(y2,
-        stan::math::ode_rk45_tol(simple_SIR_odefunctor__(), y0, t0, t, 1e-6,
-          1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta, unused),
+        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+          1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta, unused),
         "assigning variable y2");
       current_statement__ = 5;
       stan::math::check_greater_or_equal(function__, "y", y, 0);
@@ -1442,13 +1442,13 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       } 
       current_statement__ = 5;
       stan::model::assign(y,
-        stan::math::ode_rk45_tol(simple_SIR_odefunctor__(), y0, t0, t, 1e-6,
-          1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta),
+        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+          1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta),
         "assigning variable y");
       current_statement__ = 6;
       stan::model::assign(y2,
-        stan::math::ode_rk45_tol(simple_SIR_odefunctor__(), y0, t0, t, 1e-6,
-          1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta, unused),
+        stan::math::ode_rk45_tol(simple_SIR_vari_3_functor__(), y0, t0, t,
+          1e-6, 1e-6, 1000, pstream__, beta, kappa, gamma, xi, delta, unused),
         "assigning variable y2");
       current_statement__ = 5;
       stan::math::check_greater_or_equal(function__, "y", y, 0);


### PR DESCRIPTION
This is a follow on to #1259 which tries to do a similar amount of clean-up to the backend code generation. Once again, we treat `reduce_sum` as a special case still, but the other variadic HOFs share the same structure except for two details, which differ per signature:

1. Where does the `pstream` argument go in the call to the _higher order function_, e.g. `dae(f, ..., msgs, ...)`. This differs between each function and its `_tol` version.
2. Where does the `pstream` argument get passed to the `f` in the above call? For DAEs, this is 4, for ODEs 3, etc. Another way of saying this is how many non-variadic arguments does the function `f` get called with in C++. 

By adding this tiny bit of backend-specific data to the variadic signature table added in #1259 the code generation gets much nicer and cares a lot less about the specifics of `Stan_math_signatures`. If someone wants to build a non-C++ backend, they can just ignore these or set them to 0 for new signatures.


Changes to the test output only occurred because this change means that the names of the functors generated changed slightly, now it is based on the number specified in bullet 2 above rather than the name, so `_odefunctor_` becomes `_vari_3_functor_`

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Replace this text with a short note on what will change if this pull request is merged. This will be included in the release notes.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
