### PR TITLE
Skip m1 label when building on osx.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -592,7 +592,7 @@ pipeline {
                         beforeAgent true
                         expression { !skipRebuildingBinaries }
                     }
-                    agent { label 'osx' }
+                    agent { label 'osx && !m1' }
                     steps {
                         dir("${env.WORKSPACE}/osx"){
                             unstash "Stanc3Setup"


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Flatiron Jenkins has added a new Mac M1 machine, it has the same `osx` label as we were requesting before so the pipeline started using that also when available, which might have caused some extra warnings ( above the quality gate ) and some errors in a PR.
This PR will ensure we are using the non-m1 osx machine, at least until we will properly test it and ensure everything is working fine.
Many thanks to @WardBrian for figuring this out quickly.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
