### PR TITLE
Treat int returns from functions as DataOnly

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -458,8 +458,14 @@ let verify_unnormalized cf loc id =
     && not ((cf.in_fun_def && cf.in_udf_dist_def) || cf.current_block = Model)
   then Semantic_error.invalid_unnormalized_fn loc |> error
 
-let mk_fun_app ~is_cond_dist (x, y, z) =
-  if is_cond_dist then CondDistApp (x, y, z) else FunApp (x, y, z)
+let mk_fun_app ~is_cond_dist ~loc kind name args ~type_ : Ast.typed_expression =
+  let fn =
+    if is_cond_dist then CondDistApp (kind, name, args)
+    else FunApp (kind, name, args) in
+  mk_typed_expression ~expr:fn ~loc ~type_
+    ~ad_level:
+      ( if UnsizedType.is_int_type type_ then UnsizedType.DataOnly
+      else expr_ad_lub args )
 
 let check_normal_fn ~is_cond_dist loc tenv id es =
   match Env.find tenv (Utils.normalized_name id.name) with
@@ -514,13 +520,11 @@ let check_normal_fn ~is_cond_dist loc tenv id es =
         Semantic_error.returning_fn_expected_nonreturning_found loc id.name
         |> error
     | UniqueMatch (ReturnType ut, fnk, promotions) ->
-        mk_typed_expression
-          ~expr:
-            (mk_fun_app ~is_cond_dist
-               ( fnk (Fun_kind.suffix_from_name id.name)
-               , id
-               , Promotion.promote_list es promotions ) )
-          ~ad_level:(expr_ad_lub es) ~type_:ut ~loc
+        mk_fun_app ~is_cond_dist ~loc
+          (fnk (Fun_kind.suffix_from_name id.name))
+          id
+          (Promotion.promote_list es promotions)
+          ~type_:ut
     | AmbiguousMatch sigs ->
         Semantic_error.ambiguous_function_promotion loc id.name
           (Some (List.map ~f:type_of_expr_typed es))
@@ -613,11 +617,9 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
     | SignatureMismatch.UniqueMatch (ftype, promotions) ->
         (* a valid signature exists *)
         let tes = make_function_variable cf loc fname ftype :: remaining_es in
-        mk_typed_expression
-          ~expr:
-            (mk_fun_app ~is_cond_dist
-               (StanLib FnPlain, id, Promotion.promote_list tes promotions) )
-          ~ad_level:(expr_ad_lub tes) ~type_:UnsizedType.UReal ~loc
+        mk_fun_app ~is_cond_dist ~loc (StanLib FnPlain) id
+          (Promotion.promote_list tes promotions)
+          ~type_:UnsizedType.UReal
     | AmbiguousMatch ps ->
         Semantic_error.ambiguous_function_promotion loc fname.name None ps
         |> error
@@ -650,11 +652,9 @@ and check_variadic ~is_cond_dist loc cf tenv id tes =
     match find_matching_first_order_fn tenv (matching remaining_es) fname with
     | SignatureMismatch.UniqueMatch (ftype, promotions) ->
         let tes = make_function_variable cf loc fname ftype :: remaining_es in
-        mk_typed_expression
-          ~expr:
-            (mk_fun_app ~is_cond_dist
-               (StanLib FnPlain, id, Promotion.promote_list tes promotions) )
-          ~ad_level:(expr_ad_lub tes) ~type_:return_type ~loc
+        mk_fun_app ~is_cond_dist ~loc (StanLib FnPlain) id
+          (Promotion.promote_list tes promotions)
+          ~type_:return_type
     | AmbiguousMatch ps ->
         Semantic_error.ambiguous_function_promotion loc fname.name None ps
         |> error

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -1525,7 +1525,7 @@
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
            (meta <opaque>))
           ((pattern
             (NRFunApp (CompilerInternal FnValidateSize)
@@ -1538,7 +1538,7 @@
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
            (meta <opaque>))
           ((pattern
             (Decl (decl_adtype AutoDiffable) (decl_id o)
@@ -1550,13 +1550,13 @@
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-                 (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                 ((pattern
                   (FunApp (StanLib cols FnPlain AoS)
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-                 (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
            (meta <opaque>))
           ((pattern

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -1557,7 +1557,7 @@
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
            (meta <opaque>))
           ((pattern
             (NRFunApp (CompilerInternal FnValidateSize)
@@ -1570,7 +1570,7 @@
                  (((pattern (Var mat))
                    (meta
                     ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))))
+               (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
            (meta <opaque>))
           ((pattern
             (Decl (decl_adtype AutoDiffable) (decl_id o)
@@ -1582,13 +1582,13 @@
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-                 (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                 ((pattern
                   (FunApp (StanLib cols FnPlain AoS)
                    (((pattern (Var mat))
                      (meta
                       ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-                 (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))))
+                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
              (initialize true)))
            (meta <opaque>))
           ((pattern

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -7475,9 +7475,9 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
                       (meta
                        ((type_ UVector) (loc <opaque>)
                         (adlevel AutoDiffable)))))))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
-                 UReal AutoDiffable))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
         (meta <opaque>))
        ((pattern
@@ -12342,9 +12342,9 @@ matrix[10, 10] mul_two_aos: AoS
                 (((pattern (Var row_soa))
                   (meta
                    ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
-             UReal AutoDiffable))
-           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             UReal DataOnly))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var empty_user_func_aos))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -12374,9 +12374,9 @@ matrix[10, 10] mul_two_aos: AoS
                       (meta
                        ((type_ UMatrix) (loc <opaque>)
                         (adlevel AutoDiffable)))))))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
-                 UReal AutoDiffable))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
                 (FunApp (StanLib transpose FnPlain AoS)
                  (((pattern (Var int_aos_mul_aos))
@@ -12564,9 +12564,9 @@ matrix[10, 10] mul_two_aos: AoS
                 (((pattern (Var row_soa))
                   (meta
                    ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
-              (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
-             UReal AutoDiffable))
-           (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+             UReal DataOnly))
+           (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var empty_user_func_aos))
            (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable)))))))
        (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -12585,9 +12585,9 @@ matrix[10, 10] mul_two_aos: AoS
                       (meta
                        ((type_ UMatrix) (loc <opaque>)
                         (adlevel AutoDiffable)))))))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable))))
-                 UReal AutoDiffable))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                 UReal DataOnly))
+               (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))
               ((pattern
                 (FunApp (StanLib transpose FnPlain AoS)
                  (((pattern (Var int_aos_mul_aos))

--- a/test/integration/good/dataonly-int-return.stan
+++ b/test/integration/good/dataonly-int-return.stan
@@ -1,0 +1,6 @@
+parameters {
+  vector[5] x;
+}
+model {
+  x ~ normal(0, linspaced_array(size(x), 1.0, 10.0));
+}

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -1447,6 +1447,14 @@ model {
     y[t] ~ normal(y_hat[t], sigma); // independent normal noise
 }
 
+  $ ../../../../install/default/bin/stanc --auto-format dataonly-int-return.stan
+parameters {
+  vector[5] x;
+}
+model {
+  x ~ normal(0, linspaced_array(size(x), 1.0, 10.0));
+}
+
   $ ../../../../install/default/bin/stanc --auto-format declarations.stan
 data {
   int a0;


### PR DESCRIPTION
Fixes #803. This marks any function call which results in an integer as `data` rather than autodiffable. This will include things like `size`, `cols`, etc. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Functions which return integer types are considered as "data" for purposes of data-only arguments. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
