### PR TITLE
Revert "Added -u flag to ghr call to avoid random ci failure."

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -898,7 +898,7 @@ pipeline {
                 runShell("""
                     wget https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz
                     tar -zxvpf ghr_v0.12.1_linux_amd64.tar.gz
-                    ./ghr_v0.12.1_linux_amd64/ghr -u stan-buildbot -recreate ${tagName()} bin/
+                    ./ghr_v0.12.1_linux_amd64/ghr -recreate ${tagName()} bin/
                 """)
             }
         }


### PR DESCRIPTION
Reverts stan-dev/stanc3#1283

This appears to have broken uploads, which are now targetting `https://api.github.com/repos/stan-buildbot/stanc3/release` which does not exist