### PR TITLE
[CI] Define git author and commiter information as environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,10 @@ pipeline {
     environment {
         CXX = 'clang++-6.0'
         PARALLEL = 4
+        GIT_AUTHOR_NAME = 'Stan Jenkins'
+        GIT_AUTHOR_EMAIL = 'mc.stanislaw@gmail.com'
+        GIT_COMMITTER_NAME = 'Stan Jenkins'
+        GIT_COMMITTER_EMAIL = 'mc.stanislaw@gmail.com'
     }
     stages {
         stage('Kill previous builds') {
@@ -948,9 +952,6 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
                     sh """#!/bin/bash
                         set -e
-
-                        git config --global user.email "mc.stanislaw@gmail.com"
-                        git config --global user.name "Stan Jenkins"
 
                         git checkout --detach
                         git branch -D gh-pages


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fix an issue in CI where commits (mostly merges) from Jenkins are coming from a default user ( default git plugin author ). See https://github.com/stan-dev/stan/pull/3153 as an example.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
