### PR TITLE
Comment out perfReport usage until further updates of the plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -436,12 +436,12 @@ pipeline {
 
                             archiveArtifacts 'performance-tests-cmdstan/performance.xml'
 
-                            perfReport modePerformancePerTestCase: true,
-                                sourceDataFiles: 'performance-tests-cmdstan/performance.xml',
-                                modeThroughput: false,
-                                excludeResponseTime: true,
-                                errorFailedThreshold: 100,
-                                errorUnstableThreshold: 100
+//                             perfReport modePerformancePerTestCase: true,
+//                                 sourceDataFiles: 'performance-tests-cmdstan/performance.xml',
+//                                 modeThroughput: false,
+//                                 excludeResponseTime: true,
+//                                 errorFailedThreshold: 100,
+//                                 errorUnstableThreshold: 100
                         }
                     }
                     post { always { runShell("rm -rf ${env.WORKSPACE}/compile-end-to-end/*") }}
@@ -506,12 +506,12 @@ pipeline {
 
                             archiveArtifacts 'performance-tests-cmdstan/performance.xml'
 
-                            perfReport modePerformancePerTestCase: true,
-                                sourceDataFiles: 'performance-tests-cmdstan/performance.xml',
-                                modeThroughput: false,
-                                excludeResponseTime: true,
-                                errorFailedThreshold: 100,
-                                errorUnstableThreshold: 100
+//                             perfReport modePerformancePerTestCase: true,
+//                                 sourceDataFiles: 'performance-tests-cmdstan/performance.xml',
+//                                 modeThroughput: false,
+//                                 excludeResponseTime: true,
+//                                 errorFailedThreshold: 100,
+//                                 errorUnstableThreshold: 100
                         }
                     }
                     post { always { runShell("rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*") }}


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

We have some problems with a plugin [perfReport](https://github.com/jenkinsci/performance-plugin) in Jenkins
Jenkins has been updated and the plugin has a [vulnerability](https://www.jenkins.io/security/advisory/2021-11-12/#SECURITY-2394) and has been disabled automatically.

We can't enable it back for security reasons therefore we have a few choices:
1. Comment out the plugin usage and if anyone misses it we can try building it from source and maintaining our own copy ( with the [vulnerability patched](https://github.com/jenkinsci/performance-plugin/pull/205) )
2. Build it from the source
3. Wait for updates (not really likely)

For now I talked with Brian and we decided the best way to go for now (mostly to un-stuck CI) is 1, we are waiting for Rok input too.
Hey @rok-cesnovar, what do you think ?

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
