### PR TITLE
Update GHA build for Node 12 deprecation

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -51,7 +51,7 @@ jobs:
       - run: mv _build/default/src/stanc/stanc.exe ${{ matrix.os }}-stanc
 
       - name: Upload ${{ matrix.os }} stanc
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}-stanc
           path: ${{ matrix.os }}-stanc
@@ -85,7 +85,7 @@ jobs:
       - run: mv _build/default.windows/src/stanc/stanc.exe windows-stanc
 
       - name: Upload Windows stanc
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-stanc
           path: windows-stanc
@@ -97,7 +97,7 @@ jobs:
       - run: mv _build/default/src/stancjs/stancjs.bc.js stanc.js
 
       - name: Upload stanc.js
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: stanc.js
           path: stanc.js


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Update to remove Node 12 based actions due to warnings: https://github.com/stan-dev/stanc3/actions/runs/4379746524


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
