### PR TITLE
Speed up Location.of_position_opt

### DIFF
--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -1,7 +1,6 @@
 (** Delimited locations in source code *)
 
 open Core_kernel
-open Core_kernel.Poly
 
 type t = {begin_loc: Location.t; end_loc: Location.t}
 [@@deriving sexp, hash, compare]
@@ -16,7 +15,7 @@ let to_string ?printed_filename {begin_loc; end_loc} =
     | None ->
         " to "
         ^ Location.to_string
-            ~print_file:(begin_loc.filename <> end_loc.filename)
+            ~print_file:(not @@ String.equal begin_loc.filename end_loc.filename)
             ~print_line:(begin_loc.line_num <> end_loc.line_num)
             end_loc
     | Some _ -> "" in


### PR DESCRIPTION
I have been playing around with profiling using [Landmarks](https://github.com/LexiFi/landmarks) and I found something kind of surprising: `Location.of_position_opt` is currently a pretty massive time waster in the compiler.

Of the ~78 million clock cycles spent in `Parse.parse_file` for the model I was benchmarking against, ~66 million of them are _just_ calling `Location.of_position_opt`, because basically every token wants to turn a `Lexing.position` into a `Location_span.t`. And, we're using an unnecessary and slow regex search in every one of those calls.

This re-writes that function to no-longer need to do a regex search. This changes the profiler output (name; location; calls; cycles) from

```
Location.of_position_opt; src/middle/Location.ml:122; 941; 66.38M
```
to
```
Location.of_position_opt; src/middle/Location.ml:124; 941; 911.59K
```

For the `motherHOF.stan` test file this change nearly halves the wall-clock time for the compiler to run.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Speeds up some code which is critical to parsing.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
