### PR TITLE
Added -u flag to ghr call to avoid random ci failure.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -898,7 +898,7 @@ pipeline {
                 runShell("""
                     wget https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz
                     tar -zxvpf ghr_v0.12.1_linux_amd64.tar.gz
-                    ./ghr_v0.12.1_linux_amd64/ghr -recreate ${tagName()} bin/
+                    ./ghr_v0.12.1_linux_amd64/ghr -u stan-buildbot -recreate ${tagName()} bin/
                 """)
             }
         }


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

A [CI failure](https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FStanc3/detail/master/168/pipeline/) has been reported in which the ghr call was failing with the [following error](https://github.com/tcnksm/ghr/blob/master/cli.go#L197):
`Failed to set up ghr: repository owner name not found`
In order to ensure this will not randomly fail in the future, we are passing the `-u` flag pointing to our CI username [stan-buildbot](https://github.com/stan-buildbot).


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
