### PR TITLE
Expose complex overloads for eigendecomposition

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -1176,6 +1176,10 @@ let () =
   add_nullary "e" ;
   add_unqualified ("eigenvalues", ReturnType UComplexVector, [UMatrix], AoS) ;
   add_unqualified ("eigenvectors", ReturnType UComplexMatrix, [UMatrix], AoS) ;
+  add_unqualified
+    ("eigenvalues", ReturnType UComplexVector, [UComplexMatrix], AoS) ;
+  add_unqualified
+    ("eigenvectors", ReturnType UComplexMatrix, [UComplexMatrix], AoS) ;
   add_unqualified ("eigenvalues_sym", ReturnType UVector, [UMatrix], AoS) ;
   add_unqualified
     ("eigenvalues_sym", ReturnType UComplexVector, [UComplexMatrix], AoS) ;

--- a/test/integration/good/function-signatures/math/matrix/eigenvalues.stan
+++ b/test/integration/good/function-signatures/math/matrix/eigenvalues.stan
@@ -1,23 +1,28 @@
 data {
   int d_int;
-  matrix[d_int,d_int] d_matrix;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_cmatrix;
 }
-
 transformed data {
   complex_vector[d_int] transformed_data_vector;
-
+  
   transformed_data_vector = eigenvalues(d_matrix);
+  transformed_data_vector = eigenvalues(d_cmatrix);
 }
 parameters {
   real y_p;
-  matrix[d_int,d_int] p_matrix;
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_cmatrix;
 }
 transformed parameters {
   complex_vector[d_int] transformed_param_vector;
-
+  
   transformed_param_vector = eigenvalues(d_matrix);
   transformed_param_vector = eigenvalues(p_matrix);
+  
+  transformed_param_vector = eigenvalues(d_cmatrix);
+  transformed_param_vector = eigenvalues(p_cmatrix);
 }
 model {
-  y_p ~ normal(0,1);
+  y_p ~ normal(0, 1);
 }

--- a/test/integration/good/function-signatures/math/matrix/eigenvectors.stan
+++ b/test/integration/good/function-signatures/math/matrix/eigenvectors.stan
@@ -1,23 +1,28 @@
 data {
   int d_int;
-  matrix[d_int,d_int] d_matrix;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_cmatrix;
 }
-
 transformed data {
-  complex_matrix[d_int,d_int] transformed_data_matrix;
-
+  complex_matrix[d_int, d_int] transformed_data_matrix;
+  
   transformed_data_matrix = eigenvectors(d_matrix);
+  transformed_data_matrix = eigenvectors(d_cmatrix);
 }
 parameters {
   real y_p;
-  matrix[d_int,d_int] p_matrix;
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_cmatrix;
 }
 transformed parameters {
-  complex_matrix[d_int,d_int] transformed_param_matrix;
-
+  complex_matrix[d_int, d_int] transformed_param_matrix;
+  
   transformed_param_matrix = eigenvectors(d_matrix);
   transformed_param_matrix = eigenvectors(p_matrix);
+  
+  transformed_param_matrix = eigenvectors(d_cmatrix);
+  transformed_param_matrix = eigenvectors(p_cmatrix);
 }
 model {
-  y_p ~ normal(0,1);
+  y_p ~ normal(0, 1);
 }

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -4620,9 +4620,11 @@ Display all Stan math signatures exposed in the language
   double_exponential_rng(array[] real, array[] real) => array[] real
   e() => real
   eigenvalues(matrix) => complex_vector
+  eigenvalues(complex_matrix) => complex_vector
   eigenvalues_sym(matrix) => vector
   eigenvalues_sym(complex_matrix) => complex_vector
   eigenvectors(matrix) => complex_matrix
+  eigenvectors(complex_matrix) => complex_matrix
   eigenvectors_sym(matrix) => matrix
   eigenvectors_sym(complex_matrix) => complex_matrix
   elt_divide(int, int) => int


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: https://github.com/stan-dev/docs/pull/617
   
## Release notes

Adds overloads to `eigenvalues` and `eigenvectors` which accept a complex matrix as input. From https://github.com/stan-dev/math/pull/2846

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
