### PR TITLE
Code gen: Fix spelling of 'Initalizer', update formatting

### DIFF
--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -15,7 +15,6 @@ type type_ =
   | StdVector of type_
       (** A std::vector. For Eigen Vectors, use [Matrix] with a row or column size of 1 *)
   | Array of type_ * int
-  | Tuple of type_ list
   | TypeLiteral of identifier  (** Used for things like Eigen::Index *)
   | Matrix of type_ * int * int
   | Ref of type_
@@ -381,7 +380,6 @@ module Printing = struct
     | TemplateType id -> pp_identifier ppf id
     | StdVector t -> pf ppf "@[<2>std::vector<@,%a>@]" pp_type_ t
     | Array (t, i) -> pf ppf "@[<2>std::array<@,%a,@ %i>@]" pp_type_ t i
-    | Tuple ts -> pf ppf "@[<2>std::tuple<@,%a>@]" (list ~sep:comma pp_type_) ts
     | TypeLiteral id -> pp_identifier ppf id
     | Matrix (t, i, j) -> pf ppf "Eigen::Matrix<%a,%i,%i>" pp_type_ t i j
     | Const t -> pf ppf "const %a" pp_type_ t

--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -15,6 +15,7 @@ type type_ =
   | StdVector of type_
       (** A std::vector. For Eigen Vectors, use [Matrix] with a row or column size of 1 *)
   | Array of type_ * int
+  | Tuple of type_ list
   | TypeLiteral of identifier  (** Used for things like Eigen::Index *)
   | Matrix of type_ * int * int
   | Ref of type_
@@ -181,7 +182,7 @@ end
 type init =
   | Assignment of expr
   | Construction of expr list
-  | InitalizerList of expr list
+  | InitializerList of expr list
   | Uninitialized
 [@@deriving sexp]
 
@@ -380,6 +381,7 @@ module Printing = struct
     | TemplateType id -> pp_identifier ppf id
     | StdVector t -> pf ppf "@[<2>std::vector<@,%a>@]" pp_type_ t
     | Array (t, i) -> pf ppf "@[<2>std::array<@,%a,@ %i>@]" pp_type_ t i
+    | Tuple ts -> pf ppf "@[<2>std::tuple<@,%a>@]" (list ~sep:comma pp_type_) ts
     | TypeLiteral id -> pp_identifier ppf id
     | Matrix (t, i, j) -> pf ppf "Eigen::Matrix<%a,%i,%i>" pp_type_ t i j
     | Const t -> pf ppf "const %a" pp_type_ t
@@ -452,7 +454,7 @@ module Printing = struct
           ("&" ^ ptr) pp_type_ t (list ~sep:comma pp_expr) es
     | ArrayLiteral es -> pf ppf "{%a}" (list ~sep:comma pp_expr) es
     | InitializerExpr (t, es) ->
-        pf ppf "@[<2>%a{%a}@]" pp_type_ t (list ~sep:comma pp_expr) es
+        pf ppf "@[<hov 2>%a{%a}@]" pp_type_ t (list ~sep:comma pp_expr) es
     | StreamInsertion (e, es) ->
         pf ppf "%a <<@[@ %a@]" pp_expr e (list ~sep:comma pp_expr) es
     | FunCall (fn, tys, es) ->
@@ -479,12 +481,12 @@ module Printing = struct
       | Uninitialized -> ()
       | Assignment e -> pf ppf " =@ %a" pp_expr e
       | Construction es -> pf ppf "(%a)" (list ~sep:comma pp_expr) es
-      | InitalizerList es ->
-          pf ppf "{@[<hov 1>%a@]}" (list ~sep:comma pp_expr) es in
+      | InitializerList es ->
+          pf ppf "{@[<hov>%a@]}" (list ~sep:comma pp_expr) es in
     let static = if static then "static " else "" in
     let constexpr = if constexpr then "constexpr " else "" in
-    pf ppf "@[<2>%s%s%a %s%a@]" static constexpr pp_type_ type_ name pp_init
-      init
+    pf ppf "@[<hov 2>%s%s%a@ %s%a@]" static constexpr pp_type_ type_ name
+      pp_init init
 
   let rec pp_stmt ppf s =
     match s with

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -65,7 +65,7 @@ let lower_map_decl (vident, ut) : defn =
          ~type_:(TypeTrait ("Eigen::Map", [t]))
          ~name:vident
          ~init:
-           (InitalizerList
+           (InitializerList
               (Literal "nullptr" :: List.init ndims ~f:(fun _ -> Literal "0"))
            )
          () ) in
@@ -626,7 +626,7 @@ let gen_transform_inits {Program.output_vars; _} =
          ~type_:(Types.const_char_array list_len)
          ~name:"names__"
          ~init:
-           (InitalizerList
+           (InitializerList
               (List.map
                  ~f:(Fn.compose Exprs.literal_string Mangle.remove_prefix)
                  param_names ) )
@@ -636,7 +636,7 @@ let gen_transform_inits {Program.output_vars; _} =
       (make_variable_defn
          ~type_:(Const (Array (TypeLiteral "Eigen::Index", list_len)))
          ~name:"constrain_param_sizes__"
-         ~init:(InitalizerList (List.map ~f:lower_num_param constrained_params))
+         ~init:(InitializerList (List.map ~f:lower_num_param constrained_params))
          () ) in
   let num_constrained_param_size =
     let constrain_param_sizes = Var "constrain_param_sizes__" in

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1552,12 +1552,11 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 9> names__{"alpha_v", "beta", "cuts",
-                                                  "sigma", "alpha", "phi",
-                                                  "X_p", "beta_m", "X_rv_p"};
-    const std::array<Eigen::Index, 9> constrain_param_sizes__{k, k, k, 1, 1,
-                                                               1, (n * k), (n
-                                                               * k), n};
+    constexpr std::array<const char*, 9>
+      names__{"alpha_v", "beta", "cuts", "sigma", "alpha", "phi", "X_p",
+              "beta_m", "X_rv_p"};
+    const std::array<Eigen::Index, 9>
+      constrain_param_sizes__{k, k, k, 1, 1, 1, (n * k), (n * k), n};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1617,13 +1617,11 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8> names__{"cmat", "cvec", "crowvec",
-                                                  "z", "mat", "vec",
-                                                  "rowvec", "r"};
-    const std::array<Eigen::Index, 8> constrain_param_sizes__{(N * N * 2), (N
-                                                               * 2), (N * 2),
-                                                               2, (N * N), N,
-                                                               N, 1};
+    constexpr std::array<const char*, 8>
+      names__{"cmat", "cvec", "crowvec", "z", "mat", "vec", "rowvec", "r"};
+    const std::array<Eigen::Index, 8>
+      constrain_param_sizes__{(N * N * 2), (N * 2), (N * 2), 2, (N * N), N,
+                              N, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -4734,13 +4732,12 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8> names__{"cvmat", "cvvec",
-                                                  "cvrowvec", "zv", "vmat",
-                                                  "vvec", "vrowvec", "v"};
-    const std::array<Eigen::Index, 8> constrain_param_sizes__{(N * N * 2), (N
-                                                               * 2), (N * 2),
-                                                               2, (N * N), N,
-                                                               N, 1};
+    constexpr std::array<const char*, 8>
+      names__{"cvmat", "cvvec", "cvrowvec", "zv", "vmat", "vvec", "vrowvec",
+              "v"};
+    const std::array<Eigen::Index, 8>
+      constrain_param_sizes__{(N * N * 2), (N * 2), (N * 2), 2, (N * N), N,
+                              N, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -6284,8 +6281,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::vector<std::vector<std::complex<double>>>{std::vector<
                                                          std::complex<double>>{
                                                          stan::math::to_complex(
-                                                           1, 0),
-                                                         td_complex,
+                                                           1, 0), td_complex,
                                                          stan::math::to_complex(
                                                            3, 0)},
           std::vector<std::complex<double>>{stan::math::to_complex(),
@@ -6434,7 +6430,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 3;
       p_complex_array = in__.template read<
                           std::vector<std::complex<local_scalar_t__>>>(2);
-      std::vector<std::vector<std::complex<local_scalar_t__>>> p_complex_array_2d =
+      std::vector<std::vector<std::complex<local_scalar_t__>>>
+        p_complex_array_2d =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(2,
           std::vector<std::complex<local_scalar_t__>>(3,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
@@ -6451,7 +6448,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       std::vector<std::complex<local_scalar_t__>> tp_complex_array =
         std::vector<std::complex<local_scalar_t__>>(2,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      std::vector<std::vector<std::complex<local_scalar_t__>>> tp_complex_array_2d =
+      std::vector<std::vector<std::complex<local_scalar_t__>>>
+        tp_complex_array_2d =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(2,
           std::vector<std::complex<local_scalar_t__>>(3,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
@@ -6635,7 +6633,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::vector<std::complex<local_scalar_t__>> m_complex_array =
           std::vector<std::complex<local_scalar_t__>>(2,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-        std::vector<std::vector<std::complex<local_scalar_t__>>> m_complex_array_2d =
+        std::vector<std::vector<std::complex<local_scalar_t__>>>
+          m_complex_array_2d =
           std::vector<std::vector<std::complex<local_scalar_t__>>>(2,
             std::vector<std::complex<local_scalar_t__>>(3,
               std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
@@ -7005,8 +7004,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::vector<std::vector<std::complex<double>>>{std::vector<
                                                          std::complex<double>>{
                                                          stan::math::to_complex(
-                                                           1, 0),
-                                                         gq_complex,
+                                                           1, 0), gq_complex,
                                                          stan::math::to_complex(
                                                            3, 0)},
           std::vector<std::complex<double>>{stan::math::to_complex(),
@@ -7639,7 +7637,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
           stan::model::index_uni(sym1__));
       }
       out__.write(p_complex_array);
-      std::vector<std::vector<std::complex<local_scalar_t__>>> p_complex_array_2d =
+      std::vector<std::vector<std::complex<local_scalar_t__>>>
+        p_complex_array_2d =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(2,
           std::vector<std::complex<local_scalar_t__>>(3,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
@@ -7928,11 +7927,10 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"p_r", "p_complex",
-                                                  "p_complex_array",
-                                                  "p_complex_array_2d"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 2, (2 * 2),
-                                                               (2 * 3 * 2)};
+    constexpr std::array<const char*, 4>
+      names__{"p_r", "p_complex", "p_complex_array", "p_complex_array_2d"};
+    const std::array<Eigen::Index, 4>
+      constrain_param_sizes__{1, 2, (2 * 2), (2 * 3 * 2)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1647,17 +1647,12 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 15> names__{"explicit", "float",
-                                                   "friend", "goto",
-                                                   "inline", "long",
-                                                   "mutable", "namespace",
-                                                   "new", "noexcept", "not",
-                                                   "not_eq", "nullptr",
-                                                   "operator", "or"};
-    const std::array<Eigen::Index, 15> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1};
+    constexpr std::array<const char*, 15>
+      names__{"explicit", "float", "friend", "goto", "inline", "long",
+              "mutable", "namespace", "new", "noexcept", "not", "not_eq",
+              "nullptr", "operator", "or"};
+    const std::array<Eigen::Index, 15>
+      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -2173,8 +2168,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       stan::model::assign(w,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
                                                      local_scalar_t__>{1.0,
-                                                     2, 3},
-          xx, xx}, "assigning variable w");
+                                                     2, 3}, xx, xx},
+        "assigning variable w");
       std::vector<std::vector<local_scalar_t__>> td_arr33 =
         std::vector<std::vector<local_scalar_t__>>(3,
           std::vector<local_scalar_t__>(3, DUMMY_VAR__));
@@ -2248,8 +2243,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       stan::model::assign(w,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
                                                      local_scalar_t__>{1.0,
-                                                     2, 3},
-          xx, xx}, "assigning variable w");
+                                                     2, 3}, xx, xx},
+        "assigning variable w");
       current_statement__ = 4;
       stan::model::assign(td_arr33,
         std::vector<std::vector<double>>{std::vector<double>{1, 2, 3},
@@ -5940,11 +5935,13 @@ class mother_model final : public model_base_crtp<mother_model> {
   std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> d_3d_vec;
   Eigen::Matrix<double,1,-1> d_row_vec_data__;
   std::vector<Eigen::Matrix<double,1,-1>> d_1d_row_vec;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>> d_3d_row_vec;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>
+    d_3d_row_vec;
   std::vector<std::vector<Eigen::Matrix<double,-1,-1>>> d_ar_mat;
   Eigen::Matrix<double,-1,1> d_simplex_data__;
   std::vector<Eigen::Matrix<double,-1,1>> d_1d_simplex;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> d_3d_simplex;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+    d_3d_simplex;
   Eigen::Matrix<double,-1,-1> d_cfcov_54_data__;
   Eigen::Matrix<double,-1,-1> d_cfcov_33_data__;
   std::vector<Eigen::Matrix<double,-1,-1>> d_cfcov_33_ar;
@@ -5959,15 +5956,18 @@ class mother_model final : public model_base_crtp<mother_model> {
   Eigen::Matrix<double,-1,-1> d_matrix_data__;
   std::vector<Eigen::Matrix<double,-1,-1>> d_matrix_array;
   std::vector<std::vector<Eigen::Matrix<double,-1,-1>>> d_matrix_array_2d;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,-1>>>> d_matrix_array_3d;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,-1>>>>
+    d_matrix_array_3d;
   Eigen::Matrix<double,-1,1> d_vector_data__;
   std::vector<Eigen::Matrix<double,-1,1>> d_vector_array;
   std::vector<std::vector<Eigen::Matrix<double,-1,1>>> d_vector_array_2d;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> d_vector_array_3d;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+    d_vector_array_3d;
   Eigen::Matrix<double,1,-1> d_row_vector_data__;
   std::vector<Eigen::Matrix<double,1,-1>> d_row_vector_array;
   std::vector<std::vector<Eigen::Matrix<double,1,-1>>> d_row_vector_array_2d;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>> d_row_vector_array_3d;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>
+    d_row_vector_array_3d;
   int td_int;
   std::vector<int> td_1d;
   std::vector<int> td_1dk;
@@ -5977,7 +5977,8 @@ class mother_model final : public model_base_crtp<mother_model> {
   std::vector<std::vector<Eigen::Matrix<double,-1,-1>>> td_ar_mat;
   Eigen::Matrix<double,-1,1> td_simplex_data__;
   std::vector<Eigen::Matrix<double,-1,1>> td_1d_simplex;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> td_3d_simplex;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+    td_3d_simplex;
   Eigen::Matrix<double,-1,-1> td_cfcov_54_data__;
   Eigen::Matrix<double,-1,-1> td_cfcov_33_data__;
   Eigen::Matrix<double,-1,1> x_data__;
@@ -5991,19 +5992,26 @@ class mother_model final : public model_base_crtp<mother_model> {
   double transformed_data_real;
   std::vector<double> transformed_data_real_array;
   std::vector<std::vector<double>> transformed_data_real_array_2d;
-  std::vector<std::vector<std::vector<double>>> transformed_data_real_array_3d;
+  std::vector<std::vector<std::vector<double>>>
+    transformed_data_real_array_3d;
   Eigen::Matrix<double,-1,-1> transformed_data_matrix_data__;
   std::vector<Eigen::Matrix<double,-1,-1>> transformed_data_matrix_array;
-  std::vector<std::vector<Eigen::Matrix<double,-1,-1>>> transformed_data_matrix_array_2d;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,-1>>>> transformed_data_matrix_array_3d;
+  std::vector<std::vector<Eigen::Matrix<double,-1,-1>>>
+    transformed_data_matrix_array_2d;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,-1>>>>
+    transformed_data_matrix_array_3d;
   Eigen::Matrix<double,-1,1> transformed_data_vector_data__;
   std::vector<Eigen::Matrix<double,-1,1>> transformed_data_vector_array;
-  std::vector<std::vector<Eigen::Matrix<double,-1,1>>> transformed_data_vector_array_2d;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> transformed_data_vector_array_3d;
+  std::vector<std::vector<Eigen::Matrix<double,-1,1>>>
+    transformed_data_vector_array_2d;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+    transformed_data_vector_array_3d;
   Eigen::Matrix<double,1,-1> transformed_data_row_vector_data__;
   std::vector<Eigen::Matrix<double,1,-1>> transformed_data_row_vector_array;
-  std::vector<std::vector<Eigen::Matrix<double,1,-1>>> transformed_data_row_vector_array_2d;
-  std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>> transformed_data_row_vector_array_3d;
+  std::vector<std::vector<Eigen::Matrix<double,1,-1>>>
+    transformed_data_row_vector_array_2d;
+  std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>
+    transformed_data_row_vector_array_3d;
   Eigen::Map<Eigen::Matrix<double,-1,1>> d_vec{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,1,-1>> d_row_vec{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> d_simplex{nullptr, 0};
@@ -6017,11 +6025,11 @@ class mother_model final : public model_base_crtp<mother_model> {
   Eigen::Map<Eigen::Matrix<double,-1,-1>> td_cfcov_33{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> x{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> y{nullptr, 0};
-  Eigen::Map<Eigen::Matrix<double,-1,-1>> transformed_data_matrix{nullptr, 0,
-                                                                   0};
+  Eigen::Map<Eigen::Matrix<double,-1,-1>>
+    transformed_data_matrix{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> transformed_data_vector{nullptr, 0};
-  Eigen::Map<Eigen::Matrix<double,1,-1>> transformed_data_row_vector{
-    nullptr, 0};
+  Eigen::Map<Eigen::Matrix<double,1,-1>>
+    transformed_data_row_vector{nullptr, 0};
  public:
   ~mother_model() {}
   mother_model(stan::io::var_context& context__, unsigned int
@@ -8380,7 +8388,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_1d_vec = in__.template read<
                    std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(N, N);
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>> p_3d_vec =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        p_3d_vec =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
@@ -8404,7 +8413,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(N,
                        N);
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>> p_3d_row_vec =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>
+        p_3d_row_vec =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(M,
@@ -8420,7 +8430,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 4, DUMMY_VAR__);
       current_statement__ = 15;
       p_mat = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 4);
-      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> p_ar_mat =
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>
+        p_ar_mat =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(4,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(5,
             Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 3,
@@ -8444,7 +8455,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>,
                        jacobian__>(lp__, N, N);
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>> p_3d_simplex =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        p_3d_simplex =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
@@ -8495,7 +8507,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>> tp_3d_vec =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        tp_3d_vec =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
@@ -8507,7 +8520,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>> tp_3d_row_vec =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>
+        tp_3d_row_vec =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(M,
@@ -8515,7 +8529,8 @@ class mother_model final : public model_base_crtp<mother_model> {
               Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__))));
       Eigen::Matrix<local_scalar_t__,-1,-1> tp_mat =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 4, DUMMY_VAR__);
-      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> tp_ar_mat =
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>
+        tp_ar_mat =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(4,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(5,
             Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 3,
@@ -8526,7 +8541,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>> tp_3d_simplex =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        tp_3d_simplex =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
@@ -8899,7 +8915,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       current_statement__ = 10;
       p_1d_vec = in__.template read<
                    std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(N, N);
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> p_3d_vec =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+        p_3d_vec =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,-1,1>>>(M,
             std::vector<Eigen::Matrix<double,-1,1>>(K,
@@ -8924,7 +8941,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_1d_row_vec = in__.template read<
                        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(N,
                        N);
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>> p_3d_row_vec =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>
+        p_3d_row_vec =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,1,-1>>>(M,
             std::vector<Eigen::Matrix<double,1,-1>>(K,
@@ -8966,7 +8984,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       p_1d_simplex = in__.template read_constrain_simplex<
                        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>,
                        jacobian__>(lp__, N, N);
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> p_3d_simplex =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+        p_3d_simplex =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,-1,1>>>(M,
             std::vector<Eigen::Matrix<double,-1,1>>(K,
@@ -9023,7 +9042,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<double,-1,1>>(N,
           Eigen::Matrix<double,-1,1>::Constant(N,
             std::numeric_limits<double>::quiet_NaN()));
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> tp_3d_vec =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+        tp_3d_vec =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,-1,1>>>(M,
             std::vector<Eigen::Matrix<double,-1,1>>(K,
@@ -9036,7 +9056,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<double,1,-1>>(N,
           Eigen::Matrix<double,1,-1>::Constant(N,
             std::numeric_limits<double>::quiet_NaN()));
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>> tp_3d_row_vec =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>
+        tp_3d_row_vec =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,1,-1>>>(M,
             std::vector<Eigen::Matrix<double,1,-1>>(K,
@@ -9057,7 +9078,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<double,-1,1>>(N,
           Eigen::Matrix<double,-1,1>::Constant(N,
             std::numeric_limits<double>::quiet_NaN()));
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> tp_3d_simplex =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+        tp_3d_simplex =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,-1,1>>>(M,
             std::vector<Eigen::Matrix<double,-1,1>>(K,
@@ -9411,7 +9433,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<double,-1,1>>(N,
           Eigen::Matrix<double,-1,1>::Constant(N,
             std::numeric_limits<double>::quiet_NaN()));
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> gq_3d_vec =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+        gq_3d_vec =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,-1,1>>>(M,
             std::vector<Eigen::Matrix<double,-1,1>>(K,
@@ -9424,7 +9447,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<double,1,-1>>(N,
           Eigen::Matrix<double,1,-1>::Constant(N,
             std::numeric_limits<double>::quiet_NaN()));
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>> gq_3d_row_vec =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>
+        gq_3d_row_vec =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,1,-1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,1,-1>>>(M,
             std::vector<Eigen::Matrix<double,1,-1>>(K,
@@ -9442,7 +9466,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<double,-1,1>>(N,
           Eigen::Matrix<double,-1,1>::Constant(N,
             std::numeric_limits<double>::quiet_NaN()));
-      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>> gq_3d_simplex =
+      std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>
+        gq_3d_simplex =
         std::vector<std::vector<std::vector<Eigen::Matrix<double,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<double,-1,1>>>(M,
             std::vector<Eigen::Matrix<double,-1,1>>(K,
@@ -9980,7 +10005,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       }
       out__.write(p_1d_vec);
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>> p_3d_vec =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        p_3d_vec =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
@@ -10020,7 +10046,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       }
       out__.write(p_1d_row_vec);
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>> p_3d_row_vec =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>
+        p_3d_row_vec =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(M,
@@ -10052,7 +10079,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         }
       }
       out__.write(p_mat);
-      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> p_ar_mat =
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>
+        p_ar_mat =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(4,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(5,
             Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 3,
@@ -10091,7 +10119,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       }
       out__.write_free_simplex(p_1d_simplex);
       std::vector<
-        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>> p_3d_simplex =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        p_3d_simplex =
         std::vector<
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
@@ -11299,38 +11328,18 @@ class mother_model final : public model_base_crtp<mother_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 24> names__{"p_real", "p_upper",
-                                                   "p_lower",
-                                                   "offset_multiplier",
-                                                   "no_offset_multiplier",
-                                                   "offset_no_multiplier",
-                                                   "p_real_1d_ar",
-                                                   "p_real_3d_ar", "p_vec",
-                                                   "p_1d_vec", "p_3d_vec",
-                                                   "p_row_vec",
-                                                   "p_1d_row_vec",
-                                                   "p_3d_row_vec", "p_mat",
-                                                   "p_ar_mat", "p_simplex",
-                                                   "p_1d_simplex",
-                                                   "p_3d_simplex",
-                                                   "p_cfcov_54",
-                                                   "p_cfcov_33",
-                                                   "p_cfcov_33_ar", "x_p",
-                                                   "y_p"};
-    const std::array<Eigen::Index, 24> constrain_param_sizes__{1, 1, 1, 5, 5,
-                                                                5, N, (N * M
-                                                                * K), N, (N *
-                                                                N), (N * M *
-                                                                K * N), N, (N
-                                                                * N), (N * M
-                                                                * K * N), (5
-                                                                * 4), (4 * 5
-                                                                * 2 * 3), N,
-                                                                (N * N), (N *
-                                                                M * K * N),
-                                                                (5 * 4), (3 *
-                                                                3), (K * 3 *
-                                                                3), 2, 2};
+    constexpr std::array<const char*, 24>
+      names__{"p_real", "p_upper", "p_lower", "offset_multiplier",
+              "no_offset_multiplier", "offset_no_multiplier", "p_real_1d_ar",
+              "p_real_3d_ar", "p_vec", "p_1d_vec", "p_3d_vec", "p_row_vec",
+              "p_1d_row_vec", "p_3d_row_vec", "p_mat", "p_ar_mat",
+              "p_simplex", "p_1d_simplex", "p_3d_simplex", "p_cfcov_54",
+              "p_cfcov_33", "p_cfcov_33_ar", "x_p", "y_p"};
+    const std::array<Eigen::Index, 24>
+      constrain_param_sizes__{1, 1, 1, 5, 5, 5, N, (N * M * K), N, (N * N),
+                              (N * M * K * N), N, (N * N), (N * M * K * N),
+                              (5 * 4), (4 * 5 * 2 * 3), N, (N * N), (N * M *
+                              K * N), (5 * 4), (3 * 3), (K * 3 * 3), 2, 2};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -12877,9 +12886,9 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
                 std::vector<size_t>{static_cast<size_t>(2)},
                 std::vector<size_t>{static_cast<size_t>(3)},
                 std::vector<size_t>{static_cast<size_t>(3),
-                  static_cast<size_t>(3)},
+                  static_cast<size_t>(3)}, std::vector<size_t>{},
                 std::vector<size_t>{}, std::vector<size_t>{},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(3)},
                 std::vector<size_t>{static_cast<size_t>(3)},
                 std::vector<size_t>{static_cast<size_t>(3)},
@@ -12888,9 +12897,9 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
                 std::vector<size_t>{static_cast<size_t>(2)},
                 std::vector<size_t>{static_cast<size_t>(2)},
                 std::vector<size_t>{static_cast<size_t>(T),
-                  static_cast<size_t>(2)},
+                  static_cast<size_t>(2)}, std::vector<size_t>{},
                 std::vector<size_t>{}, std::vector<size_t>{},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(3)},
                 std::vector<size_t>{static_cast<size_t>(3)},
                 std::vector<size_t>{static_cast<size_t>(2)}};
@@ -13141,11 +13150,11 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 7> names__{"y0_p", "theta_p", "x_p",
-                                                  "x_p_v", "shared_params_p",
-                                                  "job_params_p", "x_r"};
-    const std::array<Eigen::Index, 7> constrain_param_sizes__{2, 1, 1, 2, 3,
-                                                               (3 * 3), 1};
+    constexpr std::array<const char*, 7>
+      names__{"y0_p", "theta_p", "x_p", "x_p_v", "shared_params_p",
+              "job_params_p", "x_r"};
+    const std::array<Eigen::Index, 7>
+      constrain_param_sizes__{2, 1, 1, 2, 3, (3 * 3), 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -18291,10 +18300,10 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"alpha", "beta", "gamma",
-                                                  "delta", "z_init", "sigma"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, 2,
-                                                               2};
+    constexpr std::array<const char*, 6>
+      names__{"alpha", "beta", "gamma", "delta", "z_init", "sigma"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, 2, 2};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -19723,12 +19732,11 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 9> names__{"alpha_v", "beta", "cuts",
-                                                  "sigma", "alpha", "phi",
-                                                  "X_p", "beta_m", "X_rv_p"};
-    const std::array<Eigen::Index, 9> constrain_param_sizes__{k, k, k, 1, 1,
-                                                               1, (n * k), (n
-                                                               * k), n};
+    constexpr std::array<const char*, 9>
+      names__{"alpha_v", "beta", "cuts", "sigma", "alpha", "phi", "X_p",
+              "beta_m", "X_rv_p"};
+    const std::array<Eigen::Index, 9>
+      constrain_param_sizes__{k, k, k, 1, 1, 1, (n * k), (n * k), n};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -20813,8 +20821,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"L_Omega", "z1"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(nt * 2 * 2),
-                                                               NS};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(nt * 2 * 2), NS};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -25150,24 +25158,14 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16> names__{"a8", "a7", "a6", "a5",
-                                                   "a4", "a3", "a2", "a1",
-                                                   "y8", "y7", "y6", "y5",
-                                                   "y4", "y3", "y2", "y1"};
-    const std::array<Eigen::Index, 16> constrain_param_sizes__{(N * N * N *
-                                                                N), (N * N *
-                                                                N), (N * N *
-                                                                N), (N * N),
-                                                                (N * N * N),
-                                                                (N * N), (N *
-                                                                N), N, (N * N
-                                                                * N * N), (N
-                                                                * N * N), (N
-                                                                * N * N), (N
-                                                                * N), (N * N
-                                                                * N), (N *
-                                                                N), (N * N),
-                                                                N};
+    constexpr std::array<const char*, 16>
+      names__{"a8", "a7", "a6", "a5", "a4", "a3", "a2", "a1", "y8", "y7",
+              "y6", "y5", "y4", "y3", "y2", "y1"};
+    const std::array<Eigen::Index, 16>
+      constrain_param_sizes__{(N * N * N * N), (N * N * N), (N * N * N), (N *
+                              N), (N * N * N), (N * N), (N * N), N, (N * N *
+                              N * N), (N * N * N), (N * N * N), (N * N), (N *
+                              N * N), (N * N), (N * N), N};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -28783,8 +28781,7 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
                   static_cast<size_t>(N), static_cast<size_t>(N)},
                 std::vector<size_t>{static_cast<size_t>(N),
                   static_cast<size_t>(N), static_cast<size_t>(N),
-                  static_cast<size_t>(N)},
-                std::vector<size_t>{},
+                  static_cast<size_t>(N)}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(N)},
                 std::vector<size_t>{static_cast<size_t>(N)},
                 std::vector<size_t>{static_cast<size_t>(N),
@@ -29115,19 +29112,13 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 13> names__{"y1", "y2", "y3", "y4",
-                                                   "y5", "y6", "y7", "y8",
-                                                   "y9", "y10", "y11", "y12",
-                                                   "y17"};
-    const std::array<Eigen::Index, 13> constrain_param_sizes__{N, (N * N), (N
-                                                                * N), (N * N
-                                                                * N), (N *
-                                                                N), (N * N *
-                                                                N), (N * N *
-                                                                N), (N * N *
-                                                                N * N), 1, N,
-                                                                N, (N * N),
-                                                                (N * N * N)};
+    constexpr std::array<const char*, 13>
+      names__{"y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8", "y9", "y10",
+              "y11", "y12", "y17"};
+    const std::array<Eigen::Index, 13>
+      constrain_param_sizes__{N, (N * N), (N * N), (N * N * N), (N * N), (N *
+                              N * N), (N * N * N), (N * N * N * N), 1, N, N,
+                              (N * N), (N * N * N)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -30125,35 +30116,20 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 33> names__{"e", "pi", "log2", "log10",
-                                                   "sqrt2", "not_a_number",
-                                                   "positive_infinity",
-                                                   "negative_infinity",
-                                                   "machine_precision",
-                                                   "inv_logit", "logit",
-                                                   "num_elements", "pow",
-                                                   "add", "sub", "multiply",
-                                                   "binomial_coefficient_log",
-                                                   "read_constrain_lb",
-                                                   "read",
-                                                   "validate_non_negative_index",
-                                                   "length",
-                                                   "validate_positive_index",
-                                                   "profile_map", "assign",
-                                                   "rvalue", "stan_print",
-                                                   "model_base_crtp",
-                                                   "index_uni",
-                                                   "bernoulli_logit_glm_lpmf",
-                                                   "reduce_sum", "segment",
-                                                   "ode_bdf", "ode_bdf_tol"};
-    const std::array<Eigen::Index, 33> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                5, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 4, 1, 1};
+    constexpr std::array<const char*, 33>
+      names__{"e", "pi", "log2", "log10", "sqrt2", "not_a_number",
+              "positive_infinity", "negative_infinity", "machine_precision",
+              "inv_logit", "logit", "num_elements", "pow", "add", "sub",
+              "multiply", "binomial_coefficient_log", "read_constrain_lb",
+              "read", "validate_non_negative_index", "length",
+              "validate_positive_index", "profile_map", "assign", "rvalue",
+              "stan_print", "model_base_crtp", "index_uni",
+              "bernoulli_logit_glm_lpmf", "reduce_sum", "segment", "ode_bdf",
+              "ode_bdf_tol"};
+    const std::array<Eigen::Index, 33>
+      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                              1, 1, 1, 1, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 4, 1,
+                              1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -33243,21 +33219,14 @@ class transform_model final : public model_base_crtp<transform_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 18> names__{"p_1", "p_2", "p_3", "p_4",
-                                                   "p_5", "p_6", "p_7",
-                                                   "p_8", "p_9", "p_10",
-                                                   "pv_1", "pv_2", "pv_3",
-                                                   "pr_1", "pr_2", "pr_3",
-                                                   "pm_1", "pm_2"};
-    const std::array<Eigen::Index, 18> constrain_param_sizes__{k, k, k, k, k,
-                                                                k, k, k, (m *
-                                                                k), (n * m *
-                                                                k), k, (m *
-                                                                k), (n * m *
-                                                                k), k, (m *
-                                                                k), (n * m *
-                                                                k), (m * k),
-                                                                (n * m * k)};
+    constexpr std::array<const char*, 18>
+      names__{"p_1", "p_2", "p_3", "p_4", "p_5", "p_6", "p_7", "p_8", "p_9",
+              "p_10", "pv_1", "pv_2", "pv_3", "pr_1", "pr_2", "pr_3", "pm_1",
+              "pm_2"};
+    const std::array<Eigen::Index, 18>
+      constrain_param_sizes__{k, k, k, k, k, k, k, k, (m * k), (n * m * k),
+                              k, (m * k), (n * m * k), k, (m * k), (n * m *
+                              k), (m * k), (n * m * k)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -35521,8 +35490,8 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"mu", "sigma", "vector_mu",
-                                                  "vector_sigma"};
+    constexpr std::array<const char*, 4>
+      names__{"mu", "sigma", "vector_mu", "vector_sigma"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, N, N};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -1518,8 +1518,8 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"beta", "gamma", "xi",
-                                                  "delta"};
+    constexpr std::array<const char*, 4>
+      names__{"beta", "gamma", "xi", "delta"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7235,13 +7235,11 @@ class distributions_model final : public model_base_crtp<distributions_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"p_real", "p_real_array",
-                                                  "p_matrix", "p_vector",
-                                                  "p_row_vector", "y_p"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, d_int,
-                                                               (d_int *
-                                                               d_int), d_int,
-                                                               d_int, 1};
+    constexpr std::array<const char*, 6>
+      names__{"p_real", "p_real_array", "p_matrix", "p_vector",
+              "p_row_vector", "y_p"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, d_int, (d_int * d_int), d_int, d_int, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -7883,13 +7881,11 @@ class restricted_model final : public model_base_crtp<restricted_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"p_real", "p_real_array",
-                                                  "p_matrix", "p_vector",
-                                                  "p_row_vector", "y_p"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, d_int,
-                                                               (d_int *
-                                                               d_int), d_int,
-                                                               d_int, 1};
+    constexpr std::array<const char*, 6>
+      names__{"p_real", "p_real_array", "p_matrix", "p_vector",
+              "p_row_vector", "y_p"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, d_int, (d_int * d_int), d_int, d_int, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -180,7 +180,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
         }
         current_statement__ = 13;
         {
-          stan::math::profile<local_scalar_t__> profile__("cholesky_decompose",
+          stan::math::profile<local_scalar_t__>
+            profile__("cholesky_decompose",
             const_cast<stan::math::profile_map&>(profiles__));
           current_statement__ = 12;
           stan::model::assign(L_cov, stan::math::cholesky_decompose(cov),
@@ -203,7 +204,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
           }
           current_statement__ = 19;
           {
-            stan::math::profile<local_scalar_t__> profile__("multi_normal_cholesky",
+            stan::math::profile<local_scalar_t__>
+              profile__("multi_normal_cholesky",
               const_cast<stan::math::profile_map&>(profiles__));
             current_statement__ = 18;
             lp_accum__.add(stan::math::multi_normal_cholesky_lpdf<propto__>(

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2448,8 +2448,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"beta", "gamma", "xi",
-                                                  "delta"};
+    constexpr std::array<const char*, 4>
+      names__{"beta", "gamma", "xi", "delta"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -3266,14 +3266,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 14;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
@@ -3702,7 +3704,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
@@ -5061,24 +5064,14 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16> names__{"sigma", "sigma_age",
-                                                   "sigma_edu",
-                                                   "sigma_state",
-                                                   "sigma_region",
-                                                   "sigma_age_edu", "b_0",
-                                                   "b_female", "b_black",
-                                                   "b_female_black",
-                                                   "b_v_prev", "b_age",
-                                                   "b_edu", "b_region",
-                                                   "b_age_edu", "b_hat"};
-    const std::array<Eigen::Index, 16> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, n_age,
-                                                                n_edu,
-                                                                n_region,
-                                                                (n_age *
-                                                                n_edu),
-                                                                n_state};
+    constexpr std::array<const char*, 16>
+      names__{"sigma", "sigma_age", "sigma_edu", "sigma_state",
+              "sigma_region", "sigma_age_edu", "b_0", "b_female", "b_black",
+              "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
+              "b_age_edu", "b_hat"};
+    const std::array<Eigen::Index, 16>
+      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu,
+                              n_region, (n_age * n_edu), n_state};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -7530,16 +7523,12 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 11> names__{"a", "b", "c", "d", "e",
-                                                   "beta", "sigma_a",
-                                                   "sigma_b", "sigma_c",
-                                                   "sigma_d", "sigma_e"};
-    const std::array<Eigen::Index, 11> constrain_param_sizes__{n_age, n_edu,
-                                                                n_age_edu,
-                                                                n_state,
-                                                                n_region_full,
-                                                                5, 1, 1, 1,
-                                                                1, 1};
+    constexpr std::array<const char*, 11>
+      names__{"a", "b", "c", "d", "e", "beta", "sigma_a", "sigma_b",
+              "sigma_c", "sigma_d", "sigma_e"};
+    const std::array<Eigen::Index, 11>
+      constrain_param_sizes__{n_age, n_edu, n_age_edu, n_state,
+                              n_region_full, 5, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -8229,8 +8218,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1,
-                                                               phi_std_raw_1dim__};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{1, phi_std_raw_1dim__};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -8965,14 +8954,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 18;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 27;
@@ -9401,7 +9392,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         current_statement__ = 18;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 27;
@@ -9619,8 +9611,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                 std::vector<size_t>{static_cast<size_t>(nind),
                   static_cast<size_t>(n_occ_minus_1)},
                 std::vector<size_t>{static_cast<size_t>(nind),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{}};
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -9760,8 +9752,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"mean_phi", "mean_p",
-                                                  "epsilon", "sigma"};
+    constexpr std::array<const char*, 4>
+      names__{"mean_phi", "mean_p", "epsilon", "sigma"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, nind, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -11195,7 +11187,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         stan::model::assign(nu, 1.0, "assigning variable nu",
           stan::model::index_uni(n_occasions));
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym14__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym14__;
       {
         int inline_prob_uncaptured_n_ind_sym15__ =
           std::numeric_limits<int>::min();
@@ -11208,7 +11201,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         current_statement__ = 24;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           lcm_sym221__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym17__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym17__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym231__,
             lcm_sym221__, DUMMY_VAR__);
         current_statement__ = 33;
@@ -11417,7 +11411,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 current_statement__ = 93;
                 stan::math::validate_non_negative_index("lp", "first[i]",
                   lcm_sym233__);
-                Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_lp_sym27__ =
+                Eigen::Matrix<local_scalar_t__,-1,1>
+                  inline_js_super_lp_lp_sym27__ =
                   Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym233__,
                     DUMMY_VAR__);
                 lcm_sym185__ = (lcm_sym233__ - 1);
@@ -11563,7 +11558,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               lcm_sym206__ = (lcm_sym238__ + 1);
               stan::math::validate_non_negative_index("lp",
                 "n_occasions + 1", lcm_sym206__);
-              Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_lp_sym27__ =
+              Eigen::Matrix<local_scalar_t__,-1,1>
+                inline_js_super_lp_lp_sym27__ =
                 Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym206__,
                   DUMMY_VAR__);
               current_statement__ = 86;
@@ -11670,7 +11666,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   current_statement__ = 93;
                   stan::math::validate_non_negative_index("lp", "first[i]",
                     lcm_sym232__);
-                  Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_lp_sym27__ =
+                  Eigen::Matrix<local_scalar_t__,-1,1>
+                    inline_js_super_lp_lp_sym27__ =
                     Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym232__,
                       DUMMY_VAR__);
                   lcm_sym184__ = (lcm_sym232__ - 1);
@@ -11829,7 +11826,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 lcm_sym206__ = (lcm_sym238__ + 1);
                 stan::math::validate_non_negative_index("lp",
                   "n_occasions + 1", lcm_sym206__);
-                Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_lp_sym27__ =
+                Eigen::Matrix<local_scalar_t__,-1,1>
+                  inline_js_super_lp_lp_sym27__ =
                   Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym206__,
                     DUMMY_VAR__);
                 current_statement__ = 86;
@@ -12128,7 +12126,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         current_statement__ = 24;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           lcm_sym136__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym4__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym4__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym145__,
             lcm_sym136__, DUMMY_VAR__);
         current_statement__ = 33;
@@ -12678,8 +12677,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
@@ -12881,11 +12880,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"mean_phi", "mean_p", "psi",
-                                                  "beta", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1,
-                                                               n_occasions,
-                                                               M, 1};
+    constexpr std::array<const char*, 6>
+      names__{"mean_phi", "mean_p", "psi", "beta", "epsilon", "sigma"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, n_occasions, M, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -14426,11 +14424,11 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"beta0", "beta1",
-                                                  "tau_theta", "tau_phi",
-                                                  "theta_std", "phi_std_raw"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, N,
-                                                               N};
+    constexpr std::array<const char*, 6>
+      names__{"beta0", "beta1", "tau_theta", "tau_phi", "theta_std",
+              "phi_std_raw"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, N, N};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -15242,14 +15240,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 14;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
@@ -15678,7 +15678,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
@@ -16248,10 +16249,13 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
           inline_summer_running_sum_sym9__ = 0;
           current_statement__ = 9;
           if (stan::math::logical_gte(lcm_sym26__, 1)) {
-            local_scalar_t__ inline_summer_inline_do_something_return_sym4___sym10__;
-            int inline_summer_inline_do_something_early_ret_check_sym5___sym11__ =
+            local_scalar_t__
+              inline_summer_inline_do_something_return_sym4___sym10__;
+            int
+              inline_summer_inline_do_something_early_ret_check_sym5___sym11__ =
               std::numeric_limits<int>::min();
-            for (int inline_summer_inline_do_something_iterator_sym6___sym12__ =
+            for (int
+                   inline_summer_inline_do_something_iterator_sym6___sym12__ =
                    1; inline_summer_inline_do_something_iterator_sym6___sym12__
                  <=
                  1; ++inline_summer_inline_do_something_iterator_sym6___sym12__) {
@@ -16264,10 +16268,13 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
               inline_summer_inline_do_something_return_sym4___sym10__);
             for (int inline_summer_n_sym13__ = 2; inline_summer_n_sym13__ <=
                  lcm_sym26__; ++inline_summer_n_sym13__) {
-              local_scalar_t__ inline_summer_inline_do_something_return_sym4___sym10__;
-              int inline_summer_inline_do_something_early_ret_check_sym5___sym11__ =
+              local_scalar_t__
+                inline_summer_inline_do_something_return_sym4___sym10__;
+              int
+                inline_summer_inline_do_something_early_ret_check_sym5___sym11__ =
                 std::numeric_limits<int>::min();
-              for (int inline_summer_inline_do_something_iterator_sym6___sym12__ =
+              for (int
+                     inline_summer_inline_do_something_iterator_sym6___sym12__ =
                      1; inline_summer_inline_do_something_iterator_sym6___sym12__
                    <=
                    1; ++inline_summer_inline_do_something_iterator_sym6___sym12__) {
@@ -16664,7 +16671,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                                                   std::numeric_limits<double>::quiet_NaN(
                                                     )));
       stan::conditional_var_value_t<local_scalar_t__,
-        Eigen::Matrix<local_scalar_t__,-1,1>> inline_multi_ret_fun_return_sym9__;
+        Eigen::Matrix<local_scalar_t__,-1,1>>
+        inline_multi_ret_fun_return_sym9__;
       int inline_multi_ret_fun_early_ret_check_sym11__ =
         std::numeric_limits<int>::min();
       for (int inline_multi_ret_fun_iterator_sym12__ = 1; inline_multi_ret_fun_iterator_sym12__
@@ -16984,8 +16992,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"p_single_ret_vec",
-                                                  "p_multi_ret_vec"};
+    constexpr std::array<const char*, 2>
+      names__{"p_single_ret_vec", "p_multi_ret_vec"};
     const std::array<Eigen::Index, 2> constrain_param_sizes__{5, 5};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -19169,7 +19177,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         stan::math::rep_matrix(mean_p, M, n_occasions),
         "assigning variable lcm_sym248__");
       stan::model::assign(p, lcm_sym248__, "assigning variable p");
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym20__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym20__;
       {
         int inline_prob_uncaptured_n_ind_sym21__ =
           std::numeric_limits<int>::min();
@@ -19182,7 +19191,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           lcm_sym239__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym23__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym23__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym249__,
             lcm_sym239__, DUMMY_VAR__);
         current_statement__ = 24;
@@ -19380,7 +19390,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 92;
                 stan::math::validate_non_negative_index("lp", "first[i]",
                   lcm_sym252__);
-                Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_lp_sym33__ =
+                Eigen::Matrix<local_scalar_t__,-1,1>
+                  inline_jolly_seber_lp_lp_sym33__ =
                   Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym252__,
                     DUMMY_VAR__);
                 lcm_sym206__ = (lcm_sym252__ - 1);
@@ -19529,7 +19540,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               lcm_sym225__ = (lcm_sym256__ + 1);
               stan::math::validate_non_negative_index("lp",
                 "n_occasions + 1", lcm_sym225__);
-              Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_lp_sym33__ =
+              Eigen::Matrix<local_scalar_t__,-1,1>
+                inline_jolly_seber_lp_lp_sym33__ =
                 Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym225__,
                   DUMMY_VAR__);
               current_statement__ = 86;
@@ -19636,7 +19648,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   current_statement__ = 92;
                   stan::math::validate_non_negative_index("lp", "first[i]",
                     lcm_sym251__);
-                  Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_lp_sym33__ =
+                  Eigen::Matrix<local_scalar_t__,-1,1>
+                    inline_jolly_seber_lp_lp_sym33__ =
                     Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym251__,
                       DUMMY_VAR__);
                   lcm_sym205__ = (lcm_sym251__ - 1);
@@ -19803,7 +19816,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 lcm_sym225__ = (lcm_sym256__ + 1);
                 stan::math::validate_non_negative_index("lp",
                   "n_occasions + 1", lcm_sym225__);
-                Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_lp_sym33__ =
+                Eigen::Matrix<local_scalar_t__,-1,1>
+                  inline_jolly_seber_lp_lp_sym33__ =
                   Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym225__,
                     DUMMY_VAR__);
                 current_statement__ = 86;
@@ -20084,7 +20098,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           lcm_sym152__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym4__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym4__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym167__,
             lcm_sym152__, DUMMY_VAR__);
         current_statement__ = 24;
@@ -20366,7 +20381,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           current_statement__ = 45;
           stan::math::validate_non_negative_index("log_cprob", "N",
             lcm_sym166__);
-          Eigen::Matrix<local_scalar_t__,-1,1> inline_seq_cprob_log_cprob_sym12__ =
+          Eigen::Matrix<local_scalar_t__,-1,1>
+            inline_seq_cprob_log_cprob_sym12__ =
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym166__,
               DUMMY_VAR__);
           local_scalar_t__ inline_seq_cprob_log_residual_prob_sym13__ =
@@ -20661,8 +20677,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 std::vector<size_t>{static_cast<size_t>(M),
                   static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
@@ -20860,12 +20876,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"mean_phi", "mean_p",
-                                                  "gamma", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1,
-                                                               n_occasions,
-                                                               epsilon_1dim__,
-                                                               1};
+    constexpr std::array<const char*, 5>
+      names__{"mean_phi", "mean_p", "gamma", "epsilon", "sigma"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{1, 1, n_occasions, epsilon_1dim__, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -22463,14 +22477,16 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
           }
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 14;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
@@ -22876,7 +22892,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
@@ -24302,8 +24319,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                 std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(R)},
                 std::vector<size_t>{static_cast<size_t>(R),
-                  static_cast<size_t>(T)},
-                std::vector<size_t>{},
+                  static_cast<size_t>(T)}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(R)},
                 std::vector<size_t>{static_cast<size_t>(R)}};
   }
@@ -24439,8 +24455,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"alpha_occ", "beta_occ",
-                                                  "alpha_p", "beta_p"};
+    constexpr std::array<const char*, 4>
+      names__{"alpha_occ", "beta_occ", "alpha_p", "beta_p"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -25194,12 +25210,11 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8> names__{"beta", "eta1", "eta2",
-                                                  "mu_a1", "mu_a2",
-                                                  "sigma_a1", "sigma_a2",
-                                                  "sigma_y"};
-    const std::array<Eigen::Index, 8> constrain_param_sizes__{1, J, J, 1, 1,
-                                                               1, 1, 1};
+    constexpr std::array<const char*, 8>
+      names__{"beta", "eta1", "eta2", "mu_a1", "mu_a2", "sigma_a1",
+              "sigma_a2", "sigma_y"};
+    const std::array<Eigen::Index, 8>
+      constrain_param_sizes__{1, J, J, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -26299,10 +26314,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"theta", "phi", "x_matrix",
-                                                  "x_vector", "x_cov"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1, (3 * 2),
-                                                               2, (2 * 2)};
+    constexpr std::array<const char*, 5>
+      names__{"theta", "phi", "x_matrix", "x_vector", "x_cov"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{1, 1, (3 * 2), 2, (2 * 2)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -27275,10 +27290,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"a", "beta", "mu_a",
-                                                  "sigma_a", "sigma_y"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{n_pair, 2, 1,
-                                                               1, 1};
+    constexpr std::array<const char*, 5>
+      names__{"a", "beta", "mu_a", "sigma_a", "sigma_y"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{n_pair, 2, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -30283,8 +30298,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"m2", "m3"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(10 * 10), (10
-                                                               * 10)};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(10 * 10), (10 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -30982,8 +30997,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                 std::vector<size_t>{}, std::vector<size_t>{},
                 std::vector<size_t>{}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(I),
-                  static_cast<size_t>(K)},
-                std::vector<size_t>{}};
+                  static_cast<size_t>(K)}, std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -31089,11 +31103,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"alpha0", "alpha1",
-                                                  "alpha2", "alpha12", "tau",
-                                                  "b"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                               (I * K)};
+    constexpr std::array<const char*, 6>
+      names__{"alpha0", "alpha1", "alpha2", "alpha12", "tau", "b"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, 1, (I * K)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -1065,8 +1065,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"beta", "gamma", "xi",
-                                                  "delta"};
+    constexpr std::array<const char*, 4>
+      names__{"beta", "gamma", "xi", "delta"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -2002,8 +2002,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             current_statement__ = 20;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 17;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -3208,24 +3207,14 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16> names__{"sigma", "sigma_age",
-                                                   "sigma_edu",
-                                                   "sigma_state",
-                                                   "sigma_region",
-                                                   "sigma_age_edu", "b_0",
-                                                   "b_female", "b_black",
-                                                   "b_female_black",
-                                                   "b_v_prev", "b_age",
-                                                   "b_edu", "b_region",
-                                                   "b_age_edu", "b_hat"};
-    const std::array<Eigen::Index, 16> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, n_age,
-                                                                n_edu,
-                                                                n_region,
-                                                                (n_age *
-                                                                n_edu),
-                                                                n_state};
+    constexpr std::array<const char*, 16>
+      names__{"sigma", "sigma_age", "sigma_edu", "sigma_state",
+              "sigma_region", "sigma_age_edu", "b_0", "b_female", "b_black",
+              "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
+              "b_age_edu", "b_hat"};
+    const std::array<Eigen::Index, 16>
+      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu,
+                              n_region, (n_age * n_edu), n_state};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -5429,16 +5418,12 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 11> names__{"a", "b", "c", "d", "e",
-                                                   "beta", "sigma_a",
-                                                   "sigma_b", "sigma_c",
-                                                   "sigma_d", "sigma_e"};
-    const std::array<Eigen::Index, 11> constrain_param_sizes__{n_age, n_edu,
-                                                                n_age_edu,
-                                                                n_state,
-                                                                n_region_full,
-                                                                5, 1, 1, 1,
-                                                                1, 1};
+    constexpr std::array<const char*, 11>
+      names__{"a", "b", "c", "d", "e", "beta", "sigma_a", "sigma_b",
+              "sigma_c", "sigma_d", "sigma_e"};
+    const std::array<Eigen::Index, 11>
+      constrain_param_sizes__{n_age, n_edu, n_age_edu, n_state,
+                              n_region_full, 5, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -6059,8 +6044,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1,
-                                                               phi_std_raw_1dim__};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{1, phi_std_raw_1dim__};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -6585,8 +6570,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             current_statement__ = 27;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 24;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -6801,8 +6785,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                 std::vector<size_t>{static_cast<size_t>(nind),
                   static_cast<size_t>(n_occ_minus_1)},
                 std::vector<size_t>{static_cast<size_t>(nind),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{}};
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -6942,8 +6926,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"mean_phi", "mean_p",
-                                                  "epsilon", "sigma"};
+    constexpr std::array<const char*, 4>
+      names__{"mean_phi", "mean_p", "epsilon", "sigma"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, nind, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -8229,8 +8213,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
@@ -8432,11 +8416,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"mean_phi", "mean_p", "psi",
-                                                  "beta", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1,
-                                                               n_occasions,
-                                                               M, 1};
+    constexpr std::array<const char*, 6>
+      names__{"mean_phi", "mean_p", "psi", "beta", "epsilon", "sigma"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, n_occasions, M, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -9567,11 +9550,11 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"beta0", "beta1",
-                                                  "tau_theta", "tau_phi",
-                                                  "theta_std", "phi_std_raw"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, N,
-                                                               N};
+    constexpr std::array<const char*, 6>
+      names__{"beta0", "beta1", "tau_theta", "tau_phi", "theta_std",
+              "phi_std_raw"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, N, N};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -10121,8 +10104,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             current_statement__ = 20;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 17;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -11616,8 +11598,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"p_single_ret_vec",
-                                                  "p_multi_ret_vec"};
+    constexpr std::array<const char*, 2>
+      names__{"p_single_ret_vec", "p_multi_ret_vec"};
     const std::array<Eigen::Index, 2> constrain_param_sizes__{5, 5};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -13559,8 +13541,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 std::vector<size_t>{static_cast<size_t>(M),
                   static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
@@ -13758,12 +13740,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"mean_phi", "mean_p",
-                                                  "gamma", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1,
-                                                               n_occasions,
-                                                               epsilon_1dim__,
-                                                               1};
+    constexpr std::array<const char*, 5>
+      names__{"mean_phi", "mean_p", "gamma", "epsilon", "sigma"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{1, 1, n_occasions, epsilon_1dim__, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -15136,8 +15116,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             current_statement__ = 20;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 17;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -16350,8 +16329,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                 std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(R)},
                 std::vector<size_t>{static_cast<size_t>(R),
-                  static_cast<size_t>(T)},
-                std::vector<size_t>{},
+                  static_cast<size_t>(T)}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(R)},
                 std::vector<size_t>{static_cast<size_t>(R)}};
   }
@@ -16487,8 +16465,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"alpha_occ", "beta_occ",
-                                                  "alpha_p", "beta_p"};
+    constexpr std::array<const char*, 4>
+      names__{"alpha_occ", "beta_occ", "alpha_p", "beta_p"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -17145,12 +17123,11 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8> names__{"beta", "eta1", "eta2",
-                                                  "mu_a1", "mu_a2",
-                                                  "sigma_a1", "sigma_a2",
-                                                  "sigma_y"};
-    const std::array<Eigen::Index, 8> constrain_param_sizes__{1, J, J, 1, 1,
-                                                               1, 1, 1};
+    constexpr std::array<const char*, 8>
+      names__{"beta", "eta1", "eta2", "mu_a1", "mu_a2", "sigma_a1",
+              "sigma_a2", "sigma_y"};
+    const std::array<Eigen::Index, 8>
+      constrain_param_sizes__{1, J, J, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -18026,10 +18003,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"theta", "phi", "x_matrix",
-                                                  "x_vector", "x_cov"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1, (3 * 2),
-                                                               2, (2 * 2)};
+    constexpr std::array<const char*, 5>
+      names__{"theta", "phi", "x_matrix", "x_vector", "x_cov"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{1, 1, (3 * 2), 2, (2 * 2)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -18900,10 +18877,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"a", "beta", "mu_a",
-                                                  "sigma_a", "sigma_y"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{n_pair, 2, 1,
-                                                               1, 1};
+    constexpr std::array<const char*, 5>
+      names__{"a", "beta", "mu_a", "sigma_a", "sigma_y"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{n_pair, 2, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -19333,8 +19310,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"m2", "m3"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(10 * 10), (10
-                                                               * 10)};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(10 * 10), (10 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -19768,8 +19745,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                 std::vector<size_t>{}, std::vector<size_t>{},
                 std::vector<size_t>{}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(I),
-                  static_cast<size_t>(K)},
-                std::vector<size_t>{}};
+                  static_cast<size_t>(K)}, std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -19875,11 +19851,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"alpha0", "alpha1",
-                                                  "alpha2", "alpha12", "tau",
-                                                  "b"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                               (I * K)};
+    constexpr std::array<const char*, 6>
+      names__{"alpha0", "alpha1", "alpha2", "alpha12", "tau", "b"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, 1, (I * K)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -1063,8 +1063,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"beta", "gamma", "xi",
-                                                  "delta"};
+    constexpr std::array<const char*, 4>
+      names__{"beta", "gamma", "xi", "delta"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -1592,14 +1592,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             stan::model::index_uni(i), stan::model::index_uni(t));
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 16;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 26;
@@ -1675,8 +1677,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             current_statement__ = 31;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -1800,7 +1801,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 26;
@@ -2923,24 +2925,14 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16> names__{"sigma", "sigma_age",
-                                                   "sigma_edu",
-                                                   "sigma_state",
-                                                   "sigma_region",
-                                                   "sigma_age_edu", "b_0",
-                                                   "b_female", "b_black",
-                                                   "b_female_black",
-                                                   "b_v_prev", "b_age",
-                                                   "b_edu", "b_region",
-                                                   "b_age_edu", "b_hat"};
-    const std::array<Eigen::Index, 16> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                                1, 1, 1, 1,
-                                                                1, 1, n_age,
-                                                                n_edu,
-                                                                n_region,
-                                                                (n_age *
-                                                                n_edu),
-                                                                n_state};
+    constexpr std::array<const char*, 16>
+      names__{"sigma", "sigma_age", "sigma_edu", "sigma_state",
+              "sigma_region", "sigma_age_edu", "b_0", "b_female", "b_black",
+              "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
+              "b_age_edu", "b_hat"};
+    const std::array<Eigen::Index, 16>
+      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu,
+                              n_region, (n_age * n_edu), n_state};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -5139,16 +5131,12 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 11> names__{"a", "b", "c", "d", "e",
-                                                   "beta", "sigma_a",
-                                                   "sigma_b", "sigma_c",
-                                                   "sigma_d", "sigma_e"};
-    const std::array<Eigen::Index, 11> constrain_param_sizes__{n_age, n_edu,
-                                                                n_age_edu,
-                                                                n_state,
-                                                                n_region_full,
-                                                                5, 1, 1, 1,
-                                                                1, 1};
+    constexpr std::array<const char*, 11>
+      names__{"a", "b", "c", "d", "e", "beta", "sigma_a", "sigma_b",
+              "sigma_c", "sigma_d", "sigma_e"};
+    const std::array<Eigen::Index, 11>
+      constrain_param_sizes__{n_age, n_edu, n_age_edu, n_state,
+                              n_region_full, 5, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -5772,8 +5760,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1,
-                                                               phi_std_raw_1dim__};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{1, phi_std_raw_1dim__};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -6265,14 +6253,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             stan::model::index_uni(i), stan::model::index_uni(t));
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 20;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 21;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 32;
@@ -6352,8 +6342,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             current_statement__ = 40;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 37;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -6488,7 +6477,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         current_statement__ = 21;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 32;
@@ -6624,8 +6614,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                 std::vector<size_t>{static_cast<size_t>(nind),
                   static_cast<size_t>(n_occ_minus_1)},
                 std::vector<size_t>{static_cast<size_t>(nind),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{}};
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -6765,8 +6755,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"mean_phi", "mean_p",
-                                                  "epsilon", "sigma"};
+    constexpr std::array<const char*, 4>
+      names__{"mean_phi", "mean_p", "epsilon", "sigma"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, nind, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -7651,7 +7641,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         stan::model::assign(nu, 1.0, "assigning variable nu",
           stan::model::index_uni(n_occasions));
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym14__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym14__;
       {
         int inline_prob_uncaptured_n_ind_sym15__;
         current_statement__ = 24;
@@ -7665,7 +7656,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         current_statement__ = 27;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           inline_prob_uncaptured_n_occasions_sym16__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym17__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym17__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(inline_prob_uncaptured_n_ind_sym15__,
             inline_prob_uncaptured_n_occasions_sym16__, DUMMY_VAR__);
         current_statement__ = 36;
@@ -7772,7 +7764,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             current_statement__ = 87;
             stan::math::validate_non_negative_index("qp", "n_occasions",
               inline_js_super_lp_n_occasions_sym24__);
-            Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_qp_sym26__;
+            Eigen::Matrix<local_scalar_t__,-1,1>
+              inline_js_super_lp_qp_sym26__;
             current_statement__ = 88;
             stan::model::assign(inline_js_super_lp_qp_sym26__,
               stan::math::subtract(1.0,
@@ -7799,7 +7792,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 current_statement__ = 98;
                 stan::math::validate_non_negative_index("lp", "first[i]",
                   first[(inline_js_super_lp_i_sym29__ - 1)]);
-                Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_lp_sym27__ =
+                Eigen::Matrix<local_scalar_t__,-1,1>
+                  inline_js_super_lp_lp_sym27__ =
                   Eigen::Matrix<local_scalar_t__,-1,1>::Constant(first[(inline_js_super_lp_i_sym29__
                     - 1)], DUMMY_VAR__);
                 current_statement__ = 100;
@@ -7926,7 +7920,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::math::validate_non_negative_index("lp",
                 "n_occasions + 1", (inline_js_super_lp_n_occasions_sym24__ +
                 1));
-              Eigen::Matrix<local_scalar_t__,-1,1> inline_js_super_lp_lp_sym27__ =
+              Eigen::Matrix<local_scalar_t__,-1,1>
+                inline_js_super_lp_lp_sym27__ =
                 Eigen::Matrix<local_scalar_t__,-1,1>::Constant((inline_js_super_lp_n_occasions_sym24__
                   + 1), DUMMY_VAR__);
               current_statement__ = 91;
@@ -8124,7 +8119,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         current_statement__ = 27;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           inline_prob_uncaptured_n_occasions_sym3__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym4__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym4__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(inline_prob_uncaptured_n_ind_sym2__,
             inline_prob_uncaptured_n_occasions_sym3__, DUMMY_VAR__);
         current_statement__ = 36;
@@ -8432,8 +8428,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
@@ -8635,11 +8631,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"mean_phi", "mean_p", "psi",
-                                                  "beta", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1,
-                                                               n_occasions,
-                                                               M, 1};
+    constexpr std::array<const char*, 6>
+      names__{"mean_phi", "mean_p", "psi", "beta", "epsilon", "sigma"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, n_occasions, M, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -9763,11 +9758,11 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"beta0", "beta1",
-                                                  "tau_theta", "tau_phi",
-                                                  "theta_std", "phi_std_raw"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, N,
-                                                               N};
+    constexpr std::array<const char*, 6>
+      names__{"beta0", "beta1", "tau_theta", "tau_phi", "theta_std",
+              "phi_std_raw"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, N, N};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -10290,14 +10285,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             stan::model::index_uni(i), stan::model::index_uni(t));
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 16;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 26;
@@ -10373,8 +10370,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             current_statement__ = 31;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -10498,7 +10494,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 26;
@@ -10963,10 +10960,13 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
         current_statement__ = 9;
         for (int inline_summer_n_sym13__ = 1; inline_summer_n_sym13__ <=
              inline_summer_N_sym8__; ++inline_summer_n_sym13__) {
-          local_scalar_t__ inline_summer_inline_do_something_return_sym4___sym10__;
-          int inline_summer_inline_do_something_early_ret_check_sym5___sym11__ =
+          local_scalar_t__
+            inline_summer_inline_do_something_return_sym4___sym10__;
+          int
+            inline_summer_inline_do_something_early_ret_check_sym5___sym11__ =
             std::numeric_limits<int>::min();
-          for (int inline_summer_inline_do_something_iterator_sym6___sym12__ =
+          for (int
+                 inline_summer_inline_do_something_iterator_sym6___sym12__ =
                  1; inline_summer_inline_do_something_iterator_sym6___sym12__
                <=
                1; ++inline_summer_inline_do_something_iterator_sym6___sym12__) {
@@ -11345,7 +11345,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                                                   std::numeric_limits<double>::quiet_NaN(
                                                     )));
       stan::conditional_var_value_t<local_scalar_t__,
-        Eigen::Matrix<local_scalar_t__,-1,1>> inline_single_ret_fun_return_sym7__;
+        Eigen::Matrix<local_scalar_t__,-1,1>>
+        inline_single_ret_fun_return_sym7__;
       stan::model::assign(tp_single_ret_vec, p_single_ret_vec,
         "assigning variable tp_single_ret_vec");
       stan::conditional_var_value_t<local_scalar_t__,
@@ -11355,13 +11356,15 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                                                   std::numeric_limits<double>::quiet_NaN(
                                                     )));
       stan::conditional_var_value_t<local_scalar_t__,
-        Eigen::Matrix<local_scalar_t__,-1,1>> inline_multi_ret_fun_return_sym9__;
+        Eigen::Matrix<local_scalar_t__,-1,1>>
+        inline_multi_ret_fun_return_sym9__;
       int inline_multi_ret_fun_early_ret_check_sym11__ =
         std::numeric_limits<int>::min();
       for (int inline_multi_ret_fun_iterator_sym12__ = 1; inline_multi_ret_fun_iterator_sym12__
            <= 1; ++inline_multi_ret_fun_iterator_sym12__) {
         stan::conditional_var_value_t<local_scalar_t__,
-          Eigen::Matrix<local_scalar_t__,-1,1>> inline_multi_ret_fun_B_sym10__ =
+          Eigen::Matrix<local_scalar_t__,-1,1>>
+          inline_multi_ret_fun_B_sym10__ =
           stan::conditional_var_value_t<local_scalar_t__,
             Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(5,
                                                     std::numeric_limits<double>::quiet_NaN(
@@ -11640,8 +11643,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"p_single_ret_vec",
-                                                  "p_multi_ret_vec"};
+    constexpr std::array<const char*, 2>
+      names__{"p_single_ret_vec", "p_multi_ret_vec"};
     const std::array<Eigen::Index, 2> constrain_param_sizes__{5, 5};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -13264,7 +13267,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 12;
       stan::model::assign(p, stan::math::rep_matrix(mean_p, M, n_occasions),
         "assigning variable p");
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym20__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym20__;
       {
         int inline_prob_uncaptured_n_ind_sym21__;
         current_statement__ = 13;
@@ -13278,7 +13282,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 16;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           inline_prob_uncaptured_n_occasions_sym22__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym23__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym23__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(inline_prob_uncaptured_n_ind_sym21__,
             inline_prob_uncaptured_n_occasions_sym22__, DUMMY_VAR__);
         current_statement__ = 25;
@@ -13366,7 +13371,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           current_statement__ = 86;
           stan::math::validate_non_negative_index("qgamma", "n_occasions",
             inline_jolly_seber_lp_n_occasions_sym30__);
-          Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_qgamma_sym31__;
+          Eigen::Matrix<local_scalar_t__,-1,1>
+            inline_jolly_seber_lp_qgamma_sym31__;
           current_statement__ = 87;
           stan::model::assign(inline_jolly_seber_lp_qgamma_sym31__,
             stan::math::subtract(1.0, gamma),
@@ -13378,7 +13384,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             current_statement__ = 88;
             stan::math::validate_non_negative_index("qp", "n_occasions",
               inline_jolly_seber_lp_n_occasions_sym30__);
-            Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_qp_sym32__;
+            Eigen::Matrix<local_scalar_t__,-1,1>
+              inline_jolly_seber_lp_qp_sym32__;
             current_statement__ = 89;
             stan::model::assign(inline_jolly_seber_lp_qp_sym32__,
               stan::math::subtract(1.0,
@@ -13403,7 +13410,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 98;
                 stan::math::validate_non_negative_index("lp", "first[i]",
                   first[(inline_jolly_seber_lp_i_sym35__ - 1)]);
-                Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_lp_sym33__ =
+                Eigen::Matrix<local_scalar_t__,-1,1>
+                  inline_jolly_seber_lp_lp_sym33__ =
                   Eigen::Matrix<local_scalar_t__,-1,1>::Constant(first[(inline_jolly_seber_lp_i_sym35__
                     - 1)], DUMMY_VAR__);
                 current_statement__ = 100;
@@ -13535,7 +13543,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               stan::math::validate_non_negative_index("lp",
                 "n_occasions + 1", (inline_jolly_seber_lp_n_occasions_sym30__
                 + 1));
-              Eigen::Matrix<local_scalar_t__,-1,1> inline_jolly_seber_lp_lp_sym33__ =
+              Eigen::Matrix<local_scalar_t__,-1,1>
+                inline_jolly_seber_lp_lp_sym33__ =
                 Eigen::Matrix<local_scalar_t__,-1,1>::Constant((inline_jolly_seber_lp_n_occasions_sym30__
                   + 1), DUMMY_VAR__);
               current_statement__ = 92;
@@ -13700,7 +13709,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 16;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           inline_prob_uncaptured_n_occasions_sym3__);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym4__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym4__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(inline_prob_uncaptured_n_ind_sym2__,
             inline_prob_uncaptured_n_occasions_sym3__, DUMMY_VAR__);
         current_statement__ = 25;
@@ -13834,7 +13844,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           current_statement__ = 47;
           stan::math::validate_non_negative_index("log_cprob", "N",
             inline_seq_cprob_N_sym11__);
-          Eigen::Matrix<local_scalar_t__,-1,1> inline_seq_cprob_log_cprob_sym12__ =
+          Eigen::Matrix<local_scalar_t__,-1,1>
+            inline_seq_cprob_log_cprob_sym12__ =
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(inline_seq_cprob_N_sym11__,
               DUMMY_VAR__);
           local_scalar_t__ inline_seq_cprob_log_residual_prob_sym13__;
@@ -14028,8 +14039,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 std::vector<size_t>{static_cast<size_t>(M),
                   static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{static_cast<size_t>(M),
-                  static_cast<size_t>(n_occasions)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(n_occasions)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
                 std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(n_occasions)},
@@ -14227,12 +14238,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"mean_phi", "mean_p",
-                                                  "gamma", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1,
-                                                               n_occasions,
-                                                               epsilon_1dim__,
-                                                               1};
+    constexpr std::array<const char*, 5>
+      names__{"mean_phi", "mean_p", "gamma", "epsilon", "sigma"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{1, 1, n_occasions, epsilon_1dim__, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -15576,14 +15585,16 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             stan::model::index_uni(i), stan::model::index_uni(t));
         }
       }
-      Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_return_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        inline_prob_uncaptured_return_sym8__;
       {
         current_statement__ = 16;
         stan::math::validate_non_negative_index("chi", "nind", nind);
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym9__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym9__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 26;
@@ -15659,8 +15670,7 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             current_statement__ = 31;
             for (int t =
                    (stan::model::rvalue(first, "first",
-                      stan::model::index_uni(i))
-                   + 1); t <=
+                      stan::model::index_uni(i)) + 1); t <=
                  stan::model::rvalue(last, "last", stan::model::index_uni(i)); ++t) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
@@ -15779,7 +15789,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
         current_statement__ = 17;
         stan::math::validate_non_negative_index("chi", "n_occasions",
           n_occasions);
-        Eigen::Matrix<local_scalar_t__,-1,-1> inline_prob_uncaptured_chi_sym2__ =
+        Eigen::Matrix<local_scalar_t__,-1,-1>
+          inline_prob_uncaptured_chi_sym2__ =
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 26;
@@ -16237,7 +16248,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       {
         local_scalar_t__ inline_baz_lpdf_return_sym18__;
         {
-          local_scalar_t__ inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym19__;
+          local_scalar_t__
+            inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym19__;
           {
             current_statement__ = 3;
             inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym19__ = stan::math::normal_lpdf<
@@ -16964,8 +16976,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                 std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(R)},
                 std::vector<size_t>{static_cast<size_t>(R),
-                  static_cast<size_t>(T)},
-                std::vector<size_t>{},
+                  static_cast<size_t>(T)}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(R)},
                 std::vector<size_t>{static_cast<size_t>(R)}};
   }
@@ -17101,8 +17112,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"alpha_occ", "beta_occ",
-                                                  "alpha_p", "beta_p"};
+    constexpr std::array<const char*, 4>
+      names__{"alpha_occ", "beta_occ", "alpha_p", "beta_p"};
     const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -17757,12 +17768,11 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8> names__{"beta", "eta1", "eta2",
-                                                  "mu_a1", "mu_a2",
-                                                  "sigma_a1", "sigma_a2",
-                                                  "sigma_y"};
-    const std::array<Eigen::Index, 8> constrain_param_sizes__{1, J, J, 1, 1,
-                                                               1, 1, 1};
+    constexpr std::array<const char*, 8>
+      names__{"beta", "eta1", "eta2", "mu_a1", "mu_a2", "sigma_a1",
+              "sigma_a2", "sigma_y"};
+    const std::array<Eigen::Index, 8>
+      constrain_param_sizes__{1, J, J, 1, 1, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -18607,10 +18617,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"theta", "phi", "x_matrix",
-                                                  "x_vector", "x_cov"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{1, 1, (3 * 2),
-                                                               2, (2 * 2)};
+    constexpr std::array<const char*, 5>
+      names__{"theta", "phi", "x_matrix", "x_vector", "x_cov"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{1, 1, (3 * 2), 2, (2 * 2)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -19171,10 +19181,10 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5> names__{"a", "beta", "mu_a",
-                                                  "sigma_a", "sigma_y"};
-    const std::array<Eigen::Index, 5> constrain_param_sizes__{n_pair, 2, 1,
-                                                               1, 1};
+    constexpr std::array<const char*, 5>
+      names__{"a", "beta", "mu_a", "sigma_a", "sigma_y"};
+    const std::array<Eigen::Index, 5>
+      constrain_param_sizes__{n_pair, 2, 1, 1, 1};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -19599,8 +19609,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"m2", "m3"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(10 * 10), (10
-                                                               * 10)};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(10 * 10), (10 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -20036,8 +20046,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                 std::vector<size_t>{}, std::vector<size_t>{},
                 std::vector<size_t>{}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(I),
-                  static_cast<size_t>(K)},
-                std::vector<size_t>{}};
+                  static_cast<size_t>(K)}, std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -20143,11 +20152,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6> names__{"alpha0", "alpha1",
-                                                  "alpha2", "alpha12", "tau",
-                                                  "b"};
-    const std::array<Eigen::Index, 6> constrain_param_sizes__{1, 1, 1, 1, 1,
-                                                               (I * K)};
+    constexpr std::array<const char*, 6>
+      names__{"alpha0", "alpha1", "alpha2", "alpha12", "tau", "b"};
+    const std::array<Eigen::Index, 6>
+      constrain_param_sizes__{1, 1, 1, 1, 1, (I * K)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -1693,8 +1693,8 @@ class constraints_model final : public model_base_crtp<constraints_model> {
                 std::vector<size_t>{static_cast<size_t>(K),
                   static_cast<size_t>(K)},
                 std::vector<size_t>{static_cast<size_t>(K),
-                  static_cast<size_t>(K)},
-                std::vector<size_t>{}, std::vector<size_t>{},
+                  static_cast<size_t>(K)}, std::vector<size_t>{},
+                std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(N)},
                 std::vector<size_t>{static_cast<size_t>(Nr)},
                 std::vector<size_t>{static_cast<size_t>(Nr)},
@@ -2004,30 +2004,16 @@ class constraints_model final : public model_base_crtp<constraints_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 22> names__{"high_low_est", "b", "h",
-                                                   "ar", "ma", "phi_beta",
-                                                   "sigma2", "Intercept",
-                                                   "mean_price",
-                                                   "sigma_price", "theta",
-                                                   "upper_test",
-                                                   "lower_upper_test",
-                                                   "row_vec_lower_upper_test",
-                                                   "offset_mult_test",
-                                                   "ordered_test",
-                                                   "unit_vec_test",
-                                                   "pos_ordered_test",
-                                                   "corr_matrix_test",
-                                                   "cov_matrix_test",
-                                                   "chol_fac_cov_test",
-                                                   "chol_fac_corr_test"};
-    const std::array<Eigen::Index, 22> constrain_param_sizes__{N, K, Nr, 2,
-                                                                1, 1, 1, 1,
-                                                                N, N, 1, N,
-                                                                N, N, N, N,
-                                                                N, N, (N *
-                                                                N), (N * N),
-                                                                (K * K), (K *
-                                                                K)};
+    constexpr std::array<const char*, 22>
+      names__{"high_low_est", "b", "h", "ar", "ma", "phi_beta", "sigma2",
+              "Intercept", "mean_price", "sigma_price", "theta",
+              "upper_test", "lower_upper_test", "row_vec_lower_upper_test",
+              "offset_mult_test", "ordered_test", "unit_vec_test",
+              "pos_ordered_test", "corr_matrix_test", "cov_matrix_test",
+              "chol_fac_cov_test", "chol_fac_corr_test"};
+    const std::array<Eigen::Index, 22>
+      constrain_param_sizes__{N, K, Nr, 2, 1, 1, 1, 1, N, N, 1, N, N, N, N,
+                              N, N, N, (N * N), (N * N), (K * K), (K * K)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -3078,7 +3064,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
                              stan::conditional_var_value_t<local_scalar_t__,
                                Eigen::Matrix<local_scalar_t__,-1,1>>>(N);
       stan::conditional_var_value_t<local_scalar_t__,
-        Eigen::Matrix<local_scalar_t__,-1,1>> p_soa_used_with_aos_in_excluded_fun =
+        Eigen::Matrix<local_scalar_t__,-1,1>>
+        p_soa_used_with_aos_in_excluded_fun =
         stan::conditional_var_value_t<local_scalar_t__,
           Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(N,
                                                   std::numeric_limits<double>::quiet_NaN(
@@ -3088,7 +3075,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
                                               stan::conditional_var_value_t<local_scalar_t__,
                                                 Eigen::Matrix<local_scalar_t__,-1,1>>>(N);
       stan::conditional_var_value_t<local_scalar_t__,
-        Eigen::Matrix<local_scalar_t__,-1,-1>> p_soa_loop_mat_multi_uni_uni_idx =
+        Eigen::Matrix<local_scalar_t__,-1,-1>>
+        p_soa_loop_mat_multi_uni_uni_idx =
         stan::conditional_var_value_t<local_scalar_t__,
           Eigen::Matrix<local_scalar_t__,-1,-1>>(Eigen::Matrix<double,-1,-1>::Constant(N,
                                                    M,
@@ -3130,13 +3118,15 @@ class indexing_model final : public model_base_crtp<indexing_model> {
       current_statement__ = 17;
       p_aos_mat = in__.template read<
                     Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M);
-      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_pass_func_outer_single_indexed1 =
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_aos_mat_pass_func_outer_single_indexed1 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
       current_statement__ = 18;
       p_aos_mat_pass_func_outer_single_indexed1 = in__.template read<
                                                     Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
                                                     M);
-      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_pass_func_outer_single_indexed2 =
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_aos_mat_pass_func_outer_single_indexed2 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
       current_statement__ = 19;
       p_aos_mat_pass_func_outer_single_indexed2 = in__.template read<
@@ -3205,7 +3195,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         stan::math::validate_non_negative_index(
           "tp_soa_used_with_aos_in_excluded_fun", "N", N);
         stan::conditional_var_value_t<local_scalar_t__,
-          Eigen::Matrix<local_scalar_t__,-1,1>> tp_soa_used_with_aos_in_excluded_fun =
+          Eigen::Matrix<local_scalar_t__,-1,1>>
+          tp_soa_used_with_aos_in_excluded_fun =
           stan::conditional_var_value_t<local_scalar_t__,
             Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(N,
                                                     std::numeric_limits<double>::quiet_NaN(
@@ -3284,7 +3275,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         stan::math::validate_non_negative_index(
           "tp_soa_single_assign_from_soa", "N", N);
         stan::conditional_var_value_t<local_scalar_t__,
-          Eigen::Matrix<local_scalar_t__,-1,1>> tp_soa_single_assign_from_soa =
+          Eigen::Matrix<local_scalar_t__,-1,1>>
+          tp_soa_single_assign_from_soa =
           stan::conditional_var_value_t<local_scalar_t__,
             Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(N,
                                                     std::numeric_limits<double>::quiet_NaN(
@@ -3390,7 +3382,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         current_statement__ = 60;
         stan::math::validate_non_negative_index(
           "tp_aos_loop_vec_v_multi_uni_idx", "N", N);
-        Eigen::Matrix<local_scalar_t__,-1,1> tp_aos_loop_vec_v_multi_uni_idx =
+        Eigen::Matrix<local_scalar_t__,-1,1>
+          tp_aos_loop_vec_v_multi_uni_idx =
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
         current_statement__ = 68;
         for (int i = 1; i <= N; ++i) {
@@ -3792,7 +3785,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
           stan::model::index_uni(sym1__));
       }
       out__.write(p_soa_rhs_loop_mul);
-      Eigen::Matrix<local_scalar_t__,-1,1> p_soa_used_with_aos_in_excluded_fun =
+      Eigen::Matrix<local_scalar_t__,-1,1>
+        p_soa_used_with_aos_in_excluded_fun =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         stan::model::assign(p_soa_used_with_aos_in_excluded_fun,
@@ -3801,7 +3795,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
           stan::model::index_uni(sym1__));
       }
       out__.write(p_soa_used_with_aos_in_excluded_fun);
-      Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_loop_mat_multi_uni_uni_idx =
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_soa_loop_mat_multi_uni_uni_idx =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
       for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
@@ -3869,7 +3864,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         }
       }
       out__.write(p_aos_mat);
-      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_pass_func_outer_single_indexed1 =
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_aos_mat_pass_func_outer_single_indexed1 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
       for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
@@ -3880,7 +3876,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         }
       }
       out__.write(p_aos_mat_pass_func_outer_single_indexed1);
-      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_pass_func_outer_single_indexed2 =
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_aos_mat_pass_func_outer_single_indexed2 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
       for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
@@ -3966,8 +3963,7 @@ class indexing_model final : public model_base_crtp<indexing_model> {
                 std::vector<size_t>{static_cast<size_t>(N),
                   static_cast<size_t>(M)},
                 std::vector<size_t>{static_cast<size_t>(N),
-                  static_cast<size_t>(M)},
-                std::vector<size_t>{},
+                  static_cast<size_t>(M)}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(M)},
                 std::vector<size_t>{static_cast<size_t>(M)},
                 std::vector<size_t>{static_cast<size_t>(M)},
@@ -4313,36 +4309,22 @@ class indexing_model final : public model_base_crtp<indexing_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 21> names__{"alpha", "p_soa_vec_v",
-                                                   "p_soa_mat",
-                                                   "p_soa_arr_vec_v",
-                                                   "p_soa_mat_uni_col_idx",
-                                                   "p_soa_vec_uni_idx",
-                                                   "p_soa_loop_mat_uni_col_idx",
-                                                   "p_soa_lhs_loop_mul",
-                                                   "p_soa_rhs_loop_mul",
-                                                   "p_soa_used_with_aos_in_excluded_fun",
-                                                   "p_soa_loop_mat_multi_uni_uni_idx",
-                                                   "p_aos_vec_v_assign_to_aos",
-                                                   "p_aos_vec_v_tp_fails_func",
-                                                   "p_aos_loop_vec_v_uni_idx",
-                                                   "p_aos_fail_assign_from_top_idx",
-                                                   "p_aos_loop_mat_uni_uni_idx",
-                                                   "p_aos_mat",
-                                                   "p_aos_mat_pass_func_outer_single_indexed1",
-                                                   "p_aos_mat_pass_func_outer_single_indexed2",
-                                                   "p_aos_mat_fail_uni_uni_idx1",
-                                                   "p_aos_mat_fail_uni_uni_idx2"};
-    const std::array<Eigen::Index, 21> constrain_param_sizes__{1, M, (N * M),
-                                                                (10 * N), (N
-                                                                * M), N, (N *
-                                                                M), N, N, N,
-                                                                (N * M), M,
-                                                                M, M, M, (N *
-                                                                M), (N * M),
-                                                                (N * M), (N *
-                                                                M), (N * M),
-                                                                (N * M)};
+    constexpr std::array<const char*, 21>
+      names__{"alpha", "p_soa_vec_v", "p_soa_mat", "p_soa_arr_vec_v",
+              "p_soa_mat_uni_col_idx", "p_soa_vec_uni_idx",
+              "p_soa_loop_mat_uni_col_idx", "p_soa_lhs_loop_mul",
+              "p_soa_rhs_loop_mul", "p_soa_used_with_aos_in_excluded_fun",
+              "p_soa_loop_mat_multi_uni_uni_idx",
+              "p_aos_vec_v_assign_to_aos", "p_aos_vec_v_tp_fails_func",
+              "p_aos_loop_vec_v_uni_idx", "p_aos_fail_assign_from_top_idx",
+              "p_aos_loop_mat_uni_uni_idx", "p_aos_mat",
+              "p_aos_mat_pass_func_outer_single_indexed1",
+              "p_aos_mat_pass_func_outer_single_indexed2",
+              "p_aos_mat_fail_uni_uni_idx1", "p_aos_mat_fail_uni_uni_idx2"};
+    const std::array<Eigen::Index, 21>
+      constrain_param_sizes__{1, M, (N * M), (10 * N), (N * M), N, (N * M),
+                              N, N, N, (N * M), M, M, M, M, (N * M), (N * M),
+                              (N * M), (N * M), (N * M), (N * M)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -4491,7 +4473,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
         stan::math::validate_non_negative_index(
           "tp_soa_multi_idx_assign_in_loop", "N", N);
         stan::conditional_var_value_t<local_scalar_t__,
-          Eigen::Matrix<local_scalar_t__,-1,1>> tp_soa_multi_idx_assign_in_loop =
+          Eigen::Matrix<local_scalar_t__,-1,1>>
+          tp_soa_multi_idx_assign_in_loop =
           stan::conditional_var_value_t<local_scalar_t__,
             Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(N,
                                                     std::numeric_limits<double>::quiet_NaN(
@@ -4516,7 +4499,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
         stan::math::validate_non_negative_index(
           "tp_soa_single_idx_in_upfrom_idx", "N", N);
         stan::conditional_var_value_t<local_scalar_t__,
-          Eigen::Matrix<local_scalar_t__,-1,1>> tp_soa_single_idx_in_upfrom_idx =
+          Eigen::Matrix<local_scalar_t__,-1,1>>
+          tp_soa_single_idx_in_upfrom_idx =
           stan::conditional_var_value_t<local_scalar_t__,
             Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(N,
                                                     std::numeric_limits<double>::quiet_NaN(
@@ -4719,8 +4703,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"alpha",
-                                                  "p_aos_loop_single_idx"};
+    constexpr std::array<const char*, 2>
+      names__{"alpha", "p_aos_loop_single_idx"};
     const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 10};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
@@ -5114,8 +5098,7 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
                 std::vector<size_t>{static_cast<size_t>(5),
                   static_cast<size_t>(10)},
                 std::vector<size_t>{static_cast<size_t>(5),
-                  static_cast<size_t>(10)},
-                std::vector<size_t>{},
+                  static_cast<size_t>(10)}, std::vector<size_t>{},
                 std::vector<size_t>{static_cast<size_t>(5),
                   static_cast<size_t>(10)},
                 std::vector<size_t>{static_cast<size_t>(5),
@@ -5268,8 +5251,8 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 3> names__{"soa_x", "aos_x", "aos_y"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{(5 * 10), (5 *
-                                                               10), (5 * 10)};
+    const std::array<Eigen::Index, 3>
+      constrain_param_sizes__{(5 * 10), (5 * 10), (5 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -5827,8 +5810,8 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"row_soa", "udf_input_aos"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(10 * 10), (10
-                                                               * 10)};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(10 * 10), (10 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -6121,8 +6104,7 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
                                                                     10),
                                                  static_cast<size_t>(10)},
                 std::vector<size_t>{static_cast<size_t>(10),
-                  static_cast<size_t>(10)},
-                std::vector<size_t>{}};
+                  static_cast<size_t>(10)}, std::vector<size_t>{}};
   }
   inline void
   constrained_param_names(std::vector<std::string>& param_names__, bool
@@ -6231,8 +6213,8 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"aos_p", "soa_p"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(10 * 10), (10
-                                                               * 10)};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(10 * 10), (10 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);
@@ -6685,8 +6667,8 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
     constexpr std::array<const char*, 2> names__{"first_pass_soa_x", "aos_x"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{(5 * 10), (5 *
-                                                               10)};
+    const std::array<Eigen::Index, 2>
+      constrain_param_sizes__{(5 * 10), (5 * 10)};
     const auto num_constrained_params__ =
       std::accumulate(constrain_param_sizes__.begin(),
         constrain_param_sizes__.end(), 0);


### PR DESCRIPTION
Follow on to #1233, fixes a mispelled type (`Initalizer` instead of `Initializer`) and formats it closer to how clang-format does

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
