### PR TITLE
Mark dae time parameters as DataOnly

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -2608,8 +2608,8 @@ let variadic_dae_tol_arg_types =
 
 let variadic_dae_mandatory_arg_types =
   [ (UnsizedType.AutoDiffable, UnsizedType.UVector); (* yy *)
-    (UnsizedType.AutoDiffable, UnsizedType.UVector); (* yp *)
-    (AutoDiffable, UReal); (AutoDiffable, UArray UReal) ]
+    (AutoDiffable, UnsizedType.UVector); (* yp *) (DataOnly, UReal); (* t0 *)
+    (DataOnly, UArray UReal) (* ts *) ]
 
 let variadic_dae_mandatory_fun_args =
   [ (UnsizedType.AutoDiffable, UnsizedType.UReal)

--- a/test/integration/bad/variadic_dae/bad_time0.stan
+++ b/test/integration/bad/variadic_dae/bad_time0.stan
@@ -1,0 +1,15 @@
+functions {
+  vector residual(real time, vector state, vector deriv) {
+    return [1,2,3]';
+  }
+}
+
+parameters {
+  real p;
+}
+
+transformed parameters {
+  array[2] vector[3] S;
+  S = dae(residual, [1, 1]', [1, -1]', p, {1, 2, 3});
+
+}

--- a/test/integration/bad/variadic_dae/bad_times_param.stan
+++ b/test/integration/bad/variadic_dae/bad_times_param.stan
@@ -1,0 +1,15 @@
+functions {
+  vector residual(real time, vector state, vector deriv) {
+    return [1,2,3]';
+  }
+}
+
+parameters {
+  real p;
+}
+
+transformed parameters {
+  array[2] vector[3] S;
+  S = dae(residual, [1, 1]', [1, -1]', 0.0, {1*p, 2*p, 3*p});
+
+}

--- a/test/integration/bad/variadic_dae/stanc.expected
+++ b/test/integration/bad/variadic_dae/stanc.expected
@@ -14,8 +14,8 @@ Ill-typed arguments supplied to function 'dae_tol':
  array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   The 7th argument must be real but got array[] real
   $ ../../../../../install/default/bin/stanc bad_initial_derivative.stan
 Semantic error in 'bad_initial_derivative.stan', line 27, column 10 to column 70:
@@ -32,8 +32,8 @@ Ill-typed arguments supplied to function 'dae_tol':
 (<F1>, vector, real, real, array[] real, real, real, int, array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   The third argument must be vector but got real
   $ ../../../../../install/default/bin/stanc bad_initial_state.stan
 Semantic error in 'bad_initial_state.stan', line 27, column 10 to column 70:
@@ -50,8 +50,8 @@ Ill-typed arguments supplied to function 'dae_tol':
 (<F1>, real, vector, real, array[] real, real, real, int, array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   The second argument must be vector but got real
   $ ../../../../../install/default/bin/stanc bad_initial_time.stan
 Semantic error in 'bad_initial_time.stan', line 27, column 10 to column 70:
@@ -68,8 +68,8 @@ Ill-typed arguments supplied to function 'dae_tol':
 (<F1>, vector, vector, vector, array[] real, real, real, int, array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   The fourth argument must be real but got vector
   $ ../../../../../install/default/bin/stanc bad_max_num_steps.stan
 Semantic error in 'bad_max_num_steps.stan', line 28, column 10 to column 68:
@@ -87,8 +87,8 @@ Ill-typed arguments supplied to function 'dae_tol':
  array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   The 8th argument must be int but got array[] real
   $ ../../../../../install/default/bin/stanc bad_no_args.stan
 Semantic error in 'bad_no_args.stan', line 27, column 10 to column 63:
@@ -105,7 +105,8 @@ Ill-typed arguments supplied to function 'dae_tol':
 (<F1>, vector, vector, real, array[] real, real, real, int)
 where F1 = (real, vector, array[] real) => vector
 Available signatures:
-(<F2>, vector, vector, real, array[] real, data real, data real, data int) => vector
+(<F2>, vector, vector, data real, data array[] real, data real, data real,
+ data int) => vector
 where F2 = (real, vector, vector) => vector
   The first argument must be
    (real, vector, vector) => vector
@@ -132,8 +133,8 @@ Ill-typed arguments supplied to function 'dae_tol':
  array[] real)
 where F1 = (real, vector, vector, array[] real, real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real, real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real, real) => vector
   The 10th argument must be real but got array[] real
   $ ../../../../../install/default/bin/stanc bad_rel_tol.stan
 Semantic error in 'bad_rel_tol.stan', line 28, column 10 to column 69:
@@ -151,9 +152,47 @@ Ill-typed arguments supplied to function 'dae_tol':
  array[] real, array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   Expected 9 arguments but found 10 arguments.
+  $ ../../../../../install/default/bin/stanc bad_time0.stan
+Semantic error in 'bad_time0.stan', line 13, column 6 to column 52:
+   -------------------------------------------------
+    11:  transformed parameters {
+    12:    array[2] vector[3] S;
+    13:    S = dae(residual, [1, 1]', [1, -1]', p, {1, 2, 3});
+               ^
+    14:  
+    15:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to function 'dae':
+(<F1>, vector, vector, real, array[] int)
+where F1 = (real, vector, vector) => vector
+Available signatures:
+(<F1>, vector, vector, data real, data array[] real) => vector
+  The fourth argument must be data-only. (Local variables are assumed to
+  depend on parameters; same goes for function inputs unless they are marked
+  with the keyword 'data'.)
+  $ ../../../../../install/default/bin/stanc bad_times_param.stan
+Semantic error in 'bad_times_param.stan', line 13, column 6 to column 60:
+   -------------------------------------------------
+    11:  transformed parameters {
+    12:    array[2] vector[3] S;
+    13:    S = dae(residual, [1, 1]', [1, -1]', 0.0, {1*p, 2*p, 3*p});
+               ^
+    14:  
+    15:  }
+   -------------------------------------------------
+
+Ill-typed arguments supplied to function 'dae':
+(<F1>, vector, vector, real, array[] real)
+where F1 = (real, vector, vector) => vector
+Available signatures:
+(<F1>, vector, vector, data real, data array[] real) => vector
+  The 5th argument must be data-only. (Local variables are assumed to depend
+  on parameters; same goes for function inputs unless they are marked with
+  the keyword 'data'.)
   $ ../../../../../install/default/bin/stanc bad_times_tol.stan
 Semantic error in 'bad_times_tol.stan', line 27, column 10 to column 69:
    -------------------------------------------------
@@ -169,6 +208,6 @@ Ill-typed arguments supplied to function 'dae_tol':
 (<F1>, vector, vector, real, array[] vector, real, real, int, array[] real)
 where F1 = (real, vector, vector, array[] real) => vector
 Available signatures:
-(<F1>, vector, vector, real, array[] real, data real, data real, data int,
- array[] real) => vector
+(<F1>, vector, vector, data real, data array[] real, data real, data real,
+ data int, array[] real) => vector
   The 5th argument must be array[] real but got array[] vector


### PR DESCRIPTION
Marked the `initial_time` and `times` parameters of the `dae` functions as DataOnly. If you look in the C++, they're `double`s:  https://github.com/stan-dev/math/blob/f4c68170c1f1e9bc1284520560204ea9e76c62cd/stan/math/rev/functor/dae.hpp#L167-L168

This causes a C++ compilation error which we should be catching in stanc, see https://discourse.mc-stan.org/t/compilation-error-on-using-the-differential-algebraic-equation-dae-solver-on-time-that-depends-on-the-parameters/29404

I'm going to ping @yizhang-yiz on this as the original author to confirm this is correct.

@rok-cesnovar IMO we can merge this during the freeze, but it doesn't warrant an RC2 all on its own. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: https://github.com/stan-dev/docs/pull/594
    
## Release notes
Marked the `initial_time` and `times` parameters of the `dae` functions as `data`. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
