### PR TITLE
In case of failure when uploading binaries, save them as artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -901,6 +901,11 @@ pipeline {
                     ./ghr_v0.12.1_linux_amd64/ghr -u stan-dev -recreate ${tagName()} bin/
                 """)
             }
+            post {
+                failure {
+                    archiveArtifacts 'bin/*'
+                }
+            }
         }
 
         stage('Upload odoc') {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

I had a talk with Brian earlier on, sometimes in rare cases the release pipeline might fail ( recently happened because of a GitHub change, the next one went back to normal ).
For that reason, we want to still have the binaries available in Jenkins when a failure like this occurs.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
