### PR TITLE
Use std::endl to flush Stan prints

### DIFF
--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -81,6 +81,7 @@ type expr =
   | TernaryIf of expr * expr * expr
   | Cast of type_ * expr
   | Index of expr * expr
+  | Deref of expr
   | AllocNew of type_ * expr list
   | OperatorNew of identifier * type_ * expr list
       (** See {{:https://en.cppreference.com/w/cpp/memory/new/operator_new}operator new} for distinctions between
@@ -473,6 +474,7 @@ module Printing = struct
     | TernaryIf (e1, e2, e3) ->
         pf ppf "%a ? %a : %a" pp_expr e1 pp_expr e2 pp_expr e3
     | Index (e1, e2) -> pf ppf "%a[%a]" pp_expr e1 pp_expr e2
+    | Deref e -> pf ppf "*(%a)" pp_expr e
     | Assign (e1, e2) -> pf ppf "%a = %a" pp_expr e1 pp_expr e2
     | PMinus e -> pf ppf "-%a" pp_expr e
     | Increment e -> pf ppf "++%a" pp_expr e

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -2696,7 +2696,7 @@ void bar(const T0__& x, const T1__& y, std::ostream* pstream__) {
     current_statement__ = 9;
     if (pstream__) {
       stan::math::stan_print(pstream__, (x / y));
-      stan::math::stan_print(pstream__, "\n");
+      *(pstream__) << std::endl;
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2734,7 +2734,7 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
       if (pstream__) {
         stan::math::stan_print(pstream__, "x = ");
         stan::math::stan_print(pstream__, x);
-        stan::math::stan_print(pstream__, "\n");
+        *(pstream__) << std::endl;
       }
       current_statement__ = 6;
       bar(static_cast<double>(1), static_cast<double>(2), pstream__);
@@ -2777,7 +2777,7 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
       if (pstream__) {
         stan::math::stan_print(pstream__, "x2 = ");
         stan::math::stan_print(pstream__, x2);
-        stan::math::stan_print(pstream__, "\n");
+        *(pstream__) << std::endl;
       }
       current_statement__ = 3;
       bar(static_cast<double>(1), static_cast<double>(2), pstream__);
@@ -5392,7 +5392,7 @@ f0(const int& a1, const std::vector<int>& a2,
     current_statement__ = 737;
     if (pstream__) {
       stan::math::stan_print(pstream__, "hi");
-      stan::math::stan_print(pstream__, "\n");
+      *(pstream__) << std::endl;
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7638,7 +7638,7 @@ class mother_model final : public model_base_crtp<mother_model> {
             stan::math::stan_print(pstream__, j);
             stan::math::stan_print(pstream__, " matrix: ");
             stan::math::stan_print(pstream__, l_mat);
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
       }
@@ -21111,13 +21111,13 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
       current_statement__ = 1;
       if (pstream__) {
         stan::math::stan_print(pstream__, "test: \320\211\360\237\230\203");
-        stan::math::stan_print(pstream__, "\n");
+        *(pstream__) << std::endl;
       }
       current_statement__ = 2;
       if (pstream__) {
         stan::math::stan_print(pstream__,
           "\316\273 \316\262 \316\266 \317\200");
-        stan::math::stan_print(pstream__, "\n");
+        *(pstream__) << std::endl;
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22016,7 +22016,7 @@ void test6(const T0__& alpha_arg__, std::ostream* pstream__) {
       if (pstream__) {
         stan::math::stan_print(pstream__,
           stan::model::rvalue(alpha, "alpha", stan::model::index_uni(1)));
-        stan::math::stan_print(pstream__, "\n");
+        *(pstream__) << std::endl;
       }
     } else {
       current_statement__ = 32;
@@ -28908,7 +28908,7 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
         current_statement__ = 45;
         if (pstream__) {
           stan::math::stan_print(pstream__, "hello world");
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
       }
     } catch (const std::exception& e) {

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -3543,8 +3543,7 @@
               (FunCall stan::math::stan_print ()
                ((Var pstream__) (Literal "\"hi\""))))
              (Expression
-              (FunCall stan::math::stan_print ()
-               ((Var pstream__) (Literal "\"\\n\""))))))
+              (StreamInsertion (Deref (Var pstream__)) ((Literal std::endl))))))
            ()))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
@@ -17979,8 +17978,8 @@
                      (FunCall stan::math::stan_print ()
                       ((Var pstream__) (Var l_mat))))
                     (Expression
-                     (FunCall stan::math::stan_print ()
-                      ((Var pstream__) (Literal "\"\\n\""))))))
+                     (StreamInsertion (Deref (Var pstream__))
+                      ((Literal std::endl))))))
                   ())))))))
            (Expression (Assign (Var current_statement__) (Literal 347)))
            (Expression

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -874,7 +874,7 @@ simple_SIR(const T0__& t, const T1__& y_arg__, const T2__& beta, const T3__&
     current_statement__ = 48;
     if (pstream__) {
       stan::math::stan_print(pstream__, unused);
-      stan::math::stan_print(pstream__, "\n");
+      *(pstream__) << std::endl;
     }
     current_statement__ = 49;
     stan::model::assign(dydt, (((-beta *

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -28202,7 +28202,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         if (pstream__) {
           stan::math::stan_print(pstream__, inline_rfun_return_sym2__);
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
         int inline_rfun_return_sym5__;
         int inline_rfun_early_ret_check_sym6__ =
@@ -28220,7 +28220,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 11;
           if (pstream__) {
             stan::math::stan_print(pstream__, "a");
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
         int inline_rfun_return_sym8__;
@@ -28621,7 +28621,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 74;
           if (pstream__) {
             stan::math::stan_print(pstream__, "hello");
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
         double temp2 = std::numeric_limits<double>::quiet_NaN();
@@ -29980,7 +29980,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 14;
         if (pstream__) {
           stan::math::stan_print(pstream__, lcm_sym16__);
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
         lcm_sym15__ = stan::math::to_complex(5, 4);
         current_statement__ = 15;

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -17991,14 +17991,14 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 8;
         if (pstream__) {
           stan::math::stan_print(pstream__, rfun(3, pstream__));
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
         current_statement__ = 10;
         if (rfun(4, pstream__)) {
           current_statement__ = 9;
           if (pstream__) {
             stan::math::stan_print(pstream__, "a");
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
         current_statement__ = 14;
@@ -18215,7 +18215,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 117;
           if (pstream__) {
             stan::math::stan_print(pstream__, "hello");
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
         current_statement__ = 120;
@@ -19455,7 +19455,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 14;
         if (pstream__) {
           stan::math::stan_print(pstream__, z);
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
         current_statement__ = 15;
         z = (stan::math::to_complex(0, 4) + 5);

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -19342,7 +19342,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         if (pstream__) {
           stan::math::stan_print(pstream__, inline_rfun_return_sym2__);
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
         int inline_rfun_return_sym5__;
         int inline_rfun_early_ret_check_sym6__ =
@@ -19360,7 +19360,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 11;
           if (pstream__) {
             stan::math::stan_print(pstream__, "a");
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
         int inline_rfun_return_sym8__;
@@ -19582,7 +19582,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 78;
           if (pstream__) {
             stan::math::stan_print(pstream__, "hello");
-            stan::math::stan_print(pstream__, "\n");
+            *(pstream__) << std::endl;
           }
         }
         local_scalar_t__ temp2 = DUMMY_VAR__;
@@ -20805,7 +20805,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 14;
         if (pstream__) {
           stan::math::stan_print(pstream__, z);
-          stan::math::stan_print(pstream__, "\n");
+          *(pstream__) << std::endl;
         }
         current_statement__ = 15;
         z = stan::math::to_complex(5, 4);


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

When printing we currently just append a `\n` character, but this will not always cause the print to flush.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
