### PR TITLE
Add missing tests and unify fatal error messages

### DIFF
--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -40,7 +40,8 @@ let transform_program (mir : Program.Typed.t)
       ; log_prob= log_prob'
       ; generate_quantities= generate_quantities' }
   | _ ->
-      raise (Failure "Something went wrong with program transformation packing!")
+      Common.FatalError.fatal_error_msg
+        [%message "Something went wrong with program transformation packing!"]
 
 (**
    Apply the transformation to each function body and to each program block separately.
@@ -53,8 +54,8 @@ let transform_program_blockwise (mir : Program.Typed.t)
     match transform fd {pattern= SList s; meta= Location_span.empty} with
     | {pattern= SList l; _} -> l
     | _ ->
-        raise
-          (Failure "Something went wrong with program transformation packing!")
+        Common.FatalError.fatal_error_msg
+          [%message "Something went wrong with program transformation packing!"]
   in
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
@@ -1202,8 +1203,8 @@ let optimize_soa (mir : Program.Typed.t) =
     match transform {pattern= SList s; meta= Location_span.empty} with
     | {pattern= SList (l : Stmt.Located.t list); _} -> l
     | _ ->
-        raise
-          (Failure "Something went wrong with program transformation packing!")
+        Common.FatalError.fatal_error_msg
+          [%message "Something went wrong with program transformation packing!"]
   in
   {mir with log_prob= transform' mir.log_prob}
 

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -245,10 +245,10 @@ let list_param_dependant_fundef_cf (mir : Program.Typed.t)
         Set.Poly.map dep_args ~f:(fun (loc, ix, arg_name) ->
             (loc, List.nth_exn arg_exprs ix, arg_name) )
     | _ ->
-        raise
-          (Failure
-             "In finding searching for parameter dependent functionarguments, \
-              mismatched function. Please report a bug.\n" ) in
+        Common.FatalError.fatal_error_msg
+          [%message
+            "In finding searching for parameter dependent function arguments, \
+             mismatched function."] in
   let arg_param_deps label arg_expr =
     var_deps info_map ~expr:(Some arg_expr) label (parameter_names_set mir)
   in

--- a/src/analysis_and_optimization/Pedantic_dist_warnings.ml
+++ b/src/analysis_and_optimization/Pedantic_dist_warnings.ml
@@ -164,7 +164,7 @@ let constr_mismatch_warning (constr : var_constraint_named) (arg : arg_info)
         let arg_fail_msg =
           Printf.sprintf "Distribution %s at %s expects more arguments." name
             (Location_span.to_string loc) in
-        raise (Failure arg_fail_msg) in
+        Common.FatalError.fatal_error_msg [%message arg_fail_msg] in
   match v with
   | Param (pname, trans), meta ->
       if transform_mismatch_constraint constr.constr trans then

--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -45,13 +45,6 @@ let is_deprecated_distribution name =
 let rename_deprecated map name =
   Map.find map name |> Option.map ~f:fst |> Option.value ~default:name
 
-let distribution_suffix name =
-  let open String in
-  is_suffix ~suffix:"_lpdf" name
-  || is_suffix ~suffix:"_lpmf" name
-  || is_suffix ~suffix:"_lcdf" name
-  || is_suffix ~suffix:"_lccdf" name
-
 let userdef_distributions stmts =
   let open String in
   List.filter_map

--- a/src/frontend/Deprecation_analysis.mli
+++ b/src/frontend/Deprecation_analysis.mli
@@ -13,7 +13,6 @@ val update_suffix : string -> Middle.UnsizedType.t -> string
 val collect_userdef_distributions :
   typed_program -> Middle.UnsizedType.t String.Map.t
 
-val distribution_suffix : string -> bool
 val without_suffix : string list -> string -> string
 val is_deprecated_distribution : string -> bool
 val deprecated_distributions : (string * string) String.Map.t

--- a/src/frontend/Environment.mli
+++ b/src/frontend/Environment.mli
@@ -12,11 +12,9 @@ type originblock =
   | TParam
   | Model
   | GQuant
-[@@deriving sexp]
 
 (** Information available for each variable *)
 type varinfo = {origin: originblock; global: bool; readonly: bool}
-[@@deriving sexp]
 
 type info =
   { type_: UnsizedType.t
@@ -25,7 +23,6 @@ type info =
       | `UserDeclared of Location_span.t
       | `StanMath
       | `UserDefined ] }
-[@@deriving sexp]
 
 type t
 

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -21,11 +21,6 @@ module TypeError = struct
         * UnsizedType.t list
         * (UnsizedType.autodifftype * UnsizedType.t) list
         * SignatureMismatch.function_mismatch
-    | IllTypedReduceSumGeneric of
-        string
-        * UnsizedType.t list
-        * (UnsizedType.autodifftype * UnsizedType.t) list
-        * SignatureMismatch.function_mismatch
     | IllTypedVariadic of
         string
         * UnsizedType.t list
@@ -126,9 +121,6 @@ module TypeError = struct
           "Condition in ternary expression must be primitive int; found type=%a"
           UnsizedType.pp ut1
     | IllTypedReduceSum (name, arg_tys, expected_args, error) ->
-        SignatureMismatch.pp_signature_mismatch ppf
-          (name, arg_tys, ([((ReturnType UReal, expected_args), error)], false))
-    | IllTypedReduceSumGeneric (name, arg_tys, expected_args, error) ->
         SignatureMismatch.pp_signature_mismatch ppf
           (name, arg_tys, ([((ReturnType UReal, expected_args), error)], false))
     | IllTypedVariadic (name, arg_tys, args, error, return_type) ->
@@ -286,7 +278,6 @@ end
 
 module ExpressionError = struct
   type t =
-    | InvalidMapRectFn of string
     | InvalidSizeDeclRng
     | InvalidRngFunction
     | InvalidUnnormalizedFunction
@@ -298,11 +289,6 @@ module ExpressionError = struct
     | IntTooLarge
 
   let pp ppf = function
-    | InvalidMapRectFn fn_name ->
-        Fmt.pf ppf
-          "Mapped function cannot be an _rng or _lp function, found function \
-           name: %s"
-          fn_name
     | InvalidSizeDeclRng ->
         Fmt.pf ppf
           "Random number generators are not allowed in top level size \
@@ -545,12 +531,6 @@ let returning_fn_expected_nonreturning_found loc name =
 let illtyped_reduce_sum loc name arg_tys args error =
   TypeError (loc, TypeError.IllTypedReduceSum (name, arg_tys, args, error))
 
-let illtyped_reduce_sum_generic loc name arg_tys expected_args error =
-  TypeError
-    ( loc
-    , TypeError.IllTypedReduceSumGeneric (name, arg_tys, expected_args, error)
-    )
-
 let illtyped_variadic loc name arg_tys args fn_rt error =
   TypeError (loc, TypeError.IllTypedVariadic (name, arg_tys, args, error, fn_rt))
 
@@ -614,9 +594,6 @@ let ident_not_in_scope loc name sug =
 
 let ident_has_unnormalized_suffix loc name =
   IdentifierError (loc, IdentifierError.UnnormalizedSuffix name)
-
-let invalid_map_rect_fn loc name =
-  ExpressionError (loc, ExpressionError.InvalidMapRectFn name)
 
 let invalid_decl_rng_fn loc =
   ExpressionError (loc, ExpressionError.InvalidSizeDeclRng)

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -50,14 +50,6 @@ val illtyped_reduce_sum :
   -> SignatureMismatch.function_mismatch
   -> t
 
-val illtyped_reduce_sum_generic :
-     Location_span.t
-  -> string
-  -> UnsizedType.t list
-  -> (UnsizedType.autodifftype * UnsizedType.t) list
-  -> SignatureMismatch.function_mismatch
-  -> t
-
 val ambiguous_function_promotion :
      Location_span.t
   -> string
@@ -99,7 +91,6 @@ val ident_is_model_name : Location_span.t -> string -> t
 val ident_is_stanmath_name : Location_span.t -> string -> t
 val ident_in_use : Location_span.t -> string -> t
 val ident_not_in_scope : Location_span.t -> string -> string option -> t
-val invalid_map_rect_fn : Location_span.t -> string -> t
 val invalid_decl_rng_fn : Location_span.t -> t
 val invalid_rng_fn : Location_span.t -> t
 val invalid_unnormalized_fn : Location_span.t -> t

--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -13,7 +13,6 @@ and details = private
 and function_mismatch = private
   | ArgError of int * type_mismatch
   | ArgNumMismatch of int * int
-[@@deriving sexp]
 
 type signature_error =
   (UnsizedType.returntype * (UnsizedType.autodifftype * UnsizedType.t) list)

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -317,7 +317,9 @@ let get_consistent_types ad_level type_ es =
 
 let check_array_expr loc es =
   match es with
-  | [] -> Semantic_error.empty_array loc |> error
+  | [] ->
+      (* NB: This is actually disallowed by parser *)
+      Semantic_error.empty_array loc |> error
   | {emeta= {ad_level; type_; _}; _} :: _ -> (
     match get_consistent_types ad_level type_ es with
     | Error (ty, meta) ->
@@ -631,7 +633,7 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
   | _ ->
       let expected_args, err =
         basic_mismatch () |> Result.error |> Option.value_exn in
-      Semantic_error.illtyped_reduce_sum_generic loc id.name
+      Semantic_error.illtyped_reduce_sum loc id.name
         (List.map ~f:type_of_expr_typed tes)
         expected_args err
       |> error

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -295,8 +295,8 @@ unsized_dims:
 no_assign:
   | UNREACHABLE
     { (* This code will never be reached *)
-      raise (Failure "This should be unreachable; the UNREACHABLE token should \
-                      never be produced")
+       Common.FatalError.fatal_error_msg
+          [%message "the UNREACHABLE token should never be produced"]
     }
 
 optional_assignment(rhs):

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -31,10 +31,10 @@ type 'expr t =
 let to_string
     ?(expr_to_string =
       fun _ ->
-        raise
-          (Failure
-             "Should not be parsing expression from string in function renaming"
-          )) x =
+        Common.FatalError.fatal_error_msg
+          [%message
+            "Should not be parsing expression from string in function renaming"])
+    x =
   Sexp.to_string (sexp_of_t expr_to_string x) ^ "__"
 
 let pp (pp_expr : 'a Fmt.t) ppf internal =

--- a/src/middle/Type.ml
+++ b/src/middle/Type.ml
@@ -7,8 +7,6 @@ let pp pp_e ppf = function
   | Sized st -> SizedType.pp pp_e ppf st
   | Unsized ust -> UnsizedType.pp ppf ust
 
-let collect_exprs = function Sized st -> SizedType.collect_exprs st | _ -> []
-
 let to_unsized = function
   | Sized st -> SizedType.to_unsized st
   | Unsized ut -> ut

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -101,10 +101,6 @@ let rec common_type = function
   | _, _ -> None
 
 (* -- Helpers -- *)
-let rec is_real_type = function
-  | UReal | UVector | URowVector | UMatrix -> true
-  | UArray x -> is_real_type x
-  | _ -> false
 
 let rec is_autodiffable = function
   | UReal | UVector | URowVector | UMatrix -> true
@@ -188,9 +184,6 @@ let is_array ut =
     ->
       false
   | UArray _ -> true
-
-let return_contains_eigen_type ret =
-  match ret with ReturnType t -> contains_eigen_type t | Void -> false
 
 let rec is_indexing_matrix = function
   | UArray t, _ :: idcs -> is_indexing_matrix (t, idcs)

--- a/src/stan_math_backend/Expression_gen.ml
+++ b/src/stan_math_backend/Expression_gen.ml
@@ -103,7 +103,9 @@ let rec pp_possibly_var_decl ppf (adtype, ut, mem_pattern) =
    |UComplexMatrix ->
       pf ppf "%a" pp_var_decl ut
   | UReal | UInt | UComplex -> pf ppf "%a" pp_unsizedtype_local (adtype, ut)
-  | x -> raise_s [%message (x : UnsizedType.t) "not implemented yet"]
+  | x ->
+      Common.FatalError.fatal_error_msg
+        [%message (x : UnsizedType.t) "not implemented yet"]
 
 let suffix_args = function
   | Fun_kind.FnRng -> ["base_rng__"]

--- a/test/integration/bad/algebra_solver/bad_data_qualifer.stan
+++ b/test/integration/bad/algebra_solver/bad_data_qualifer.stan
@@ -1,0 +1,36 @@
+functions {
+  vector algebra_system (data vector y,
+                         vector theta,
+                         array[] real x_r,
+                         array[] int x_i) {
+    vector[2] f_y;
+    f_y[1] = y[1] - theta[1];
+    f_y[2] = y[2] - theta[2];
+    return f_y;
+  }
+}
+
+
+data {
+
+}
+
+transformed data {
+  vector[2] y;
+  array[0] real x_r;
+  array[0] real x_i;
+}
+
+parameters {
+  vector[2] theta_p;
+  real dummy_parameter;
+}
+
+transformed parameters {
+  vector[2] y_s_p;
+  y_s_p = solve_newton(algebra_system, y, theta_p, x_r, x_i, 0.01, 0.01, 10);
+}
+
+model {
+  dummy_parameter ~ normal(0, 1);
+}

--- a/test/integration/bad/algebra_solver/stanc.expected
+++ b/test/integration/bad/algebra_solver/stanc.expected
@@ -1,3 +1,26 @@
+  $ ../../../../../install/default/bin/stanc bad_data_qualifer.stan
+Semantic error in 'bad_data_qualifer.stan', line 31, column 10 to column 76:
+   -------------------------------------------------
+    29:  transformed parameters {
+    30:    vector[2] y_s_p;
+    31:    y_s_p = solve_newton(algebra_system, y, theta_p, x_r, x_i, 0.01, 0.01, 10);
+                   ^
+    32:  }
+    33:  
+   -------------------------------------------------
+
+Ill-typed arguments supplied to function 'solve_newton':
+(<F1>, vector, vector, array[] real, array[] real, real, real, int)
+where F1 = (data vector, vector, array[] real, array[] int) => vector
+Available signatures:
+(<F2>, vector) => vector
+where F2 = (vector) => vector
+  The first argument must be
+   (vector) => vector
+  but got
+   (data vector, vector, array[] real, array[] int) => vector
+  These are not compatible because:
+    The first argument has an incompatible data-qualifier.
   $ ../../../../../install/default/bin/stanc bad_fun_type.stan
 Semantic error in 'bad_fun_type.stan', line 31, column 10 to column 62:
    -------------------------------------------------

--- a/test/integration/bad/function-signatures/duplicate-args.stan
+++ b/test/integration/bad/function-signatures/duplicate-args.stan
@@ -1,0 +1,5 @@
+functions {
+  void foo(int bar, real bar){
+    ;
+  }
+}

--- a/test/integration/bad/function-signatures/stanc.expected
+++ b/test/integration/bad/function-signatures/stanc.expected
@@ -1,3 +1,14 @@
+  $ ../../../../../install/default/bin/stanc duplicate-args.stan
+Semantic error in 'duplicate-args.stan', line 2, column 2 to line 4, column 3:
+   -------------------------------------------------
+     1:  functions {
+     2:    void foo(int bar, real bar){
+           ^
+     3:      ;
+     4:    }
+   -------------------------------------------------
+
+All function arguments must have distinct identifiers.
   $ ../../../../../install/default/bin/stanc falling_factorial.stan
 Semantic error in 'falling_factorial.stan', line 7, column 26 to column 59:
    -------------------------------------------------

--- a/test/integration/bad/lang/bad_lmpf.stan
+++ b/test/integration/bad/lang/bad_lmpf.stan
@@ -1,0 +1,5 @@
+functions {
+  real my_dist_lpmf(real foo){
+    return 1.0;
+  }
+}

--- a/test/integration/bad/lang/bad_lpdf.stan
+++ b/test/integration/bad/lang/bad_lpdf.stan
@@ -1,0 +1,5 @@
+functions {
+  real my_dist_lpdf(){
+    return 1.0;
+  }
+}

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -557,6 +557,28 @@ Semantic error in 'bad_function2.stan', line 3, column 3 to column 7:
    -------------------------------------------------
 
 A non-returning function was expected but an undeclared identifier 'y' was supplied.
+  $ ../../../../../install/default/bin/stanc bad_lmpf.stan
+Semantic error in 'bad_lmpf.stan', line 2, column 2 to line 4, column 3:
+   -------------------------------------------------
+     1:  functions {
+     2:    real my_dist_lpmf(real foo){
+           ^
+     3:      return 1.0;
+     4:    }
+   -------------------------------------------------
+
+Probability mass functions require integer variates (first argument). Instead found type real.
+  $ ../../../../../install/default/bin/stanc bad_lpdf.stan
+Semantic error in 'bad_lpdf.stan', line 2, column 2 to line 4, column 3:
+   -------------------------------------------------
+     1:  functions {
+     2:    real my_dist_lpdf(){
+           ^
+     3:      return 1.0;
+     4:    }
+   -------------------------------------------------
+
+Probability density functions require real variates (first argument).
   $ ../../../../../install/default/bin/stanc bad_periods_data.stan
 Syntax error in 'bad_periods_data.stan', line 2, column 7, lexing error:
    -------------------------------------------------

--- a/test/integration/bad/print-bad.stan
+++ b/test/integration/bad/print-bad.stan
@@ -1,0 +1,9 @@
+functions {
+  real foo(){
+    return 1.0;
+  }
+}
+
+model {
+  print(foo);
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1937,6 +1937,17 @@ Ill-typed arguments supplied to postfix operator '. Available signatures:
 (complex_vector) => complex_row_vector
 (complex_matrix) => complex_matrix
 Instead supplied argument of incompatible type: array[] int.
+  $ ../../../../install/default/bin/stanc print-bad.stan
+Semantic error in 'print-bad.stan', line 8, column 8 to column 11:
+   -------------------------------------------------
+     6:  
+     7:  model {
+     8:    print(foo);
+                 ^
+     9:  }
+   -------------------------------------------------
+
+Functions cannot be printed.
   $ ../../../../install/default/bin/stanc print-void.stan
 Semantic error in 'print-void.stan', line 8, column 8 to column 14:
    -------------------------------------------------
@@ -2295,6 +2306,17 @@ Semantic error in 'target-reserved.stan', line 2, column 7 to column 13:
    -------------------------------------------------
 
 Identifier 'target' clashes with reserved keyword.
+  $ ../../../../install/default/bin/stanc target_pe_bad.stan
+Semantic error in 'target_pe_bad.stan', line 8, column 2 to column 16:
+   -------------------------------------------------
+     6:  
+     7:  model {
+     8:    target += foo;
+           ^
+     9:  }
+   -------------------------------------------------
+
+A (container of) real or int was expected. Instead found type () => real.
   $ ../../../../install/default/bin/stanc ternaryif-fntype.stan
 Semantic error in 'ternaryif-fntype.stan', line 13, column 6 to column 28:
    -------------------------------------------------

--- a/test/integration/bad/target_pe_bad.stan
+++ b/test/integration/bad/target_pe_bad.stan
@@ -1,0 +1,9 @@
+functions {
+  real foo(){
+    return 1.0;
+  }
+}
+
+model {
+  target += foo;
+}

--- a/test/integration/cli-args/canonicalize/canonical.expected
+++ b/test/integration/cli-args/canonicalize/canonical.expected
@@ -245,6 +245,20 @@ Warning in 'deprecated.stan', line 36, column 2: Nested multi-indexing on the
     in expressions. This is considered a bug and will be disallowed in Stan
     2.32.0. The indexing can be automatically fixed using the canonicalize
     flag for stanc.
+  $ ../../../../../install/default/bin/stanc --print-canonical deprecated_tilde.stan
+functions {
+  real test_log_lpmf(int bar, real foo) {
+    return foo;
+  }
+  real test_log_lpdf(real bar, real foo) {
+    return foo;
+  }
+}
+model {
+  1 ~ test_log(2.5);
+  1.2 ~ test_log(2.5);
+}
+
   $ ../../../../../install/default/bin/stanc --print-canonical funs.stanfunctions
 // comment test comment
 void test(int x, int y) {

--- a/test/integration/cli-args/canonicalize/deprecated_tilde.stan
+++ b/test/integration/cli-args/canonicalize/deprecated_tilde.stan
@@ -1,0 +1,14 @@
+functions {
+   real test_log_lpmf(int bar, real foo){
+    return foo;
+   }
+  real test_log_lpdf(real bar, real foo){
+    return foo;
+   }
+
+}
+
+model {
+  1 ~ test_log_lpmf(2.5);
+  1.2 ~ test_log_lpdf(2.5);
+}

--- a/test/integration/cli-args/canonicalize/deprecations-only.expected
+++ b/test/integration/cli-args/canonicalize/deprecations-only.expected
@@ -225,6 +225,20 @@ Warning in 'deprecated.stan', line 36, column 2: Nested multi-indexing on the
     in expressions. This is considered a bug and will be disallowed in Stan
     2.32.0. The indexing can be automatically fixed using the canonicalize
     flag for stanc.
+  $ ../../../../../install/default/bin/stanc --auto-format --canonicalize deprecations deprecated_tilde.stan
+functions {
+  real test_log_lpmf(int bar, real foo) {
+    return foo;
+  }
+  real test_log_lpdf(real bar, real foo) {
+    return foo;
+  }
+}
+model {
+  1 ~ test_log(2.5);
+  1.2 ~ test_log(2.5);
+}
+
   $ ../../../../../install/default/bin/stanc --auto-format --canonicalize deprecations funs.stanfunctions
 // comment test comment
 void test(int x, int y) {

--- a/test/integration/cli-args/canonicalize/everything-but.expected
+++ b/test/integration/cli-args/canonicalize/everything-but.expected
@@ -208,6 +208,19 @@ Semantic error in 'deprecated.stan', line 46, column 6 to column 18:
 
 ~ statement should refer to a distribution without its "_lpdf/_lupdf" or "_lpmf/_lupmf" suffix.
 For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
+  $ ../../../../../install/default/bin/stanc --auto-format --canonicalize braces,parentheses deprecated_tilde.stan
+Semantic error in 'deprecated_tilde.stan', line 12, column 6 to column 19:
+   -------------------------------------------------
+    10:  
+    11:  model {
+    12:    1 ~ test_log_lpmf(2.5);
+               ^
+    13:    1.2 ~ test_log_lpdf(2.5);
+    14:  }
+   -------------------------------------------------
+
+~ statement should refer to a distribution without its "_lpdf/_lupdf" or "_lpmf/_lupmf" suffix.
+For example, "target += normal_lpdf(y, 0, 1)" should become "y ~ normal(0, 1)."
   $ ../../../../../install/default/bin/stanc --auto-format --canonicalize braces,parentheses funs.stanfunctions
 // comment test comment
 void test(int x, int y) {

--- a/test/integration/cli-args/warn-pedantic/distribution-warnings.stan
+++ b/test/integration/cli-args/warn-pedantic/distribution-warnings.stan
@@ -122,6 +122,8 @@ model {
   mat ~ multi_gp_cholesky(chol_cov, vec);
   vec ~ multi_student_t(unb_p, vec, mat);
   vec ~ multi_student_t(pos_p, vec, cov);
+  vec ~ multi_student_t_cholesky(unb_p, vec, cov);
+  vec ~ multi_student_t_cholesky(pos_p, vec, chol_cov);
   mat ~ gaussian_dlm_obs(mat, mat, mat, mat, vec, mat);
   mat ~ gaussian_dlm_obs(mat, mat, cov, cov, vec, mat);
   vec ~ dirichlet(vec);
@@ -132,6 +134,10 @@ model {
   chol_corr ~ lkj_corr_cholesky(pos_p);
   mat ~ wishart(unb_p, mat);
   cov ~ wishart(pos_p, cov);
+  mat ~ wishart_cholesky(unb_p, cov);
+  chol_cov ~ wishart_cholesky(pos_p, chol_cov);
   mat ~ inv_wishart(unb_p, mat);
   cov ~ inv_wishart(pos_p, cov);
+  mat ~ inv_wishart_cholesky(unb_p, cov);
+  chol_cov ~ inv_wishart_cholesky(pos_p, chol_cov);
 }

--- a/test/integration/cli-args/warn-pedantic/lp_fun.stan
+++ b/test/integration/cli-args/warn-pedantic/lp_fun.stan
@@ -1,0 +1,14 @@
+functions {
+  void test_lp(real r) {
+     target += normal_lpdf(r | 0, 1);
+  }
+}
+parameters {
+  real y;
+}
+transformed parameters {
+  test_lp(y);
+}
+model {
+  y ~ normal(0, 1);
+}

--- a/test/integration/cli-args/warn-pedantic/stanc.expected
+++ b/test/integration/cli-args/warn-pedantic/stanc.expected
@@ -1,61 +1,95 @@
   $ ../../../../../install/default/bin/stanc --warn-pedantic  distribution-warnings.stan
-Warning in 'distribution-warnings.stan', line 135, column 27: A inv_wishart
+Warning in 'distribution-warnings.stan', line 141, column 36: A
+    inv_wishart_cholesky distribution is given parameter cov as a scale
+    matrix (argument 2), but cov was not constrained to be Cholesky factor of
+    covariance.
+Warning in 'distribution-warnings.stan', line 141, column 29: A
+    inv_wishart_cholesky distribution is given parameter unb_p as degrees of
+    freedom (argument 1), but unb_p was not constrained to be strictly
+    positive.
+Warning in 'distribution-warnings.stan', line 141, column 2: Parameter mat is
+    given a inv_wishart_cholesky distribution, which has Cholesky factor of
+    covariance support, but mat was not constrained to be Cholesky factor of
+    covariance.
+Warning in 'distribution-warnings.stan', line 139, column 27: A inv_wishart
     distribution is given parameter mat as a scale matrix (argument 2), but
     mat was not constrained to be covariance.
-Warning in 'distribution-warnings.stan', line 135, column 20: A inv_wishart
+Warning in 'distribution-warnings.stan', line 139, column 20: A inv_wishart
+    distribution is given parameter unb_p as degrees of freedom (argument 1),
+    but unb_p was not constrained to be strictly positive.
+Warning in 'distribution-warnings.stan', line 139, column 2: Parameter mat is
+    given a inv_wishart distribution, which has covariance support, but mat
+    was not constrained to be covariance.
+Warning in 'distribution-warnings.stan', line 138, column 2: The parameter
+    chol_cov is on the left-hand side of more than one tilde statement.
+Warning in 'distribution-warnings.stan', line 137, column 32: A
+    wishart_cholesky distribution is given parameter cov as a scale matrix
+    (argument 2), but cov was not constrained to be Cholesky factor of
+    covariance.
+Warning in 'distribution-warnings.stan', line 137, column 25: A
+    wishart_cholesky distribution is given parameter unb_p as degrees of
+    freedom (argument 1), but unb_p was not constrained to be strictly
+    positive.
+Warning in 'distribution-warnings.stan', line 137, column 2: Parameter mat is
+    given a wishart_cholesky distribution, which has Cholesky factor of
+    covariance support, but mat was not constrained to be Cholesky factor of
+    covariance.
+Warning in 'distribution-warnings.stan', line 136, column 2: The parameter
+    cov is on the left-hand side of more than one tilde statement.
+Warning in 'distribution-warnings.stan', line 135, column 23: A wishart
+    distribution is given parameter mat as a scale matrix (argument 2), but
+    mat was not constrained to be covariance.
+Warning in 'distribution-warnings.stan', line 135, column 16: A wishart
     distribution is given parameter unb_p as degrees of freedom (argument 1),
     but unb_p was not constrained to be strictly positive.
 Warning in 'distribution-warnings.stan', line 135, column 2: Parameter mat is
-    given a inv_wishart distribution, which has covariance support, but mat
-    was not constrained to be covariance.
-Warning in 'distribution-warnings.stan', line 134, column 2: The parameter
-    cov is on the left-hand side of more than one tilde statement.
-Warning in 'distribution-warnings.stan', line 133, column 23: A wishart
-    distribution is given parameter mat as a scale matrix (argument 2), but
-    mat was not constrained to be covariance.
-Warning in 'distribution-warnings.stan', line 133, column 16: A wishart
-    distribution is given parameter unb_p as degrees of freedom (argument 1),
-    but unb_p was not constrained to be strictly positive.
-Warning in 'distribution-warnings.stan', line 133, column 2: Parameter mat is
     given a wishart distribution, which has covariance support, but mat was
     not constrained to be covariance.
-Warning in 'distribution-warnings.stan', line 131, column 27: A
+Warning in 'distribution-warnings.stan', line 133, column 27: A
     lkj_corr_cholesky distribution is given parameter unb_p as a shape
     parameter (argument 1), but unb_p was not constrained to be strictly
     positive.
-Warning in 'distribution-warnings.stan', line 131, column 2: Parameter corr
+Warning in 'distribution-warnings.stan', line 133, column 2: Parameter corr
     is given a lkj_corr_cholesky distribution, which has Cholesky factor of
     correlation support, but corr was not constrained to be Cholesky factor
     of correlation.
-Warning in 'distribution-warnings.stan', line 130, column 2: The parameter
+Warning in 'distribution-warnings.stan', line 132, column 2: The parameter
     corr is on the left-hand side of more than one tilde statement.
-Warning in 'distribution-warnings.stan', line 130, column 2: It is suggested
+Warning in 'distribution-warnings.stan', line 132, column 2: It is suggested
     to reparameterize your model to replace lkj_corr with lkj_corr_cholesky,
     the Cholesky factor variant. lkj_corr tends to run slower, consume more
     memory, and has higher risk of numerical errors.
-Warning in 'distribution-warnings.stan', line 129, column 17: A lkj_corr
+Warning in 'distribution-warnings.stan', line 131, column 17: A lkj_corr
     distribution is given parameter unb_p as a shape parameter (argument 1),
     but unb_p was not constrained to be strictly positive.
-Warning in 'distribution-warnings.stan', line 129, column 2: It is suggested
+Warning in 'distribution-warnings.stan', line 131, column 2: It is suggested
     to reparameterize your model to replace lkj_corr with lkj_corr_cholesky,
     the Cholesky factor variant. lkj_corr tends to run slower, consume more
     memory, and has higher risk of numerical errors.
-Warning in 'distribution-warnings.stan', line 129, column 2: Parameter mat is
+Warning in 'distribution-warnings.stan', line 131, column 2: Parameter mat is
     given a lkj_corr distribution, which has correlation support, but mat was
     not constrained to be correlation.
-Warning in 'distribution-warnings.stan', line 127, column 18: A dirichlet
+Warning in 'distribution-warnings.stan', line 129, column 18: A dirichlet
     distribution is given parameter vec as a count parameter (argument 1),
     but vec was not constrained to be strictly positive.
-Warning in 'distribution-warnings.stan', line 127, column 2: Parameter vec is
+Warning in 'distribution-warnings.stan', line 129, column 2: Parameter vec is
     given a dirichlet distribution, which has simplex support, but vec was
     not constrained to be simplex.
-Warning in 'distribution-warnings.stan', line 125, column 40: A
+Warning in 'distribution-warnings.stan', line 127, column 40: A
     gaussian_dlm_obs distribution is given parameter mat as system covariance
     matrix (argument 4), but mat was not constrained to be covariance.
-Warning in 'distribution-warnings.stan', line 125, column 35: A
+Warning in 'distribution-warnings.stan', line 127, column 35: A
     gaussian_dlm_obs distribution is given parameter mat as observation
     covariance matrix (argument 3), but mat was not constrained to be
     covariance.
+Warning in 'distribution-warnings.stan', line 125, column 45: A
+    multi_student_t_cholesky distribution is given parameter cov as a
+    covariance matrix (argument 3), but cov was not constrained to be
+    Cholesky factor of covariance.
+Warning in 'distribution-warnings.stan', line 125, column 33: A
+    multi_student_t_cholesky distribution is given parameter unb_p as degrees
+    of freedom (argument 1), but unb_p was not constrained to be strictly
+    positive.
 Warning in 'distribution-warnings.stan', line 123, column 36: A
     multi_student_t distribution is given parameter mat as a scale matrix
     (argument 3), but mat was not constrained to be covariance.
@@ -477,6 +511,8 @@ Warning in 'jacobian_warning_user.stan', line 5, column 2: Left-hand side of
     sampling statement (~) may contain a non-linear transform of a parameter
     or local variable. If it does, you need to include a target += statement
     with the log absolute determinant of the Jacobian of the transform.
+  $ ../../../../../install/default/bin/stanc --warn-pedantic  lp_fun.stan
+Warning: The parameter y has 2 priors.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  missing-prior-false-alarm.stan
 Warning: The parameter theta has no priors. This means either no prior is
     provided, or the prior(s) depend on data variables. In the later case,

--- a/test/integration/good/warning/deprecated_syntax.stan
+++ b/test/integration/good/warning/deprecated_syntax.stan
@@ -62,6 +62,9 @@ model {
   }
   while (z) {
     // real as boolean value
+    if (1.0){
+      // same
+    }
     if (x && !z || xyz[3]) {
       // more boolean reals
     }

--- a/test/integration/good/warning/pretty.expected
+++ b/test/integration/good/warning/pretty.expected
@@ -1490,6 +1490,9 @@ model {
   }
   while (z) {
     // real as boolean value
+    if (1.0) {
+      // same
+    }
     if (x && !z || xyz[3]) {
       // more boolean reals
     }
@@ -1613,15 +1616,19 @@ Warning in 'deprecated_syntax.stan', line 63, column 9: Condition of type
     real is deprecated and will be disallowed in Stan 2.34. Use an explicit
     != 0 comparison instead. This can be automatically changed using the
     canonicalize flag for stanc
-Warning in 'deprecated_syntax.stan', line 65, column 19: Using a real as a
+Warning in 'deprecated_syntax.stan', line 65, column 8: Condition of type
+    real is deprecated and will be disallowed in Stan 2.34. Use an explicit
+    != 0 comparison instead. This can be automatically changed using the
+    canonicalize flag for stanc
+Warning in 'deprecated_syntax.stan', line 68, column 19: Using a real as a
     boolean value is deprecated and will be disallowed in Stan 2.34. Use an
     explicit != 0 comparison instead. This can be automatically changed using
     the canonicalize flag for stanc
-Warning in 'deprecated_syntax.stan', line 65, column 8: Using a real as a
+Warning in 'deprecated_syntax.stan', line 68, column 8: Using a real as a
     boolean value is deprecated and will be disallowed in Stan 2.34. Use an
     explicit != 0 comparison instead. This can be automatically changed using
     the canonicalize flag for stanc
-Warning in 'deprecated_syntax.stan', line 65, column 14: Using a real as a
+Warning in 'deprecated_syntax.stan', line 68, column 14: Using a real as a
     boolean value is deprecated and will be disallowed in Stan 2.34. Use an
     explicit != 0 comparison instead. This can be automatically changed using
     the canonicalize flag for stanc


### PR DESCRIPTION
Similar to #1269. This adds some missing test cases and replaces any remaining instances of `raise (Failure ...` with `Common.FatalError`s which properly include the link to the bug tracker.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes



## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
