### PR TITLE
Update generated `transform_inits_impl` to directly accept a var_context.

### DIFF
--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -499,6 +499,8 @@ let function_inlining (mir : Program.Typed.t) =
            autodiff_inline_map ) in
   { mir with
     transform_inits= autodiffable_inline_function_statements mir.transform_inits
+  ; unconstrain_array=
+      autodiffable_inline_function_statements mir.unconstrain_array
   ; log_prob= autodiffable_inline_function_statements mir.log_prob
   ; generate_quantities=
       dataonly_inline_function_statements mir.generate_quantities }
@@ -864,6 +866,7 @@ let transform_mir_blocks (mir : (Expr.Typed.t, Stmt.Located.t) Program.t)
   ; log_prob= transformer mir.log_prob
   ; generate_quantities= transformer mir.generate_quantities
   ; transform_inits= transformer mir.transform_inits
+  ; unconstrain_array= transformer mir.unconstrain_array
   ; output_vars= mir.output_vars
   ; prog_name= mir.prog_name
   ; prog_path= mir.prog_path }

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -812,8 +812,9 @@ let trans_prog filename (p : Ast.typed_program) : Program.Typed.t =
     trans_block ud_dists
       {transform_action= Constrain; dadlevel= AutoDiffable}
       Parameters p in
-  (* Backends will add to transform_inits as needed *)
+  (* Backends will add to transform_inits and unconstrain_array as needed *)
   let transform_inits = [] in
+  let unconstrain_array = [] in
   let out_param, paramsizes, param_gq =
     trans_block ud_dists {declc with transform_action= Constrain} Parameters p
   in
@@ -882,6 +883,7 @@ let trans_prog filename (p : Ast.typed_program) : Program.Typed.t =
   ; log_prob
   ; generate_quantities
   ; transform_inits
+  ; unconstrain_array
   ; output_vars
   ; prog_name= normalize_prog_name !Typechecker.model_name
   ; prog_path= filename }

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -9,7 +9,7 @@ type 'expr t =
   | FnNegInf
   (* In AST_to_MIR being used as StanLib *)
   | FnReadData
-  | FnReadSerializer
+  | FnReadDeserializer
   (* XXX move these to a backend specific file?*)
   | FnReadParam of
       { constrain: 'expr Transformation.t
@@ -45,13 +45,13 @@ let pp (pp_expr : 'a Fmt.t) ppf internal =
 
 (* Does this function call change state? Can we call it twice with the same results?
 
-   E.g., FnReadSerializer moves the serializer forward, so calling it again has
+   E.g., FnReadDeserializer moves the serializer forward, so calling it again has
    different results
 
    Useful for optimizations
 *)
 let can_side_effect = function
-  | FnReadParam _ | FnReadData | FnReadSerializer | FnWriteParam _
+  | FnReadParam _ | FnReadData | FnReadDeserializer | FnWriteParam _
    |FnValidateSize | FnValidateSizeSimplex | FnValidateSizeUnitVector
    |FnReadWriteEventsOpenCL _ ->
       true

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -45,10 +45,10 @@ let pp (pp_expr : 'a Fmt.t) ppf internal =
 
 (* Does this function call change state? Can we call it twice with the same results?
 
-   E.g., FnReadDeserializer moves the serializer forward, so calling it again has
-   different results
+   E.g., FnReadDeserializer moves the deserializer forward, so calling it again has
+    different results
 
-   Useful for optimizations
+    Useful for optimizations
 *)
 let can_side_effect = function
   | FnReadParam _ | FnReadData | FnReadDeserializer | FnWriteParam _

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -9,7 +9,7 @@ type 'expr t =
   | FnNegInf
   (* In AST_to_MIR being used as StanLib *)
   | FnReadData
-  | FnReadDataSerializer
+  | FnReadSerializer
   (* XXX move these to a backend specific file?*)
   | FnReadParam of
       { constrain: 'expr Transformation.t
@@ -45,13 +45,13 @@ let pp (pp_expr : 'a Fmt.t) ppf internal =
 
 (* Does this function call change state? Can we call it twice with the same results?
 
-   E.g., FnReadDataSerializer moves the serializer forward, so calling it again has
+   E.g., FnReadSerializer moves the serializer forward, so calling it again has
    different results
 
    Useful for optimizations
 *)
 let can_side_effect = function
-  | FnReadParam _ | FnReadData | FnReadDataSerializer | FnWriteParam _
+  | FnReadParam _ | FnReadData | FnReadSerializer | FnWriteParam _
    |FnValidateSize | FnValidateSizeSimplex | FnValidateSizeUnitVector
    |FnReadWriteEventsOpenCL _ ->
       true

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -33,7 +33,11 @@ type ('a, 'b) t =
   ; log_prob: 'b list (*assumes data & params are in scope and ready*)
   ; generate_quantities: 'b list
         (* assumes data & params ready & in scope*)
-        (* TODO the following two items are really backend-specific *)
+        (* NOTE: the following two items are really backend-specific,
+           and are set to [] by Ast_to_mir before being populated in
+           Stan_math_backend.Transform_Mir.
+           It would be nice to abstract this out somehow
+        *)
   ; transform_inits: 'b list
   ; unconstrain_array: 'b list
   ; output_vars: (string * 'a outvar) list

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -31,8 +31,11 @@ type ('a, 'b) t =
   ; input_vars: (string * 'a SizedType.t) list
   ; prepare_data: 'b list (* data & transformed data decls and statements *)
   ; log_prob: 'b list (*assumes data & params are in scope and ready*)
-  ; generate_quantities: 'b list (* assumes data & params ready & in scope*)
+  ; generate_quantities: 'b list
+        (* assumes data & params ready & in scope*)
+        (* TODO the following two items are really backend-specific *)
   ; transform_inits: 'b list
+  ; unconstrain_array: 'b list
   ; output_vars: (string * 'a outvar) list
   ; prog_name: string
   ; prog_path: string }

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -41,13 +41,6 @@ type ('a, 'b) t =
   ; prog_path: string }
 [@@deriving sexp, map, fold]
 
-let map_stmts f p =
-  { p with
-    prepare_data= f p.prepare_data
-  ; log_prob= f p.log_prob
-  ; generate_quantities= f p.generate_quantities
-  ; transform_inits= f p.transform_inits }
-
 (* -- Pretty printers -- *)
 let pp_fun_arg_decl ppf (autodifftype, name, unsizedtype) =
   Fmt.pf ppf "%a%a %s" UnsizedType.pp_autodifftype autodifftype UnsizedType.pp

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -97,12 +97,21 @@ let is_recursive_container st =
 (** Return a type's array dimensions and the type inside the (possibly nested) array *)
 let rec get_array_dims st =
   match st with
-  | SInt | SReal | SComplex | SVector _ | SRowVector _ | SComplexVector _
-   |SComplexRowVector _ | SMatrix _ | SComplexMatrix _ ->
-      (st, [])
+  | SInt | SReal | SComplex -> (st, [])
+  | SVector (_, d) | SRowVector (_, d) | SComplexVector d | SComplexRowVector d
+    ->
+      (st, [d])
+  | SMatrix (_, d1, d2) | SComplexMatrix (d1, d2) -> (st, [d1; d2])
   | SArray (st, dim) ->
       let st', dims = get_array_dims st in
       (st', dim :: dims)
+
+let rec internal_scalar st =
+  match st with
+  | SInt | SReal | SComplex -> st
+  | SVector _ | SRowVector _ | SMatrix _ -> SReal
+  | SComplexVector _ | SComplexRowVector _ | SComplexMatrix _ -> SComplex
+  | SArray (t, _) -> internal_scalar t
 
 let num_elems_expr st =
   Expr.Helpers.binop_list (get_dims_io st) Operator.Times

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -97,11 +97,9 @@ let is_recursive_container st =
 (** Return a type's array dimensions and the type inside the (possibly nested) array *)
 let rec get_array_dims st =
   match st with
-  | SInt | SReal | SComplex -> (st, [])
-  | SVector (_, d) | SRowVector (_, d) | SComplexVector d | SComplexRowVector d
-    ->
-      (st, [d])
-  | SMatrix (_, d1, d2) | SComplexMatrix (d1, d2) -> (st, [d1; d2])
+  | SInt | SReal | SComplex | SVector _ | SRowVector _ | SComplexVector _
+   |SComplexRowVector _ | SMatrix _ | SComplexMatrix _ ->
+      (st, [])
   | SArray (st, dim) ->
       let st', dims = get_array_dims st in
       (st', dim :: dims)

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -424,8 +424,8 @@ and lower_compiler_internal ad ut f es =
   | FnReadData -> read_data ut es
   | FnReadDataSerializer ->
       serializer_in.@<>(( "read"
-                        , [lower_unsizedtype_local AutoDiffable UReal]
-                        , [] ))
+                        , [lower_unsizedtype_local AutoDiffable ut]
+                        , lower_exprs es ))
   | FnReadParam {constrain; dims; mem_pattern} -> (
       let constrain_opt = constraint_to_string constrain in
       match constrain_opt with

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -422,7 +422,7 @@ and lower_compiler_internal ad ut f es =
           [%message
             "Unexpected type for row vector literal" (ut : UnsizedType.t)] )
   | FnReadData -> read_data ut es
-  | FnReadDataSerializer ->
+  | FnReadSerializer ->
       serializer_in.@<>(( "read"
                         , [lower_unsizedtype_local AutoDiffable ut]
                         , lower_exprs es ))

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -103,7 +103,7 @@ let templates udf suffix =
   | FnTarget when udf -> [TemplateType "propto__"]
   | _ -> []
 
-let serializer_in = Var "in__"
+let deserializer = Var "in__"
 
 let rec local_scalar ut ad =
   match (ut, ad) with
@@ -422,27 +422,27 @@ and lower_compiler_internal ad ut f es =
           [%message
             "Unexpected type for row vector literal" (ut : UnsizedType.t)] )
   | FnReadData -> read_data ut es
-  | FnReadSerializer ->
-      serializer_in.@<>(( "read"
-                        , [lower_unsizedtype_local AutoDiffable ut]
-                        , lower_exprs es ))
+  | FnReadDeserializer ->
+      deserializer.@<>(( "read"
+                       , [lower_unsizedtype_local AutoDiffable ut]
+                       , lower_exprs es ))
   | FnReadParam {constrain; dims; mem_pattern} -> (
       let constrain_opt = constraint_to_string constrain in
       match constrain_opt with
       | None ->
-          serializer_in.@<>(( "template read"
-                            , [ lower_possibly_var_decl AutoDiffable ut
-                                  mem_pattern ]
-                            , lower_exprs dims ))
+          deserializer.@<>(( "template read"
+                           , [ lower_possibly_var_decl AutoDiffable ut
+                                 mem_pattern ]
+                           , lower_exprs dims ))
       | Some constraint_string ->
           let constraint_args = transform_args constrain in
           let lp =
             Expr.Fixed.{pattern= Var "lp__"; meta= Expr.Typed.Meta.empty} in
           let args = constraint_args @ [lp] @ dims in
-          serializer_in.@<>(( "template read_constrain_" ^ constraint_string
-                            , [ lower_possibly_var_decl AutoDiffable ut
-                                  mem_pattern; TemplateType "jacobian__" ]
-                            , lower_exprs args )) )
+          deserializer.@<>(( "template read_constrain_" ^ constraint_string
+                           , [ lower_possibly_var_decl AutoDiffable ut
+                                 mem_pattern; TemplateType "jacobian__" ]
+                           , lower_exprs args )) )
   | FnDeepCopy ->
       lower_fun_app Fun_kind.FnPlain "stan::model::deep_copy" es Mem_pattern.AoS
         (Some UnsizedType.Void)

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -15,12 +15,6 @@ let get_unconstrained_param_st lst =
       Some (SizedType.get_dims_io st)
   | _ -> None
 
-let get_constrained_param_st lst =
-  match lst with
-  | _, {Program.out_block= Parameters; out_constrained_st= st; _} ->
-      Some (SizedType.get_dims_io st)
-  | _ -> None
-
 let lower_num_param (dims : Expr.Typed.t list) =
   match List.reduce ~f:Expression_syntax.( * ) (lower_exprs dims) with
   | Some d when List.length dims = 1 -> d
@@ -279,13 +273,31 @@ let gen_write_array {Program.prog_name; generate_quantities; _} =
 
 let gen_transform_inits_impl {Program.transform_inits; _} =
   let templates =
+    [Typename "VecVar"; Require ("stan::require_vector_t", ["VecVar"])] in
+  let args =
+    [ (Types.const_ref (TypeLiteral "stan::io::var_context"), "context__")
+    ; (Ref (TemplateType "VecVar"), "vars__")
+    ; (Pointer (TypeLiteral "std::ostream"), "pstream__ = nullptr") ] in
+  let intro =
+    [ Using ("local_scalar_t__", Some Double); Decls.serializer_out
+    ; Decls.current_statement ]
+    @ Decls.dummy_var in
+  FunDef
+    (make_fun_defn
+       ~templates_init:([templates], true)
+       ~inline:true ~return_type:Void ~name:"transform_inits_impl" ~args
+       ~body:(intro @ [Stmts.rethrow_located (lower_statements transform_inits)])
+       ~cv_qualifiers:[Const] () )
+
+let gen_unconstrain_array_impl {Program.unconstrain_array; _} =
+  let templates =
     [ Typename "VecVar"; Typename "VecI"
     ; Require ("stan::require_vector_t", ["VecVar"])
     ; Require ("stan::require_vector_like_vt", ["std::is_integral"; "VecI"]) ]
   in
   let args =
-    [ (Ref (TemplateType "VecVar"), "params_r__")
-    ; (Ref (TemplateType "VecI"), "params_i__")
+    [ (Types.const_ref (TemplateType "VecVar"), "params_r__")
+    ; (Types.const_ref (TemplateType "VecI"), "params_i__")
     ; (Ref (TemplateType "VecVar"), "vars__")
     ; (Pointer (TypeLiteral "std::ostream"), "pstream__ = nullptr") ] in
   let intro =
@@ -295,8 +307,9 @@ let gen_transform_inits_impl {Program.transform_inits; _} =
   FunDef
     (make_fun_defn
        ~templates_init:([templates], true)
-       ~inline:true ~return_type:Void ~name:"transform_inits_impl" ~args
-       ~body:(intro @ [Stmts.rethrow_located (lower_statements transform_inits)])
+       ~inline:true ~return_type:Void ~name:"unconstrain_array_impl" ~args
+       ~body:
+         (intro @ [Stmts.rethrow_located (lower_statements unconstrain_array)])
        ~cv_qualifiers:[Const] () )
 
 let gen_extend_vector name type_ elts =
@@ -653,112 +666,53 @@ let gen_overloads {Program.output_vars; _} =
                           let open Expression_syntax in
                           [params_r_vec.@!("data"); params_r_vec.@!("size")] )
                     ) ) ]
-           ~cv_qualifiers:[Const; Final] () ) ] in
+           ~cv_qualifiers:[Const; Final] () )
+    ; (let args =
+         [ (Types.const_ref (TypeLiteral "stan::io::var_context"), "context")
+         ; (Ref (Types.std_vector Int), "params_i")
+         ; (Ref (Types.std_vector Double), "vars")
+         ; (Pointer (TypeLiteral "std::ostream"), "pstream__ = nullptr") ] in
+       let body =
+         let open Expression_syntax in
+         [ Expression (Var "vars").@?(("resize", [Var "num_params_r__"]))
+         ; Expression
+             (Exprs.fun_call "transform_inits_impl"
+                [Var "context"; Var "vars"; Var "pstream__"] ) ] in
+       FunDef
+         (make_fun_defn ~inline:true ~return_type:Void ~name:"transform_inits"
+            ~args ~body ~cv_qualifiers:[Const] () ) ) ] in
+  let unconstrain_array =
+    let open Expression_syntax in
+    [ FunDef
+        (make_fun_defn ~inline:true ~return_type:Void ~name:"unconstrain_array"
+           ~args:
+             [ (Types.const_ref (Types.std_vector Double), "params_constrained")
+             ; (Ref (Types.std_vector Double), "params_unconstrained"); pstream
+             ]
+           ~body:
+             [ VariableDefn
+                 (make_variable_defn
+                    ~type_:Types.(Const (std_vector Int))
+                    ~name:"params_i" () )
+             ; Expression
+                 (Var "params_unconstrained").@?(( "resize"
+                                                 , [Var "num_params_r__"] ))
+             ; Expression
+                 (Exprs.fun_call "unconstrain_array_impl"
+                    [ Var "params_constrained"; Var "params_i"
+                    ; Var "params_unconstrained"; Var "pstream" ] ) ]
+           ~cv_qualifiers:[Const (*; Final*)] () ) ] in
   (GlobalComment "Begin method overload boilerplate" :: write_arrays)
-  @ log_probs @ transform_inits
-
-let gen_transform_inits {Program.output_vars; _} =
-  let args =
-    [ (Types.const_ref (TypeLiteral "stan::io::var_context"), "context")
-    ; (Ref (Types.std_vector Int), "params_i")
-    ; (Ref (Types.std_vector Double), "vars")
-    ; (Pointer (TypeLiteral "std::ostream"), "pstream__ = nullptr") ] in
-  let list_names ((stri : string), (Program.{out_block; _} : 'a Program.outvar))
-      =
-    match out_block with Parameters -> Some stri | _ -> None in
-  let param_names = List.filter_map ~f:list_names output_vars in
-  let list_len = List.length param_names in
-  let constrained_params =
-    List.filter_map ~f:get_constrained_param_st output_vars in
-  let names_array =
-    VariableDefn
-      (make_variable_defn ~constexpr:true
-         ~type_:(Types.const_char_array list_len)
-         ~name:"names__"
-         ~init:
-           (InitializerList
-              (List.map
-                 ~f:(Fn.compose Exprs.literal_string Mangle.remove_prefix)
-                 param_names ) )
-         () ) in
-  let constrained_params_arr =
-    VariableDefn
-      (make_variable_defn
-         ~type_:(Const (Array (TypeLiteral "Eigen::Index", list_len)))
-         ~name:"constrain_param_sizes__"
-         ~init:(InitializerList (List.map ~f:lower_num_param constrained_params))
-         () ) in
-  let num_constrained_param_size =
-    let constrain_param_sizes = Var "constrain_param_sizes__" in
-    let open Expression_syntax in
-    VariableDefn
-      (make_variable_defn ~type_:(Const Auto) ~name:"num_constrained_params__"
-         ~init:
-           (Assignment
-              (Exprs.fun_call "std::accumulate"
-                 [ constrain_param_sizes.@!("begin")
-                 ; constrain_param_sizes.@!("end"); Literal "0" ] ) )
-         () ) in
-  let flatten_and_call =
-    let open Expression_syntax in
-    [ VariableDefn
-        (make_variable_defn ~type_:(Types.std_vector Double)
-           ~name:"params_r_flat__"
-           ~init:(Construction [Var "num_constrained_params__"])
-           () )
-    ; VariableDefn
-        (make_variable_defn ~type_:(TypeLiteral "Eigen::Index")
-           ~name:"size_iter__" ~init:(Assignment (Literal "0")) () )
-    ; VariableDefn
-        (make_variable_defn ~type_:(TypeLiteral "Eigen::Index")
-           ~name:"flat_iter__" ~init:(Assignment (Literal "0")) () )
-    ; ForEach
-        ( (Ref (Ref Auto), "param_name__")
-        , Var "names__"
-        , Block
-            [ VariableDefn
-                (make_variable_defn ~type_:(Const Auto) ~name:"param_vec__"
-                   ~init:
-                     (Assignment
-                        (Var "context").@?(("vals_r", [Var "param_name__"])) )
-                   () )
-            ; For
-                ( make_variable_defn ~type_:(TypeLiteral "Eigen::Index")
-                    ~name:"i" ~init:(Assignment (Literal "0")) ()
-                , BinOp
-                    ( Var "i"
-                    , Lthn
-                    , Index (Var "constrain_param_sizes__", Var "size_iter__")
-                    )
-                , Increment (Var "i")
-                , Block
-                    [ Expression
-                        (Assign
-                           ( Index (Var "params_r_flat__", Var "flat_iter__")
-                           , Index (Var "param_vec__", Var "i") ) )
-                    ; Expression (Increment (Var "flat_iter__")) ] )
-            ; Expression (Increment (Var "size_iter__")) ] )
-    ; Expression (Var "vars").@?(("resize", [Var "num_params_r__"]))
-    ; Expression
-        (Exprs.fun_call "transform_inits_impl"
-           [Var "params_r_flat__"; Var "params_i"; Var "vars"; Var "pstream__"] )
-    ] in
-  FunDef
-    (make_fun_defn ~inline:true ~return_type:Void ~name:"transform_inits" ~args
-       ~body:
-         ( [names_array; constrained_params_arr; num_constrained_param_size]
-         @ flatten_and_call )
-       ~cv_qualifiers:[Const] () )
+  @ log_probs @ transform_inits @ unconstrain_array
 
 let lower_model_public p =
-  [ gen_log_prob p; gen_write_array p; gen_transform_inits_impl p
-  ; (* Begin metadata methods *) gen_get_param_names p
-  ; (* Post-data metadata methods *) gen_get_dims p
+  [ gen_log_prob p; gen_write_array p; gen_unconstrain_array_impl p
+  ; gen_transform_inits_impl p; (* Begin metadata methods *)
+    gen_get_param_names p; (* Post-data metadata methods *) gen_get_dims p
   ; gen_constrained_param_names p; gen_unconstrained_param_names p
   ; gen_constrained_types p; gen_unconstrained_types p ]
   (* Boilerplate *)
   @ gen_overloads p
-  @ [gen_transform_inits p]
 
 let model_public_basics name =
   [ FunDef

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -301,7 +301,7 @@ let plain_deserializer_read loc out_constrained_st =
   let emeta = Expr.Typed.Meta.create ~loc ~type_:ut ~adlevel:AutoDiffable () in
   Expr.(
     Helpers.(
-      internal_funapp FnReadSerializer dims Typed.Meta.{emeta with type_= ut}))
+      internal_funapp FnReadDeserializer dims Typed.Meta.{emeta with type_= ut}))
 
 let param_deserializer_read smeta
     (decl_id, Program.{out_constrained_st= cst; out_block; out_trans; _}) =

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -297,7 +297,7 @@ let read_constrain_dims constrain_transform st =
 
 let data_serializer_read loc out_constrained_st =
   let ut = SizedType.to_unsized out_constrained_st in
-  let dims = SizedType.get_dims_io out_constrained_st in
+  let dims = SizedType.get_dims out_constrained_st in
   let emeta = Expr.Typed.Meta.create ~loc ~type_:ut ~adlevel:AutoDiffable () in
   Expr.(
     Helpers.(

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -552,7 +552,8 @@ let map_prog_stmt_lists f (p : ('a, 'b) Program.t) =
     Program.prepare_data= f p.prepare_data
   ; log_prob= f p.log_prob
   ; generate_quantities= f p.generate_quantities
-  ; transform_inits= f p.transform_inits }
+  ; transform_inits= f p.transform_inits
+  ; unconstrain_array= f p.unconstrain_array }
 
 let trans_prog (p : Program.Typed.t) =
   (* name mangling of c++ keywords*)

--- a/test/integration/cli-args/allow-undefined/cpp.expected
+++ b/test/integration/cli-args/allow-undefined/cpp.expected
@@ -157,10 +157,27 @@ class external_model final : public model_base_crtp<external_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -267,24 +284,17 @@ class external_model final : public model_base_crtp<external_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/cli-args/allow-undefined/cpp.expected
+++ b/test/integration/cli-args/allow-undefined/cpp.expected
@@ -292,7 +292,18 @@ class external_model final : public model_base_crtp<external_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/cli-args/filename-in-msg/filename_good.expected
+++ b/test/integration/cli-args/filename-in-msg/filename_good.expected
@@ -126,10 +126,27 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -236,24 +253,17 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/cli-args/filename-in-msg/filename_good.expected
+++ b/test/integration/cli-args/filename-in-msg/filename_good.expected
@@ -261,7 +261,18 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1320,8 +1320,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1376,6 +1376,116 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       stan::model::assign(X_rv_p,
         in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(n),
         "assigning variable X_rv_p");
+      out__.write(X_rv_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> alpha_v =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> alpha_v_flat__;
+        alpha_v_flat__ = context__.vals_r("alpha_v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(alpha_v, alpha_v_flat__[(pos__ - 1)],
+            "assigning variable alpha_v", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(alpha_v);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> cuts =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> cuts_flat__;
+        cuts_flat__ = context__.vals_r("cuts");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(cuts, cuts_flat__[(pos__ - 1)],
+            "assigning variable cuts", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(cuts);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
+      out__.write(alpha);
+      local_scalar_t__ phi = DUMMY_VAR__;
+      phi = context__.vals_r("phi")[(1 - 1)];
+      out__.write(phi);
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(X_p);
+      Eigen::Matrix<local_scalar_t__,-1,-1> beta_m =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_m_flat__;
+        beta_m_flat__ = context__.vals_r("beta_m");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
+            stan::model::assign(beta_m, beta_m_flat__[(pos__ - 1)],
+              "assigning variable beta_m", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(beta_m);
+      Eigen::Matrix<local_scalar_t__,1,-1> X_rv_p =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(n, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_rv_p_flat__;
+        X_rv_p_flat__ = context__.vals_r("X_rv_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
+          stan::model::assign(X_rv_p, X_rv_p_flat__[(pos__ - 1)],
+            "assigning variable X_rv_p", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(X_rv_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1550,27 +1660,17 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 9>
-      names__{"alpha_v", "beta", "cuts", "sigma", "alpha", "phi", "X_p",
-              "beta_m", "X_rv_p"};
-    const std::array<Eigen::Index, 9>
-      constrain_param_sizes__{k, k, k, 1, 1, 1, (n * k), (n * k), n};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1334,24 +1334,21 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> alpha_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(alpha_v, in__.read<local_scalar_t__>(),
-          "assigning variable alpha_v", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(alpha_v,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable alpha_v");
       out__.write(alpha_v);
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable beta");
       out__.write(beta);
       Eigen::Matrix<local_scalar_t__,-1,1> cuts =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(cuts, in__.read<local_scalar_t__>(),
-          "assigning variable cuts", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(cuts,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable cuts");
       out__.write(cuts);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
@@ -1364,30 +1361,21 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       out__.write(phi);
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n, k),
+        "assigning variable X_p");
       out__.write(X_p);
       Eigen::Matrix<local_scalar_t__,-1,-1> beta_m =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
-          stan::model::assign(beta_m, in__.read<local_scalar_t__>(),
-            "assigning variable beta_m", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(beta_m,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n, k),
+        "assigning variable beta_m");
       out__.write(beta_m);
       Eigen::Matrix<local_scalar_t__,1,-1> X_rv_p =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(n, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
-        stan::model::assign(X_rv_p, in__.read<local_scalar_t__>(),
-          "assigning variable X_rv_p", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(X_rv_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(n),
+        "assigning variable X_rv_p");
       out__.write(X_rv_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1668,7 +1668,18 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1742,7 +1742,18 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2887,7 +2898,18 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4991,7 +5013,18 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -5566,7 +5599,18 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -8190,7 +8234,18 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -8688,7 +8743,18 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -9244,7 +9310,18 @@ class user_function_templating_model final : public model_base_crtp<user_functio
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1298,57 +1298,45 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1> cmat =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>::Constant(N, N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(cmat, in__.read<local_scalar_t__>(),
-            "assigning variable cmat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(cmat,
+        in__.read<Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>>(N, N),
+        "assigning variable cmat");
       out__.write(cmat);
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> cvec =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(cvec, in__.read<local_scalar_t__>(),
-          "assigning variable cvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(cvec,
+        in__.read<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>(N),
+        "assigning variable cvec");
       out__.write(cvec);
       Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> crowvec =
         Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(crowvec, in__.read<local_scalar_t__>(),
-          "assigning variable crowvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(crowvec,
+        in__.read<Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>>(N),
+        "assigning variable crowvec");
       out__.write(crowvec);
       std::complex<local_scalar_t__> z =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      z = in__.read<local_scalar_t__>();
+      z = in__.read<std::complex<local_scalar_t__>>();
       out__.write(z);
       Eigen::Matrix<local_scalar_t__,-1,-1> mat =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(mat, in__.read<local_scalar_t__>(),
-            "assigning variable mat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(mat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable mat");
       out__.write(mat);
       Eigen::Matrix<local_scalar_t__,-1,1> vec =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(vec, in__.read<local_scalar_t__>(),
-          "assigning variable vec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable vec");
       out__.write(vec);
       Eigen::Matrix<local_scalar_t__,1,-1> rowvec =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(rowvec, in__.read<local_scalar_t__>(),
-          "assigning variable rowvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(rowvec,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable rowvec");
       out__.write(rowvec);
       local_scalar_t__ r = DUMMY_VAR__;
       r = in__.read<local_scalar_t__>();
@@ -4448,57 +4436,45 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1> cvmat =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>::Constant(N, N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(cvmat, in__.read<local_scalar_t__>(),
-            "assigning variable cvmat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(cvmat,
+        in__.read<Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>>(N, N),
+        "assigning variable cvmat");
       out__.write(cvmat);
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> cvvec =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(cvvec, in__.read<local_scalar_t__>(),
-          "assigning variable cvvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(cvvec,
+        in__.read<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>(N),
+        "assigning variable cvvec");
       out__.write(cvvec);
       Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> cvrowvec =
         Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(cvrowvec, in__.read<local_scalar_t__>(),
-          "assigning variable cvrowvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(cvrowvec,
+        in__.read<Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>>(N),
+        "assigning variable cvrowvec");
       out__.write(cvrowvec);
       std::complex<local_scalar_t__> zv =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      zv = in__.read<local_scalar_t__>();
+      zv = in__.read<std::complex<local_scalar_t__>>();
       out__.write(zv);
       Eigen::Matrix<local_scalar_t__,-1,-1> vmat =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(vmat, in__.read<local_scalar_t__>(),
-            "assigning variable vmat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(vmat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable vmat");
       out__.write(vmat);
       Eigen::Matrix<local_scalar_t__,-1,1> vvec =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(vvec, in__.read<local_scalar_t__>(),
-          "assigning variable vvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(vvec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable vvec");
       out__.write(vvec);
       Eigen::Matrix<local_scalar_t__,1,-1> vrowvec =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(vrowvec, in__.read<local_scalar_t__>(),
-          "assigning variable vrowvec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(vrowvec,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable vrowvec");
       out__.write(vrowvec);
       local_scalar_t__ v = DUMMY_VAR__;
       v = in__.read<local_scalar_t__>();
@@ -7597,13 +7573,14 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       out__.write(p_r);
       std::complex<local_scalar_t__> p_complex =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      p_complex = in__.read<local_scalar_t__>();
+      p_complex = in__.read<std::complex<local_scalar_t__>>();
       out__.write(p_complex);
       std::vector<std::complex<local_scalar_t__>> p_complex_array =
         std::vector<std::complex<local_scalar_t__>>(2,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(p_complex_array, in__.read<local_scalar_t__>(),
+        stan::model::assign(p_complex_array,
+          in__.read<std::complex<local_scalar_t__>>(),
           "assigning variable p_complex_array",
           stan::model::index_uni(sym1__));
       }
@@ -7616,7 +7593,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
           stan::model::assign(p_complex_array_2d,
-            in__.read<local_scalar_t__>(),
+            in__.read<std::complex<local_scalar_t__>>(),
             "assigning variable p_complex_array_2d",
             stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
         }

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -1283,8 +1283,8 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1340,6 +1340,117 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       out__.write(rowvec);
       local_scalar_t__ r = DUMMY_VAR__;
       r = in__.read<local_scalar_t__>();
+      out__.write(r);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1> cmat =
+        Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>::Constant(N, N,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> cmat_flat__;
+        cmat_flat__ = context__.vals_c("cmat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(cmat, cmat_flat__[(pos__ - 1)],
+              "assigning variable cmat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(cmat);
+      Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> cvec =
+        Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> cvec_flat__;
+        cvec_flat__ = context__.vals_c("cvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(cvec, cvec_flat__[(pos__ - 1)],
+            "assigning variable cvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(cvec);
+      Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> crowvec =
+        Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>::Constant(N,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> crowvec_flat__;
+        crowvec_flat__ = context__.vals_c("crowvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(crowvec, crowvec_flat__[(pos__ - 1)],
+            "assigning variable crowvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(crowvec);
+      std::complex<local_scalar_t__> z =
+        std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
+      z = context__.vals_c("z")[(1 - 1)];
+      out__.write(z);
+      Eigen::Matrix<local_scalar_t__,-1,-1> mat =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> mat_flat__;
+        mat_flat__ = context__.vals_r("mat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(mat, mat_flat__[(pos__ - 1)],
+              "assigning variable mat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(mat);
+      Eigen::Matrix<local_scalar_t__,-1,1> vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> vec_flat__;
+        vec_flat__ = context__.vals_r("vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(vec, vec_flat__[(pos__ - 1)],
+            "assigning variable vec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(vec);
+      Eigen::Matrix<local_scalar_t__,1,-1> rowvec =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> rowvec_flat__;
+        rowvec_flat__ = context__.vals_r("rowvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(rowvec, rowvec_flat__[(pos__ - 1)],
+            "assigning variable rowvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(rowvec);
+      local_scalar_t__ r = DUMMY_VAR__;
+      r = context__.vals_r("r")[(1 - 1)];
       out__.write(r);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1623,27 +1734,17 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8>
-      names__{"cmat", "cvec", "crowvec", "z", "mat", "vec", "rowvec", "r"};
-    const std::array<Eigen::Index, 8>
-      constrain_param_sizes__{(N * N * 2), (N * 2), (N * 2), 2, (N * N), N,
-                              N, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2561,10 +2662,27 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2761,24 +2879,17 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4421,8 +4532,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4478,6 +4589,117 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       out__.write(vrowvec);
       local_scalar_t__ v = DUMMY_VAR__;
       v = in__.read<local_scalar_t__>();
+      out__.write(v);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1> cvmat =
+        Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>::Constant(N, N,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> cvmat_flat__;
+        cvmat_flat__ = context__.vals_c("cvmat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(cvmat, cvmat_flat__[(pos__ - 1)],
+              "assigning variable cvmat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(cvmat);
+      Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> cvvec =
+        Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> cvvec_flat__;
+        cvvec_flat__ = context__.vals_c("cvvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(cvvec, cvvec_flat__[(pos__ - 1)],
+            "assigning variable cvvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(cvvec);
+      Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> cvrowvec =
+        Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>::Constant(N,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> cvrowvec_flat__;
+        cvrowvec_flat__ = context__.vals_c("cvrowvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(cvrowvec, cvrowvec_flat__[(pos__ - 1)],
+            "assigning variable cvrowvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(cvrowvec);
+      std::complex<local_scalar_t__> zv =
+        std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
+      zv = context__.vals_c("zv")[(1 - 1)];
+      out__.write(zv);
+      Eigen::Matrix<local_scalar_t__,-1,-1> vmat =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> vmat_flat__;
+        vmat_flat__ = context__.vals_r("vmat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(vmat, vmat_flat__[(pos__ - 1)],
+              "assigning variable vmat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(vmat);
+      Eigen::Matrix<local_scalar_t__,-1,1> vvec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> vvec_flat__;
+        vvec_flat__ = context__.vals_r("vvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(vvec, vvec_flat__[(pos__ - 1)],
+            "assigning variable vvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(vvec);
+      Eigen::Matrix<local_scalar_t__,1,-1> vrowvec =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> vrowvec_flat__;
+        vrowvec_flat__ = context__.vals_r("vrowvec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(vrowvec, vrowvec_flat__[(pos__ - 1)],
+            "assigning variable vrowvec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(vrowvec);
+      local_scalar_t__ v = DUMMY_VAR__;
+      v = context__.vals_r("v")[(1 - 1)];
       out__.write(v);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4761,28 +4983,17 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8>
-      names__{"cvmat", "cvvec", "cvrowvec", "zv", "vmat", "vvec", "vrowvec",
-              "v"};
-    const std::array<Eigen::Index, 8>
-      constrain_param_sizes__{(N * N * 2), (N * 2), (N * 2), 2, (N * N), N,
-                              N, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -5220,10 +5431,27 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -5330,24 +5558,17 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -7556,8 +7777,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7596,6 +7817,65 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             in__.read<std::complex<local_scalar_t__>>(),
             "assigning variable p_complex_array_2d",
             stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+        }
+      }
+      out__.write(p_complex_array_2d);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ p_r = DUMMY_VAR__;
+      p_r = context__.vals_r("p_r")[(1 - 1)];
+      out__.write(p_r);
+      std::complex<local_scalar_t__> p_complex =
+        std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
+      p_complex = context__.vals_c("p_complex")[(1 - 1)];
+      out__.write(p_complex);
+      std::vector<std::complex<local_scalar_t__>> p_complex_array =
+        std::vector<std::complex<local_scalar_t__>>(2,
+          std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
+      {
+        std::vector<std::complex<local_scalar_t__>> p_complex_array_flat__;
+        p_complex_array_flat__ = context__.vals_c("p_complex_array");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(p_complex_array, p_complex_array_flat__[(pos__
+            - 1)], "assigning variable p_complex_array",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_complex_array);
+      std::vector<std::vector<std::complex<local_scalar_t__>>>
+        p_complex_array_2d =
+        std::vector<std::vector<std::complex<local_scalar_t__>>>(2,
+          std::vector<std::complex<local_scalar_t__>>(3,
+            std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
+      {
+        std::vector<std::complex<local_scalar_t__>> p_complex_array_2d_flat__;
+        p_complex_array_2d_flat__ = context__.vals_c("p_complex_array_2d");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+            stan::model::assign(p_complex_array_2d,
+              p_complex_array_2d_flat__[(pos__ - 1)],
+              "assigning variable p_complex_array_2d",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
         }
       }
       out__.write(p_complex_array_2d);
@@ -7902,26 +8182,17 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"p_r", "p_complex", "p_complex_array", "p_complex_array_2d"};
-    const std::array<Eigen::Index, 4>
-      constrain_param_sizes__{1, 2, (2 * 2), (2 * 3 * 2)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -8189,10 +8460,27 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -8392,24 +8680,17 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -8828,10 +9109,27 @@ class user_function_templating_model final : public model_base_crtp<user_functio
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -8938,24 +9236,17 @@ class user_function_templating_model final : public model_base_crtp<user_functio
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -417,7 +417,18 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -712,7 +723,18 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1299,7 +1321,18 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2308,7 +2341,18 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2746,7 +2790,18 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -3102,7 +3157,18 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -3530,7 +3596,18 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12049,7 +12126,18 @@ class mother_model final : public model_base_crtp<mother_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -13938,7 +14026,18 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -18510,7 +18609,18 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19160,7 +19270,18 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -20691,7 +20812,18 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21351,7 +21483,18 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21773,7 +21916,18 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22059,7 +22213,18 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22436,7 +22601,18 @@ class promotion_model final : public model_base_crtp<promotion_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -23191,7 +23367,18 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -23711,7 +23898,18 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -26139,7 +26337,18 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -29774,7 +29983,18 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -30900,7 +31120,18 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -31298,7 +31529,18 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -31626,7 +31868,18 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -34240,7 +34493,18 @@ class transform_model final : public model_base_crtp<transform_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -34660,7 +34924,18 @@ class truncate_model final : public model_base_crtp<truncate_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -34975,7 +35250,18 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -35297,7 +35583,18 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -35646,7 +35943,18 @@ class variable_named_context_model final : public model_base_crtp<variable_named
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -36634,7 +36942,18 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -3402,9 +3402,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       pos__ = 1;
       std::vector<local_scalar_t__> xx =
         std::vector<local_scalar_t__>(3, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        xx[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(xx, in__.read<std::vector<local_scalar_t__>>(3),
+        "assigning variable xx");
       out__.write(xx);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10399,27 +10398,27 @@ class mother_model final : public model_base_crtp<mother_model> {
       out__.write_free_ub(p_upper, p_lower);
       std::vector<local_scalar_t__> offset_multiplier =
         std::vector<local_scalar_t__>(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        offset_multiplier[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(offset_multiplier,
+        in__.read<std::vector<local_scalar_t__>>(5),
+        "assigning variable offset_multiplier");
       out__.write_free_offset_multiplier(1, 2, offset_multiplier);
       std::vector<local_scalar_t__> no_offset_multiplier =
         std::vector<local_scalar_t__>(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        no_offset_multiplier[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(no_offset_multiplier,
+        in__.read<std::vector<local_scalar_t__>>(5),
+        "assigning variable no_offset_multiplier");
       out__.write_free_offset_multiplier(0, 2, no_offset_multiplier);
       std::vector<local_scalar_t__> offset_no_multiplier =
         std::vector<local_scalar_t__>(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        offset_no_multiplier[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(offset_no_multiplier,
+        in__.read<std::vector<local_scalar_t__>>(5),
+        "assigning variable offset_no_multiplier");
       out__.write_free_offset_multiplier(3, 1, offset_no_multiplier);
       std::vector<local_scalar_t__> p_real_1d_ar =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        p_real_1d_ar[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_real_1d_ar,
+        in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable p_real_1d_ar");
       out__.write_free_lb(0, p_real_1d_ar);
       std::vector<std::vector<std::vector<local_scalar_t__>>> p_real_3d_ar =
         std::vector<std::vector<std::vector<local_scalar_t__>>>(N,
@@ -10444,9 +10443,11 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_1d_vec,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-          "assigning variable p_1d_vec", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(p_1d_vec, in__.read<local_scalar_t__>(),
+            "assigning variable p_1d_vec", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(p_1d_vec);
       std::vector<
@@ -10457,13 +10458,17 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
             std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
               Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__))));
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(p_3d_vec,
-              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-              "assigning variable p_3d_vec", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+              stan::model::assign(p_3d_vec, in__.read<local_scalar_t__>(),
+                "assigning variable p_3d_vec",
+                stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
           }
         }
       }
@@ -10478,9 +10483,11 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_1d_row_vec,
-          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-          "assigning variable p_1d_row_vec", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(p_1d_row_vec, in__.read<local_scalar_t__>(),
+            "assigning variable p_1d_row_vec",
+            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+        }
       }
       out__.write(p_1d_row_vec);
       std::vector<
@@ -10491,14 +10498,18 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(M,
             std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(K,
               Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__))));
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(p_3d_row_vec,
-              in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-              "assigning variable p_3d_row_vec",
-              stan::model::index_uni(sym3__), stan::model::index_uni(sym2__),
-              stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+              stan::model::assign(p_3d_row_vec,
+                in__.read<local_scalar_t__>(),
+                "assigning variable p_3d_row_vec",
+                stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
           }
         }
       }
@@ -10515,12 +10526,18 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(5,
             Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 3,
               DUMMY_VAR__)));
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 4; ++sym2__) {
-          stan::model::assign(p_ar_mat,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 3),
-            "assigning variable p_ar_mat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= 5; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= 4; ++sym4__) {
+              stan::model::assign(p_ar_mat, in__.read<local_scalar_t__>(),
+                "assigning variable p_ar_mat",
+                stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
+          }
         }
       }
       out__.write_free_lub(0, 1, p_ar_mat);
@@ -10534,9 +10551,11 @@ class mother_model final : public model_base_crtp<mother_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_1d_simplex,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-          "assigning variable p_1d_simplex", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(p_1d_simplex, in__.read<local_scalar_t__>(),
+            "assigning variable p_1d_simplex",
+            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+        }
       }
       out__.write_free_simplex(p_1d_simplex);
       std::vector<
@@ -10547,14 +10566,18 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
             std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
               Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__))));
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(p_3d_simplex,
-              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-              "assigning variable p_3d_simplex",
-              stan::model::index_uni(sym3__), stan::model::index_uni(sym2__),
-              stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+              stan::model::assign(p_3d_simplex,
+                in__.read<local_scalar_t__>(),
+                "assigning variable p_3d_simplex",
+                stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
           }
         }
       }
@@ -10574,10 +10597,15 @@ class mother_model final : public model_base_crtp<mother_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> p_cfcov_33_ar =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(K,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 3, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        stan::model::assign(p_cfcov_33_ar,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(3, 3),
-          "assigning variable p_cfcov_33_ar", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
+            stan::model::assign(p_cfcov_33_ar, in__.read<local_scalar_t__>(),
+              "assigning variable p_cfcov_33_ar",
+              stan::model::index_uni(sym3__), stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+          }
+        }
       }
       out__.write_free_cholesky_factor_cov(p_cfcov_33_ar);
       Eigen::Matrix<local_scalar_t__,-1,1> x_p =
@@ -13592,21 +13620,19 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       pos__ = 1;
       std::vector<local_scalar_t__> y0_p =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        y0_p[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(y0_p, in__.read<std::vector<local_scalar_t__>>(2),
+        "assigning variable y0_p");
       out__.write(y0_p);
       std::vector<local_scalar_t__> theta_p =
         std::vector<local_scalar_t__>(1, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 1; ++sym1__) {
-        theta_p[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(theta_p,
+        in__.read<std::vector<local_scalar_t__>>(1),
+        "assigning variable theta_p");
       out__.write(theta_p);
       std::vector<local_scalar_t__> x_p =
         std::vector<local_scalar_t__>(1, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 1; ++sym1__) {
-        x_p[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(x_p, in__.read<std::vector<local_scalar_t__>>(1),
+        "assigning variable x_p");
       out__.write(x_p);
       Eigen::Matrix<local_scalar_t__,-1,1> x_p_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
@@ -13624,9 +13650,11 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(3,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(3, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        stan::model::assign(job_params_p,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(3),
-          "assigning variable job_params_p", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+          stan::model::assign(job_params_p, in__.read<local_scalar_t__>(),
+            "assigning variable job_params_p",
+            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+        }
       }
       out__.write(job_params_p);
       local_scalar_t__ x_r = DUMMY_VAR__;
@@ -18388,9 +18416,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       out__.write(r);
       std::vector<local_scalar_t__> ra =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        ra[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(ra, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable ra");
       out__.write(ra);
       Eigen::Matrix<local_scalar_t__,-1,1> v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
@@ -19064,15 +19091,14 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       out__.write_free_lb(0, delta);
       std::vector<local_scalar_t__> z_init =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        z_init[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(z_init,
+        in__.read<std::vector<local_scalar_t__>>(2),
+        "assigning variable z_init");
       out__.write_free_lb(0, z_init);
       std::vector<local_scalar_t__> sigma =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        sigma[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(sigma, in__.read<std::vector<local_scalar_t__>>(2),
+        "assigning variable sigma");
       out__.write_free_lb(0, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21714,10 +21740,14 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> L_Omega =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(nt,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= nt; ++sym1__) {
-        stan::model::assign(L_Omega,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
-          "assigning variable L_Omega", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= nt; ++sym3__) {
+            stan::model::assign(L_Omega, in__.read<local_scalar_t__>(),
+              "assigning variable L_Omega", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
+        }
       }
       out__.write_free_cholesky_factor_corr(L_Omega);
       Eigen::Matrix<local_scalar_t__,-1,1> z1 =
@@ -23720,21 +23750,18 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       pos__ = 1;
       std::vector<local_scalar_t__> y1 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        y1[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(y1, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable y1");
       out__.write(y1);
       std::vector<local_scalar_t__> y2 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        y2[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(y2, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable y2");
       out__.write(y2);
       std::vector<local_scalar_t__> y3 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        y3[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(y3, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable y3");
       out__.write(y3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -25493,10 +25520,15 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
               DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(a8,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
-            "assigning variable a8", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+              stan::model::assign(a8, in__.read<local_scalar_t__>(),
+                "assigning variable a8", stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
+          }
         }
       }
       out__.write(a8);
@@ -25506,10 +25538,11 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(a7,
-            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-            "assigning variable a7", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(a7, in__.read<local_scalar_t__>(),
+              "assigning variable a7", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write(a7);
@@ -25519,10 +25552,11 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(a6,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-            "assigning variable a6", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(a6, in__.read<local_scalar_t__>(),
+              "assigning variable a6", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write(a6);
@@ -25539,34 +25573,41 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(a4,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
-          "assigning variable a4", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(a4, in__.read<local_scalar_t__>(),
+              "assigning variable a4", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
+        }
       }
       out__.write(a4);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> a3 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(a3,
-          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-          "assigning variable a3", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(a3, in__.read<local_scalar_t__>(),
+            "assigning variable a3", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(a3);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> a2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(a2,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-          "assigning variable a2", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(a2, in__.read<local_scalar_t__>(),
+            "assigning variable a2", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(a2);
       std::vector<local_scalar_t__> a1 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        a1[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(a1, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable a1");
       out__.write(a1);
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> y8 =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(N,
@@ -25575,10 +25616,15 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
               DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y8,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
-            "assigning variable y8", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+              stan::model::assign(y8, in__.read<local_scalar_t__>(),
+                "assigning variable y8", stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
+          }
         }
       }
       out__.write(y8);
@@ -25588,10 +25634,11 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y7,
-            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-            "assigning variable y7", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(y7, in__.read<local_scalar_t__>(),
+              "assigning variable y7", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write(y7);
@@ -25601,10 +25648,11 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y6,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-            "assigning variable y6", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(y6, in__.read<local_scalar_t__>(),
+              "assigning variable y6", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write(y6);
@@ -25621,34 +25669,41 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y4,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
-          "assigning variable y4", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(y4, in__.read<local_scalar_t__>(),
+              "assigning variable y4", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
+        }
       }
       out__.write(y4);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> y3 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y3,
-          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-          "assigning variable y3", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(y3, in__.read<local_scalar_t__>(),
+            "assigning variable y3", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(y3);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> y2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y2,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-          "assigning variable y2", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(y2, in__.read<local_scalar_t__>(),
+            "assigning variable y2", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(y2);
       std::vector<local_scalar_t__> y1 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        y1[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(y1, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable y1");
       out__.write(y1);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -29259,35 +29314,42 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       pos__ = 1;
       std::vector<local_scalar_t__> y1 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        y1[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(y1, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable y1");
       out__.write(y1);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> y2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y2,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-          "assigning variable y2", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(y2, in__.read<local_scalar_t__>(),
+            "assigning variable y2", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(y2);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> y3 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y3,
-          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-          "assigning variable y3", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          stan::model::assign(y3, in__.read<local_scalar_t__>(),
+            "assigning variable y3", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(y3);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> y4 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y4,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
-          "assigning variable y4", stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(y4, in__.read<local_scalar_t__>(),
+              "assigning variable y4", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
+        }
       }
       out__.write(y4);
       std::vector<std::vector<local_scalar_t__>> y5 =
@@ -29305,10 +29367,11 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y6,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-            "assigning variable y6", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(y6, in__.read<local_scalar_t__>(),
+              "assigning variable y6", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write(y6);
@@ -29318,10 +29381,11 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y7,
-            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
-            "assigning variable y7", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(y7, in__.read<local_scalar_t__>(),
+              "assigning variable y7", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write(y7);
@@ -29332,10 +29396,15 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
               DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y8,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
-            "assigning variable y8", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+              stan::model::assign(y8, in__.read<local_scalar_t__>(),
+                "assigning variable y8", stan::model::index_uni(sym4__),
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+            }
+          }
         }
       }
       out__.write(y8);
@@ -33480,25 +33549,22 @@ class transform_model final : public model_base_crtp<transform_model> {
       pos__ = 1;
       std::vector<local_scalar_t__> p_1 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_1[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_1, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_1");
       out__.write_free_lb(stan::model::rvalue(ds, "ds",
                             stan::model::index_uni(1),
                             stan::model::index_uni(1)), p_1);
       std::vector<local_scalar_t__> p_2 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_2[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_2, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_2");
       out__.write_free_ub(stan::model::rvalue(ds, "ds",
                             stan::model::index_uni(1),
                             stan::model::index_uni(1)), p_2);
       std::vector<local_scalar_t__> p_3 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_3[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_3, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_3");
       out__.write_free_lub(stan::model::rvalue(ds, "ds",
                              stan::model::index_uni(1),
                              stan::model::index_uni(1)),
@@ -33506,42 +33572,37 @@ class transform_model final : public model_base_crtp<transform_model> {
           stan::model::index_uni(2)), p_3);
       std::vector<local_scalar_t__> p_4 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_4[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_4, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_4");
       out__.write_free_lub(0,
         stan::model::rvalue(ds, "ds", stan::model::index_uni(1),
           stan::model::index_uni(2)), p_4);
       std::vector<local_scalar_t__> p_5 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_5[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_5, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_5");
       out__.write_free_lub(stan::model::rvalue(ds, "ds",
                              stan::model::index_uni(1),
                              stan::model::index_uni(1)), 1, p_5);
       std::vector<local_scalar_t__> p_6 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_6[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_6, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_6");
       out__.write_free_offset_multiplier(stan::model::rvalue(ds, "ds",
                                            stan::model::index_uni(1),
                                            stan::model::index_uni(1)), 1,
         p_6);
       std::vector<local_scalar_t__> p_7 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_7[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_7, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_7");
       out__.write_free_offset_multiplier(0,
         stan::model::rvalue(ds, "ds", stan::model::index_uni(1),
           stan::model::index_uni(1)), p_7);
       std::vector<local_scalar_t__> p_8 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        p_8[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_8, in__.read<std::vector<local_scalar_t__>>(k),
+        "assigning variable p_8");
       out__.write_free_offset_multiplier(stan::model::rvalue(ds, "ds",
                                            stan::model::index_uni(1),
                                            stan::model::index_uni(1)),
@@ -33583,10 +33644,12 @@ class transform_model final : public model_base_crtp<transform_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> pv_2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(m,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
-        stan::model::assign(pv_2,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
-          "assigning variable pv_2", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+          stan::model::assign(pv_2, in__.read<local_scalar_t__>(),
+            "assigning variable pv_2", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write_free_lb(stan::model::rvalue(dv, "dv",
                             stan::model::index_uni(1)), pv_2);
@@ -33594,12 +33657,13 @@ class transform_model final : public model_base_crtp<transform_model> {
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(n,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(m,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__)));
-      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
-          stan::model::assign(pv_3,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
-            "assigning variable pv_3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+            stan::model::assign(pv_3, in__.read<local_scalar_t__>(),
+              "assigning variable pv_3", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write_free_ub(dv, pv_3);
@@ -33616,10 +33680,12 @@ class transform_model final : public model_base_crtp<transform_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> pr_2 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(m,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
-        stan::model::assign(pr_2,
-          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(k),
-          "assigning variable pr_2", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+          stan::model::assign(pr_2, in__.read<local_scalar_t__>(),
+            "assigning variable pr_2", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write_free_lb(stan::model::rvalue(dr, "dr",
                             stan::model::index_uni(1)), pr_2);
@@ -33627,12 +33693,13 @@ class transform_model final : public model_base_crtp<transform_model> {
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(n,
           std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(m,
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__)));
-      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
-          stan::model::assign(pr_3,
-            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(k),
-            "assigning variable pr_3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+            stan::model::assign(pr_3, in__.read<local_scalar_t__>(),
+              "assigning variable pr_3", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write_free_ub(dr, pr_3);
@@ -33646,10 +33713,14 @@ class transform_model final : public model_base_crtp<transform_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> pm_2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(n,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(m, k, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
-        stan::model::assign(pm_2,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(m, k),
-          "assigning variable pm_2", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+            stan::model::assign(pm_2, in__.read<local_scalar_t__>(),
+              "assigning variable pm_2", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
+        }
       }
       out__.write_free_ub(dm, pm_2);
     } catch (const std::exception& e) {

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -238,10 +238,9 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       out__.write_free_lb(0, tau);
       Eigen::Matrix<local_scalar_t__,-1,1> theta_tilde =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        stan::model::assign(theta_tilde, in__.read<local_scalar_t__>(),
-          "assigning variable theta_tilde", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(theta_tilde,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable theta_tilde");
       out__.write(theta_tilde);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2462,10 +2461,9 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       out__.write_free_lb(0, tau);
       Eigen::Matrix<local_scalar_t__,-1,1> theta_tilde =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        stan::model::assign(theta_tilde, in__.read<local_scalar_t__>(),
-          "assigning variable theta_tilde", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(theta_tilde,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable theta_tilde");
       out__.write(theta_tilde);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10202,20 +10200,17 @@ class mother_model final : public model_base_crtp<mother_model> {
       out__.write_free_lb(0, p_real_3d_ar);
       Eigen::Matrix<local_scalar_t__,-1,1> p_vec =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_vec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable p_vec");
       out__.write_free_lb(0, p_vec);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_1d_vec =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_1d_vec, in__.read<local_scalar_t__>(),
-            "assigning variable p_1d_vec", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(p_1d_vec,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+          "assigning variable p_1d_vec", stan::model::index_uni(sym1__));
       }
       out__.write(p_1d_vec);
       std::vector<
@@ -10226,37 +10221,30 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
             std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
               Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__))));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-              stan::model::assign(p_3d_vec, in__.read<local_scalar_t__>(),
-                "assigning variable p_3d_vec",
-                stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(p_3d_vec,
+              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+              "assigning variable p_3d_vec", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
           }
         }
       }
       out__.write(p_3d_vec);
       Eigen::Matrix<local_scalar_t__,1,-1> p_row_vec =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_row_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_row_vec", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_row_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable p_row_vec");
       out__.write(p_row_vec);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> p_1d_row_vec =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_1d_row_vec, in__.read<local_scalar_t__>(),
-            "assigning variable p_1d_row_vec",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(p_1d_row_vec,
+          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+          "assigning variable p_1d_row_vec", stan::model::index_uni(sym1__));
       }
       out__.write(p_1d_row_vec);
       std::vector<
@@ -10267,31 +10255,23 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(M,
             std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(K,
               Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__))));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-              stan::model::assign(p_3d_row_vec,
-                in__.read<local_scalar_t__>(),
-                "assigning variable p_3d_row_vec",
-                stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(p_3d_row_vec,
+              in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+              "assigning variable p_3d_row_vec",
+              stan::model::index_uni(sym3__), stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
           }
         }
       }
       out__.write(p_3d_row_vec);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_mat =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 4, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(p_mat, in__.read<local_scalar_t__>(),
-            "assigning variable p_mat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_mat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 4),
+        "assigning variable p_mat");
       out__.write(p_mat);
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>
         p_ar_mat =
@@ -10299,37 +10279,28 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(5,
             Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 3,
               DUMMY_VAR__)));
-      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= 5; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= 4; ++sym4__) {
-              stan::model::assign(p_ar_mat, in__.read<local_scalar_t__>(),
-                "assigning variable p_ar_mat",
-                stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
-          }
+      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= 4; ++sym2__) {
+          stan::model::assign(p_ar_mat,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 3),
+            "assigning variable p_ar_mat", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write_free_lub(0, 1, p_ar_mat);
       Eigen::Matrix<local_scalar_t__,-1,1> p_simplex =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_simplex, in__.read<local_scalar_t__>(),
-          "assigning variable p_simplex", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_simplex,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable p_simplex");
       out__.write_free_simplex(p_simplex);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_1d_simplex =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_1d_simplex, in__.read<local_scalar_t__>(),
-            "assigning variable p_1d_simplex",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(p_1d_simplex,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+          "assigning variable p_1d_simplex", stan::model::index_uni(sym1__));
       }
       out__.write_free_simplex(p_1d_simplex);
       std::vector<
@@ -10340,69 +10311,50 @@ class mother_model final : public model_base_crtp<mother_model> {
           std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
             std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
               Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__))));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-              stan::model::assign(p_3d_simplex,
-                in__.read<local_scalar_t__>(),
-                "assigning variable p_3d_simplex",
-                stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+            stan::model::assign(p_3d_simplex,
+              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+              "assigning variable p_3d_simplex",
+              stan::model::index_uni(sym3__), stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
           }
         }
       }
       out__.write_free_simplex(p_3d_simplex);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_cfcov_54 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 4, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(p_cfcov_54, in__.read<local_scalar_t__>(),
-            "assigning variable p_cfcov_54", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_cfcov_54,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 4),
+        "assigning variable p_cfcov_54");
       out__.write_free_cholesky_factor_cov(p_cfcov_54);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_cfcov_33 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 3, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-          stan::model::assign(p_cfcov_33, in__.read<local_scalar_t__>(),
-            "assigning variable p_cfcov_33", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_cfcov_33,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(3, 3),
+        "assigning variable p_cfcov_33");
       out__.write_free_cholesky_factor_cov(p_cfcov_33);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> p_cfcov_33_ar =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(K,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 3, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
-            stan::model::assign(p_cfcov_33_ar, in__.read<local_scalar_t__>(),
-              "assigning variable p_cfcov_33_ar",
-              stan::model::index_uni(sym3__), stan::model::index_uni(sym2__),
-              stan::model::index_uni(sym1__));
-          }
-        }
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        stan::model::assign(p_cfcov_33_ar,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(3, 3),
+          "assigning variable p_cfcov_33_ar", stan::model::index_uni(sym1__));
       }
       out__.write_free_cholesky_factor_cov(p_cfcov_33_ar);
       Eigen::Matrix<local_scalar_t__,-1,1> x_p =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(x_p, in__.read<local_scalar_t__>(),
-          "assigning variable x_p", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(x_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable x_p");
       out__.write(x_p);
       Eigen::Matrix<local_scalar_t__,-1,1> y_p =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(y_p, in__.read<local_scalar_t__>(),
-          "assigning variable y_p", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(y_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable y_p");
       out__.write(y_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13065,28 +13017,23 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       out__.write(x_p);
       Eigen::Matrix<local_scalar_t__,-1,1> x_p_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(x_p_v, in__.read<local_scalar_t__>(),
-          "assigning variable x_p_v", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(x_p_v,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable x_p_v");
       out__.write(x_p_v);
       Eigen::Matrix<local_scalar_t__,-1,1> shared_params_p =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(3, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        stan::model::assign(shared_params_p, in__.read<local_scalar_t__>(),
-          "assigning variable shared_params_p",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(shared_params_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(3),
+        "assigning variable shared_params_p");
       out__.write(shared_params_p);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> job_params_p =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(3,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(3, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-          stan::model::assign(job_params_p, in__.read<local_scalar_t__>(),
-            "assigning variable job_params_p",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(job_params_p,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(3),
+          "assigning variable job_params_p", stan::model::index_uni(sym1__));
       }
       out__.write(job_params_p);
       local_scalar_t__ x_r = DUMMY_VAR__;
@@ -17777,10 +17724,9 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       out__.write(ra);
       Eigen::Matrix<local_scalar_t__,-1,1> v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(v, in__.read<local_scalar_t__>(),
-          "assigning variable v", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(v,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable v");
       out__.write(v);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19782,24 +19728,21 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> alpha_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(alpha_v, in__.read<local_scalar_t__>(),
-          "assigning variable alpha_v", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(alpha_v,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable alpha_v");
       out__.write(alpha_v);
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable beta");
       out__.write(beta);
       Eigen::Matrix<local_scalar_t__,-1,1> cuts =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(cuts, in__.read<local_scalar_t__>(),
-          "assigning variable cuts", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(cuts,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable cuts");
       out__.write(cuts);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
@@ -19812,30 +19755,21 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       out__.write(phi);
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n, k),
+        "assigning variable X_p");
       out__.write(X_p);
       Eigen::Matrix<local_scalar_t__,-1,-1> beta_m =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
-          stan::model::assign(beta_m, in__.read<local_scalar_t__>(),
-            "assigning variable beta_m", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(beta_m,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n, k),
+        "assigning variable beta_m");
       out__.write(beta_m);
       Eigen::Matrix<local_scalar_t__,1,-1> X_rv_p =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(n, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
-        stan::model::assign(X_rv_p, in__.read<local_scalar_t__>(),
-          "assigning variable X_rv_p", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(X_rv_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(n),
+        "assigning variable X_rv_p");
       out__.write(X_rv_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20892,22 +20826,17 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> L_Omega =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(nt,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= nt; ++sym3__) {
-            stan::model::assign(L_Omega, in__.read<local_scalar_t__>(),
-              "assigning variable L_Omega", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
-        }
+      for (int sym1__ = 1; sym1__ <= nt; ++sym1__) {
+        stan::model::assign(L_Omega,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
+          "assigning variable L_Omega", stan::model::index_uni(sym1__));
       }
       out__.write_free_cholesky_factor_corr(L_Omega);
       Eigen::Matrix<local_scalar_t__,-1,1> z1 =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(NS, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= NS; ++sym1__) {
-        stan::model::assign(z1, in__.read<local_scalar_t__>(),
-          "assigning variable z1", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(z1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(NS),
+        "assigning variable z1");
       out__.write_free_lb(stan::model::rvalue(L_Omega, "L_Omega",
                             stan::model::index_uni(1),
                             stan::model::index_uni(1),
@@ -22274,10 +22203,9 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> gamma =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(times, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= times; ++sym1__) {
-        stan::model::assign(gamma, in__.read<local_scalar_t__>(),
-          "assigning variable gamma", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(gamma,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(times),
+        "assigning variable gamma");
       out__.write(gamma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -24512,15 +24440,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
               DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-              stan::model::assign(a8, in__.read<local_scalar_t__>(),
-                "assigning variable a8", stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
-          }
+          stan::model::assign(a8,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+            "assigning variable a8", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(a8);
@@ -24530,11 +24453,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(a7, in__.read<local_scalar_t__>(),
-              "assigning variable a7", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+          stan::model::assign(a7,
+            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+            "assigning variable a7", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(a7);
@@ -24544,11 +24466,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(a6, in__.read<local_scalar_t__>(),
-              "assigning variable a6", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+          stan::model::assign(a6,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+            "assigning variable a6", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(a6);
@@ -24565,35 +24486,27 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(a4, in__.read<local_scalar_t__>(),
-              "assigning variable a4", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
-        }
+        stan::model::assign(a4,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+          "assigning variable a4", stan::model::index_uni(sym1__));
       }
       out__.write(a4);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> a3 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(a3, in__.read<local_scalar_t__>(),
-            "assigning variable a3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(a3,
+          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+          "assigning variable a3", stan::model::index_uni(sym1__));
       }
       out__.write(a3);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> a2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(a2, in__.read<local_scalar_t__>(),
-            "assigning variable a2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(a2,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+          "assigning variable a2", stan::model::index_uni(sym1__));
       }
       out__.write(a2);
       std::vector<local_scalar_t__> a1 =
@@ -24609,15 +24522,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
               DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-              stan::model::assign(y8, in__.read<local_scalar_t__>(),
-                "assigning variable y8", stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
-          }
+          stan::model::assign(y8,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+            "assigning variable y8", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(y8);
@@ -24627,11 +24535,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(y7, in__.read<local_scalar_t__>(),
-              "assigning variable y7", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+          stan::model::assign(y7,
+            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+            "assigning variable y7", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(y7);
@@ -24641,11 +24548,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(y6, in__.read<local_scalar_t__>(),
-              "assigning variable y6", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+          stan::model::assign(y6,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+            "assigning variable y6", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(y6);
@@ -24662,35 +24568,27 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(y4, in__.read<local_scalar_t__>(),
-              "assigning variable y4", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
-        }
+        stan::model::assign(y4,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+          "assigning variable y4", stan::model::index_uni(sym1__));
       }
       out__.write(y4);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> y3 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y3, in__.read<local_scalar_t__>(),
-            "assigning variable y3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(y3,
+          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+          "assigning variable y3", stan::model::index_uni(sym1__));
       }
       out__.write(y3);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> y2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y2, in__.read<local_scalar_t__>(),
-            "assigning variable y2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(y2,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+          "assigning variable y2", stan::model::index_uni(sym1__));
       }
       out__.write(y2);
       std::vector<local_scalar_t__> y1 =
@@ -28017,35 +27915,27 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y2, in__.read<local_scalar_t__>(),
-            "assigning variable y2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(y2,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+          "assigning variable y2", stan::model::index_uni(sym1__));
       }
       out__.write(y2);
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> y3 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y3, in__.read<local_scalar_t__>(),
-            "assigning variable y3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+        stan::model::assign(y3,
+          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+          "assigning variable y3", stan::model::index_uni(sym1__));
       }
       out__.write(y3);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> y4 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(y4, in__.read<local_scalar_t__>(),
-              "assigning variable y4", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
-        }
+        stan::model::assign(y4,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+          "assigning variable y4", stan::model::index_uni(sym1__));
       }
       out__.write(y4);
       std::vector<std::vector<local_scalar_t__>> y5 =
@@ -28063,11 +27953,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(y6, in__.read<local_scalar_t__>(),
-              "assigning variable y6", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+          stan::model::assign(y6,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+            "assigning variable y6", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(y6);
@@ -28077,11 +27966,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            stan::model::assign(y7, in__.read<local_scalar_t__>(),
-              "assigning variable y7", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+          stan::model::assign(y7,
+            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+            "assigning variable y7", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(y7);
@@ -28092,15 +27980,10 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
               DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
-            for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
-              stan::model::assign(y8, in__.read<local_scalar_t__>(),
-                "assigning variable y8", stan::model::index_uni(sym4__),
-                stan::model::index_uni(sym3__),
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
-          }
+          stan::model::assign(y8,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+            "assigning variable y8", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write(y8);
@@ -28109,27 +27992,21 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       out__.write(y9);
       Eigen::Matrix<local_scalar_t__,-1,1> y10 =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y10, in__.read<local_scalar_t__>(),
-          "assigning variable y10", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(y10,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable y10");
       out__.write(y10);
       Eigen::Matrix<local_scalar_t__,1,-1> y11 =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y11, in__.read<local_scalar_t__>(),
-          "assigning variable y11", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(y11,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable y11");
       out__.write(y11);
       Eigen::Matrix<local_scalar_t__,-1,-1> y12 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(y12, in__.read<local_scalar_t__>(),
-            "assigning variable y12", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(y12,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable y12");
       out__.write(y12);
       std::vector<std::vector<std::vector<local_scalar_t__>>> y17 =
         std::vector<std::vector<std::vector<local_scalar_t__>>>(N,
@@ -29233,12 +29110,9 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
       out__.write(length);
       Eigen::Matrix<local_scalar_t__,-1,1> validate_positive_index =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(validate_positive_index,
-          in__.read<local_scalar_t__>(),
-          "assigning variable validate_positive_index",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(validate_positive_index,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable validate_positive_index");
       out__.write_free_simplex(validate_positive_index);
       local_scalar_t__ profile_map = DUMMY_VAR__;
       profile_map = in__.read<local_scalar_t__>();
@@ -29266,10 +29140,9 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
       out__.write(reduce_sum);
       Eigen::Matrix<local_scalar_t__,-1,1> segment =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(4, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
-        stan::model::assign(segment, in__.read<local_scalar_t__>(),
-          "assigning variable segment", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(segment,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(4),
+        "assigning variable segment");
       out__.write(segment);
       local_scalar_t__ ode_bdf = DUMMY_VAR__;
       ode_bdf = in__.read<local_scalar_t__>();
@@ -31945,10 +31818,9 @@ class transform_model final : public model_base_crtp<transform_model> {
       out__.write_free_lub(0, ds, p_10);
       Eigen::Matrix<local_scalar_t__,-1,1> pv_1 =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(pv_1, in__.read<local_scalar_t__>(),
-          "assigning variable pv_1", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(pv_1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+        "assigning variable pv_1");
       out__.write_free_lub(stan::model::rvalue(dv, "dv",
                              stan::model::index_uni(1),
                              stan::model::index_uni(1)),
@@ -31957,12 +31829,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> pv_2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(m,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
-          stan::model::assign(pv_2, in__.read<local_scalar_t__>(),
-            "assigning variable pv_2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
+        stan::model::assign(pv_2,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+          "assigning variable pv_2", stan::model::index_uni(sym1__));
       }
       out__.write_free_lb(stan::model::rvalue(dv, "dv",
                             stan::model::index_uni(1)), pv_2);
@@ -31970,22 +31840,20 @@ class transform_model final : public model_base_crtp<transform_model> {
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(n,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(m,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__)));
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
-            stan::model::assign(pv_3, in__.read<local_scalar_t__>(),
-              "assigning variable pv_3", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
+          stan::model::assign(pv_3,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(k),
+            "assigning variable pv_3", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write_free_ub(dv, pv_3);
       Eigen::Matrix<local_scalar_t__,1,-1> pr_1 =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        stan::model::assign(pr_1, in__.read<local_scalar_t__>(),
-          "assigning variable pr_1", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(pr_1,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(k),
+        "assigning variable pr_1");
       out__.write_free_lub(stan::model::rvalue(dr, "dr",
                              stan::model::index_uni(1),
                              stan::model::index_uni(1)),
@@ -31994,12 +31862,10 @@ class transform_model final : public model_base_crtp<transform_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> pr_2 =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(m,
           Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
-          stan::model::assign(pr_2, in__.read<local_scalar_t__>(),
-            "assigning variable pr_2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
+        stan::model::assign(pr_2,
+          in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(k),
+          "assigning variable pr_2", stan::model::index_uni(sym1__));
       }
       out__.write_free_lb(stan::model::rvalue(dr, "dr",
                             stan::model::index_uni(1)), pr_2);
@@ -32007,38 +31873,29 @@ class transform_model final : public model_base_crtp<transform_model> {
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(n,
           std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(m,
             Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__)));
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
-            stan::model::assign(pr_3, in__.read<local_scalar_t__>(),
-              "assigning variable pr_3", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+      for (int sym1__ = 1; sym1__ <= m; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
+          stan::model::assign(pr_3,
+            in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(k),
+            "assigning variable pr_3", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write_free_ub(dr, pr_3);
       Eigen::Matrix<local_scalar_t__,-1,-1> pm_1 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(m, k, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
-          stan::model::assign(pm_1, in__.read<local_scalar_t__>(),
-            "assigning variable pm_1", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(pm_1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(m, k),
+        "assigning variable pm_1");
       out__.write_free_lb(stan::model::rvalue(dm, "dm",
                             stan::model::index_uni(1)), pm_1);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> pm_2 =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(n,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(m, k, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
-            stan::model::assign(pm_2, in__.read<local_scalar_t__>(),
-              "assigning variable pm_2", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
-        }
+      for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
+        stan::model::assign(pm_2,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(m, k),
+          "assigning variable pm_2", stan::model::index_uni(sym1__));
       }
       out__.write_free_ub(dm, pm_2);
     } catch (const std::exception& e) {
@@ -34784,17 +34641,15 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
       out__.write_free_lb(0, sigma);
       Eigen::Matrix<local_scalar_t__,-1,1> vector_mu =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(vector_mu, in__.read<local_scalar_t__>(),
-          "assigning variable vector_mu", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(vector_mu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable vector_mu");
       out__.write(vector_mu);
       Eigen::Matrix<local_scalar_t__,1,-1> vector_sigma =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(vector_sigma, in__.read<local_scalar_t__>(),
-          "assigning variable vector_sigma", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(vector_sigma,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable vector_sigma");
       out__.write(vector_sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -218,8 +218,8 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -241,6 +241,42 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       stan::model::assign(theta_tilde,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
         "assigning variable theta_tilde");
+      out__.write(theta_tilde);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mu = DUMMY_VAR__;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      local_scalar_t__ tau = DUMMY_VAR__;
+      tau = context__.vals_r("tau")[(1 - 1)];
+      out__.write_free_lb(0, tau);
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_tilde =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> theta_tilde_flat__;
+        theta_tilde_flat__ = context__.vals_r("theta_tilde");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+          stan::model::assign(theta_tilde, theta_tilde_flat__[(pos__ - 1)],
+            "assigning variable theta_tilde", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(theta_tilde);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -373,24 +409,17 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "tau", "theta_tilde"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, 1, J};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -540,8 +569,8 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -554,6 +583,26 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       pos__ = 1;
       local_scalar_t__ bar = DUMMY_VAR__;
       bar = in__.read<local_scalar_t__>();
+      out__.write(bar);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ bar = DUMMY_VAR__;
+      bar = context__.vals_r("bar")[(1 - 1)];
       out__.write(bar);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -655,24 +704,17 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"bar"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1010,8 +1052,8 @@ class container_promotion_model final : public model_base_crtp<container_promoti
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1024,6 +1066,26 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       pos__ = 1;
       local_scalar_t__ y = DUMMY_VAR__;
       y = in__.read<local_scalar_t__>();
+      out__.write(y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ y = DUMMY_VAR__;
+      y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1229,24 +1291,17 @@ class container_promotion_model final : public model_base_crtp<container_promoti
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"y"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1930,8 +1985,8 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1986,6 +2041,68 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       out__.write(_stan_operator);
       local_scalar_t__ _stan_or = DUMMY_VAR__;
       _stan_or = in__.read<local_scalar_t__>();
+      out__.write(_stan_or);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ _stan_explicit = DUMMY_VAR__;
+      _stan_explicit = context__.vals_r("explicit")[(1 - 1)];
+      out__.write(_stan_explicit);
+      local_scalar_t__ _stan_float = DUMMY_VAR__;
+      _stan_float = context__.vals_r("float")[(1 - 1)];
+      out__.write(_stan_float);
+      local_scalar_t__ _stan_friend = DUMMY_VAR__;
+      _stan_friend = context__.vals_r("friend")[(1 - 1)];
+      out__.write(_stan_friend);
+      local_scalar_t__ _stan_goto = DUMMY_VAR__;
+      _stan_goto = context__.vals_r("goto")[(1 - 1)];
+      out__.write(_stan_goto);
+      local_scalar_t__ _stan_inline = DUMMY_VAR__;
+      _stan_inline = context__.vals_r("inline")[(1 - 1)];
+      out__.write(_stan_inline);
+      local_scalar_t__ _stan_long = DUMMY_VAR__;
+      _stan_long = context__.vals_r("long")[(1 - 1)];
+      out__.write(_stan_long);
+      local_scalar_t__ _stan_mutable = DUMMY_VAR__;
+      _stan_mutable = context__.vals_r("mutable")[(1 - 1)];
+      out__.write(_stan_mutable);
+      local_scalar_t__ _stan_namespace = DUMMY_VAR__;
+      _stan_namespace = context__.vals_r("namespace")[(1 - 1)];
+      out__.write(_stan_namespace);
+      local_scalar_t__ _stan_new = DUMMY_VAR__;
+      _stan_new = context__.vals_r("new")[(1 - 1)];
+      out__.write(_stan_new);
+      local_scalar_t__ _stan_noexcept = DUMMY_VAR__;
+      _stan_noexcept = context__.vals_r("noexcept")[(1 - 1)];
+      out__.write(_stan_noexcept);
+      local_scalar_t__ _stan_not = DUMMY_VAR__;
+      _stan_not = context__.vals_r("not")[(1 - 1)];
+      out__.write(_stan_not);
+      local_scalar_t__ _stan_not_eq = DUMMY_VAR__;
+      _stan_not_eq = context__.vals_r("not_eq")[(1 - 1)];
+      out__.write(_stan_not_eq);
+      local_scalar_t__ _stan_nullptr = DUMMY_VAR__;
+      _stan_nullptr = context__.vals_r("nullptr")[(1 - 1)];
+      out__.write(_stan_nullptr);
+      local_scalar_t__ _stan_operator = DUMMY_VAR__;
+      _stan_operator = context__.vals_r("operator")[(1 - 1)];
+      out__.write(_stan_operator);
+      local_scalar_t__ _stan_or = DUMMY_VAR__;
+      _stan_or = context__.vals_r("or")[(1 - 1)];
       out__.write(_stan_or);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2183,28 +2300,17 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 15>
-      names__{"explicit", "float", "friend", "goto", "inline", "long",
-              "mutable", "namespace", "new", "noexcept", "not", "not_eq",
-              "nullptr", "operator", "or"};
-    const std::array<Eigen::Index, 15>
-      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2441,8 +2547,8 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -2464,6 +2570,42 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       stan::model::assign(theta_tilde,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
         "assigning variable theta_tilde");
+      out__.write(theta_tilde);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mu = DUMMY_VAR__;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      local_scalar_t__ tau = DUMMY_VAR__;
+      tau = context__.vals_r("tau")[(1 - 1)];
+      out__.write_free_lb(0, tau);
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_tilde =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> theta_tilde_flat__;
+        theta_tilde_flat__ = context__.vals_r("theta_tilde");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+          stan::model::assign(theta_tilde, theta_tilde_flat__[(pos__ - 1)],
+            "assigning variable theta_tilde", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(theta_tilde);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2596,24 +2738,17 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "tau", "theta_tilde"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, 1, J};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2832,10 +2967,27 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -2942,24 +3094,17 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3177,8 +3322,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -3194,6 +3339,27 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
         xx[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(xx);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<local_scalar_t__> xx =
+        std::vector<local_scalar_t__>(3, DUMMY_VAR__);
+      xx = context__.vals_r("xx");
       out__.write(xx);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3356,24 +3522,17 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"xx"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{3};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -10140,8 +10299,8 @@ class mother_model final : public model_base_crtp<mother_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -10355,6 +10514,369 @@ class mother_model final : public model_base_crtp<mother_model> {
       stan::model::assign(y_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
         "assigning variable y_p");
+      out__.write(y_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ p_real = DUMMY_VAR__;
+      p_real = context__.vals_r("p_real")[(1 - 1)];
+      out__.write(p_real);
+      local_scalar_t__ p_upper = DUMMY_VAR__;
+      p_upper = context__.vals_r("p_upper")[(1 - 1)];
+      out__.write_free_lb(p_real, p_upper);
+      local_scalar_t__ p_lower = DUMMY_VAR__;
+      p_lower = context__.vals_r("p_lower")[(1 - 1)];
+      out__.write_free_ub(p_upper, p_lower);
+      std::vector<local_scalar_t__> offset_multiplier =
+        std::vector<local_scalar_t__>(5, DUMMY_VAR__);
+      offset_multiplier = context__.vals_r("offset_multiplier");
+      out__.write_free_offset_multiplier(1, 2, offset_multiplier);
+      std::vector<local_scalar_t__> no_offset_multiplier =
+        std::vector<local_scalar_t__>(5, DUMMY_VAR__);
+      no_offset_multiplier = context__.vals_r("no_offset_multiplier");
+      out__.write_free_offset_multiplier(0, 2, no_offset_multiplier);
+      std::vector<local_scalar_t__> offset_no_multiplier =
+        std::vector<local_scalar_t__>(5, DUMMY_VAR__);
+      offset_no_multiplier = context__.vals_r("offset_no_multiplier");
+      out__.write_free_offset_multiplier(3, 1, offset_no_multiplier);
+      std::vector<local_scalar_t__> p_real_1d_ar =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      p_real_1d_ar = context__.vals_r("p_real_1d_ar");
+      out__.write_free_lb(0, p_real_1d_ar);
+      std::vector<std::vector<std::vector<local_scalar_t__>>> p_real_3d_ar =
+        std::vector<std::vector<std::vector<local_scalar_t__>>>(N,
+          std::vector<std::vector<local_scalar_t__>>(M,
+            std::vector<local_scalar_t__>(K, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> p_real_3d_ar_flat__;
+        p_real_3d_ar_flat__ = context__.vals_r("p_real_3d_ar");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= M; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(p_real_3d_ar, p_real_3d_ar_flat__[(pos__ -
+                1)], "assigning variable p_real_3d_ar",
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_lb(0, p_real_3d_ar);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_vec_flat__;
+        p_vec_flat__ = context__.vals_r("p_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_vec, p_vec_flat__[(pos__ - 1)],
+            "assigning variable p_vec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lb(0, p_vec);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_1d_vec =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> p_1d_vec_flat__;
+        p_1d_vec_flat__ = context__.vals_r("p_1d_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_1d_vec, p_1d_vec_flat__[(pos__ - 1)],
+              "assigning variable p_1d_vec", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_1d_vec);
+      std::vector<
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        p_3d_vec =
+        std::vector<
+          std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
+          std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
+            std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
+              Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__))));
+      {
+        std::vector<local_scalar_t__> p_3d_vec_flat__;
+        p_3d_vec_flat__ = context__.vals_r("p_3d_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+                stan::model::assign(p_3d_vec, p_3d_vec_flat__[(pos__ - 1)],
+                  "assigning variable p_3d_vec",
+                  stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write(p_3d_vec);
+      Eigen::Matrix<local_scalar_t__,1,-1> p_row_vec =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_row_vec_flat__;
+        p_row_vec_flat__ = context__.vals_r("p_row_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_row_vec, p_row_vec_flat__[(pos__ - 1)],
+            "assigning variable p_row_vec", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_row_vec);
+      std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> p_1d_row_vec =
+        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> p_1d_row_vec_flat__;
+        p_1d_row_vec_flat__ = context__.vals_r("p_1d_row_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_1d_row_vec, p_1d_row_vec_flat__[(pos__ -
+              1)], "assigning variable p_1d_row_vec",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_1d_row_vec);
+      std::vector<
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>
+        p_3d_row_vec =
+        std::vector<
+          std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>>(N,
+          std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(M,
+            std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(K,
+              Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__))));
+      {
+        std::vector<local_scalar_t__> p_3d_row_vec_flat__;
+        p_3d_row_vec_flat__ = context__.vals_r("p_3d_row_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+                stan::model::assign(p_3d_row_vec, p_3d_row_vec_flat__[(pos__
+                  - 1)], "assigning variable p_3d_row_vec",
+                  stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write(p_3d_row_vec);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_mat =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 4, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_mat_flat__;
+        p_mat_flat__ = context__.vals_r("p_mat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(p_mat, p_mat_flat__[(pos__ - 1)],
+              "assigning variable p_mat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_mat);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>
+        p_ar_mat =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(4,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(5,
+            Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 3,
+              DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> p_ar_mat_flat__;
+        p_ar_mat_flat__ = context__.vals_r("p_ar_mat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= 5; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= 4; ++sym4__) {
+                stan::model::assign(p_ar_mat, p_ar_mat_flat__[(pos__ - 1)],
+                  "assigning variable p_ar_mat",
+                  stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write_free_lub(0, 1, p_ar_mat);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_simplex =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_simplex_flat__;
+        p_simplex_flat__ = context__.vals_r("p_simplex");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_simplex, p_simplex_flat__[(pos__ - 1)],
+            "assigning variable p_simplex", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_simplex(p_simplex);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_1d_simplex =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> p_1d_simplex_flat__;
+        p_1d_simplex_flat__ = context__.vals_r("p_1d_simplex");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_1d_simplex, p_1d_simplex_flat__[(pos__ -
+              1)], "assigning variable p_1d_simplex",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_simplex(p_1d_simplex);
+      std::vector<
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>
+        p_3d_simplex =
+        std::vector<
+          std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>>(N,
+          std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(M,
+            std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
+              Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__))));
+      {
+        std::vector<local_scalar_t__> p_3d_simplex_flat__;
+        p_3d_simplex_flat__ = context__.vals_r("p_3d_simplex");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= M; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+                stan::model::assign(p_3d_simplex, p_3d_simplex_flat__[(pos__
+                  - 1)], "assigning variable p_3d_simplex",
+                  stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write_free_simplex(p_3d_simplex);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_cfcov_54 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 4, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_cfcov_54_flat__;
+        p_cfcov_54_flat__ = context__.vals_r("p_cfcov_54");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(p_cfcov_54, p_cfcov_54_flat__[(pos__ - 1)],
+              "assigning variable p_cfcov_54",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_cholesky_factor_cov(p_cfcov_54);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_cfcov_33 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 3, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_cfcov_33_flat__;
+        p_cfcov_33_flat__ = context__.vals_r("p_cfcov_33");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+            stan::model::assign(p_cfcov_33, p_cfcov_33_flat__[(pos__ - 1)],
+              "assigning variable p_cfcov_33",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_cholesky_factor_cov(p_cfcov_33);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> p_cfcov_33_ar =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(K,
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 3, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> p_cfcov_33_ar_flat__;
+        p_cfcov_33_ar_flat__ = context__.vals_r("p_cfcov_33_ar");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= K; ++sym3__) {
+              stan::model::assign(p_cfcov_33_ar, p_cfcov_33_ar_flat__[(pos__
+                - 1)], "assigning variable p_cfcov_33_ar",
+                stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_cholesky_factor_cov(p_cfcov_33_ar);
+      Eigen::Matrix<local_scalar_t__,-1,1> x_p =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_p_flat__;
+        x_p_flat__ = context__.vals_r("x_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(x_p, x_p_flat__[(pos__ - 1)],
+            "assigning variable x_p", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(x_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> y_p =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> y_p_flat__;
+        y_p_flat__ = context__.vals_r("y_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(y_p, y_p_flat__[(pos__ - 1)],
+            "assigning variable y_p", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(y_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11519,34 +12041,17 @@ class mother_model final : public model_base_crtp<mother_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 24>
-      names__{"p_real", "p_upper", "p_lower", "offset_multiplier",
-              "no_offset_multiplier", "offset_no_multiplier", "p_real_1d_ar",
-              "p_real_3d_ar", "p_vec", "p_1d_vec", "p_3d_vec", "p_row_vec",
-              "p_1d_row_vec", "p_3d_row_vec", "p_mat", "p_ar_mat",
-              "p_simplex", "p_1d_simplex", "p_3d_simplex", "p_cfcov_54",
-              "p_cfcov_33", "p_cfcov_33_ar", "x_p", "y_p"};
-    const std::array<Eigen::Index, 24>
-      constrain_param_sizes__{1, 1, 1, 5, 5, 5, N, (N * M * K), N, (N * N),
-                              (N * M * K * N), N, (N * N), (N * M * K * N),
-                              (5 * 4), (4 * 5 * 2 * 3), N, (N * N), (N * M *
-                              K * N), (5 * 4), (3 * 3), (K * 3 * 3), 2, 2};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -12985,8 +13490,8 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -13038,6 +13543,82 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       out__.write(job_params_p);
       local_scalar_t__ x_r = DUMMY_VAR__;
       x_r = in__.read<local_scalar_t__>();
+      out__.write(x_r);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<local_scalar_t__> y0_p =
+        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
+      y0_p = context__.vals_r("y0_p");
+      out__.write(y0_p);
+      std::vector<local_scalar_t__> theta_p =
+        std::vector<local_scalar_t__>(1, DUMMY_VAR__);
+      theta_p = context__.vals_r("theta_p");
+      out__.write(theta_p);
+      std::vector<local_scalar_t__> x_p =
+        std::vector<local_scalar_t__>(1, DUMMY_VAR__);
+      x_p = context__.vals_r("x_p");
+      out__.write(x_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> x_p_v =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_p_v_flat__;
+        x_p_v_flat__ = context__.vals_r("x_p_v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(x_p_v, x_p_v_flat__[(pos__ - 1)],
+            "assigning variable x_p_v", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(x_p_v);
+      Eigen::Matrix<local_scalar_t__,-1,1> shared_params_p =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(3, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> shared_params_p_flat__;
+        shared_params_p_flat__ = context__.vals_r("shared_params_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          stan::model::assign(shared_params_p, shared_params_p_flat__[(pos__
+            - 1)], "assigning variable shared_params_p",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(shared_params_p);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> job_params_p =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(3,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(3, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> job_params_p_flat__;
+        job_params_p_flat__ = context__.vals_r("job_params_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 3; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+            stan::model::assign(job_params_p, job_params_p_flat__[(pos__ -
+              1)], "assigning variable job_params_p",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(job_params_p);
+      local_scalar_t__ x_r = DUMMY_VAR__;
+      x_r = context__.vals_r("x_r")[(1 - 1)];
       out__.write(x_r);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13349,27 +13930,17 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 7>
-      names__{"y0_p", "theta_p", "x_p", "x_p_v", "shared_params_p",
-              "job_params_p", "x_r"};
-    const std::array<Eigen::Index, 7>
-      constrain_param_sizes__{2, 1, 1, 2, 3, (3 * 3), 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -17701,8 +18272,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -17727,6 +18298,43 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       stan::model::assign(v,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
         "assigning variable v");
+      out__.write(v);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ r = DUMMY_VAR__;
+      r = context__.vals_r("r")[(1 - 1)];
+      out__.write(r);
+      std::vector<local_scalar_t__> ra =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      ra = context__.vals_r("ra");
+      out__.write(ra);
+      Eigen::Matrix<local_scalar_t__,-1,1> v =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> v_flat__;
+        v_flat__ = context__.vals_r("v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(v, v_flat__[(pos__ - 1)],
+            "assigning variable v", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(v);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -17894,24 +18502,17 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"r", "ra", "v"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, N, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18327,8 +18928,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -18362,6 +18963,43 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
         sigma[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write_free_lb(0, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
+      out__.write_free_lb(0, alpha);
+      local_scalar_t__ beta = DUMMY_VAR__;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write_free_lb(0, beta);
+      local_scalar_t__ gamma = DUMMY_VAR__;
+      gamma = context__.vals_r("gamma")[(1 - 1)];
+      out__.write_free_lb(0, gamma);
+      local_scalar_t__ delta = DUMMY_VAR__;
+      delta = context__.vals_r("delta")[(1 - 1)];
+      out__.write_free_lb(0, delta);
+      std::vector<local_scalar_t__> z_init =
+        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
+      z_init = context__.vals_r("z_init");
+      out__.write_free_lb(0, z_init);
+      std::vector<local_scalar_t__> sigma =
+        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
+      sigma = context__.vals_r("sigma");
       out__.write_free_lb(0, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18514,26 +19152,17 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"alpha", "beta", "gamma", "delta", "z_init", "sigma"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, 2, 2};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -19714,8 +20343,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -19770,6 +20399,116 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       stan::model::assign(X_rv_p,
         in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(n),
         "assigning variable X_rv_p");
+      out__.write(X_rv_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> alpha_v =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> alpha_v_flat__;
+        alpha_v_flat__ = context__.vals_r("alpha_v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(alpha_v, alpha_v_flat__[(pos__ - 1)],
+            "assigning variable alpha_v", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(alpha_v);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> cuts =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> cuts_flat__;
+        cuts_flat__ = context__.vals_r("cuts");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(cuts, cuts_flat__[(pos__ - 1)],
+            "assigning variable cuts", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(cuts);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
+      out__.write(alpha);
+      local_scalar_t__ phi = DUMMY_VAR__;
+      phi = context__.vals_r("phi")[(1 - 1)];
+      out__.write(phi);
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(X_p);
+      Eigen::Matrix<local_scalar_t__,-1,-1> beta_m =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n, k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_m_flat__;
+        beta_m_flat__ = context__.vals_r("beta_m");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= n; ++sym2__) {
+            stan::model::assign(beta_m, beta_m_flat__[(pos__ - 1)],
+              "assigning variable beta_m", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(beta_m);
+      Eigen::Matrix<local_scalar_t__,1,-1> X_rv_p =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(n, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_rv_p_flat__;
+        X_rv_p_flat__ = context__.vals_r("X_rv_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n; ++sym1__) {
+          stan::model::assign(X_rv_p, X_rv_p_flat__[(pos__ - 1)],
+            "assigning variable X_rv_p", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(X_rv_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19944,27 +20683,17 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 9>
-      names__{"alpha_v", "beta", "cuts", "sigma", "alpha", "phi", "X_p",
-              "beta_m", "X_rv_p"};
-    const std::array<Eigen::Index, 9>
-      constrain_param_sizes__{k, k, k, 1, 1, 1, (n * k), (n * k), n};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20470,8 +21199,8 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -20487,6 +21216,29 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
       out__.write(y);
       local_scalar_t__ z = DUMMY_VAR__;
       z = in__.read<local_scalar_t__>();
+      out__.write(z);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ y = DUMMY_VAR__;
+      y = context__.vals_r("y")[(1 - 1)];
+      out__.write(y);
+      local_scalar_t__ z = DUMMY_VAR__;
+      z = context__.vals_r("z")[(1 - 1)];
       out__.write(z);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20591,24 +21343,17 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"y", "z"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20811,8 +21556,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -20837,6 +21582,59 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
       stan::model::assign(z1,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(NS),
         "assigning variable z1");
+      out__.write_free_lb(stan::model::rvalue(L_Omega, "L_Omega",
+                            stan::model::index_uni(1),
+                            stan::model::index_uni(1),
+                            stan::model::index_uni(2)), z1);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> L_Omega =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(nt,
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> L_Omega_flat__;
+        L_Omega_flat__ = context__.vals_r("L_Omega");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= nt; ++sym3__) {
+              stan::model::assign(L_Omega, L_Omega_flat__[(pos__ - 1)],
+                "assigning variable L_Omega", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_cholesky_factor_corr(L_Omega);
+      Eigen::Matrix<local_scalar_t__,-1,1> z1 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(NS, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> z1_flat__;
+        z1_flat__ = context__.vals_r("z1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= NS; ++sym1__) {
+          stan::model::assign(z1, z1_flat__[(pos__ - 1)],
+            "assigning variable z1", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write_free_lb(stan::model::rvalue(L_Omega, "L_Omega",
                             stan::model::index_uni(1),
                             stan::model::index_uni(1),
@@ -20967,25 +21765,17 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"L_Omega", "z1"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(nt * 2 * 2), NS};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -21134,10 +21924,27 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21244,24 +22051,17 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -21469,10 +22269,27 @@ class promotion_model final : public model_base_crtp<promotion_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21611,24 +22428,17 @@ class promotion_model final : public model_base_crtp<promotion_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22189,8 +22999,8 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -22206,6 +23016,36 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
       stan::model::assign(gamma,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(times),
         "assigning variable gamma");
+      out__.write(gamma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> gamma =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(times, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> gamma_flat__;
+        gamma_flat__ = context__.vals_r("gamma");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= times; ++sym1__) {
+          stan::model::assign(gamma, gamma_flat__[(pos__ - 1)],
+            "assigning variable gamma", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(gamma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22343,24 +23183,17 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"gamma"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{times};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22686,8 +23519,8 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -22715,6 +23548,35 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         y3[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(y3);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<local_scalar_t__> y1 =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      y1 = context__.vals_r("y1");
+      out__.write(y1);
+      std::vector<local_scalar_t__> y2 =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      y2 = context__.vals_r("y2");
+      out__.write(y2);
+      std::vector<local_scalar_t__> y3 =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      y3 = context__.vals_r("y3");
       out__.write(y3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22841,24 +23703,17 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"y1", "y2", "y3"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{N, N, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -24421,8 +25276,8 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -24596,6 +25451,307 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         y1[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(y1);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> a8 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
+            Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N,
+              DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> a8_flat__;
+        a8_flat__ = context__.vals_r("a8");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+                stan::model::assign(a8, a8_flat__[(pos__ - 1)],
+                  "assigning variable a8", stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write(a8);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>> a7 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+            Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> a7_flat__;
+        a7_flat__ = context__.vals_r("a7");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(a7, a7_flat__[(pos__ - 1)],
+                "assigning variable a7", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(a7);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> a6 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> a6_flat__;
+        a6_flat__ = context__.vals_r("a6");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(a6, a6_flat__[(pos__ - 1)],
+                "assigning variable a6", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(a6);
+      std::vector<std::vector<local_scalar_t__>> a5 =
+        std::vector<std::vector<local_scalar_t__>>(N,
+          std::vector<local_scalar_t__>(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> a5_flat__;
+        a5_flat__ = context__.vals_r("a5");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(a5, a5_flat__[(pos__ - 1)],
+              "assigning variable a5", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(a5);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> a4 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> a4_flat__;
+        a4_flat__ = context__.vals_r("a4");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(a4, a4_flat__[(pos__ - 1)],
+                "assigning variable a4", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(a4);
+      std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> a3 =
+        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> a3_flat__;
+        a3_flat__ = context__.vals_r("a3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(a3, a3_flat__[(pos__ - 1)],
+              "assigning variable a3", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(a3);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> a2 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> a2_flat__;
+        a2_flat__ = context__.vals_r("a2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(a2, a2_flat__[(pos__ - 1)],
+              "assigning variable a2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(a2);
+      std::vector<local_scalar_t__> a1 =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      a1 = context__.vals_r("a1");
+      out__.write(a1);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> y8 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
+            Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N,
+              DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y8_flat__;
+        y8_flat__ = context__.vals_r("y8");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+                stan::model::assign(y8, y8_flat__[(pos__ - 1)],
+                  "assigning variable y8", stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write(y8);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>> y7 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+            Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y7_flat__;
+        y7_flat__ = context__.vals_r("y7");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y7, y7_flat__[(pos__ - 1)],
+                "assigning variable y7", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(y7);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> y6 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y6_flat__;
+        y6_flat__ = context__.vals_r("y6");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y6, y6_flat__[(pos__ - 1)],
+                "assigning variable y6", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(y6);
+      std::vector<std::vector<local_scalar_t__>> y5 =
+        std::vector<std::vector<local_scalar_t__>>(N,
+          std::vector<local_scalar_t__>(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y5_flat__;
+        y5_flat__ = context__.vals_r("y5");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y5, y5_flat__[(pos__ - 1)],
+              "assigning variable y5", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y5);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> y4 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y4_flat__;
+        y4_flat__ = context__.vals_r("y4");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y4, y4_flat__[(pos__ - 1)],
+                "assigning variable y4", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(y4);
+      std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> y3 =
+        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y3_flat__;
+        y3_flat__ = context__.vals_r("y3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y3, y3_flat__[(pos__ - 1)],
+              "assigning variable y3", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y3);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> y2 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y2_flat__;
+        y2_flat__ = context__.vals_r("y2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y2, y2_flat__[(pos__ - 1)],
+              "assigning variable y2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y2);
+      std::vector<local_scalar_t__> y1 =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      y1 = context__.vals_r("y1");
       out__.write(y1);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -24975,30 +26131,17 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16>
-      names__{"a8", "a7", "a6", "a5", "a4", "a3", "a2", "a1", "y8", "y7",
-              "y6", "y5", "y4", "y3", "y2", "y1"};
-    const std::array<Eigen::Index, 16>
-      constrain_param_sizes__{(N * N * N * N), (N * N * N), (N * N * N), (N *
-                              N), (N * N * N), (N * N), (N * N), N, (N * N *
-                              N * N), (N * N * N), (N * N * N), (N * N), (N *
-                              N * N), (N * N), (N * N), N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -27893,8 +29036,8 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -28017,6 +29160,231 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
           for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
             y17[(sym3__ - 1)][(sym2__ - 1)][(sym1__ -
               1)] = in__.read<local_scalar_t__>();
+          }
+        }
+      }
+      out__.write(y17);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<local_scalar_t__> y1 =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      y1 = context__.vals_r("y1");
+      out__.write(y1);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> y2 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y2_flat__;
+        y2_flat__ = context__.vals_r("y2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y2, y2_flat__[(pos__ - 1)],
+              "assigning variable y2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y2);
+      std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> y3 =
+        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y3_flat__;
+        y3_flat__ = context__.vals_r("y3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y3, y3_flat__[(pos__ - 1)],
+              "assigning variable y3", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y3);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> y4 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y4_flat__;
+        y4_flat__ = context__.vals_r("y4");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y4, y4_flat__[(pos__ - 1)],
+                "assigning variable y4", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(y4);
+      std::vector<std::vector<local_scalar_t__>> y5 =
+        std::vector<std::vector<local_scalar_t__>>(N,
+          std::vector<local_scalar_t__>(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> y5_flat__;
+        y5_flat__ = context__.vals_r("y5");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y5, y5_flat__[(pos__ - 1)],
+              "assigning variable y5", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y5);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> y6 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(N,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y6_flat__;
+        y6_flat__ = context__.vals_r("y6");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y6, y6_flat__[(pos__ - 1)],
+                "assigning variable y6", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(y6);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>> y7 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(N,
+            Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y7_flat__;
+        y7_flat__ = context__.vals_r("y7");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y7, y7_flat__[(pos__ - 1)],
+                "assigning variable y7", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(y7);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> y8 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(N,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
+            Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N,
+              DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y8_flat__;
+        y8_flat__ = context__.vals_r("y8");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              for (int sym4__ = 1; sym4__ <= N; ++sym4__) {
+                stan::model::assign(y8, y8_flat__[(pos__ - 1)],
+                  "assigning variable y8", stan::model::index_uni(sym4__),
+                  stan::model::index_uni(sym3__),
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write(y8);
+      local_scalar_t__ y9 = DUMMY_VAR__;
+      y9 = context__.vals_r("y9")[(1 - 1)];
+      out__.write(y9);
+      Eigen::Matrix<local_scalar_t__,-1,1> y10 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> y10_flat__;
+        y10_flat__ = context__.vals_r("y10");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(y10, y10_flat__[(pos__ - 1)],
+            "assigning variable y10", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(y10);
+      Eigen::Matrix<local_scalar_t__,1,-1> y11 =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> y11_flat__;
+        y11_flat__ = context__.vals_r("y11");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(y11, y11_flat__[(pos__ - 1)],
+            "assigning variable y11", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(y11);
+      Eigen::Matrix<local_scalar_t__,-1,-1> y12 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> y12_flat__;
+        y12_flat__ = context__.vals_r("y12");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(y12, y12_flat__[(pos__ - 1)],
+              "assigning variable y12", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(y12);
+      std::vector<std::vector<std::vector<local_scalar_t__>>> y17 =
+        std::vector<std::vector<std::vector<local_scalar_t__>>>(N,
+          std::vector<std::vector<local_scalar_t__>>(N,
+            std::vector<local_scalar_t__>(N, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> y17_flat__;
+        y17_flat__ = context__.vals_r("y17");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= N; ++sym3__) {
+              stan::model::assign(y17, y17_flat__[(pos__ - 1)],
+                "assigning variable y17", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
           }
         }
       }
@@ -28398,29 +29766,17 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 13>
-      names__{"y1", "y2", "y3", "y4", "y5", "y6", "y7", "y8", "y9", "y10",
-              "y11", "y12", "y17"};
-    const std::array<Eigen::Index, 13>
-      constrain_param_sizes__{N, (N * N), (N * N), (N * N * N), (N * N), (N *
-                              N * N), (N * N * N), (N * N * N * N), 1, N, N,
-                              (N * N), (N * N * N)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -29033,8 +30389,8 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -29149,6 +30505,147 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
       out__.write(ode_bdf);
       local_scalar_t__ ode_bdf_tol = DUMMY_VAR__;
       ode_bdf_tol = in__.read<local_scalar_t__>();
+      out__.write(ode_bdf_tol);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ e = DUMMY_VAR__;
+      e = context__.vals_r("e")[(1 - 1)];
+      out__.write(e);
+      local_scalar_t__ pi = DUMMY_VAR__;
+      pi = context__.vals_r("pi")[(1 - 1)];
+      out__.write(pi);
+      local_scalar_t__ log2 = DUMMY_VAR__;
+      log2 = context__.vals_r("log2")[(1 - 1)];
+      out__.write(log2);
+      local_scalar_t__ log10 = DUMMY_VAR__;
+      log10 = context__.vals_r("log10")[(1 - 1)];
+      out__.write(log10);
+      local_scalar_t__ sqrt2 = DUMMY_VAR__;
+      sqrt2 = context__.vals_r("sqrt2")[(1 - 1)];
+      out__.write(sqrt2);
+      local_scalar_t__ not_a_number = DUMMY_VAR__;
+      not_a_number = context__.vals_r("not_a_number")[(1 - 1)];
+      out__.write(not_a_number);
+      local_scalar_t__ positive_infinity = DUMMY_VAR__;
+      positive_infinity = context__.vals_r("positive_infinity")[(1 - 1)];
+      out__.write(positive_infinity);
+      local_scalar_t__ negative_infinity = DUMMY_VAR__;
+      negative_infinity = context__.vals_r("negative_infinity")[(1 - 1)];
+      out__.write(negative_infinity);
+      local_scalar_t__ machine_precision = DUMMY_VAR__;
+      machine_precision = context__.vals_r("machine_precision")[(1 - 1)];
+      out__.write(machine_precision);
+      local_scalar_t__ inv_logit = DUMMY_VAR__;
+      inv_logit = context__.vals_r("inv_logit")[(1 - 1)];
+      out__.write(inv_logit);
+      local_scalar_t__ logit = DUMMY_VAR__;
+      logit = context__.vals_r("logit")[(1 - 1)];
+      out__.write(logit);
+      local_scalar_t__ num_elements = DUMMY_VAR__;
+      num_elements = context__.vals_r("num_elements")[(1 - 1)];
+      out__.write(num_elements);
+      local_scalar_t__ pow = DUMMY_VAR__;
+      pow = context__.vals_r("pow")[(1 - 1)];
+      out__.write(pow);
+      local_scalar_t__ add = DUMMY_VAR__;
+      add = context__.vals_r("add")[(1 - 1)];
+      out__.write(add);
+      local_scalar_t__ sub = DUMMY_VAR__;
+      sub = context__.vals_r("sub")[(1 - 1)];
+      out__.write(sub);
+      local_scalar_t__ multiply = DUMMY_VAR__;
+      multiply = context__.vals_r("multiply")[(1 - 1)];
+      out__.write(multiply);
+      local_scalar_t__ binomial_coefficient_log = DUMMY_VAR__;
+      binomial_coefficient_log = context__.vals_r("binomial_coefficient_log")[(1
+        - 1)];
+      out__.write(binomial_coefficient_log);
+      local_scalar_t__ read_constrain_lb = DUMMY_VAR__;
+      read_constrain_lb = context__.vals_r("read_constrain_lb")[(1 - 1)];
+      out__.write_free_lb(0, read_constrain_lb);
+      local_scalar_t__ read = DUMMY_VAR__;
+      read = context__.vals_r("read")[(1 - 1)];
+      out__.write(read);
+      local_scalar_t__ validate_non_negative_index = DUMMY_VAR__;
+      validate_non_negative_index = context__.vals_r("validate_non_negative_index")[(1
+        - 1)];
+      out__.write(validate_non_negative_index);
+      local_scalar_t__ length = DUMMY_VAR__;
+      length = context__.vals_r("length")[(1 - 1)];
+      out__.write(length);
+      Eigen::Matrix<local_scalar_t__,-1,1> validate_positive_index =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> validate_positive_index_flat__;
+        validate_positive_index_flat__ = context__.vals_r("validate_positive_index");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(validate_positive_index,
+            validate_positive_index_flat__[(pos__ - 1)],
+            "assigning variable validate_positive_index",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_simplex(validate_positive_index);
+      local_scalar_t__ profile_map = DUMMY_VAR__;
+      profile_map = context__.vals_r("profile_map")[(1 - 1)];
+      out__.write(profile_map);
+      local_scalar_t__ assign = DUMMY_VAR__;
+      assign = context__.vals_r("assign")[(1 - 1)];
+      out__.write(assign);
+      local_scalar_t__ rvalue = DUMMY_VAR__;
+      rvalue = context__.vals_r("rvalue")[(1 - 1)];
+      out__.write(rvalue);
+      local_scalar_t__ stan_print = DUMMY_VAR__;
+      stan_print = context__.vals_r("stan_print")[(1 - 1)];
+      out__.write(stan_print);
+      local_scalar_t__ model_base_crtp = DUMMY_VAR__;
+      model_base_crtp = context__.vals_r("model_base_crtp")[(1 - 1)];
+      out__.write(model_base_crtp);
+      local_scalar_t__ index_uni = DUMMY_VAR__;
+      index_uni = context__.vals_r("index_uni")[(1 - 1)];
+      out__.write(index_uni);
+      local_scalar_t__ bernoulli_logit_glm_lpmf = DUMMY_VAR__;
+      bernoulli_logit_glm_lpmf = context__.vals_r("bernoulli_logit_glm_lpmf")[(1
+        - 1)];
+      out__.write(bernoulli_logit_glm_lpmf);
+      local_scalar_t__ reduce_sum = DUMMY_VAR__;
+      reduce_sum = context__.vals_r("reduce_sum")[(1 - 1)];
+      out__.write(reduce_sum);
+      Eigen::Matrix<local_scalar_t__,-1,1> segment =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(4, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> segment_flat__;
+        segment_flat__ = context__.vals_r("segment");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 4; ++sym1__) {
+          stan::model::assign(segment, segment_flat__[(pos__ - 1)],
+            "assigning variable segment", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(segment);
+      local_scalar_t__ ode_bdf = DUMMY_VAR__;
+      ode_bdf = context__.vals_r("ode_bdf")[(1 - 1)];
+      out__.write(ode_bdf);
+      local_scalar_t__ ode_bdf_tol = DUMMY_VAR__;
+      ode_bdf_tol = context__.vals_r("ode_bdf_tol")[(1 - 1)];
       out__.write(ode_bdf_tol);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -29395,36 +30892,17 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 33>
-      names__{"e", "pi", "log2", "log10", "sqrt2", "not_a_number",
-              "positive_infinity", "negative_infinity", "machine_precision",
-              "inv_logit", "logit", "num_elements", "pow", "add", "sub",
-              "multiply", "binomial_coefficient_log", "read_constrain_lb",
-              "read", "validate_non_negative_index", "length",
-              "validate_positive_index", "profile_map", "assign", "rvalue",
-              "stan_print", "model_base_crtp", "index_uni",
-              "bernoulli_logit_glm_lpmf", "reduce_sum", "segment", "ode_bdf",
-              "ode_bdf_tol"};
-    const std::array<Eigen::Index, 33>
-      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                              1, 1, 1, 1, 1, 5, 1, 1, 1, 1, 1, 1, 1, 1, 4, 1,
-                              1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -29685,10 +31163,27 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -29795,24 +31290,17 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -29995,8 +31483,8 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -30009,6 +31497,26 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       x = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ x = DUMMY_VAR__;
+      x = context__.vals_r("x")[(1 - 1)];
       out__.write_free_lb(0, x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -30110,24 +31618,17 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"x"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -31712,8 +33213,8 @@ class transform_model final : public model_base_crtp<transform_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -31896,6 +33397,264 @@ class transform_model final : public model_base_crtp<transform_model> {
         stan::model::assign(pm_2,
           in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(m, k),
           "assigning variable pm_2", stan::model::index_uni(sym1__));
+      }
+      out__.write_free_ub(dm, pm_2);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<local_scalar_t__> p_1 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_1 = context__.vals_r("p_1");
+      out__.write_free_lb(stan::model::rvalue(ds, "ds",
+                            stan::model::index_uni(1),
+                            stan::model::index_uni(1)), p_1);
+      std::vector<local_scalar_t__> p_2 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_2 = context__.vals_r("p_2");
+      out__.write_free_ub(stan::model::rvalue(ds, "ds",
+                            stan::model::index_uni(1),
+                            stan::model::index_uni(1)), p_2);
+      std::vector<local_scalar_t__> p_3 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_3 = context__.vals_r("p_3");
+      out__.write_free_lub(stan::model::rvalue(ds, "ds",
+                             stan::model::index_uni(1),
+                             stan::model::index_uni(1)),
+        stan::model::rvalue(ds, "ds", stan::model::index_uni(1),
+          stan::model::index_uni(2)), p_3);
+      std::vector<local_scalar_t__> p_4 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_4 = context__.vals_r("p_4");
+      out__.write_free_lub(0,
+        stan::model::rvalue(ds, "ds", stan::model::index_uni(1),
+          stan::model::index_uni(2)), p_4);
+      std::vector<local_scalar_t__> p_5 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_5 = context__.vals_r("p_5");
+      out__.write_free_lub(stan::model::rvalue(ds, "ds",
+                             stan::model::index_uni(1),
+                             stan::model::index_uni(1)), 1, p_5);
+      std::vector<local_scalar_t__> p_6 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_6 = context__.vals_r("p_6");
+      out__.write_free_offset_multiplier(stan::model::rvalue(ds, "ds",
+                                           stan::model::index_uni(1),
+                                           stan::model::index_uni(1)), 1,
+        p_6);
+      std::vector<local_scalar_t__> p_7 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_7 = context__.vals_r("p_7");
+      out__.write_free_offset_multiplier(0,
+        stan::model::rvalue(ds, "ds", stan::model::index_uni(1),
+          stan::model::index_uni(1)), p_7);
+      std::vector<local_scalar_t__> p_8 =
+        std::vector<local_scalar_t__>(k, DUMMY_VAR__);
+      p_8 = context__.vals_r("p_8");
+      out__.write_free_offset_multiplier(stan::model::rvalue(ds, "ds",
+                                           stan::model::index_uni(1),
+                                           stan::model::index_uni(1)),
+        stan::model::rvalue(ds, "ds", stan::model::index_uni(1),
+          stan::model::index_uni(2)), p_8);
+      std::vector<std::vector<local_scalar_t__>> p_9 =
+        std::vector<std::vector<local_scalar_t__>>(m,
+          std::vector<local_scalar_t__>(k, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> p_9_flat__;
+        p_9_flat__ = context__.vals_r("p_9");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            stan::model::assign(p_9, p_9_flat__[(pos__ - 1)],
+              "assigning variable p_9", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_lub(stan::model::rvalue(ds, "ds",
+                             stan::model::index_uni(1)), 1, p_9);
+      std::vector<std::vector<std::vector<local_scalar_t__>>> p_10 =
+        std::vector<std::vector<std::vector<local_scalar_t__>>>(n,
+          std::vector<std::vector<local_scalar_t__>>(m,
+            std::vector<local_scalar_t__>(k, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> p_10_flat__;
+        p_10_flat__ = context__.vals_r("p_10");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+              stan::model::assign(p_10, p_10_flat__[(pos__ - 1)],
+                "assigning variable p_10", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_lub(0, ds, p_10);
+      Eigen::Matrix<local_scalar_t__,-1,1> pv_1 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> pv_1_flat__;
+        pv_1_flat__ = context__.vals_r("pv_1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(pv_1, pv_1_flat__[(pos__ - 1)],
+            "assigning variable pv_1", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(stan::model::rvalue(dv, "dv",
+                             stan::model::index_uni(1),
+                             stan::model::index_uni(1)),
+        stan::model::rvalue(dv, "dv", stan::model::index_uni(1),
+          stan::model::index_uni(2)), pv_1);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> pv_2 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(m,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> pv_2_flat__;
+        pv_2_flat__ = context__.vals_r("pv_2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            stan::model::assign(pv_2, pv_2_flat__[(pos__ - 1)],
+              "assigning variable pv_2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_lb(stan::model::rvalue(dv, "dv",
+                            stan::model::index_uni(1)), pv_2);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> pv_3 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(n,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(m,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> pv_3_flat__;
+        pv_3_flat__ = context__.vals_r("pv_3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+              stan::model::assign(pv_3, pv_3_flat__[(pos__ - 1)],
+                "assigning variable pv_3", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_ub(dv, pv_3);
+      Eigen::Matrix<local_scalar_t__,1,-1> pr_1 =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> pr_1_flat__;
+        pr_1_flat__ = context__.vals_r("pr_1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          stan::model::assign(pr_1, pr_1_flat__[(pos__ - 1)],
+            "assigning variable pr_1", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(stan::model::rvalue(dr, "dr",
+                             stan::model::index_uni(1),
+                             stan::model::index_uni(1)),
+        stan::model::rvalue(dr, "dr", stan::model::index_uni(1),
+          stan::model::index_uni(2)), pr_1);
+      std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> pr_2 =
+        std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(m,
+          Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> pr_2_flat__;
+        pr_2_flat__ = context__.vals_r("pr_2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            stan::model::assign(pr_2, pr_2_flat__[(pos__ - 1)],
+              "assigning variable pr_2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_lb(stan::model::rvalue(dr, "dr",
+                            stan::model::index_uni(1)), pr_2);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>> pr_3 =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>>(n,
+          std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(m,
+            Eigen::Matrix<local_scalar_t__,1,-1>::Constant(k, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> pr_3_flat__;
+        pr_3_flat__ = context__.vals_r("pr_3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+              stan::model::assign(pr_3, pr_3_flat__[(pos__ - 1)],
+                "assigning variable pr_3", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_ub(dr, pr_3);
+      Eigen::Matrix<local_scalar_t__,-1,-1> pm_1 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(m, k, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> pm_1_flat__;
+        pm_1_flat__ = context__.vals_r("pm_1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            stan::model::assign(pm_1, pm_1_flat__[(pos__ - 1)],
+              "assigning variable pm_1", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_lb(stan::model::rvalue(dm, "dm",
+                            stan::model::index_uni(1)), pm_1);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> pm_2 =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(n,
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(m, k, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> pm_2_flat__;
+        pm_2_flat__ = context__.vals_r("pm_2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= k; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= m; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= n; ++sym3__) {
+              stan::model::assign(pm_2, pm_2_flat__[(pos__ - 1)],
+                "assigning variable pm_2", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
       }
       out__.write_free_ub(dm, pm_2);
     } catch (const std::exception& e) {
@@ -32473,30 +34232,17 @@ class transform_model final : public model_base_crtp<transform_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 18>
-      names__{"p_1", "p_2", "p_3", "p_4", "p_5", "p_6", "p_7", "p_8", "p_9",
-              "p_10", "pv_1", "pv_2", "pv_3", "pr_1", "pr_2", "pr_3", "pm_1",
-              "pm_2"};
-    const std::array<Eigen::Index, 18>
-      constrain_param_sizes__{k, k, k, k, k, k, k, k, (m * k), (n * m * k),
-                              k, (m * k), (n * m * k), k, (m * k), (n * m *
-                              k), (m * k), (n * m * k)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -32762,8 +34508,8 @@ class truncate_model final : public model_base_crtp<truncate_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -32779,6 +34525,29 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       out__.write(m);
       local_scalar_t__ y = DUMMY_VAR__;
       y = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ m = DUMMY_VAR__;
+      m = context__.vals_r("m")[(1 - 1)];
+      out__.write(m);
+      local_scalar_t__ y = DUMMY_VAR__;
+      y = context__.vals_r("y")[(1 - 1)];
       out__.write_free_lb(0, y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -32883,24 +34652,17 @@ class truncate_model final : public model_base_crtp<truncate_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"m", "y"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -33070,8 +34832,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -33084,6 +34846,26 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       x = in__.read<local_scalar_t__>();
+      out__.write(x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ x = DUMMY_VAR__;
+      x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -33185,24 +34967,17 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"x"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -33379,8 +35154,8 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -33393,6 +35168,26 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       x = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ x = DUMMY_VAR__;
+      x = context__.vals_r("x")[(1 - 1)];
       out__.write_free_lb(0, x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -33494,24 +35289,17 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"x"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -33706,8 +35494,8 @@ class variable_named_context_model final : public model_base_crtp<variable_named
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -33723,6 +35511,29 @@ class variable_named_context_model final : public model_base_crtp<variable_named
       out__.write(mu);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mu = DUMMY_VAR__;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lb(0, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -33827,24 +35638,17 @@ class variable_named_context_model final : public model_base_crtp<variable_named
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mu", "sigma"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -34621,8 +36425,8 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -34650,6 +36454,55 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
       stan::model::assign(vector_sigma,
         in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
         "assigning variable vector_sigma");
+      out__.write(vector_sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mu = DUMMY_VAR__;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
+      out__.write_free_lb(0, sigma);
+      Eigen::Matrix<local_scalar_t__,-1,1> vector_mu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> vector_mu_flat__;
+        vector_mu_flat__ = context__.vals_r("vector_mu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(vector_mu, vector_mu_flat__[(pos__ - 1)],
+            "assigning variable vector_mu", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(vector_mu);
+      Eigen::Matrix<local_scalar_t__,1,-1> vector_sigma =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> vector_sigma_flat__;
+        vector_sigma_flat__ = context__.vals_r("vector_sigma");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(vector_sigma, vector_sigma_flat__[(pos__ - 1)],
+            "assigning variable vector_sigma", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(vector_sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -34773,25 +36626,17 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"mu", "sigma", "vector_mu", "vector_sigma"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, N, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -486,7 +486,18 @@ class operators_model final : public model_base_crtp<operators_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -964,7 +975,18 @@ class simple_function_model final : public model_base_crtp<simple_function_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1465,7 +1487,18 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -235,27 +235,21 @@ class operators_model final : public model_base_crtp<operators_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(v, in__.read<local_scalar_t__>(),
-          "assigning variable v", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(v,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable v");
       out__.write(v);
       Eigen::Matrix<local_scalar_t__,1,-1> rv =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(rv, in__.read<local_scalar_t__>(),
-          "assigning variable rv", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(rv,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable rv");
       out__.write(rv);
       Eigen::Matrix<local_scalar_t__,-1,-1> A =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(A, in__.read<local_scalar_t__>(),
-            "assigning variable A", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(A,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable A");
       out__.write(A);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1175,24 +1169,22 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable a");
       out__.write(a);
       Eigen::Matrix<local_scalar_t__,-1,1> b =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(b, in__.read<local_scalar_t__>(),
-          "assigning variable b", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable b");
       out__.write(b);
       local_scalar_t__ r = DUMMY_VAR__;
       r = in__.read<local_scalar_t__>();
       out__.write(r);
       std::complex<local_scalar_t__> zp =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      zp = in__.read<local_scalar_t__>();
+      zp = in__.read<std::complex<local_scalar_t__>>();
       out__.write(zp);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -221,8 +221,8 @@ class operators_model final : public model_base_crtp<operators_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -250,6 +250,65 @@ class operators_model final : public model_base_crtp<operators_model> {
       stan::model::assign(A,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
         "assigning variable A");
+      out__.write(A);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> v =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> v_flat__;
+        v_flat__ = context__.vals_r("v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(v, v_flat__[(pos__ - 1)],
+            "assigning variable v", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(v);
+      Eigen::Matrix<local_scalar_t__,1,-1> rv =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> rv_flat__;
+        rv_flat__ = context__.vals_r("rv");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(rv, rv_flat__[(pos__ - 1)],
+            "assigning variable rv", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(rv);
+      Eigen::Matrix<local_scalar_t__,-1,-1> A =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> A_flat__;
+        A_flat__ = context__.vals_r("A");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(A, A_flat__[(pos__ - 1)],
+              "assigning variable A", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(A);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -419,24 +478,17 @@ class operators_model final : public model_base_crtp<operators_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"v", "rv", "A"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{N, N, (N * N)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -777,10 +829,27 @@ class simple_function_model final : public model_base_crtp<simple_function_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -887,24 +956,17 @@ class simple_function_model final : public model_base_crtp<simple_function_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1155,8 +1217,8 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1185,6 +1247,56 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       std::complex<local_scalar_t__> zp =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
       zp = in__.read<std::complex<local_scalar_t__>>();
+      out__.write(zp);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(a, a_flat__[(pos__ - 1)],
+            "assigning variable a", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> b =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(b, b_flat__[(pos__ - 1)],
+            "assigning variable b", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b);
+      local_scalar_t__ r = DUMMY_VAR__;
+      r = context__.vals_r("r")[(1 - 1)];
+      out__.write(r);
+      std::complex<local_scalar_t__> zp =
+        std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
+      zp = context__.vals_c("zp")[(1 - 1)];
       out__.write(zp);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1345,24 +1457,17 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"a", "b", "r", "zp"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{2, 2, 1, 2};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -9644,18 +9644,12 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
                    ((Var N) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_vec)
-                    (MethodCall (Var in__) read
-                     ((TypeLiteral local_scalar_t__)) ())
-                    (Literal "\"assigning variable p_vec\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_vec)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 1)) ((Var N)))
+                 (Literal "\"assigning variable p_vec\""))))
               (Expression
                (MethodCall (Var out__) write_free_lb ()
                 ((Literal 0) (Var p_vec))))
@@ -9677,19 +9671,14 @@
                 (init (Assignment (Literal 1))))
                (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
-                  (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_1d_vec)
-                       (MethodCall (Var in__) read
-                        ((TypeLiteral local_scalar_t__)) ())
-                       (Literal "\"assigning variable p_1d_vec\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+                ((Expression
+                  (FunCall stan::model::assign ()
+                   ((Var p_1d_vec)
+                    (MethodCall (Var in__) read
+                     ((Matrix (TypeLiteral local_scalar_t__) -1 1))
+                     ((Var N)))
+                    (Literal "\"assigning variable p_1d_vec\"")
+                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
               (Expression (MethodCall (Var out__) write () ((Var p_1d_vec))))
               (VariableDefn
                ((static false) (constexpr false)
@@ -9720,39 +9709,29 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
+                  (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
                   (Block
                    ((For
                      ((static false) (constexpr false) (type_ Int)
                       (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var M))
+                     (BinOp (Var sym3__) LEq (Var N))
                      (Increment (Var sym3__))
                      (Block
-                      ((For
-                        ((static false) (constexpr false) (type_ Int)
-                         (name sym4__) (init (Assignment (Literal 1))))
-                        (BinOp (Var sym4__) LEq (Var N))
-                        (Increment (Var sym4__))
-                        (Block
-                         ((Expression
-                           (FunCall stan::model::assign ()
-                            ((Var p_3d_vec)
-                             (MethodCall (Var in__) read
-                              ((TypeLiteral local_scalar_t__)) ())
-                             (Literal "\"assigning variable p_3d_vec\"")
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym4__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym3__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym2__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym1__))))))))))))))))))
+                      ((Expression
+                        (FunCall stan::model::assign ()
+                         ((Var p_3d_vec)
+                          (MethodCall (Var in__) read
+                           ((Matrix (TypeLiteral local_scalar_t__) -1 1))
+                           ((Var N)))
+                          (Literal "\"assigning variable p_3d_vec\"")
+                          (FunCall stan::model::index_uni () ((Var sym3__)))
+                          (FunCall stan::model::index_uni () ((Var sym2__)))
+                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
               (Expression (MethodCall (Var out__) write () ((Var p_3d_vec))))
               (VariableDefn
                ((static false) (constexpr false)
@@ -9763,18 +9742,12 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) 1 -1) Constant ()
                    ((Var N) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_row_vec)
-                    (MethodCall (Var in__) read
-                     ((TypeLiteral local_scalar_t__)) ())
-                    (Literal "\"assigning variable p_row_vec\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_row_vec)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) 1 -1)) ((Var N)))
+                 (Literal "\"assigning variable p_row_vec\""))))
               (Expression
                (MethodCall (Var out__) write () ((Var p_row_vec))))
               (VariableDefn
@@ -9795,19 +9768,14 @@
                 (init (Assignment (Literal 1))))
                (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
-                  (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_1d_row_vec)
-                       (MethodCall (Var in__) read
-                        ((TypeLiteral local_scalar_t__)) ())
-                       (Literal "\"assigning variable p_1d_row_vec\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+                ((Expression
+                  (FunCall stan::model::assign ()
+                   ((Var p_1d_row_vec)
+                    (MethodCall (Var in__) read
+                     ((Matrix (TypeLiteral local_scalar_t__) 1 -1))
+                     ((Var N)))
+                    (Literal "\"assigning variable p_1d_row_vec\"")
+                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
               (Expression
                (MethodCall (Var out__) write () ((Var p_1d_row_vec))))
               (VariableDefn
@@ -9839,39 +9807,29 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
+                  (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
                   (Block
                    ((For
                      ((static false) (constexpr false) (type_ Int)
                       (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var M))
+                     (BinOp (Var sym3__) LEq (Var N))
                      (Increment (Var sym3__))
                      (Block
-                      ((For
-                        ((static false) (constexpr false) (type_ Int)
-                         (name sym4__) (init (Assignment (Literal 1))))
-                        (BinOp (Var sym4__) LEq (Var N))
-                        (Increment (Var sym4__))
-                        (Block
-                         ((Expression
-                           (FunCall stan::model::assign ()
-                            ((Var p_3d_row_vec)
-                             (MethodCall (Var in__) read
-                              ((TypeLiteral local_scalar_t__)) ())
-                             (Literal "\"assigning variable p_3d_row_vec\"")
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym4__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym3__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym2__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym1__))))))))))))))))))
+                      ((Expression
+                        (FunCall stan::model::assign ()
+                         ((Var p_3d_row_vec)
+                          (MethodCall (Var in__) read
+                           ((Matrix (TypeLiteral local_scalar_t__) 1 -1))
+                           ((Var N)))
+                          (Literal "\"assigning variable p_3d_row_vec\"")
+                          (FunCall stan::model::index_uni () ((Var sym3__)))
+                          (FunCall stan::model::index_uni () ((Var sym2__)))
+                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
               (Expression
                (MethodCall (Var out__) write () ((Var p_3d_row_vec))))
               (VariableDefn
@@ -9883,25 +9841,13 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant ()
                    ((Literal 5) (Literal 4) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 4)) (Increment (Var sym1__))
-               (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Literal 5))
-                  (Increment (Var sym2__))
-                  (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_mat)
-                       (MethodCall (Var in__) read
-                        ((TypeLiteral local_scalar_t__)) ())
-                       (Literal "\"assigning variable p_mat\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_mat)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                  ((Literal 5) (Literal 4)))
+                 (Literal "\"assigning variable p_mat\""))))
               (Expression (MethodCall (Var out__) write () ((Var p_mat))))
               (VariableDefn
                ((static false) (constexpr false)
@@ -9925,40 +9871,23 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 3)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Literal 5)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Literal 2))
+                  (BinOp (Var sym2__) LEq (Literal 4))
                   (Increment (Var sym2__))
                   (Block
-                   ((For
-                     ((static false) (constexpr false) (type_ Int)
-                      (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Literal 5))
-                     (Increment (Var sym3__))
-                     (Block
-                      ((For
-                        ((static false) (constexpr false) (type_ Int)
-                         (name sym4__) (init (Assignment (Literal 1))))
-                        (BinOp (Var sym4__) LEq (Literal 4))
-                        (Increment (Var sym4__))
-                        (Block
-                         ((Expression
-                           (FunCall stan::model::assign ()
-                            ((Var p_ar_mat)
-                             (MethodCall (Var in__) read
-                              ((TypeLiteral local_scalar_t__)) ())
-                             (Literal "\"assigning variable p_ar_mat\"")
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym4__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym3__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym2__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym1__))))))))))))))))))
+                   ((Expression
+                     (FunCall stan::model::assign ()
+                      ((Var p_ar_mat)
+                       (MethodCall (Var in__) read
+                        ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                        ((Literal 2) (Literal 3)))
+                       (Literal "\"assigning variable p_ar_mat\"")
+                       (FunCall stan::model::index_uni () ((Var sym2__)))
+                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
               (Expression
                (MethodCall (Var out__) write_free_lub ()
                 ((Literal 0) (Literal 1) (Var p_ar_mat))))
@@ -9971,18 +9900,12 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
                    ((Var N) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_simplex)
-                    (MethodCall (Var in__) read
-                     ((TypeLiteral local_scalar_t__)) ())
-                    (Literal "\"assigning variable p_simplex\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_simplex)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 1)) ((Var N)))
+                 (Literal "\"assigning variable p_simplex\""))))
               (Expression
                (MethodCall (Var out__) write_free_simplex ()
                 ((Var p_simplex))))
@@ -10004,19 +9927,14 @@
                 (init (Assignment (Literal 1))))
                (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
-                  (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_1d_simplex)
-                       (MethodCall (Var in__) read
-                        ((TypeLiteral local_scalar_t__)) ())
-                       (Literal "\"assigning variable p_1d_simplex\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+                ((Expression
+                  (FunCall stan::model::assign ()
+                   ((Var p_1d_simplex)
+                    (MethodCall (Var in__) read
+                     ((Matrix (TypeLiteral local_scalar_t__) -1 1))
+                     ((Var N)))
+                    (Literal "\"assigning variable p_1d_simplex\"")
+                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
               (Expression
                (MethodCall (Var out__) write_free_simplex ()
                 ((Var p_1d_simplex))))
@@ -10049,39 +9967,29 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
+                  (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
                   (Block
                    ((For
                      ((static false) (constexpr false) (type_ Int)
                       (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var M))
+                     (BinOp (Var sym3__) LEq (Var N))
                      (Increment (Var sym3__))
                      (Block
-                      ((For
-                        ((static false) (constexpr false) (type_ Int)
-                         (name sym4__) (init (Assignment (Literal 1))))
-                        (BinOp (Var sym4__) LEq (Var N))
-                        (Increment (Var sym4__))
-                        (Block
-                         ((Expression
-                           (FunCall stan::model::assign ()
-                            ((Var p_3d_simplex)
-                             (MethodCall (Var in__) read
-                              ((TypeLiteral local_scalar_t__)) ())
-                             (Literal "\"assigning variable p_3d_simplex\"")
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym4__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym3__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym2__)))
-                             (FunCall stan::model::index_uni ()
-                              ((Var sym1__))))))))))))))))))
+                      ((Expression
+                        (FunCall stan::model::assign ()
+                         ((Var p_3d_simplex)
+                          (MethodCall (Var in__) read
+                           ((Matrix (TypeLiteral local_scalar_t__) -1 1))
+                           ((Var N)))
+                          (Literal "\"assigning variable p_3d_simplex\"")
+                          (FunCall stan::model::index_uni () ((Var sym3__)))
+                          (FunCall stan::model::index_uni () ((Var sym2__)))
+                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
               (Expression
                (MethodCall (Var out__) write_free_simplex ()
                 ((Var p_3d_simplex))))
@@ -10094,25 +10002,13 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant ()
                    ((Literal 5) (Literal 4) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 4)) (Increment (Var sym1__))
-               (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Literal 5))
-                  (Increment (Var sym2__))
-                  (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_cfcov_54)
-                       (MethodCall (Var in__) read
-                        ((TypeLiteral local_scalar_t__)) ())
-                       (Literal "\"assigning variable p_cfcov_54\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_cfcov_54)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                  ((Literal 5) (Literal 4)))
+                 (Literal "\"assigning variable p_cfcov_54\""))))
               (Expression
                (MethodCall (Var out__) write_free_cholesky_factor_cov ()
                 ((Var p_cfcov_54))))
@@ -10125,25 +10021,13 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant ()
                    ((Literal 3) (Literal 3) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 3)) (Increment (Var sym1__))
-               (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Literal 3))
-                  (Increment (Var sym2__))
-                  (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_cfcov_33)
-                       (MethodCall (Var in__) read
-                        ((TypeLiteral local_scalar_t__)) ())
-                       (Literal "\"assigning variable p_cfcov_33\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_cfcov_33)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                  ((Literal 3) (Literal 3)))
+                 (Literal "\"assigning variable p_cfcov_33\""))))
               (Expression
                (MethodCall (Var out__) write_free_cholesky_factor_cov ()
                 ((Var p_cfcov_33))))
@@ -10163,29 +10047,16 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 3)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
                (Block
-                ((For
-                  ((static false) (constexpr false) (type_ Int) (name sym2__)
-                   (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Literal 3))
-                  (Increment (Var sym2__))
-                  (Block
-                   ((For
-                     ((static false) (constexpr false) (type_ Int)
-                      (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var K))
-                     (Increment (Var sym3__))
-                     (Block
-                      ((Expression
-                        (FunCall stan::model::assign ()
-                         ((Var p_cfcov_33_ar)
-                          (MethodCall (Var in__) read
-                           ((TypeLiteral local_scalar_t__)) ())
-                          (Literal "\"assigning variable p_cfcov_33_ar\"")
-                          (FunCall stan::model::index_uni () ((Var sym3__)))
-                          (FunCall stan::model::index_uni () ((Var sym2__)))
-                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
+                ((Expression
+                  (FunCall stan::model::assign ()
+                   ((Var p_cfcov_33_ar)
+                    (MethodCall (Var in__) read
+                     ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                     ((Literal 3) (Literal 3)))
+                    (Literal "\"assigning variable p_cfcov_33_ar\"")
+                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
               (Expression
                (MethodCall (Var out__) write_free_cholesky_factor_cov ()
                 ((Var p_cfcov_33_ar))))
@@ -10198,18 +10069,13 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
                    ((Literal 2) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 2)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var x_p)
-                    (MethodCall (Var in__) read
-                     ((TypeLiteral local_scalar_t__)) ())
-                    (Literal "\"assigning variable x_p\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var x_p)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 1))
+                  ((Literal 2)))
+                 (Literal "\"assigning variable x_p\""))))
               (Expression (MethodCall (Var out__) write () ((Var x_p))))
               (VariableDefn
                ((static false) (constexpr false)
@@ -10220,18 +10086,13 @@
                   (StaticMethodCall
                    (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
                    ((Literal 2) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 2)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var y_p)
-                    (MethodCall (Var in__) read
-                     ((TypeLiteral local_scalar_t__)) ())
-                    (Literal "\"assigning variable y_p\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var y_p)
+                 (MethodCall (Var in__) read
+                  ((Matrix (TypeLiteral local_scalar_t__) -1 1))
+                  ((Literal 2)))
+                 (Literal "\"assigning variable y_p\""))))
               (Expression (MethodCall (Var out__) write () ((Var y_p)))))
              ((Const (Ref (TypeLiteral std::exception))) e)
              ((Expression

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -15914,8 +15914,32 @@
               (type_ (Const (StdVector Int))) (name params_i)
               (init Uninitialized)))
             (Expression
-             (MethodCall (Var params_unconstrained) resize ()
-              ((Var num_params_r__))))
+             (Assign (Var params_unconstrained)
+              (Constructor (StdVector Double)
+               ((Var num_params_r__)
+                (FunCall std::numeric_limits<double>::quiet_NaN () ())))))
+            (Expression
+             (FunCall unconstrain_array_impl ()
+              ((Var params_constrained) (Var params_i)
+               (Var params_unconstrained) (Var pstream)))))))))
+       (FunDef
+        ((templates_init ((()) false)) (inline true) (return_type Void)
+         (name unconstrain_array)
+         (args
+          (((Const (Ref (Matrix Double -1 1))) params_constrained)
+           ((Ref (Matrix Double -1 1)) params_unconstrained)
+           ((Pointer (TypeLiteral std::ostream)) "pstream = nullptr")))
+         (cv_qualifiers (Const))
+         (body
+          (((VariableDefn
+             ((static false) (constexpr false)
+              (type_ (Const (StdVector Int))) (name params_i)
+              (init Uninitialized)))
+            (Expression
+             (Assign (Var params_unconstrained)
+              (StaticMethodCall (Matrix Double -1 1) Constant ()
+               ((Var num_params_r__)
+                (FunCall std::numeric_limits<double>::quiet_NaN () ())))))
             (Expression
              (FunCall unconstrain_array_impl ()
               ((Var params_constrained) (Var params_i)

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -9430,10 +9430,10 @@
              (Require stan::require_vector_t (VecVar))
              (Require stan::require_vector_like_vt (std::is_integral VecI))))
            true))
-         (inline true) (return_type Void) (name transform_inits_impl)
+         (inline true) (return_type Void) (name unconstrain_array_impl)
          (args
-          (((Ref (TemplateType VecVar)) params_r__)
-           ((Ref (TemplateType VecI)) params_i__)
+          (((Const (Ref (TemplateType VecVar))) params_r__)
+           ((Const (Ref (TemplateType VecI))) params_i__)
            ((Ref (TemplateType VecVar)) vars__)
            ((Pointer (TypeLiteral std::ostream)) "pstream__ = nullptr")))
          (cv_qualifiers (Const))
@@ -10093,6 +10093,1028 @@
                   ((Matrix (TypeLiteral local_scalar_t__) -1 1))
                   ((Literal 2)))
                  (Literal "\"assigning variable y_p\""))))
+              (Expression (MethodCall (Var out__) write () ((Var y_p)))))
+             ((Const (Ref (TypeLiteral std::exception))) e)
+             ((Expression
+               (FunCall stan::lang::rethrow_located ()
+                ((Var e)
+                 (Index (Var locations_array__) (Var current_statement__))))))))))))
+       (FunDef
+        ((templates_init
+          ((((Typename VecVar) (Require stan::require_vector_t (VecVar))))
+           true))
+         (inline true) (return_type Void) (name transform_inits_impl)
+         (args
+          (((Const (Ref (TypeLiteral stan::io::var_context))) context__)
+           ((Ref (TemplateType VecVar)) vars__)
+           ((Pointer (TypeLiteral std::ostream)) "pstream__ = nullptr")))
+         (cv_qualifiers (Const))
+         (body
+          (((Using local_scalar_t__ (Double))
+            (VariableDefn
+             ((static false) (constexpr false)
+              (type_
+               (TypeTrait stan::io::serializer
+                ((TypeLiteral local_scalar_t__))))
+              (name out__) (init (Construction ((Var vars__))))))
+            (VariableDefn
+             ((static false) (constexpr false) (type_ Int)
+              (name current_statement__) (init (Assignment (Literal 0)))))
+            (VariableDefn
+             ((static false) (constexpr false)
+              (type_ (TypeLiteral local_scalar_t__)) (name DUMMY_VAR__)
+              (init
+               (Construction
+                ((FunCall std::numeric_limits<double>::quiet_NaN () ()))))))
+            (Comment "suppress unused var warning")
+            (Expression (Cast Void (Var DUMMY_VAR__)))
+            (TryCatch
+             ((VariableDefn
+               ((static false) (constexpr false) (type_ Int) (name pos__)
+                (init
+                 (Assignment (FunCall std::numeric_limits<int>::min () ())))))
+              (Expression (Assign (Var pos__) (Literal 1)))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (TypeLiteral local_scalar_t__)) (name p_real)
+                (init (Assignment (Var DUMMY_VAR__)))))
+              (Expression
+               (Assign (Var p_real)
+                (Index
+                 (MethodCall (Var context__) vals_r ()
+                  ((Literal "\"p_real\"")))
+                 (Parens (BinOp (Literal 1) Subtract (Literal 1))))))
+              (Expression (MethodCall (Var out__) write () ((Var p_real))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (TypeLiteral local_scalar_t__)) (name p_upper)
+                (init (Assignment (Var DUMMY_VAR__)))))
+              (Expression
+               (Assign (Var p_upper)
+                (Index
+                 (MethodCall (Var context__) vals_r ()
+                  ((Literal "\"p_upper\"")))
+                 (Parens (BinOp (Literal 1) Subtract (Literal 1))))))
+              (Expression
+               (MethodCall (Var out__) write_free_lb ()
+                ((Var p_real) (Var p_upper))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (TypeLiteral local_scalar_t__)) (name p_lower)
+                (init (Assignment (Var DUMMY_VAR__)))))
+              (Expression
+               (Assign (Var p_lower)
+                (Index
+                 (MethodCall (Var context__) vals_r ()
+                  ((Literal "\"p_lower\"")))
+                 (Parens (BinOp (Literal 1) Subtract (Literal 1))))))
+              (Expression
+               (MethodCall (Var out__) write_free_ub ()
+                ((Var p_upper) (Var p_lower))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                (name offset_multiplier)
+                (init
+                 (Assignment
+                  (Constructor (StdVector (TypeLiteral local_scalar_t__))
+                   ((Literal 5) (Var DUMMY_VAR__)))))))
+              (Expression
+               (Assign (Var offset_multiplier)
+                (MethodCall (Var context__) vals_r ()
+                 ((Literal "\"offset_multiplier\"")))))
+              (Expression
+               (MethodCall (Var out__) write_free_offset_multiplier ()
+                ((Literal 1) (Literal 2) (Var offset_multiplier))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                (name no_offset_multiplier)
+                (init
+                 (Assignment
+                  (Constructor (StdVector (TypeLiteral local_scalar_t__))
+                   ((Literal 5) (Var DUMMY_VAR__)))))))
+              (Expression
+               (Assign (Var no_offset_multiplier)
+                (MethodCall (Var context__) vals_r ()
+                 ((Literal "\"no_offset_multiplier\"")))))
+              (Expression
+               (MethodCall (Var out__) write_free_offset_multiplier ()
+                ((Literal 0) (Literal 2) (Var no_offset_multiplier))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                (name offset_no_multiplier)
+                (init
+                 (Assignment
+                  (Constructor (StdVector (TypeLiteral local_scalar_t__))
+                   ((Literal 5) (Var DUMMY_VAR__)))))))
+              (Expression
+               (Assign (Var offset_no_multiplier)
+                (MethodCall (Var context__) vals_r ()
+                 ((Literal "\"offset_no_multiplier\"")))))
+              (Expression
+               (MethodCall (Var out__) write_free_offset_multiplier ()
+                ((Literal 3) (Literal 1) (Var offset_no_multiplier))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                (name p_real_1d_ar)
+                (init
+                 (Assignment
+                  (Constructor (StdVector (TypeLiteral local_scalar_t__))
+                   ((Var N) (Var DUMMY_VAR__)))))))
+              (Expression
+               (Assign (Var p_real_1d_ar)
+                (MethodCall (Var context__) vals_r ()
+                 ((Literal "\"p_real_1d_ar\"")))))
+              (Expression
+               (MethodCall (Var out__) write_free_lb ()
+                ((Literal 0) (Var p_real_1d_ar))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector
+                  (StdVector (StdVector (TypeLiteral local_scalar_t__)))))
+                (name p_real_3d_ar)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector
+                    (StdVector (StdVector (TypeLiteral local_scalar_t__))))
+                   ((Var N)
+                    (Constructor
+                     (StdVector (StdVector (TypeLiteral local_scalar_t__)))
+                     ((Var M)
+                      (Constructor (StdVector (TypeLiteral local_scalar_t__))
+                       ((Var K) (Var DUMMY_VAR__)))))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_real_3d_ar_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_real_3d_ar_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_real_3d_ar\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
+                    (Block
+                     ((For
+                       ((static false) (constexpr false) (type_ Int)
+                        (name sym3__) (init (Assignment (Literal 1))))
+                       (BinOp (Var sym3__) LEq (Var N))
+                       (Increment (Var sym3__))
+                       (Block
+                        ((Expression
+                          (FunCall stan::model::assign ()
+                           ((Var p_real_3d_ar)
+                            (Index (Var p_real_3d_ar_flat__)
+                             (Parens
+                              (BinOp (Var pos__) Subtract (Literal 1))))
+                            (Literal "\"assigning variable p_real_3d_ar\"")
+                            (FunCall stan::model::index_uni ()
+                             ((Var sym3__)))
+                            (FunCall stan::model::index_uni ()
+                             ((Var sym2__)))
+                            (FunCall stan::model::index_uni ()
+                             ((Var sym1__))))))
+                         (Expression
+                          (Assign (Var pos__)
+                           (Parens (BinOp (Var pos__) Add (Literal 1))))))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_lb ()
+                ((Literal 0) (Var p_real_3d_ar))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                (name p_vec)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
+                   ((Var N) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_vec_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_vec_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_vec\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((Expression
+                    (FunCall stan::model::assign ()
+                     ((Var p_vec)
+                      (Index (Var p_vec_flat__)
+                       (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                      (Literal "\"assigning variable p_vec\"")
+                      (FunCall stan::model::index_uni () ((Var sym1__))))))
+                   (Expression
+                    (Assign (Var pos__)
+                     (Parens (BinOp (Var pos__) Add (Literal 1))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_lb ()
+                ((Literal 0) (Var p_vec))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1)))
+                (name p_1d_vec)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                   ((Var N)
+                    (StaticMethodCall
+                     (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
+                     ((Var N) (Var DUMMY_VAR__)))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_1d_vec_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_1d_vec_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_1d_vec\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
+                    (Block
+                     ((Expression
+                       (FunCall stan::model::assign ()
+                        ((Var p_1d_vec)
+                         (Index (Var p_1d_vec_flat__)
+                          (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                         (Literal "\"assigning variable p_1d_vec\"")
+                         (FunCall stan::model::index_uni () ((Var sym2__)))
+                         (FunCall stan::model::index_uni () ((Var sym1__))))))
+                      (Expression
+                       (Assign (Var pos__)
+                        (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))
+              (Expression (MethodCall (Var out__) write () ((Var p_1d_vec))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector
+                  (StdVector
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1)))))
+                (name p_3d_vec)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector
+                    (StdVector
+                     (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1))))
+                   ((Var N)
+                    (Constructor
+                     (StdVector
+                      (StdVector
+                       (Matrix (TypeLiteral local_scalar_t__) -1 1)))
+                     ((Var M)
+                      (Constructor
+                       (StdVector
+                        (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                       ((Var K)
+                        (StaticMethodCall
+                         (Matrix (TypeLiteral local_scalar_t__) -1 1)
+                         Constant () ((Var N) (Var DUMMY_VAR__)))))))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_3d_vec_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_3d_vec_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_3d_vec\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
+                    (Block
+                     ((For
+                       ((static false) (constexpr false) (type_ Int)
+                        (name sym3__) (init (Assignment (Literal 1))))
+                       (BinOp (Var sym3__) LEq (Var M))
+                       (Increment (Var sym3__))
+                       (Block
+                        ((For
+                          ((static false) (constexpr false) (type_ Int)
+                           (name sym4__) (init (Assignment (Literal 1))))
+                          (BinOp (Var sym4__) LEq (Var N))
+                          (Increment (Var sym4__))
+                          (Block
+                           ((Expression
+                             (FunCall stan::model::assign ()
+                              ((Var p_3d_vec)
+                               (Index (Var p_3d_vec_flat__)
+                                (Parens
+                                 (BinOp (Var pos__) Subtract (Literal 1))))
+                               (Literal "\"assigning variable p_3d_vec\"")
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym4__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym3__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym2__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym1__))))))
+                            (Expression
+                             (Assign (Var pos__)
+                              (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))))))))
+              (Expression (MethodCall (Var out__) write () ((Var p_3d_vec))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) 1 -1))
+                (name p_row_vec)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) 1 -1) Constant ()
+                   ((Var N) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_row_vec_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_row_vec_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_row_vec\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((Expression
+                    (FunCall stan::model::assign ()
+                     ((Var p_row_vec)
+                      (Index (Var p_row_vec_flat__)
+                       (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                      (Literal "\"assigning variable p_row_vec\"")
+                      (FunCall stan::model::index_uni () ((Var sym1__))))))
+                   (Expression
+                    (Assign (Var pos__)
+                     (Parens (BinOp (Var pos__) Add (Literal 1))))))))))
+              (Expression
+               (MethodCall (Var out__) write () ((Var p_row_vec))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector (Matrix (TypeLiteral local_scalar_t__) 1 -1)))
+                (name p_1d_row_vec)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) 1 -1))
+                   ((Var N)
+                    (StaticMethodCall
+                     (Matrix (TypeLiteral local_scalar_t__) 1 -1) Constant ()
+                     ((Var N) (Var DUMMY_VAR__)))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_1d_row_vec_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_1d_row_vec_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_1d_row_vec\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
+                    (Block
+                     ((Expression
+                       (FunCall stan::model::assign ()
+                        ((Var p_1d_row_vec)
+                         (Index (Var p_1d_row_vec_flat__)
+                          (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                         (Literal "\"assigning variable p_1d_row_vec\"")
+                         (FunCall stan::model::index_uni () ((Var sym2__)))
+                         (FunCall stan::model::index_uni () ((Var sym1__))))))
+                      (Expression
+                       (Assign (Var pos__)
+                        (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))
+              (Expression
+               (MethodCall (Var out__) write () ((Var p_1d_row_vec))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector
+                  (StdVector
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) 1 -1)))))
+                (name p_3d_row_vec)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector
+                    (StdVector
+                     (StdVector (Matrix (TypeLiteral local_scalar_t__) 1 -1))))
+                   ((Var N)
+                    (Constructor
+                     (StdVector
+                      (StdVector
+                       (Matrix (TypeLiteral local_scalar_t__) 1 -1)))
+                     ((Var M)
+                      (Constructor
+                       (StdVector
+                        (Matrix (TypeLiteral local_scalar_t__) 1 -1))
+                       ((Var K)
+                        (StaticMethodCall
+                         (Matrix (TypeLiteral local_scalar_t__) 1 -1)
+                         Constant () ((Var N) (Var DUMMY_VAR__)))))))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_3d_row_vec_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_3d_row_vec_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_3d_row_vec\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
+                    (Block
+                     ((For
+                       ((static false) (constexpr false) (type_ Int)
+                        (name sym3__) (init (Assignment (Literal 1))))
+                       (BinOp (Var sym3__) LEq (Var M))
+                       (Increment (Var sym3__))
+                       (Block
+                        ((For
+                          ((static false) (constexpr false) (type_ Int)
+                           (name sym4__) (init (Assignment (Literal 1))))
+                          (BinOp (Var sym4__) LEq (Var N))
+                          (Increment (Var sym4__))
+                          (Block
+                           ((Expression
+                             (FunCall stan::model::assign ()
+                              ((Var p_3d_row_vec)
+                               (Index (Var p_3d_row_vec_flat__)
+                                (Parens
+                                 (BinOp (Var pos__) Subtract (Literal 1))))
+                               (Literal
+                                "\"assigning variable p_3d_row_vec\"")
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym4__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym3__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym2__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym1__))))))
+                            (Expression
+                             (Assign (Var pos__)
+                              (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))))))))
+              (Expression
+               (MethodCall (Var out__) write () ((Var p_3d_row_vec))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                (name p_mat)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant ()
+                   ((Literal 5) (Literal 4) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_mat_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_mat_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_mat\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 4))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Literal 5))
+                    (Increment (Var sym2__))
+                    (Block
+                     ((Expression
+                       (FunCall stan::model::assign ()
+                        ((Var p_mat)
+                         (Index (Var p_mat_flat__)
+                          (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                         (Literal "\"assigning variable p_mat\"")
+                         (FunCall stan::model::index_uni () ((Var sym2__)))
+                         (FunCall stan::model::index_uni () ((Var sym1__))))))
+                      (Expression
+                       (Assign (Var pos__)
+                        (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))
+              (Expression (MethodCall (Var out__) write () ((Var p_mat))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector
+                  (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 -1))))
+                (name p_ar_mat)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector
+                    (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 -1)))
+                   ((Literal 4)
+                    (Constructor
+                     (StdVector
+                      (Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                     ((Literal 5)
+                      (StaticMethodCall
+                       (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant
+                       () ((Literal 2) (Literal 3) (Var DUMMY_VAR__)))))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_ar_mat_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_ar_mat_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_ar_mat\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 3))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Literal 2))
+                    (Increment (Var sym2__))
+                    (Block
+                     ((For
+                       ((static false) (constexpr false) (type_ Int)
+                        (name sym3__) (init (Assignment (Literal 1))))
+                       (BinOp (Var sym3__) LEq (Literal 5))
+                       (Increment (Var sym3__))
+                       (Block
+                        ((For
+                          ((static false) (constexpr false) (type_ Int)
+                           (name sym4__) (init (Assignment (Literal 1))))
+                          (BinOp (Var sym4__) LEq (Literal 4))
+                          (Increment (Var sym4__))
+                          (Block
+                           ((Expression
+                             (FunCall stan::model::assign ()
+                              ((Var p_ar_mat)
+                               (Index (Var p_ar_mat_flat__)
+                                (Parens
+                                 (BinOp (Var pos__) Subtract (Literal 1))))
+                               (Literal "\"assigning variable p_ar_mat\"")
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym4__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym3__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym2__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym1__))))))
+                            (Expression
+                             (Assign (Var pos__)
+                              (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_lub ()
+                ((Literal 0) (Literal 1) (Var p_ar_mat))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                (name p_simplex)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
+                   ((Var N) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_simplex_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_simplex_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_simplex\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((Expression
+                    (FunCall stan::model::assign ()
+                     ((Var p_simplex)
+                      (Index (Var p_simplex_flat__)
+                       (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                      (Literal "\"assigning variable p_simplex\"")
+                      (FunCall stan::model::index_uni () ((Var sym1__))))))
+                   (Expression
+                    (Assign (Var pos__)
+                     (Parens (BinOp (Var pos__) Add (Literal 1))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_simplex ()
+                ((Var p_simplex))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1)))
+                (name p_1d_simplex)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                   ((Var N)
+                    (StaticMethodCall
+                     (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
+                     ((Var N) (Var DUMMY_VAR__)))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_1d_simplex_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_1d_simplex_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_1d_simplex\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
+                    (Block
+                     ((Expression
+                       (FunCall stan::model::assign ()
+                        ((Var p_1d_simplex)
+                         (Index (Var p_1d_simplex_flat__)
+                          (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                         (Literal "\"assigning variable p_1d_simplex\"")
+                         (FunCall stan::model::index_uni () ((Var sym2__)))
+                         (FunCall stan::model::index_uni () ((Var sym1__))))))
+                      (Expression
+                       (Assign (Var pos__)
+                        (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_simplex ()
+                ((Var p_1d_simplex))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector
+                  (StdVector
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1)))))
+                (name p_3d_simplex)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector
+                    (StdVector
+                     (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 1))))
+                   ((Var N)
+                    (Constructor
+                     (StdVector
+                      (StdVector
+                       (Matrix (TypeLiteral local_scalar_t__) -1 1)))
+                     ((Var M)
+                      (Constructor
+                       (StdVector
+                        (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                       ((Var K)
+                        (StaticMethodCall
+                         (Matrix (TypeLiteral local_scalar_t__) -1 1)
+                         Constant () ((Var N) (Var DUMMY_VAR__)))))))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_3d_simplex_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_3d_simplex_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_3d_simplex\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
+                    (Block
+                     ((For
+                       ((static false) (constexpr false) (type_ Int)
+                        (name sym3__) (init (Assignment (Literal 1))))
+                       (BinOp (Var sym3__) LEq (Var M))
+                       (Increment (Var sym3__))
+                       (Block
+                        ((For
+                          ((static false) (constexpr false) (type_ Int)
+                           (name sym4__) (init (Assignment (Literal 1))))
+                          (BinOp (Var sym4__) LEq (Var N))
+                          (Increment (Var sym4__))
+                          (Block
+                           ((Expression
+                             (FunCall stan::model::assign ()
+                              ((Var p_3d_simplex)
+                               (Index (Var p_3d_simplex_flat__)
+                                (Parens
+                                 (BinOp (Var pos__) Subtract (Literal 1))))
+                               (Literal
+                                "\"assigning variable p_3d_simplex\"")
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym4__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym3__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym2__)))
+                               (FunCall stan::model::index_uni ()
+                                ((Var sym1__))))))
+                            (Expression
+                             (Assign (Var pos__)
+                              (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_simplex ()
+                ((Var p_3d_simplex))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                (name p_cfcov_54)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant ()
+                   ((Literal 5) (Literal 4) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_cfcov_54_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_cfcov_54_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_cfcov_54\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 4))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Literal 5))
+                    (Increment (Var sym2__))
+                    (Block
+                     ((Expression
+                       (FunCall stan::model::assign ()
+                        ((Var p_cfcov_54)
+                         (Index (Var p_cfcov_54_flat__)
+                          (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                         (Literal "\"assigning variable p_cfcov_54\"")
+                         (FunCall stan::model::index_uni () ((Var sym2__)))
+                         (FunCall stan::model::index_uni () ((Var sym1__))))))
+                      (Expression
+                       (Assign (Var pos__)
+                        (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_cholesky_factor_cov ()
+                ((Var p_cfcov_54))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                (name p_cfcov_33)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant ()
+                   ((Literal 3) (Literal 3) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_cfcov_33_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_cfcov_33_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_cfcov_33\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 3))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Literal 3))
+                    (Increment (Var sym2__))
+                    (Block
+                     ((Expression
+                       (FunCall stan::model::assign ()
+                        ((Var p_cfcov_33)
+                         (Index (Var p_cfcov_33_flat__)
+                          (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                         (Literal "\"assigning variable p_cfcov_33\"")
+                         (FunCall stan::model::index_uni () ((Var sym2__)))
+                         (FunCall stan::model::index_uni () ((Var sym1__))))))
+                      (Expression
+                       (Assign (Var pos__)
+                        (Parens (BinOp (Var pos__) Add (Literal 1)))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_cholesky_factor_cov ()
+                ((Var p_cfcov_33))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_
+                 (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 -1)))
+                (name p_cfcov_33_ar)
+                (init
+                 (Assignment
+                  (Constructor
+                   (StdVector (Matrix (TypeLiteral local_scalar_t__) -1 -1))
+                   ((Var K)
+                    (StaticMethodCall
+                     (Matrix (TypeLiteral local_scalar_t__) -1 -1) Constant
+                     () ((Literal 3) (Literal 3) (Var DUMMY_VAR__)))))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name p_cfcov_33_ar_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var p_cfcov_33_ar_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"p_cfcov_33_ar\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 3))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((For
+                    ((static false) (constexpr false) (type_ Int)
+                     (name sym2__) (init (Assignment (Literal 1))))
+                    (BinOp (Var sym2__) LEq (Literal 3))
+                    (Increment (Var sym2__))
+                    (Block
+                     ((For
+                       ((static false) (constexpr false) (type_ Int)
+                        (name sym3__) (init (Assignment (Literal 1))))
+                       (BinOp (Var sym3__) LEq (Var K))
+                       (Increment (Var sym3__))
+                       (Block
+                        ((Expression
+                          (FunCall stan::model::assign ()
+                           ((Var p_cfcov_33_ar)
+                            (Index (Var p_cfcov_33_ar_flat__)
+                             (Parens
+                              (BinOp (Var pos__) Subtract (Literal 1))))
+                            (Literal "\"assigning variable p_cfcov_33_ar\"")
+                            (FunCall stan::model::index_uni ()
+                             ((Var sym3__)))
+                            (FunCall stan::model::index_uni ()
+                             ((Var sym2__)))
+                            (FunCall stan::model::index_uni ()
+                             ((Var sym1__))))))
+                         (Expression
+                          (Assign (Var pos__)
+                           (Parens (BinOp (Var pos__) Add (Literal 1))))))))))))))))
+              (Expression
+               (MethodCall (Var out__) write_free_cholesky_factor_cov ()
+                ((Var p_cfcov_33_ar))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                (name x_p)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
+                   ((Literal 2) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name x_p_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var x_p_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"x_p\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 2))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((Expression
+                    (FunCall stan::model::assign ()
+                     ((Var x_p)
+                      (Index (Var x_p_flat__)
+                       (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                      (Literal "\"assigning variable x_p\"")
+                      (FunCall stan::model::index_uni () ((Var sym1__))))))
+                   (Expression
+                    (Assign (Var pos__)
+                     (Parens (BinOp (Var pos__) Add (Literal 1))))))))))
+              (Expression (MethodCall (Var out__) write () ((Var x_p))))
+              (VariableDefn
+               ((static false) (constexpr false)
+                (type_ (Matrix (TypeLiteral local_scalar_t__) -1 1))
+                (name y_p)
+                (init
+                 (Assignment
+                  (StaticMethodCall
+                   (Matrix (TypeLiteral local_scalar_t__) -1 1) Constant ()
+                   ((Literal 2) (Var DUMMY_VAR__)))))))
+              (Block
+               ((VariableDefn
+                 ((static false) (constexpr false)
+                  (type_ (StdVector (TypeLiteral local_scalar_t__)))
+                  (name y_p_flat__) (init Uninitialized)))
+                (Expression
+                 (Assign (Var y_p_flat__)
+                  (MethodCall (Var context__) vals_r ()
+                   ((Literal "\"y_p\"")))))
+                (Expression (Assign (Var pos__) (Literal 1)))
+                (For
+                 ((static false) (constexpr false) (type_ Int) (name sym1__)
+                  (init (Assignment (Literal 1))))
+                 (BinOp (Var sym1__) LEq (Literal 2))
+                 (Increment (Var sym1__))
+                 (Block
+                  ((Expression
+                    (FunCall stan::model::assign ()
+                     ((Var y_p)
+                      (Index (Var y_p_flat__)
+                       (Parens (BinOp (Var pos__) Subtract (Literal 1))))
+                      (Literal "\"assigning variable y_p\"")
+                      (FunCall stan::model::index_uni () ((Var sym1__))))))
+                   (Expression
+                    (Assign (Var pos__)
+                     (Parens (BinOp (Var pos__) Add (Literal 1))))))))))
               (Expression (MethodCall (Var out__) write () ((Var y_p)))))
              ((Const (Ref (TypeLiteral std::exception))) e)
              ((Expression
@@ -14873,110 +15895,31 @@
            ((Pointer (TypeLiteral std::ostream)) "pstream__ = nullptr")))
          (cv_qualifiers (Const))
          (body
-          (((VariableDefn
-             ((static false) (constexpr true)
-              (type_ (Array (Const (Pointer (TypeLiteral char))) 24))
-              (name names__)
-              (init
-               (InitializerList
-                ((Literal "\"p_real\"") (Literal "\"p_upper\"")
-                 (Literal "\"p_lower\"") (Literal "\"offset_multiplier\"")
-                 (Literal "\"no_offset_multiplier\"")
-                 (Literal "\"offset_no_multiplier\"")
-                 (Literal "\"p_real_1d_ar\"") (Literal "\"p_real_3d_ar\"")
-                 (Literal "\"p_vec\"") (Literal "\"p_1d_vec\"")
-                 (Literal "\"p_3d_vec\"") (Literal "\"p_row_vec\"")
-                 (Literal "\"p_1d_row_vec\"") (Literal "\"p_3d_row_vec\"")
-                 (Literal "\"p_mat\"") (Literal "\"p_ar_mat\"")
-                 (Literal "\"p_simplex\"") (Literal "\"p_1d_simplex\"")
-                 (Literal "\"p_3d_simplex\"") (Literal "\"p_cfcov_54\"")
-                 (Literal "\"p_cfcov_33\"") (Literal "\"p_cfcov_33_ar\"")
-                 (Literal "\"x_p\"") (Literal "\"y_p\""))))))
-            (VariableDefn
-             ((static false) (constexpr false)
-              (type_ (Const (Array (TypeLiteral Eigen::Index) 24)))
-              (name constrain_param_sizes__)
-              (init
-               (InitializerList
-                ((Literal 1) (Literal 1) (Literal 1) (Literal 5) (Literal 5)
-                 (Literal 5) (Var N)
-                 (Parens
-                  (BinOp (BinOp (Var N) Multiply (Var M)) Multiply (Var K)))
-                 (Var N) (Parens (BinOp (Var N) Multiply (Var N)))
-                 (Parens
-                  (BinOp
-                   (BinOp (BinOp (Var N) Multiply (Var M)) Multiply (Var K))
-                   Multiply (Var N)))
-                 (Var N) (Parens (BinOp (Var N) Multiply (Var N)))
-                 (Parens
-                  (BinOp
-                   (BinOp (BinOp (Var N) Multiply (Var M)) Multiply (Var K))
-                   Multiply (Var N)))
-                 (Parens (BinOp (Literal 5) Multiply (Literal 4)))
-                 (Parens
-                  (BinOp
-                   (BinOp (BinOp (Literal 4) Multiply (Literal 5)) Multiply
-                    (Literal 2))
-                   Multiply (Literal 3)))
-                 (Var N) (Parens (BinOp (Var N) Multiply (Var N)))
-                 (Parens
-                  (BinOp
-                   (BinOp (BinOp (Var N) Multiply (Var M)) Multiply (Var K))
-                   Multiply (Var N)))
-                 (Parens (BinOp (Literal 5) Multiply (Literal 4)))
-                 (Parens (BinOp (Literal 3) Multiply (Literal 3)))
-                 (Parens
-                  (BinOp (BinOp (Var K) Multiply (Literal 3)) Multiply
-                   (Literal 3)))
-                 (Literal 2) (Literal 2))))))
-            (VariableDefn
-             ((static false) (constexpr false) (type_ (Const Auto))
-              (name num_constrained_params__)
-              (init
-               (Assignment
-                (FunCall std::accumulate ()
-                 ((MethodCall (Var constrain_param_sizes__) begin () ())
-                  (MethodCall (Var constrain_param_sizes__) end () ())
-                  (Literal 0)))))))
-            (VariableDefn
-             ((static false) (constexpr false) (type_ (StdVector Double))
-              (name params_r_flat__)
-              (init (Construction ((Var num_constrained_params__))))))
-            (VariableDefn
-             ((static false) (constexpr false)
-              (type_ (TypeLiteral Eigen::Index)) (name size_iter__)
-              (init (Assignment (Literal 0)))))
-            (VariableDefn
-             ((static false) (constexpr false)
-              (type_ (TypeLiteral Eigen::Index)) (name flat_iter__)
-              (init (Assignment (Literal 0)))))
-            (ForEach ((Ref (Ref Auto)) param_name__) (Var names__)
-             (Block
-              ((VariableDefn
-                ((static false) (constexpr false) (type_ (Const Auto))
-                 (name param_vec__)
-                 (init
-                  (Assignment
-                   (MethodCall (Var context) vals_r () ((Var param_name__)))))))
-               (For
-                ((static false) (constexpr false)
-                 (type_ (TypeLiteral Eigen::Index)) (name i)
-                 (init (Assignment (Literal 0))))
-                (BinOp (Var i) Lthn
-                 (Index (Var constrain_param_sizes__) (Var size_iter__)))
-                (Increment (Var i))
-                (Block
-                 ((Expression
-                   (Assign (Index (Var params_r_flat__) (Var flat_iter__))
-                    (Index (Var param_vec__) (Var i))))
-                  (Expression (Increment (Var flat_iter__))))))
-               (Expression (Increment (Var size_iter__))))))
-            (Expression
+          (((Expression
              (MethodCall (Var vars) resize () ((Var num_params_r__))))
             (Expression
              (FunCall transform_inits_impl ()
-              ((Var params_r_flat__) (Var params_i) (Var vars)
-               (Var pstream__)))))))))))
+              ((Var context) (Var vars) (Var pstream__)))))))))
+       (FunDef
+        ((templates_init ((()) false)) (inline true) (return_type Void)
+         (name unconstrain_array)
+         (args
+          (((Const (Ref (StdVector Double))) params_constrained)
+           ((Ref (StdVector Double)) params_unconstrained)
+           ((Pointer (TypeLiteral std::ostream)) "pstream = nullptr")))
+         (cv_qualifiers (Const))
+         (body
+          (((VariableDefn
+             ((static false) (constexpr false)
+              (type_ (Const (StdVector Int))) (name params_i)
+              (init Uninitialized)))
+            (Expression
+             (MethodCall (Var params_unconstrained) resize ()
+              ((Var num_params_r__))))
+            (Expression
+             (FunCall unconstrain_array_impl ()
+              ((Var params_constrained) (Var params_i)
+               (Var params_unconstrained) (Var pstream)))))))))))
      (constructor
       ((args
         (((Ref (TypeLiteral stan::io::var_context)) context__)

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -9508,17 +9508,12 @@
                  (Assignment
                   (Constructor (StdVector (TypeLiteral local_scalar_t__))
                    ((Literal 5) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 5)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (Assign
-                   (Index (Var offset_multiplier)
-                    (Parens (BinOp (Var sym1__) Subtract (Literal 1))))
-                   (MethodCall (Var in__) read
-                    ((TypeLiteral local_scalar_t__)) ()))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var offset_multiplier)
+                 (MethodCall (Var in__) read
+                  ((StdVector (TypeLiteral local_scalar_t__))) ((Literal 5)))
+                 (Literal "\"assigning variable offset_multiplier\""))))
               (Expression
                (MethodCall (Var out__) write_free_offset_multiplier ()
                 ((Literal 1) (Literal 2) (Var offset_multiplier))))
@@ -9530,17 +9525,12 @@
                  (Assignment
                   (Constructor (StdVector (TypeLiteral local_scalar_t__))
                    ((Literal 5) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 5)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (Assign
-                   (Index (Var no_offset_multiplier)
-                    (Parens (BinOp (Var sym1__) Subtract (Literal 1))))
-                   (MethodCall (Var in__) read
-                    ((TypeLiteral local_scalar_t__)) ()))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var no_offset_multiplier)
+                 (MethodCall (Var in__) read
+                  ((StdVector (TypeLiteral local_scalar_t__))) ((Literal 5)))
+                 (Literal "\"assigning variable no_offset_multiplier\""))))
               (Expression
                (MethodCall (Var out__) write_free_offset_multiplier ()
                 ((Literal 0) (Literal 2) (Var no_offset_multiplier))))
@@ -9552,17 +9542,12 @@
                  (Assignment
                   (Constructor (StdVector (TypeLiteral local_scalar_t__))
                    ((Literal 5) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 5)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (Assign
-                   (Index (Var offset_no_multiplier)
-                    (Parens (BinOp (Var sym1__) Subtract (Literal 1))))
-                   (MethodCall (Var in__) read
-                    ((TypeLiteral local_scalar_t__)) ()))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var offset_no_multiplier)
+                 (MethodCall (Var in__) read
+                  ((StdVector (TypeLiteral local_scalar_t__))) ((Literal 5)))
+                 (Literal "\"assigning variable offset_no_multiplier\""))))
               (Expression
                (MethodCall (Var out__) write_free_offset_multiplier ()
                 ((Literal 3) (Literal 1) (Var offset_no_multiplier))))
@@ -9574,17 +9559,12 @@
                  (Assignment
                   (Constructor (StdVector (TypeLiteral local_scalar_t__))
                    ((Var N) (Var DUMMY_VAR__)))))))
-              (For
-               ((static false) (constexpr false) (type_ Int) (name sym1__)
-                (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
-               (Block
-                ((Expression
-                  (Assign
-                   (Index (Var p_real_1d_ar)
-                    (Parens (BinOp (Var sym1__) Subtract (Literal 1))))
-                   (MethodCall (Var in__) read
-                    ((TypeLiteral local_scalar_t__)) ()))))))
+              (Expression
+               (FunCall stan::model::assign ()
+                ((Var p_real_1d_ar)
+                 (MethodCall (Var in__) read
+                  ((StdVector (TypeLiteral local_scalar_t__))) ((Var N)))
+                 (Literal "\"assigning variable p_real_1d_ar\""))))
               (Expression
                (MethodCall (Var out__) write_free_lb ()
                 ((Literal 0) (Var p_real_1d_ar))))
@@ -9671,14 +9651,19 @@
                 (init (Assignment (Literal 1))))
                (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_1d_vec)
-                    (MethodCall (Var in__) read
-                     ((Matrix (TypeLiteral local_scalar_t__) -1 1))
-                     ((Var N)))
-                    (Literal "\"assigning variable p_1d_vec\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+                ((For
+                  ((static false) (constexpr false) (type_ Int) (name sym2__)
+                   (init (Assignment (Literal 1))))
+                  (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
+                  (Block
+                   ((Expression
+                     (FunCall stan::model::assign ()
+                      ((Var p_1d_vec)
+                       (MethodCall (Var in__) read
+                        ((TypeLiteral local_scalar_t__)) ())
+                       (Literal "\"assigning variable p_1d_vec\"")
+                       (FunCall stan::model::index_uni () ((Var sym2__)))
+                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
               (Expression (MethodCall (Var out__) write () ((Var p_1d_vec))))
               (VariableDefn
                ((static false) (constexpr false)
@@ -9709,29 +9694,39 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
+                  (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
                   (Block
                    ((For
                      ((static false) (constexpr false) (type_ Int)
                       (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var N))
+                     (BinOp (Var sym3__) LEq (Var M))
                      (Increment (Var sym3__))
                      (Block
-                      ((Expression
-                        (FunCall stan::model::assign ()
-                         ((Var p_3d_vec)
-                          (MethodCall (Var in__) read
-                           ((Matrix (TypeLiteral local_scalar_t__) -1 1))
-                           ((Var N)))
-                          (Literal "\"assigning variable p_3d_vec\"")
-                          (FunCall stan::model::index_uni () ((Var sym3__)))
-                          (FunCall stan::model::index_uni () ((Var sym2__)))
-                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
+                      ((For
+                        ((static false) (constexpr false) (type_ Int)
+                         (name sym4__) (init (Assignment (Literal 1))))
+                        (BinOp (Var sym4__) LEq (Var N))
+                        (Increment (Var sym4__))
+                        (Block
+                         ((Expression
+                           (FunCall stan::model::assign ()
+                            ((Var p_3d_vec)
+                             (MethodCall (Var in__) read
+                              ((TypeLiteral local_scalar_t__)) ())
+                             (Literal "\"assigning variable p_3d_vec\"")
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym4__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym3__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym2__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym1__))))))))))))))))))
               (Expression (MethodCall (Var out__) write () ((Var p_3d_vec))))
               (VariableDefn
                ((static false) (constexpr false)
@@ -9768,14 +9763,19 @@
                 (init (Assignment (Literal 1))))
                (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_1d_row_vec)
-                    (MethodCall (Var in__) read
-                     ((Matrix (TypeLiteral local_scalar_t__) 1 -1))
-                     ((Var N)))
-                    (Literal "\"assigning variable p_1d_row_vec\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+                ((For
+                  ((static false) (constexpr false) (type_ Int) (name sym2__)
+                   (init (Assignment (Literal 1))))
+                  (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
+                  (Block
+                   ((Expression
+                     (FunCall stan::model::assign ()
+                      ((Var p_1d_row_vec)
+                       (MethodCall (Var in__) read
+                        ((TypeLiteral local_scalar_t__)) ())
+                       (Literal "\"assigning variable p_1d_row_vec\"")
+                       (FunCall stan::model::index_uni () ((Var sym2__)))
+                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
               (Expression
                (MethodCall (Var out__) write () ((Var p_1d_row_vec))))
               (VariableDefn
@@ -9807,29 +9807,39 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
+                  (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
                   (Block
                    ((For
                      ((static false) (constexpr false) (type_ Int)
                       (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var N))
+                     (BinOp (Var sym3__) LEq (Var M))
                      (Increment (Var sym3__))
                      (Block
-                      ((Expression
-                        (FunCall stan::model::assign ()
-                         ((Var p_3d_row_vec)
-                          (MethodCall (Var in__) read
-                           ((Matrix (TypeLiteral local_scalar_t__) 1 -1))
-                           ((Var N)))
-                          (Literal "\"assigning variable p_3d_row_vec\"")
-                          (FunCall stan::model::index_uni () ((Var sym3__)))
-                          (FunCall stan::model::index_uni () ((Var sym2__)))
-                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
+                      ((For
+                        ((static false) (constexpr false) (type_ Int)
+                         (name sym4__) (init (Assignment (Literal 1))))
+                        (BinOp (Var sym4__) LEq (Var N))
+                        (Increment (Var sym4__))
+                        (Block
+                         ((Expression
+                           (FunCall stan::model::assign ()
+                            ((Var p_3d_row_vec)
+                             (MethodCall (Var in__) read
+                              ((TypeLiteral local_scalar_t__)) ())
+                             (Literal "\"assigning variable p_3d_row_vec\"")
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym4__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym3__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym2__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym1__))))))))))))))))))
               (Expression
                (MethodCall (Var out__) write () ((Var p_3d_row_vec))))
               (VariableDefn
@@ -9871,23 +9881,40 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Literal 5)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Literal 3)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Literal 4))
+                  (BinOp (Var sym2__) LEq (Literal 2))
                   (Increment (Var sym2__))
                   (Block
-                   ((Expression
-                     (FunCall stan::model::assign ()
-                      ((Var p_ar_mat)
-                       (MethodCall (Var in__) read
-                        ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
-                        ((Literal 2) (Literal 3)))
-                       (Literal "\"assigning variable p_ar_mat\"")
-                       (FunCall stan::model::index_uni () ((Var sym2__)))
-                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
+                   ((For
+                     ((static false) (constexpr false) (type_ Int)
+                      (name sym3__) (init (Assignment (Literal 1))))
+                     (BinOp (Var sym3__) LEq (Literal 5))
+                     (Increment (Var sym3__))
+                     (Block
+                      ((For
+                        ((static false) (constexpr false) (type_ Int)
+                         (name sym4__) (init (Assignment (Literal 1))))
+                        (BinOp (Var sym4__) LEq (Literal 4))
+                        (Increment (Var sym4__))
+                        (Block
+                         ((Expression
+                           (FunCall stan::model::assign ()
+                            ((Var p_ar_mat)
+                             (MethodCall (Var in__) read
+                              ((TypeLiteral local_scalar_t__)) ())
+                             (Literal "\"assigning variable p_ar_mat\"")
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym4__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym3__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym2__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym1__))))))))))))))))))
               (Expression
                (MethodCall (Var out__) write_free_lub ()
                 ((Literal 0) (Literal 1) (Var p_ar_mat))))
@@ -9927,14 +9954,19 @@
                 (init (Assignment (Literal 1))))
                (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_1d_simplex)
-                    (MethodCall (Var in__) read
-                     ((Matrix (TypeLiteral local_scalar_t__) -1 1))
-                     ((Var N)))
-                    (Literal "\"assigning variable p_1d_simplex\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+                ((For
+                  ((static false) (constexpr false) (type_ Int) (name sym2__)
+                   (init (Assignment (Literal 1))))
+                  (BinOp (Var sym2__) LEq (Var N)) (Increment (Var sym2__))
+                  (Block
+                   ((Expression
+                     (FunCall stan::model::assign ()
+                      ((Var p_1d_simplex)
+                       (MethodCall (Var in__) read
+                        ((TypeLiteral local_scalar_t__)) ())
+                       (Literal "\"assigning variable p_1d_simplex\"")
+                       (FunCall stan::model::index_uni () ((Var sym2__)))
+                       (FunCall stan::model::index_uni () ((Var sym1__))))))))))))
               (Expression
                (MethodCall (Var out__) write_free_simplex ()
                 ((Var p_1d_simplex))))
@@ -9967,29 +9999,39 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Var N)) (Increment (Var sym1__))
                (Block
                 ((For
                   ((static false) (constexpr false) (type_ Int) (name sym2__)
                    (init (Assignment (Literal 1))))
-                  (BinOp (Var sym2__) LEq (Var M)) (Increment (Var sym2__))
+                  (BinOp (Var sym2__) LEq (Var K)) (Increment (Var sym2__))
                   (Block
                    ((For
                      ((static false) (constexpr false) (type_ Int)
                       (name sym3__) (init (Assignment (Literal 1))))
-                     (BinOp (Var sym3__) LEq (Var N))
+                     (BinOp (Var sym3__) LEq (Var M))
                      (Increment (Var sym3__))
                      (Block
-                      ((Expression
-                        (FunCall stan::model::assign ()
-                         ((Var p_3d_simplex)
-                          (MethodCall (Var in__) read
-                           ((Matrix (TypeLiteral local_scalar_t__) -1 1))
-                           ((Var N)))
-                          (Literal "\"assigning variable p_3d_simplex\"")
-                          (FunCall stan::model::index_uni () ((Var sym3__)))
-                          (FunCall stan::model::index_uni () ((Var sym2__)))
-                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
+                      ((For
+                        ((static false) (constexpr false) (type_ Int)
+                         (name sym4__) (init (Assignment (Literal 1))))
+                        (BinOp (Var sym4__) LEq (Var N))
+                        (Increment (Var sym4__))
+                        (Block
+                         ((Expression
+                           (FunCall stan::model::assign ()
+                            ((Var p_3d_simplex)
+                             (MethodCall (Var in__) read
+                              ((TypeLiteral local_scalar_t__)) ())
+                             (Literal "\"assigning variable p_3d_simplex\"")
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym4__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym3__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym2__)))
+                             (FunCall stan::model::index_uni ()
+                              ((Var sym1__))))))))))))))))))
               (Expression
                (MethodCall (Var out__) write_free_simplex ()
                 ((Var p_3d_simplex))))
@@ -10047,16 +10089,29 @@
               (For
                ((static false) (constexpr false) (type_ Int) (name sym1__)
                 (init (Assignment (Literal 1))))
-               (BinOp (Var sym1__) LEq (Var K)) (Increment (Var sym1__))
+               (BinOp (Var sym1__) LEq (Literal 3)) (Increment (Var sym1__))
                (Block
-                ((Expression
-                  (FunCall stan::model::assign ()
-                   ((Var p_cfcov_33_ar)
-                    (MethodCall (Var in__) read
-                     ((Matrix (TypeLiteral local_scalar_t__) -1 -1))
-                     ((Literal 3) (Literal 3)))
-                    (Literal "\"assigning variable p_cfcov_33_ar\"")
-                    (FunCall stan::model::index_uni () ((Var sym1__)))))))))
+                ((For
+                  ((static false) (constexpr false) (type_ Int) (name sym2__)
+                   (init (Assignment (Literal 1))))
+                  (BinOp (Var sym2__) LEq (Literal 3))
+                  (Increment (Var sym2__))
+                  (Block
+                   ((For
+                     ((static false) (constexpr false) (type_ Int)
+                      (name sym3__) (init (Assignment (Literal 1))))
+                     (BinOp (Var sym3__) LEq (Var K))
+                     (Increment (Var sym3__))
+                     (Block
+                      ((Expression
+                        (FunCall stan::model::assign ()
+                         ((Var p_cfcov_33_ar)
+                          (MethodCall (Var in__) read
+                           ((TypeLiteral local_scalar_t__)) ())
+                          (Literal "\"assigning variable p_cfcov_33_ar\"")
+                          (FunCall stan::model::index_uni () ((Var sym3__)))
+                          (FunCall stan::model::index_uni () ((Var sym2__)))
+                          (FunCall stan::model::index_uni () ((Var sym1__)))))))))))))))
               (Expression
                (MethodCall (Var out__) write_free_cholesky_factor_cov ()
                 ((Var p_cfcov_33_ar))))

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -11913,7 +11913,7 @@
           (meta ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly)))))))
       ()))
     (meta <opaque>))))
- (transform_inits ())
+ (transform_inits ()) (unconstrain_array ())
  (output_vars
   ((p_real
     ((out_unconstrained_st SReal) (out_constrained_st SReal)

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -463,10 +463,9 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       out__.write(y);
       Eigen::Matrix<local_scalar_t__,-1,1> y0 =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(y0, in__.read<local_scalar_t__>(),
-          "assigning variable y0", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(y0,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable y0");
       out__.write(y0);
       local_scalar_t__ t0 = DUMMY_VAR__;
       t0 = in__.read<local_scalar_t__>();

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -446,8 +446,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -475,6 +475,46 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
         times[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(times);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ y = DUMMY_VAR__;
+      y = context__.vals_r("y")[(1 - 1)];
+      out__.write(y);
+      Eigen::Matrix<local_scalar_t__,-1,1> y0 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> y0_flat__;
+        y0_flat__ = context__.vals_r("y0");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(y0, y0_flat__[(pos__ - 1)],
+            "assigning variable y0", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(y0);
+      local_scalar_t__ t0 = DUMMY_VAR__;
+      t0 = context__.vals_r("t0")[(1 - 1)];
+      out__.write(t0);
+      std::vector<local_scalar_t__> times =
+        std::vector<local_scalar_t__>(N, DUMMY_VAR__);
+      times = context__.vals_r("times");
       out__.write(times);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -621,24 +661,17 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4> names__{"y", "y0", "t0", "times"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, N, 1, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1247,8 +1280,8 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1270,6 +1303,35 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       out__.write_free_lb(0, xi);
       local_scalar_t__ delta = DUMMY_VAR__;
       delta = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, delta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ beta = DUMMY_VAR__;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write_free_lb(0, beta);
+      local_scalar_t__ gamma = DUMMY_VAR__;
+      gamma = context__.vals_r("gamma")[(1 - 1)];
+      out__.write_free_lb(0, gamma);
+      local_scalar_t__ xi = DUMMY_VAR__;
+      xi = context__.vals_r("xi")[(1 - 1)];
+      out__.write_free_lb(0, xi);
+      local_scalar_t__ delta = DUMMY_VAR__;
+      delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1419,25 +1481,17 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"beta", "gamma", "xi", "delta"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -669,7 +669,18 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1489,7 +1500,18 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -472,9 +472,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       out__.write(t0);
       std::vector<local_scalar_t__> times =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        times[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(times, in__.read<std::vector<local_scalar_t__>>(N),
+        "assigning variable times");
       out__.write(times);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7069,27 +7069,21 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       Eigen::Matrix<local_scalar_t__,-1,-1> p_matrix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(d_int, d_int,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-          stan::model::assign(p_matrix, in__.read<local_scalar_t__>(),
-            "assigning variable p_matrix", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_matrix,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(d_int, d_int),
+        "assigning variable p_matrix");
       out__.write(p_matrix);
       Eigen::Matrix<local_scalar_t__,-1,1> p_vector =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(d_int, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        stan::model::assign(p_vector, in__.read<local_scalar_t__>(),
-          "assigning variable p_vector", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(d_int),
+        "assigning variable p_vector");
       out__.write(p_vector);
       Eigen::Matrix<local_scalar_t__,1,-1> p_row_vector =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(d_int, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        stan::model::assign(p_row_vector, in__.read<local_scalar_t__>(),
-          "assigning variable p_row_vector", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_row_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(d_int),
+        "assigning variable p_row_vector");
       out__.write(p_row_vector);
       local_scalar_t__ y_p = DUMMY_VAR__;
       y_p = in__.read<local_scalar_t__>();
@@ -7733,27 +7727,21 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       Eigen::Matrix<local_scalar_t__,-1,-1> p_matrix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(d_int, d_int,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
-          stan::model::assign(p_matrix, in__.read<local_scalar_t__>(),
-            "assigning variable p_matrix", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_matrix,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(d_int, d_int),
+        "assigning variable p_matrix");
       out__.write(p_matrix);
       Eigen::Matrix<local_scalar_t__,-1,1> p_vector =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(d_int, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        stan::model::assign(p_vector, in__.read<local_scalar_t__>(),
-          "assigning variable p_vector", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(d_int),
+        "assigning variable p_vector");
       out__.write(p_vector);
       Eigen::Matrix<local_scalar_t__,1,-1> p_row_vector =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(d_int, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        stan::model::assign(p_row_vector, in__.read<local_scalar_t__>(),
-          "assigning variable p_row_vector", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_row_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(d_int),
+        "assigning variable p_row_vector");
       out__.write(p_row_vector);
       local_scalar_t__ y_p = DUMMY_VAR__;
       y_p = in__.read<local_scalar_t__>();

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7062,9 +7062,9 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       out__.write(p_real);
       std::vector<local_scalar_t__> p_real_array =
         std::vector<local_scalar_t__>(d_int, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        p_real_array[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_real_array,
+        in__.read<std::vector<local_scalar_t__>>(d_int),
+        "assigning variable p_real_array");
       out__.write(p_real_array);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_matrix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(d_int, d_int,
@@ -7791,9 +7791,9 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       out__.write(p_real);
       std::vector<local_scalar_t__> p_real_array =
         std::vector<local_scalar_t__>(d_int, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
-        p_real_array[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(p_real_array,
+        in__.read<std::vector<local_scalar_t__>>(d_int),
+        "assigning variable p_real_array");
       out__.write(p_real_array);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_matrix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(d_int, d_int,

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7045,8 +7045,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7087,6 +7087,76 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       out__.write(p_row_vector);
       local_scalar_t__ y_p = DUMMY_VAR__;
       y_p = in__.read<local_scalar_t__>();
+      out__.write(y_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ p_real = DUMMY_VAR__;
+      p_real = context__.vals_r("p_real")[(1 - 1)];
+      out__.write(p_real);
+      std::vector<local_scalar_t__> p_real_array =
+        std::vector<local_scalar_t__>(d_int, DUMMY_VAR__);
+      p_real_array = context__.vals_r("p_real_array");
+      out__.write(p_real_array);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_matrix =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(d_int, d_int,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_matrix_flat__;
+        p_matrix_flat__ = context__.vals_r("p_matrix");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
+            stan::model::assign(p_matrix, p_matrix_flat__[(pos__ - 1)],
+              "assigning variable p_matrix", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_matrix);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_vector =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(d_int, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_vector_flat__;
+        p_vector_flat__ = context__.vals_r("p_vector");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
+          stan::model::assign(p_vector, p_vector_flat__[(pos__ - 1)],
+            "assigning variable p_vector", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_vector);
+      Eigen::Matrix<local_scalar_t__,1,-1> p_row_vector =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(d_int, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_row_vector_flat__;
+        p_row_vector_flat__ = context__.vals_r("p_row_vector");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
+          stan::model::assign(p_row_vector, p_row_vector_flat__[(pos__ - 1)],
+            "assigning variable p_row_vector", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_row_vector);
+      local_scalar_t__ y_p = DUMMY_VAR__;
+      y_p = context__.vals_r("y_p")[(1 - 1)];
       out__.write(y_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7247,27 +7317,17 @@ class distributions_model final : public model_base_crtp<distributions_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"p_real", "p_real_array", "p_matrix", "p_vector",
-              "p_row_vector", "y_p"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, d_int, (d_int * d_int), d_int, d_int, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -7703,8 +7763,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7745,6 +7805,76 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       out__.write(p_row_vector);
       local_scalar_t__ y_p = DUMMY_VAR__;
       y_p = in__.read<local_scalar_t__>();
+      out__.write(y_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ p_real = DUMMY_VAR__;
+      p_real = context__.vals_r("p_real")[(1 - 1)];
+      out__.write(p_real);
+      std::vector<local_scalar_t__> p_real_array =
+        std::vector<local_scalar_t__>(d_int, DUMMY_VAR__);
+      p_real_array = context__.vals_r("p_real_array");
+      out__.write(p_real_array);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_matrix =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(d_int, d_int,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_matrix_flat__;
+        p_matrix_flat__ = context__.vals_r("p_matrix");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= d_int; ++sym2__) {
+            stan::model::assign(p_matrix, p_matrix_flat__[(pos__ - 1)],
+              "assigning variable p_matrix", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_matrix);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_vector =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(d_int, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_vector_flat__;
+        p_vector_flat__ = context__.vals_r("p_vector");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
+          stan::model::assign(p_vector, p_vector_flat__[(pos__ - 1)],
+            "assigning variable p_vector", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_vector);
+      Eigen::Matrix<local_scalar_t__,1,-1> p_row_vector =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(d_int, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_row_vector_flat__;
+        p_row_vector_flat__ = context__.vals_r("p_row_vector");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= d_int; ++sym1__) {
+          stan::model::assign(p_row_vector, p_row_vector_flat__[(pos__ - 1)],
+            "assigning variable p_row_vector", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_row_vector);
+      local_scalar_t__ y_p = DUMMY_VAR__;
+      y_p = context__.vals_r("y_p")[(1 - 1)];
       out__.write(y_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7905,27 +8035,17 @@ class restricted_model final : public model_base_crtp<restricted_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"p_real", "p_real_array", "p_matrix", "p_vector",
-              "p_row_vector", "y_p"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, d_int, (d_int * d_int), d_int, d_int, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7325,7 +7325,18 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -8043,7 +8054,18 @@ class restricted_model final : public model_base_crtp<restricted_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -281,8 +281,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -301,6 +301,32 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       out__.write_free_lb(0, alpha);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ rho = DUMMY_VAR__;
+      rho = context__.vals_r("rho")[(1 - 1)];
+      out__.write_free_lb(0, rho);
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
+      out__.write_free_lb(0, alpha);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lb(0, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -407,24 +433,17 @@ class simple_function_model final : public model_base_crtp<simple_function_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"rho", "alpha", "sigma"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -441,7 +441,18 @@ class simple_function_model final : public model_base_crtp<simple_function_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/code-gen/profiling/transformed_mir.expected
+++ b/test/integration/good/code-gen/profiling/transformed_mir.expected
@@ -555,7 +555,110 @@
     (meta <opaque>))
    ((pattern
      (Assignment (rho UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str rho))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var rho))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (alpha UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var alpha))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (sigma UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str sigma))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id rho) (decl_type (Sized SReal))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (rho UReal ())
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -577,7 +680,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (alpha UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -599,7 +702,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (sigma UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern

--- a/test/integration/good/code-gen/profiling/transformed_mir.expected
+++ b/test/integration/good/code-gen/profiling/transformed_mir.expected
@@ -658,7 +658,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (rho UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -680,7 +680,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (alpha UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -702,7 +702,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (sigma UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -20407,29 +20407,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_vec UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_vec UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -20468,37 +20451,16 @@
        ((pattern
          (Block
           (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_1d_vec UVector
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UVector) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
+             (Assignment
+              (p_1d_vec UVector
+               ((Single
+                 ((pattern (Var sym1__))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              ((pattern
+                (FunApp (CompilerInternal FnReadDataSerializer)
+                 (((pattern (Var N))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -20535,7 +20497,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var N))
+       ((pattern (Var K))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -20546,7 +20508,7 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Var K))
+               ((pattern (Var M))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
@@ -20558,63 +20520,40 @@
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
-                       ((pattern (Var M))
+                       ((pattern (Var N))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (body
                        ((pattern
                          (Block
                           (((pattern
-                             (For (loopvar sym4__)
-                              (lower
-                               ((pattern (Lit Int 1))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (upper
-                               ((pattern (Var N))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (body
-                               ((pattern
-                                 (Block
-                                  (((pattern
-                                     (Assignment
-                                      (p_3d_vec UVector
-                                       ((Single
-                                         ((pattern (Var sym4__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym3__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym2__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym1__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))))
-                                      ((pattern
-                                        (FunApp
-                                         (CompilerInternal
-                                          FnReadDataSerializer)
-                                         (((pattern (Var N))
-                                           (meta
-                                            ((type_ UInt) (loc <opaque>)
-                                             (adlevel DataOnly)))))))
-                                       (meta
-                                        ((type_ UVector) (loc <opaque>)
-                                         (adlevel AutoDiffable))))))
-                                    (meta <opaque>)))))
-                                (meta <opaque>)))))
+                             (Assignment
+                              (p_3d_vec UVector
+                               ((Single
+                                 ((pattern (Var sym3__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym2__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym1__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))))
+                              ((pattern
+                                (FunApp
+                                 (CompilerInternal FnReadDataSerializer)
+                                 (((pattern (Var N))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>)
+                                     (adlevel DataOnly)))))))
+                               (meta
+                                ((type_ UVector) (loc <opaque>)
+                                 (adlevel AutoDiffable))))))
                             (meta <opaque>)))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
@@ -20643,30 +20582,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_row_vec URowVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta
-                ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_row_vec URowVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -20701,37 +20622,17 @@
        ((pattern
          (Block
           (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_1d_row_vec URowVector
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ URowVector) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
+             (Assignment
+              (p_1d_row_vec URowVector
+               ((Single
+                 ((pattern (Var sym1__))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              ((pattern
+                (FunApp (CompilerInternal FnReadDataSerializer)
+                 (((pattern (Var N))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta
+                ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -20769,7 +20670,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var N))
+       ((pattern (Var K))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -20780,7 +20681,7 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Var K))
+               ((pattern (Var M))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
@@ -20792,63 +20693,40 @@
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
-                       ((pattern (Var M))
+                       ((pattern (Var N))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (body
                        ((pattern
                          (Block
                           (((pattern
-                             (For (loopvar sym4__)
-                              (lower
-                               ((pattern (Lit Int 1))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (upper
-                               ((pattern (Var N))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (body
-                               ((pattern
-                                 (Block
-                                  (((pattern
-                                     (Assignment
-                                      (p_3d_row_vec URowVector
-                                       ((Single
-                                         ((pattern (Var sym4__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym3__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym2__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym1__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))))
-                                      ((pattern
-                                        (FunApp
-                                         (CompilerInternal
-                                          FnReadDataSerializer)
-                                         (((pattern (Var N))
-                                           (meta
-                                            ((type_ UInt) (loc <opaque>)
-                                             (adlevel DataOnly)))))))
-                                       (meta
-                                        ((type_ URowVector) (loc <opaque>)
-                                         (adlevel AutoDiffable))))))
-                                    (meta <opaque>)))))
-                                (meta <opaque>)))))
+                             (Assignment
+                              (p_3d_row_vec URowVector
+                               ((Single
+                                 ((pattern (Var sym3__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym2__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym1__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))))
+                              ((pattern
+                                (FunApp
+                                 (CompilerInternal FnReadDataSerializer)
+                                 (((pattern (Var N))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>)
+                                     (adlevel DataOnly)))))))
+                               (meta
+                                ((type_ URowVector) (loc <opaque>)
+                                 (adlevel AutoDiffable))))))
                             (meta <opaque>)))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
@@ -20879,53 +20757,14 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 4))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_mat UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 4))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_mat UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 4))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -20959,7 +20798,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Lit Int 3))
+       ((pattern (Lit Int 5))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -20970,81 +20809,33 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Lit Int 2))
+               ((pattern (Lit Int 4))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
                  (Block
                   (((pattern
-                     (For (loopvar sym3__)
-                      (lower
-                       ((pattern (Lit Int 1))
-                        (meta
-                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (upper
-                       ((pattern (Lit Int 5))
-                        (meta
-                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (body
-                       ((pattern
-                         (Block
-                          (((pattern
-                             (For (loopvar sym4__)
-                              (lower
-                               ((pattern (Lit Int 1))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (upper
-                               ((pattern (Lit Int 4))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (body
-                               ((pattern
-                                 (Block
-                                  (((pattern
-                                     (Assignment
-                                      (p_ar_mat UMatrix
-                                       ((Single
-                                         ((pattern (Var sym4__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym3__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym2__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym1__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))))
-                                      ((pattern
-                                        (FunApp
-                                         (CompilerInternal
-                                          FnReadDataSerializer)
-                                         (((pattern (Lit Int 2))
-                                           (meta
-                                            ((type_ UInt) (loc <opaque>)
-                                             (adlevel DataOnly))))
-                                          ((pattern (Lit Int 3))
-                                           (meta
-                                            ((type_ UInt) (loc <opaque>)
-                                             (adlevel DataOnly)))))))
-                                       (meta
-                                        ((type_ UMatrix) (loc <opaque>)
-                                         (adlevel AutoDiffable))))))
-                                    (meta <opaque>)))))
-                                (meta <opaque>)))))
-                            (meta <opaque>)))))
-                        (meta <opaque>)))))
+                     (Assignment
+                      (p_ar_mat UMatrix
+                       ((Single
+                         ((pattern (Var sym2__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                        (Single
+                         ((pattern (Var sym1__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      ((pattern
+                        (FunApp (CompilerInternal FnReadDataSerializer)
+                         (((pattern (Lit Int 2))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                          ((pattern (Lit Int 3))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                       (meta
+                        ((type_ UMatrix) (loc <opaque>)
+                         (adlevel AutoDiffable))))))
                     (meta <opaque>)))))
                 (meta <opaque>)))))
             (meta <opaque>)))))
@@ -21077,29 +20868,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_simplex UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_simplex UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -21134,37 +20908,16 @@
        ((pattern
          (Block
           (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_1d_simplex UVector
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UVector) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
+             (Assignment
+              (p_1d_simplex UVector
+               ((Single
+                 ((pattern (Var sym1__))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              ((pattern
+                (FunApp (CompilerInternal FnReadDataSerializer)
+                 (((pattern (Var N))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -21201,7 +20954,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var N))
+       ((pattern (Var K))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -21212,7 +20965,7 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Var K))
+               ((pattern (Var M))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
@@ -21224,63 +20977,40 @@
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
-                       ((pattern (Var M))
+                       ((pattern (Var N))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (body
                        ((pattern
                          (Block
                           (((pattern
-                             (For (loopvar sym4__)
-                              (lower
-                               ((pattern (Lit Int 1))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (upper
-                               ((pattern (Var N))
-                                (meta
-                                 ((type_ UInt) (loc <opaque>)
-                                  (adlevel DataOnly)))))
-                              (body
-                               ((pattern
-                                 (Block
-                                  (((pattern
-                                     (Assignment
-                                      (p_3d_simplex UVector
-                                       ((Single
-                                         ((pattern (Var sym4__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym3__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym2__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))
-                                        (Single
-                                         ((pattern (Var sym1__))
-                                          (meta
-                                           ((type_ UInt) (loc <opaque>)
-                                            (adlevel DataOnly)))))))
-                                      ((pattern
-                                        (FunApp
-                                         (CompilerInternal
-                                          FnReadDataSerializer)
-                                         (((pattern (Var N))
-                                           (meta
-                                            ((type_ UInt) (loc <opaque>)
-                                             (adlevel DataOnly)))))))
-                                       (meta
-                                        ((type_ UVector) (loc <opaque>)
-                                         (adlevel AutoDiffable))))))
-                                    (meta <opaque>)))))
-                                (meta <opaque>)))))
+                             (Assignment
+                              (p_3d_simplex UVector
+                               ((Single
+                                 ((pattern (Var sym3__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym2__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym1__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))))
+                              ((pattern
+                                (FunApp
+                                 (CompilerInternal FnReadDataSerializer)
+                                 (((pattern (Var N))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>)
+                                     (adlevel DataOnly)))))))
+                               (meta
+                                ((type_ UVector) (loc <opaque>)
+                                 (adlevel AutoDiffable))))))
                             (meta <opaque>)))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
@@ -21311,53 +21041,14 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 4))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_cfcov_54 UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 4))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_cfcov_54 UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 4))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -21380,53 +21071,14 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 3))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 3))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_cfcov_33 UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 3))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 3))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_cfcov_33 UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 3))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -21457,71 +21109,24 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Lit Int 3))
+       ((pattern (Var K))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
          (Block
           (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 3))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (For (loopvar sym3__)
-                      (lower
-                       ((pattern (Lit Int 1))
-                        (meta
-                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (upper
-                       ((pattern (Var K))
-                        (meta
-                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                      (body
-                       ((pattern
-                         (Block
-                          (((pattern
-                             (Assignment
-                              (p_cfcov_33_ar UMatrix
-                               ((Single
-                                 ((pattern (Var sym3__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym2__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym1__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))))
-                              ((pattern
-                                (FunApp
-                                 (CompilerInternal FnReadDataSerializer)
-                                 (((pattern (Lit Int 3))
-                                   (meta
-                                    ((type_ UInt) (loc <opaque>)
-                                     (adlevel DataOnly))))
-                                  ((pattern (Lit Int 3))
-                                   (meta
-                                    ((type_ UInt) (loc <opaque>)
-                                     (adlevel DataOnly)))))))
-                               (meta
-                                ((type_ UMatrix) (loc <opaque>)
-                                 (adlevel AutoDiffable))))))
-                            (meta <opaque>)))))
-                        (meta <opaque>)))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
+             (Assignment
+              (p_cfcov_33_ar UMatrix
+               ((Single
+                 ((pattern (Var sym1__))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              ((pattern
+                (FunApp (CompilerInternal FnReadDataSerializer)
+                 (((pattern (Lit Int 3))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                  ((pattern (Lit Int 3))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -21544,29 +21149,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 2))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (x_p UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Lit Int 2))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (x_p UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 2))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -21587,29 +21175,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 2))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (y_p UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Lit Int 2))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (y_p UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 2))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -20067,7 +20067,2241 @@
     (meta <opaque>))
    ((pattern
      (Assignment (p_real UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str p_real))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_real))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_upper)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_upper UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str p_upper))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Var p_real))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+        (var
+         ((pattern (Var p_upper))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_lower)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_lower UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str p_lower))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Upper
+           ((pattern (Var p_upper))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+        (var
+         ((pattern (Var p_lower))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id offset_multiplier)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (offset_multiplier (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str offset_multiplier))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((OffsetMultiplier
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var offset_multiplier))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id no_offset_multiplier)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (no_offset_multiplier (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str no_offset_multiplier))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Multiplier
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var no_offset_multiplier))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id offset_no_multiplier)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (offset_no_multiplier (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str offset_no_multiplier))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Offset
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var offset_no_multiplier))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_real_1d_ar)
+      (decl_type
+       (Sized
+        (SArray SReal
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_real_1d_ar (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadData)
+         (((pattern (Lit Str p_real_1d_ar))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var p_real_1d_ar))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_real_3d_ar)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray SReal
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_real_3d_ar_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_real_3d_ar_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_real_3d_ar))
+               (meta
+                ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var M))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Var N))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment
+                                  (p_real_3d_ar
+                                   (UArray (UArray (UArray UReal)))
+                                   ((Single
+                                     ((pattern (Var sym3__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>)
+                                        (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym2__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>)
+                                        (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym1__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>)
+                                        (adlevel DataOnly)))))))
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var p_real_3d_ar_flat__))
+                                      (meta
+                                       ((type_ (UArray UReal)) (loc <opaque>)
+                                        (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var pos__))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>)
+                                          (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>)
+                                     (adlevel DataOnly))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment (pos__ UInt ())
+                                  ((pattern
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                     (((pattern (Var pos__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>)
+                                         (adlevel DataOnly))))
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>)
+                                         (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>)
+                                     (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var p_real_3d_ar))
+          (meta
+           ((type_ (UArray (UArray (UArray UReal)))) (loc <opaque>)
+            (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_vec)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_vec_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_vec_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_vec))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_vec UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_vec_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var p_vec))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_1d_vec)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_1d_vec_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_1d_vec_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_1d_vec))
+               (meta
+                ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_1d_vec (UArray UVector)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_1d_vec_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_1d_vec))
+          (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_3d_vec)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray
+           (SVector AoS
+            ((pattern (Var N))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_3d_vec_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_3d_vec_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_3d_vec))
+               (meta
+                ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var K))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Var M))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar sym4__)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Var N))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment
+                                          (p_3d_vec
+                                           (UArray (UArray (UArray UVector)))
+                                           ((Single
+                                             ((pattern (Var sym4__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym3__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym2__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym1__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var p_3d_vec_flat__))
+                                              (meta
+                                               ((type_ (UArray UReal))
+                                                (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var pos__))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment (pos__ UInt ())
+                                          ((pattern
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
+                                             (((pattern (Var pos__))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Lit Int 1))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_3d_vec))
+          (meta
+           ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
+            (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_row_vec)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_row_vec_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_row_vec_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_row_vec))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_row_vec URowVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_row_vec_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_row_vec))
+          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_1d_row_vec)
+      (decl_type
+       (Sized
+        (SArray
+         (SRowVector AoS
+          ((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_1d_row_vec_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_1d_row_vec_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_1d_row_vec))
+               (meta
+                ((type_ (UArray URowVector)) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_1d_row_vec (UArray URowVector)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_1d_row_vec_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_1d_row_vec))
+          (meta
+           ((type_ (UArray URowVector)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_3d_row_vec)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray
+           (SRowVector AoS
+            ((pattern (Var N))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_3d_row_vec_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_3d_row_vec_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_3d_row_vec))
+               (meta
+                ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var K))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Var M))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar sym4__)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Var N))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment
+                                          (p_3d_row_vec
+                                           (UArray
+                                            (UArray (UArray URowVector)))
+                                           ((Single
+                                             ((pattern (Var sym4__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym3__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym2__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym1__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern
+                                               (Var p_3d_row_vec_flat__))
+                                              (meta
+                                               ((type_ (UArray UReal))
+                                                (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var pos__))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment (pos__ UInt ())
+                                          ((pattern
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
+                                             (((pattern (Var pos__))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Lit Int 1))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_3d_row_vec))
+          (meta
+           ((type_ (UArray (UArray (UArray URowVector)))) (loc <opaque>)
+            (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_mat)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_mat_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_mat_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_mat))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_mat UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_mat_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_mat))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_ar_mat)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SMatrix AoS
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 4))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_ar_mat_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_ar_mat_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_ar_mat))
+               (meta
+                ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 2))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Lit Int 5))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar sym4__)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Lit Int 4))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment
+                                          (p_ar_mat (UArray (UArray UMatrix))
+                                           ((Single
+                                             ((pattern (Var sym4__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym3__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym2__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym1__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern (Var p_ar_mat_flat__))
+                                              (meta
+                                               ((type_ (UArray UReal))
+                                                (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var pos__))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment (pos__ UInt ())
+                                          ((pattern
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
+                                             (((pattern (Var pos__))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Lit Int 1))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var p_ar_mat))
+          (meta
+           ((type_ (UArray (UArray UMatrix))) (loc <opaque>)
+            (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_simplex)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_simplex_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_simplex_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_simplex))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_simplex UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_simplex_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Simplex))
+        (var
+         ((pattern (Var p_simplex))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_1d_simplex)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_1d_simplex_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_1d_simplex_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_1d_simplex))
+               (meta
+                ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_1d_simplex (UArray UVector)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_1d_simplex_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Simplex))
+        (var
+         ((pattern (Var p_1d_simplex))
+          (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_3d_simplex)
+      (decl_type
+       (Sized
+        (SArray
+         (SArray
+          (SArray
+           (SVector AoS
+            ((pattern (Var N))
+             (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_3d_simplex_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_3d_simplex_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_3d_simplex))
+               (meta
+                ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
+                 (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var K))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Var M))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (For (loopvar sym4__)
+                                  (lower
+                                   ((pattern (Lit Int 1))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (upper
+                                   ((pattern (Var N))
+                                    (meta
+                                     ((type_ UInt) (loc <opaque>)
+                                      (adlevel DataOnly)))))
+                                  (body
+                                   ((pattern
+                                     (Block
+                                      (((pattern
+                                         (Assignment
+                                          (p_3d_simplex
+                                           (UArray (UArray (UArray UVector)))
+                                           ((Single
+                                             ((pattern (Var sym4__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym3__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym2__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))
+                                            (Single
+                                             ((pattern (Var sym1__))
+                                              (meta
+                                               ((type_ UInt) (loc <opaque>)
+                                                (adlevel DataOnly)))))))
+                                          ((pattern
+                                            (Indexed
+                                             ((pattern
+                                               (Var p_3d_simplex_flat__))
+                                              (meta
+                                               ((type_ (UArray UReal))
+                                                (loc <opaque>)
+                                                (adlevel DataOnly))))
+                                             ((Single
+                                               ((pattern (Var pos__))
+                                                (meta
+                                                 ((type_ UInt) (loc <opaque>)
+                                                  (adlevel DataOnly))))))))
+                                           (meta
+                                            ((type_ UReal) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>))
+                                       ((pattern
+                                         (Assignment (pos__ UInt ())
+                                          ((pattern
+                                            (FunApp
+                                             (StanLib Plus__ FnPlain AoS)
+                                             (((pattern (Var pos__))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly))))
+                                              ((pattern (Lit Int 1))
+                                               (meta
+                                                ((type_ UInt) (loc <opaque>)
+                                                 (adlevel DataOnly)))))))
+                                           (meta
+                                            ((type_ UInt) (loc <opaque>)
+                                             (adlevel DataOnly))))))
+                                        (meta <opaque>)))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Simplex))
+        (var
+         ((pattern (Var p_3d_simplex))
+          (meta
+           ((type_ (UArray (UArray (UArray UVector)))) (loc <opaque>)
+            (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_54)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 4))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_54_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_cfcov_54_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_cfcov_54))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 4))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_cfcov_54 UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_cfcov_54_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (CholeskyCov))
+        (var
+         ((pattern (Var p_cfcov_54))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 3))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 3))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_cfcov_33_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_cfcov_33))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_cfcov_33 UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_cfcov_33_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (CholeskyCov))
+        (var
+         ((pattern (Var p_cfcov_33))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33_ar)
+      (decl_type
+       (Sized
+        (SArray
+         (SMatrix AoS
+          ((pattern (Lit Int 3))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 3))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Var K))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_cfcov_33_ar_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_cfcov_33_ar_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_cfcov_33_ar))
+               (meta
+                ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 3))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 3))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (For (loopvar sym3__)
+                          (lower
+                           ((pattern (Lit Int 1))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (upper
+                           ((pattern (Var K))
+                            (meta
+                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                          (body
+                           ((pattern
+                             (Block
+                              (((pattern
+                                 (Assignment
+                                  (p_cfcov_33_ar (UArray UMatrix)
+                                   ((Single
+                                     ((pattern (Var sym3__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>)
+                                        (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym2__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>)
+                                        (adlevel DataOnly)))))
+                                    (Single
+                                     ((pattern (Var sym1__))
+                                      (meta
+                                       ((type_ UInt) (loc <opaque>)
+                                        (adlevel DataOnly)))))))
+                                  ((pattern
+                                    (Indexed
+                                     ((pattern (Var p_cfcov_33_ar_flat__))
+                                      (meta
+                                       ((type_ (UArray UReal)) (loc <opaque>)
+                                        (adlevel DataOnly))))
+                                     ((Single
+                                       ((pattern (Var pos__))
+                                        (meta
+                                         ((type_ UInt) (loc <opaque>)
+                                          (adlevel DataOnly))))))))
+                                   (meta
+                                    ((type_ UReal) (loc <opaque>)
+                                     (adlevel DataOnly))))))
+                                (meta <opaque>))
+                               ((pattern
+                                 (Assignment (pos__ UInt ())
+                                  ((pattern
+                                    (FunApp (StanLib Plus__ FnPlain AoS)
+                                     (((pattern (Var pos__))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>)
+                                         (adlevel DataOnly))))
+                                      ((pattern (Lit Int 1))
+                                       (meta
+                                        ((type_ UInt) (loc <opaque>)
+                                         (adlevel DataOnly)))))))
+                                   (meta
+                                    ((type_ UInt) (loc <opaque>)
+                                     (adlevel DataOnly))))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (CholeskyCov))
+        (var
+         ((pattern (Var p_cfcov_33_ar))
+          (meta ((type_ (UArray UMatrix)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id x_p)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id x_p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (x_p_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str x_p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (x_p UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var x_p_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var x_p))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id y_p)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id y_p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (y_p_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str y_p))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (y_p UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var y_p_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var y_p))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_real)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (p_real UReal ())
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -20085,7 +22319,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (p_upper UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -20107,7 +22341,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (p_lower UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -20149,7 +22383,7 @@
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
@@ -20195,7 +22429,7 @@
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
@@ -20239,7 +22473,7 @@
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
@@ -20283,7 +22517,7 @@
                ((Single
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
                (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
@@ -20370,8 +22604,8 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp
-                                 (CompilerInternal FnReadDataSerializer) ()))
+                                (FunApp (CompilerInternal FnReadSerializer)
+                                 ()))
                                (meta
                                 ((type_ UReal) (loc <opaque>)
                                  (adlevel AutoDiffable))))))
@@ -20409,7 +22643,7 @@
    ((pattern
      (Assignment (p_vec UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -20457,7 +22691,7 @@
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
+                (FunApp (CompilerInternal FnReadSerializer)
                  (((pattern (Var N))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -20545,8 +22779,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp
-                                 (CompilerInternal FnReadDataSerializer)
+                                (FunApp (CompilerInternal FnReadSerializer)
                                  (((pattern (Var N))
                                    (meta
                                     ((type_ UInt) (loc <opaque>)
@@ -20584,7 +22817,7 @@
    ((pattern
      (Assignment (p_row_vec URowVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -20628,7 +22861,7 @@
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
+                (FunApp (CompilerInternal FnReadSerializer)
                  (((pattern (Var N))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                (meta
@@ -20718,8 +22951,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp
-                                 (CompilerInternal FnReadDataSerializer)
+                                (FunApp (CompilerInternal FnReadSerializer)
                                  (((pattern (Var N))
                                    (meta
                                     ((type_ UInt) (loc <opaque>)
@@ -20759,7 +22991,7 @@
    ((pattern
      (Assignment (p_mat UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -20826,7 +23058,7 @@
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
+                        (FunApp (CompilerInternal FnReadSerializer)
                          (((pattern (Lit Int 2))
                            (meta
                             ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
@@ -20870,7 +23102,7 @@
    ((pattern
      (Assignment (p_simplex UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -20914,7 +23146,7 @@
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
+                (FunApp (CompilerInternal FnReadSerializer)
                  (((pattern (Var N))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -21002,8 +23234,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp
-                                 (CompilerInternal FnReadDataSerializer)
+                                (FunApp (CompilerInternal FnReadSerializer)
                                  (((pattern (Var N))
                                    (meta
                                     ((type_ UInt) (loc <opaque>)
@@ -21043,7 +23274,7 @@
    ((pattern
      (Assignment (p_cfcov_54 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -21073,7 +23304,7 @@
    ((pattern
      (Assignment (p_cfcov_33 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -21121,7 +23352,7 @@
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
+                (FunApp (CompilerInternal FnReadSerializer)
                  (((pattern (Lit Int 3))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
                   ((pattern (Lit Int 3))
@@ -21151,7 +23382,7 @@
    ((pattern
      (Assignment (x_p UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -21177,7 +23408,7 @@
    ((pattern
      (Assignment (y_p UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -22301,7 +22301,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (p_real UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -22319,7 +22319,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (p_upper UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -22341,7 +22341,7 @@
     (meta <opaque>))
    ((pattern
      (Assignment (p_lower UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -22369,7 +22369,7 @@
    ((pattern
      (Assignment (offset_multiplier (UArray UReal) ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -22401,7 +22401,7 @@
    ((pattern
      (Assignment (no_offset_multiplier (UArray UReal) ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -22431,7 +22431,7 @@
    ((pattern
      (Assignment (offset_no_multiplier (UArray UReal) ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -22461,7 +22461,7 @@
    ((pattern
      (Assignment (p_real_1d_ar (UArray UReal) ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -22548,7 +22548,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp (CompilerInternal FnReadSerializer)
+                                (FunApp (CompilerInternal FnReadDeserializer)
                                  ()))
                                (meta
                                 ((type_ UReal) (loc <opaque>)
@@ -22587,7 +22587,7 @@
    ((pattern
      (Assignment (p_vec UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -22651,7 +22651,7 @@
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                        (FunApp (CompilerInternal FnReadDeserializer) ()))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
                     (meta <opaque>)))))
@@ -22761,7 +22761,8 @@
                                             (adlevel DataOnly)))))))
                                       ((pattern
                                         (FunApp
-                                         (CompilerInternal FnReadSerializer)
+                                         (CompilerInternal
+                                          FnReadDeserializer)
                                          ()))
                                        (meta
                                         ((type_ UReal) (loc <opaque>)
@@ -22798,7 +22799,7 @@
    ((pattern
      (Assignment (p_row_vec URowVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -22858,7 +22859,7 @@
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                        (FunApp (CompilerInternal FnReadDeserializer) ()))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
                     (meta <opaque>)))))
@@ -22969,7 +22970,8 @@
                                             (adlevel DataOnly)))))))
                                       ((pattern
                                         (FunApp
-                                         (CompilerInternal FnReadSerializer)
+                                         (CompilerInternal
+                                          FnReadDeserializer)
                                          ()))
                                        (meta
                                         ((type_ UReal) (loc <opaque>)
@@ -23008,7 +23010,7 @@
    ((pattern
      (Assignment (p_mat UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -23116,7 +23118,8 @@
                                             (adlevel DataOnly)))))))
                                       ((pattern
                                         (FunApp
-                                         (CompilerInternal FnReadSerializer)
+                                         (CompilerInternal
+                                          FnReadDeserializer)
                                          ()))
                                        (meta
                                         ((type_ UReal) (loc <opaque>)
@@ -23159,7 +23162,7 @@
    ((pattern
      (Assignment (p_simplex UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -23219,7 +23222,7 @@
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                        (FunApp (CompilerInternal FnReadDeserializer) ()))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
                     (meta <opaque>)))))
@@ -23329,7 +23332,8 @@
                                             (adlevel DataOnly)))))))
                                       ((pattern
                                         (FunApp
-                                         (CompilerInternal FnReadSerializer)
+                                         (CompilerInternal
+                                          FnReadDeserializer)
                                          ()))
                                        (meta
                                         ((type_ UReal) (loc <opaque>)
@@ -23368,7 +23372,7 @@
    ((pattern
      (Assignment (p_cfcov_54 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 4))
@@ -23398,7 +23402,7 @@
    ((pattern
      (Assignment (p_cfcov_33 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 3))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 3))
@@ -23482,7 +23486,7 @@
                                    ((type_ UInt) (loc <opaque>)
                                     (adlevel DataOnly)))))))
                               ((pattern
-                                (FunApp (CompilerInternal FnReadSerializer)
+                                (FunApp (CompilerInternal FnReadDeserializer)
                                  ()))
                                (meta
                                 ((type_ UReal) (loc <opaque>)
@@ -23515,7 +23519,7 @@
    ((pattern
      (Assignment (x_p UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -23541,7 +23545,7 @@
    ((pattern
      (Assignment (y_p UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -22367,26 +22367,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 5))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (offset_multiplier UReal
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (offset_multiplier (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -22413,26 +22399,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 5))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (no_offset_multiplier UReal
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (no_offset_multiplier (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -22457,26 +22429,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 5))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (offset_no_multiplier UReal
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (offset_no_multiplier (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -22501,26 +22459,12 @@
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_real_1d_ar UReal
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
-               (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_real_1d_ar (UArray UReal) ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -22685,16 +22629,33 @@
        ((pattern
          (Block
           (((pattern
-             (Assignment
-              (p_1d_vec UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Assignment
+                      (p_1d_vec UVector
+                       ((Single
+                         ((pattern (Var sym2__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                        (Single
+                         ((pattern (Var sym1__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      ((pattern
+                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                       (meta
+                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -22731,7 +22692,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var K))
+       ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -22742,7 +22703,7 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Var M))
+               ((pattern (Var K))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
@@ -22754,39 +22715,59 @@
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
-                       ((pattern (Var N))
+                       ((pattern (Var M))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (body
                        ((pattern
                          (Block
                           (((pattern
-                             (Assignment
-                              (p_3d_vec UVector
-                               ((Single
-                                 ((pattern (Var sym3__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym2__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym1__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))))
-                              ((pattern
-                                (FunApp (CompilerInternal FnReadSerializer)
-                                 (((pattern (Var N))
-                                   (meta
-                                    ((type_ UInt) (loc <opaque>)
-                                     (adlevel DataOnly)))))))
-                               (meta
-                                ((type_ UVector) (loc <opaque>)
-                                 (adlevel AutoDiffable))))))
+                             (For (loopvar sym4__)
+                              (lower
+                               ((pattern (Lit Int 1))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (upper
+                               ((pattern (Var N))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (body
+                               ((pattern
+                                 (Block
+                                  (((pattern
+                                     (Assignment
+                                      (p_3d_vec UVector
+                                       ((Single
+                                         ((pattern (Var sym4__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym3__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym2__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym1__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))))
+                                      ((pattern
+                                        (FunApp
+                                         (CompilerInternal FnReadSerializer)
+                                         ()))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable))))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
                             (meta <opaque>)))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
@@ -22855,17 +22836,33 @@
        ((pattern
          (Block
           (((pattern
-             (Assignment
-              (p_1d_row_vec URowVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta
-                ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Assignment
+                      (p_1d_row_vec URowVector
+                       ((Single
+                         ((pattern (Var sym2__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                        (Single
+                         ((pattern (Var sym1__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      ((pattern
+                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                       (meta
+                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -22903,7 +22900,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var K))
+       ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -22914,7 +22911,7 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Var M))
+               ((pattern (Var K))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
@@ -22926,39 +22923,59 @@
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
-                       ((pattern (Var N))
+                       ((pattern (Var M))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (body
                        ((pattern
                          (Block
                           (((pattern
-                             (Assignment
-                              (p_3d_row_vec URowVector
-                               ((Single
-                                 ((pattern (Var sym3__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym2__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym1__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))))
-                              ((pattern
-                                (FunApp (CompilerInternal FnReadSerializer)
-                                 (((pattern (Var N))
-                                   (meta
-                                    ((type_ UInt) (loc <opaque>)
-                                     (adlevel DataOnly)))))))
-                               (meta
-                                ((type_ URowVector) (loc <opaque>)
-                                 (adlevel AutoDiffable))))))
+                             (For (loopvar sym4__)
+                              (lower
+                               ((pattern (Lit Int 1))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (upper
+                               ((pattern (Var N))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (body
+                               ((pattern
+                                 (Block
+                                  (((pattern
+                                     (Assignment
+                                      (p_3d_row_vec URowVector
+                                       ((Single
+                                         ((pattern (Var sym4__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym3__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym2__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym1__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))))
+                                      ((pattern
+                                        (FunApp
+                                         (CompilerInternal FnReadSerializer)
+                                         ()))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable))))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
                             (meta <opaque>)))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
@@ -23030,7 +23047,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Lit Int 5))
+       ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -23041,33 +23058,73 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Lit Int 4))
+               ((pattern (Lit Int 2))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
                  (Block
                   (((pattern
-                     (Assignment
-                      (p_ar_mat UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadSerializer)
-                         (((pattern (Lit Int 2))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 3))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
+                     (For (loopvar sym3__)
+                      (lower
+                       ((pattern (Lit Int 1))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (upper
+                       ((pattern (Lit Int 5))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (body
+                       ((pattern
+                         (Block
+                          (((pattern
+                             (For (loopvar sym4__)
+                              (lower
+                               ((pattern (Lit Int 1))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (upper
+                               ((pattern (Lit Int 4))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (body
+                               ((pattern
+                                 (Block
+                                  (((pattern
+                                     (Assignment
+                                      (p_ar_mat UMatrix
+                                       ((Single
+                                         ((pattern (Var sym4__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym3__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym2__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym1__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))))
+                                      ((pattern
+                                        (FunApp
+                                         (CompilerInternal FnReadSerializer)
+                                         ()))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable))))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
                     (meta <opaque>)))))
                 (meta <opaque>)))))
             (meta <opaque>)))))
@@ -23140,16 +23197,33 @@
        ((pattern
          (Block
           (((pattern
-             (Assignment
-              (p_1d_simplex UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Var N))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Assignment
+                      (p_1d_simplex UVector
+                       ((Single
+                         ((pattern (Var sym2__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                        (Single
+                         ((pattern (Var sym1__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      ((pattern
+                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                       (meta
+                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -23186,7 +23260,7 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var K))
+       ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
@@ -23197,7 +23271,7 @@
                ((pattern (Lit Int 1))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (upper
-               ((pattern (Var M))
+               ((pattern (Var K))
                 (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
               (body
                ((pattern
@@ -23209,39 +23283,59 @@
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (upper
-                       ((pattern (Var N))
+                       ((pattern (Var M))
                         (meta
                          ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
                       (body
                        ((pattern
                          (Block
                           (((pattern
-                             (Assignment
-                              (p_3d_simplex UVector
-                               ((Single
-                                 ((pattern (Var sym3__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym2__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))
-                                (Single
-                                 ((pattern (Var sym1__))
-                                  (meta
-                                   ((type_ UInt) (loc <opaque>)
-                                    (adlevel DataOnly)))))))
-                              ((pattern
-                                (FunApp (CompilerInternal FnReadSerializer)
-                                 (((pattern (Var N))
-                                   (meta
-                                    ((type_ UInt) (loc <opaque>)
-                                     (adlevel DataOnly)))))))
-                               (meta
-                                ((type_ UVector) (loc <opaque>)
-                                 (adlevel AutoDiffable))))))
+                             (For (loopvar sym4__)
+                              (lower
+                               ((pattern (Lit Int 1))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (upper
+                               ((pattern (Var N))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly)))))
+                              (body
+                               ((pattern
+                                 (Block
+                                  (((pattern
+                                     (Assignment
+                                      (p_3d_simplex UVector
+                                       ((Single
+                                         ((pattern (Var sym4__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym3__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym2__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))
+                                        (Single
+                                         ((pattern (Var sym1__))
+                                          (meta
+                                           ((type_ UInt) (loc <opaque>)
+                                            (adlevel DataOnly)))))))
+                                      ((pattern
+                                        (FunApp
+                                         (CompilerInternal FnReadSerializer)
+                                         ()))
+                                       (meta
+                                        ((type_ UReal) (loc <opaque>)
+                                         (adlevel AutoDiffable))))))
+                                    (meta <opaque>)))))
+                                (meta <opaque>)))))
                             (meta <opaque>)))))
                         (meta <opaque>)))))
                     (meta <opaque>)))))
@@ -23340,24 +23434,63 @@
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var K))
+       ((pattern (Lit Int 3))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
          (Block
           (((pattern
-             (Assignment
-              (p_cfcov_33_ar UMatrix
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadSerializer)
-                 (((pattern (Lit Int 3))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                  ((pattern (Lit Int 3))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Lit Int 3))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (For (loopvar sym3__)
+                      (lower
+                       ((pattern (Lit Int 1))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (upper
+                       ((pattern (Var K))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                      (body
+                       ((pattern
+                         (Block
+                          (((pattern
+                             (Assignment
+                              (p_cfcov_33_ar UMatrix
+                               ((Single
+                                 ((pattern (Var sym3__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym2__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))
+                                (Single
+                                 ((pattern (Var sym1__))
+                                  (meta
+                                   ((type_ UInt) (loc <opaque>)
+                                    (adlevel DataOnly)))))))
+                              ((pattern
+                                (FunApp (CompilerInternal FnReadSerializer)
+                                 ()))
+                               (meta
+                                ((type_ UReal) (loc <opaque>)
+                                 (adlevel AutoDiffable))))))
+                            (meta <opaque>)))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1946,7 +1946,18 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2643,7 +2654,18 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4469,7 +4491,18 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4875,7 +4908,18 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -6479,7 +6523,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -7641,7 +7696,18 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -7953,7 +8019,18 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -8262,7 +8339,18 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -8738,7 +8826,18 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -9123,7 +9222,18 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -10343,7 +10453,18 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -11090,7 +11211,18 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12658,7 +12790,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -15815,7 +15958,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -16876,7 +17030,18 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -17508,7 +17673,18 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19112,7 +19288,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19549,7 +19736,18 @@ class function_in_function_inline_model final : public model_base_crtp<function_
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19988,7 +20186,18 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -20589,7 +20798,18 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -20940,7 +21160,18 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21338,7 +21569,18 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -24529,7 +24771,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -24837,7 +25090,18 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -25150,7 +25414,18 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -25482,7 +25757,18 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -26930,7 +27216,18 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -27386,7 +27683,18 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -28233,7 +28541,18 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -29065,7 +29384,18 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -30222,7 +30552,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -30549,7 +30890,18 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -30910,7 +31262,18 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -31634,7 +31997,18 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -34886,7 +35260,18 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -35768,7 +36153,18 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -36332,7 +36728,18 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -36785,7 +37192,18 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -37361,7 +37779,18 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -19,9 +19,9 @@ static constexpr std::array<const char*, 11> locations_array__ =
   " (in 'ad-level-deep-dependence.stan', line 7, column 4 to column 23)"};
 class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_deep_dependence_model> {
  private:
-  double lcm_sym17__;
-  double lcm_sym16__;
-  int lcm_sym15__;
+  double lcm_sym20__;
+  double lcm_sym19__;
+  int lcm_sym18__;
   Eigen::Matrix<double,-1,-1> X_d_data__;
   Eigen::Map<Eigen::Matrix<double,-1,-1>> X_d{nullptr, 0, 0};
  public:
@@ -895,12 +895,12 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) function__;
     try {
+      Eigen::Matrix<double,-1,-1> lcm_sym17__;
+      Eigen::Matrix<double,-1,-1> lcm_sym16__;
+      Eigen::Matrix<double,-1,-1> lcm_sym15__;
       Eigen::Matrix<double,-1,-1> lcm_sym14__;
       Eigen::Matrix<double,-1,-1> lcm_sym13__;
       Eigen::Matrix<double,-1,-1> lcm_sym12__;
-      Eigen::Matrix<double,-1,-1> lcm_sym11__;
-      Eigen::Matrix<double,-1,-1> lcm_sym10__;
-      Eigen::Matrix<double,-1,-1> lcm_sym9__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,-1>> X_p;
       current_statement__ = 1;
@@ -914,36 +914,36 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       Eigen::Matrix<double,-1,-1> X_tp2 =
         Eigen::Matrix<double,-1,-1>::Constant(10, 10,
           std::numeric_limits<double>::quiet_NaN());
-      stan::model::assign(lcm_sym9__, stan::math::exp(X_d),
-        "assigning variable lcm_sym9__");
-      stan::model::assign(X_tp2, lcm_sym9__, "assigning variable X_tp2");
-      Eigen::Matrix<double,-1,-1> X_tp3 =
-        Eigen::Matrix<double,-1,-1>::Constant(10, 10,
-          std::numeric_limits<double>::quiet_NaN());
-      stan::model::assign(lcm_sym10__, stan::math::exp(lcm_sym9__),
-        "assigning variable lcm_sym10__");
-      stan::model::assign(X_tp3, lcm_sym10__, "assigning variable X_tp3");
-      Eigen::Matrix<double,-1,-1> X_tp4 =
-        Eigen::Matrix<double,-1,-1>::Constant(10, 10,
-          std::numeric_limits<double>::quiet_NaN());
-      stan::model::assign(lcm_sym11__, stan::math::exp(lcm_sym10__),
-        "assigning variable lcm_sym11__");
-      stan::model::assign(X_tp4, lcm_sym11__, "assigning variable X_tp4");
-      Eigen::Matrix<double,-1,-1> X_tp5 =
-        Eigen::Matrix<double,-1,-1>::Constant(10, 10,
-          std::numeric_limits<double>::quiet_NaN());
-      stan::model::assign(lcm_sym12__, stan::math::exp(lcm_sym11__),
+      stan::model::assign(lcm_sym12__, stan::math::exp(X_d),
         "assigning variable lcm_sym12__");
-      stan::model::assign(X_tp5, lcm_sym12__, "assigning variable X_tp5");
-      Eigen::Matrix<double,-1,-1> X_tp6 =
+      stan::model::assign(X_tp2, lcm_sym12__, "assigning variable X_tp2");
+      Eigen::Matrix<double,-1,-1> X_tp3 =
         Eigen::Matrix<double,-1,-1>::Constant(10, 10,
           std::numeric_limits<double>::quiet_NaN());
       stan::model::assign(lcm_sym13__, stan::math::exp(lcm_sym12__),
         "assigning variable lcm_sym13__");
-      stan::model::assign(X_tp6, lcm_sym13__, "assigning variable X_tp6");
+      stan::model::assign(X_tp3, lcm_sym13__, "assigning variable X_tp3");
+      Eigen::Matrix<double,-1,-1> X_tp4 =
+        Eigen::Matrix<double,-1,-1>::Constant(10, 10,
+          std::numeric_limits<double>::quiet_NaN());
+      stan::model::assign(lcm_sym14__, stan::math::exp(lcm_sym13__),
+        "assigning variable lcm_sym14__");
+      stan::model::assign(X_tp4, lcm_sym14__, "assigning variable X_tp4");
+      Eigen::Matrix<double,-1,-1> X_tp5 =
+        Eigen::Matrix<double,-1,-1>::Constant(10, 10,
+          std::numeric_limits<double>::quiet_NaN());
+      stan::model::assign(lcm_sym15__, stan::math::exp(lcm_sym14__),
+        "assigning variable lcm_sym15__");
+      stan::model::assign(X_tp5, lcm_sym15__, "assigning variable X_tp5");
+      Eigen::Matrix<double,-1,-1> X_tp6 =
+        Eigen::Matrix<double,-1,-1>::Constant(10, 10,
+          std::numeric_limits<double>::quiet_NaN());
+      stan::model::assign(lcm_sym16__, stan::math::exp(lcm_sym15__),
+        "assigning variable lcm_sym16__");
+      stan::model::assign(X_tp6, lcm_sym16__, "assigning variable X_tp6");
       Eigen::Matrix<double,-1,-1> X_tp7;
       current_statement__ = 8;
-      stan::model::assign(X_tp7, stan::math::exp(lcm_sym13__),
+      stan::model::assign(X_tp7, stan::math::exp(lcm_sym16__),
         "assigning variable X_tp7");
       current_statement__ = 9;
       stan::model::assign(X_tp1, X_p, "assigning variable X_tp1");
@@ -984,14 +984,14 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) function__;
     try {
+      Eigen::Matrix<double,-1,-1> lcm_sym11__;
+      Eigen::Matrix<double,-1,-1> lcm_sym10__;
+      Eigen::Matrix<double,-1,-1> lcm_sym9__;
       Eigen::Matrix<double,-1,-1> lcm_sym8__;
       Eigen::Matrix<double,-1,-1> lcm_sym7__;
       Eigen::Matrix<double,-1,-1> lcm_sym6__;
-      Eigen::Matrix<double,-1,-1> lcm_sym5__;
-      Eigen::Matrix<double,-1,-1> lcm_sym4__;
-      Eigen::Matrix<double,-1,-1> lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
+      int lcm_sym5__;
+      int lcm_sym4__;
       Eigen::Matrix<double,-1,-1> X_p;
       current_statement__ = 1;
       X_p = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10);
@@ -1024,34 +1024,34 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       }
       current_statement__ = 2;
       stan::model::assign(X_tp1, X_d, "assigning variable X_tp1");
-      stan::model::assign(lcm_sym3__, stan::math::exp(X_d),
-        "assigning variable lcm_sym3__");
-      stan::model::assign(X_tp2, lcm_sym3__, "assigning variable X_tp2");
-      stan::model::assign(lcm_sym4__, stan::math::exp(lcm_sym3__),
-        "assigning variable lcm_sym4__");
-      stan::model::assign(X_tp3, lcm_sym4__, "assigning variable X_tp3");
-      stan::model::assign(lcm_sym5__, stan::math::exp(lcm_sym4__),
-        "assigning variable lcm_sym5__");
-      stan::model::assign(X_tp4, lcm_sym5__, "assigning variable X_tp4");
-      stan::model::assign(lcm_sym6__, stan::math::exp(lcm_sym5__),
+      stan::model::assign(lcm_sym6__, stan::math::exp(X_d),
         "assigning variable lcm_sym6__");
-      stan::model::assign(X_tp5, lcm_sym6__, "assigning variable X_tp5");
+      stan::model::assign(X_tp2, lcm_sym6__, "assigning variable X_tp2");
       stan::model::assign(lcm_sym7__, stan::math::exp(lcm_sym6__),
         "assigning variable lcm_sym7__");
-      stan::model::assign(X_tp6, lcm_sym7__, "assigning variable X_tp6");
+      stan::model::assign(X_tp3, lcm_sym7__, "assigning variable X_tp3");
       stan::model::assign(lcm_sym8__, stan::math::exp(lcm_sym7__),
         "assigning variable lcm_sym8__");
-      stan::model::assign(X_tp7, lcm_sym8__, "assigning variable X_tp7");
+      stan::model::assign(X_tp4, lcm_sym8__, "assigning variable X_tp4");
+      stan::model::assign(lcm_sym9__, stan::math::exp(lcm_sym8__),
+        "assigning variable lcm_sym9__");
+      stan::model::assign(X_tp5, lcm_sym9__, "assigning variable X_tp5");
+      stan::model::assign(lcm_sym10__, stan::math::exp(lcm_sym9__),
+        "assigning variable lcm_sym10__");
+      stan::model::assign(X_tp6, lcm_sym10__, "assigning variable X_tp6");
+      stan::model::assign(lcm_sym11__, stan::math::exp(lcm_sym10__),
+        "assigning variable lcm_sym11__");
+      stan::model::assign(X_tp7, lcm_sym11__, "assigning variable X_tp7");
       current_statement__ = 9;
       stan::model::assign(X_tp1, X_p, "assigning variable X_tp1");
       if (emit_transformed_parameters__) {
         out__.write(X_p);
-        out__.write(lcm_sym3__);
-        out__.write(lcm_sym4__);
-        out__.write(lcm_sym5__);
         out__.write(lcm_sym6__);
         out__.write(lcm_sym7__);
         out__.write(lcm_sym8__);
+        out__.write(lcm_sym9__);
+        out__.write(lcm_sym10__);
+        out__.write(lcm_sym11__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
         return ;
@@ -1064,8 +1064,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1080,6 +1080,637 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym3__;
+      double lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<double> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        {
+          {
+            stan::model::assign(X_p,
+              stan::model::rvalue(X_p_flat__, "X_p_flat__",
+                stan::model::index_uni(1)), "assigning variable X_p",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(6));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(7));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(8));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(9));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(10));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1131,53 +1762,53 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-      for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+    for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+      for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
         param_names__.emplace_back(std::string() + "X_p" + '.' +
-          std::to_string(sym19__) + '.' + std::to_string(sym18__));
+          std::to_string(sym22__) + '.' + std::to_string(sym21__));
       }
     }
     if (emit_transformed_parameters__) {
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp1" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp2" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp3" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp4" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp5" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp6" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp7" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
     }
@@ -1187,53 +1818,53 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-      for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+    for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+      for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
         param_names__.emplace_back(std::string() + "X_p" + '.' +
-          std::to_string(sym19__) + '.' + std::to_string(sym18__));
+          std::to_string(sym22__) + '.' + std::to_string(sym21__));
       }
     }
     if (emit_transformed_parameters__) {
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp1" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp2" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp3" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp4" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp5" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp6" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
-      for (int sym18__ = 1; sym18__ <= 10; ++sym18__) {
-        for (int sym19__ = 1; sym19__ <= 10; ++sym19__) {
+      for (int sym21__ = 1; sym21__ <= 10; ++sym21__) {
+        for (int sym22__ = 1; sym22__ <= 10; ++sym22__) {
           param_names__.emplace_back(std::string() + "X_tp7" + '.' +
-            std::to_string(sym19__) + '.' + std::to_string(sym18__));
+            std::to_string(sym22__) + '.' + std::to_string(sym21__));
         }
       }
     }
@@ -1307,24 +1938,17 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1826,8 +2450,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1849,6 +2473,35 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       out__.write_free_lb(0, xi);
       local_scalar_t__ delta;
       delta = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, delta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ beta;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write_free_lb(0, beta);
+      local_scalar_t__ gamma;
+      gamma = context__.vals_r("gamma")[(1 - 1)];
+      out__.write_free_lb(0, gamma);
+      local_scalar_t__ xi;
+      xi = context__.vals_r("xi")[(1 - 1)];
+      out__.write_free_lb(0, xi);
+      local_scalar_t__ delta;
+      delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1982,25 +2635,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"beta", "gamma", "xi", "delta"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2037,9 +2682,9 @@ static constexpr std::array<const char*, 6> locations_array__ =
   " (in 'ad-levels-deep.stan', line 2, column 4 to column 26)"};
 class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> {
  private:
-  double lcm_sym9__;
-  double lcm_sym8__;
-  int lcm_sym7__;
+  double lcm_sym12__;
+  double lcm_sym11__;
+  int lcm_sym10__;
   Eigen::Matrix<double,-1,-1> X_data_data__;
   Eigen::Map<Eigen::Matrix<double,-1,-1>> X_data{nullptr, 0, 0};
  public:
@@ -2912,8 +3557,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) function__;
     try {
-      Eigen::Matrix<double,-1,-1> lcm_sym6__;
-      Eigen::Matrix<double,-1,-1> lcm_sym5__;
+      Eigen::Matrix<double,-1,-1> lcm_sym9__;
+      Eigen::Matrix<double,-1,-1> lcm_sym8__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,-1>> X_p;
       current_statement__ = 1;
@@ -2927,12 +3572,12 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
                                                    10,
                                                    std::numeric_limits<double>::quiet_NaN(
                                                      )));
-      stan::model::assign(lcm_sym5__, stan::math::exp(X_data),
-        "assigning variable lcm_sym5__");
-      stan::model::assign(X_tp1, lcm_sym5__, "assigning variable X_tp1");
+      stan::model::assign(lcm_sym8__, stan::math::exp(X_data),
+        "assigning variable lcm_sym8__");
+      stan::model::assign(X_tp1, lcm_sym8__, "assigning variable X_tp1");
       Eigen::Matrix<double,-1,-1> X_tp2;
       current_statement__ = 3;
-      stan::model::assign(X_tp2, stan::math::exp(lcm_sym5__),
+      stan::model::assign(X_tp2, stan::math::exp(lcm_sym8__),
         "assigning variable X_tp2");
       current_statement__ = 4;
       stan::model::assign(X_tp1, X_p, "assigning variable X_tp1");
@@ -2973,10 +3618,10 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) function__;
     try {
-      Eigen::Matrix<double,-1,-1> lcm_sym4__;
-      Eigen::Matrix<double,-1,-1> lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
+      Eigen::Matrix<double,-1,-1> lcm_sym7__;
+      Eigen::Matrix<double,-1,-1> lcm_sym6__;
+      int lcm_sym5__;
+      int lcm_sym4__;
       Eigen::Matrix<double,-1,-1> X_p;
       current_statement__ = 1;
       X_p = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10);
@@ -2992,17 +3637,17 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      stan::model::assign(lcm_sym3__, stan::math::exp(X_data),
-        "assigning variable lcm_sym3__");
-      stan::model::assign(X_tp1, lcm_sym3__, "assigning variable X_tp1");
-      stan::model::assign(lcm_sym4__, stan::math::exp(lcm_sym3__),
-        "assigning variable lcm_sym4__");
-      stan::model::assign(X_tp2, lcm_sym4__, "assigning variable X_tp2");
+      stan::model::assign(lcm_sym6__, stan::math::exp(X_data),
+        "assigning variable lcm_sym6__");
+      stan::model::assign(X_tp1, lcm_sym6__, "assigning variable X_tp1");
+      stan::model::assign(lcm_sym7__, stan::math::exp(lcm_sym6__),
+        "assigning variable lcm_sym7__");
+      stan::model::assign(X_tp2, lcm_sym7__, "assigning variable X_tp2");
       current_statement__ = 4;
       stan::model::assign(X_tp1, X_p, "assigning variable X_tp1");
       if (emit_transformed_parameters__) {
         out__.write(X_p);
-        out__.write(lcm_sym4__);
+        out__.write(lcm_sym7__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
         return ;
@@ -3015,8 +3660,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -3031,6 +3676,637 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym3__;
+      double lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<double> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        {
+          {
+            stan::model::assign(X_p,
+              stan::model::rvalue(X_p_flat__, "X_p_flat__",
+                stan::model::index_uni(1)), "assigning variable X_p",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(6));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(7));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(8));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(9));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(1),
+              stan::model::index_uni(10));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(2),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(3),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(4),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(5),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(6),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(7),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(8),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(9),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+                "assigning variable X_p", stan::model::index_uni(10),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3071,23 +4347,23 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym10__ = 1; sym10__ <= 10; ++sym10__) {
-      for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
+    for (int sym13__ = 1; sym13__ <= 10; ++sym13__) {
+      for (int sym14__ = 1; sym14__ <= 10; ++sym14__) {
         param_names__.emplace_back(std::string() + "X_p" + '.' +
-          std::to_string(sym11__) + '.' + std::to_string(sym10__));
+          std::to_string(sym14__) + '.' + std::to_string(sym13__));
       }
     }
     if (emit_transformed_parameters__) {
-      for (int sym10__ = 1; sym10__ <= 10; ++sym10__) {
-        for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
+      for (int sym13__ = 1; sym13__ <= 10; ++sym13__) {
+        for (int sym14__ = 1; sym14__ <= 10; ++sym14__) {
           param_names__.emplace_back(std::string() + "X_tp1" + '.' +
-            std::to_string(sym11__) + '.' + std::to_string(sym10__));
+            std::to_string(sym14__) + '.' + std::to_string(sym13__));
         }
       }
-      for (int sym10__ = 1; sym10__ <= 10; ++sym10__) {
-        for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
+      for (int sym13__ = 1; sym13__ <= 10; ++sym13__) {
+        for (int sym14__ = 1; sym14__ <= 10; ++sym14__) {
           param_names__.emplace_back(std::string() + "X_tp2" + '.' +
-            std::to_string(sym11__) + '.' + std::to_string(sym10__));
+            std::to_string(sym14__) + '.' + std::to_string(sym13__));
         }
       }
     }
@@ -3097,23 +4373,23 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym10__ = 1; sym10__ <= 10; ++sym10__) {
-      for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
+    for (int sym13__ = 1; sym13__ <= 10; ++sym13__) {
+      for (int sym14__ = 1; sym14__ <= 10; ++sym14__) {
         param_names__.emplace_back(std::string() + "X_p" + '.' +
-          std::to_string(sym11__) + '.' + std::to_string(sym10__));
+          std::to_string(sym14__) + '.' + std::to_string(sym13__));
       }
     }
     if (emit_transformed_parameters__) {
-      for (int sym10__ = 1; sym10__ <= 10; ++sym10__) {
-        for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
+      for (int sym13__ = 1; sym13__ <= 10; ++sym13__) {
+        for (int sym14__ = 1; sym14__ <= 10; ++sym14__) {
           param_names__.emplace_back(std::string() + "X_tp1" + '.' +
-            std::to_string(sym11__) + '.' + std::to_string(sym10__));
+            std::to_string(sym14__) + '.' + std::to_string(sym13__));
         }
       }
-      for (int sym10__ = 1; sym10__ <= 10; ++sym10__) {
-        for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
+      for (int sym13__ = 1; sym13__ <= 10; ++sym13__) {
+        for (int sym14__ = 1; sym14__ <= 10; ++sym14__) {
           param_names__.emplace_back(std::string() + "X_tp2" + '.' +
-            std::to_string(sym11__) + '.' + std::to_string(sym10__));
+            std::to_string(sym14__) + '.' + std::to_string(sym13__));
         }
       }
     }
@@ -3185,24 +4461,17 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3311,8 +4580,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) function__;
     try {
-      local_scalar_t__ lcm_sym4__;
-      Eigen::Matrix<local_scalar_t__,1,-1> lcm_sym3__;
+      local_scalar_t__ lcm_sym8__;
+      Eigen::Matrix<local_scalar_t__,1,-1> lcm_sym7__;
       Eigen::Matrix<local_scalar_t__,-1,-1> X;
       current_statement__ = 1;
       X = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N);
@@ -3331,11 +4600,11 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
           Eigen::Matrix<double,1,-1> vec2 =
             Eigen::Matrix<double,1,-1>::Constant(N,
               std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym3__, stan::math::columns_dot_self(X),
-            "assigning variable lcm_sym3__");
+          stan::model::assign(lcm_sym7__, stan::math::columns_dot_self(X),
+            "assigning variable lcm_sym7__");
         }
-        lcm_sym4__ = stan::math::sum(lcm_sym3__);
-        lp_accum__.add(lcm_sym4__);
+        lcm_sym8__ = stan::math::sum(lcm_sym7__);
+        lp_accum__.add(lcm_sym8__);
         current_statement__ = 7;
         stan::math::validate_non_negative_index("vec3", "N", N);
         Eigen::Matrix<double,1,-1> vec3 =
@@ -3349,7 +4618,7 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
               std::numeric_limits<double>::quiet_NaN());
         }
         current_statement__ = 12;
-        lp_accum__.add(lcm_sym4__);
+        lp_accum__.add(lcm_sym8__);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3388,8 +4657,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym2__;
-      int lcm_sym1__;
+      int lcm_sym6__;
+      int lcm_sym5__;
       Eigen::Matrix<double,-1,-1> X;
       current_statement__ = 1;
       X = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N);
@@ -3410,8 +4679,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -3426,6 +4695,65 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       stan::model::assign(X,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
         "assigning variable X");
+      out__.write(X);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym4__;
+      double lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<double> X_flat__;
+        X_flat__ = context__.vals_r("X");
+        pos__ = 1;
+        lcm_sym1__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym1__) {
+          if (lcm_sym1__) {
+            stan::model::assign(X,
+              stan::model::rvalue(X_flat__, "X_flat__",
+                stan::model::index_uni(1)), "assigning variable X",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            for (int sym2__ = 2; sym2__ <= N; ++sym2__) {
+              stan::model::assign(X, X_flat__[(pos__ - 1)],
+                "assigning variable X", stan::model::index_uni(sym2__),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
+            if (lcm_sym1__) {
+              stan::model::assign(X, X_flat__[(pos__ - 1)],
+                "assigning variable X", stan::model::index_uni(1),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= N; ++sym2__) {
+                stan::model::assign(X, X_flat__[(pos__ - 1)],
+                  "assigning variable X", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
       out__.write(X);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3453,10 +4781,10 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym5__ = 1; sym5__ <= N; ++sym5__) {
-      for (int sym6__ = 1; sym6__ <= N; ++sym6__) {
+    for (int sym9__ = 1; sym9__ <= N; ++sym9__) {
+      for (int sym10__ = 1; sym10__ <= N; ++sym10__) {
         param_names__.emplace_back(std::string() + "X" + '.' +
-          std::to_string(sym6__) + '.' + std::to_string(sym5__));
+          std::to_string(sym10__) + '.' + std::to_string(sym9__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -3466,10 +4794,10 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym5__ = 1; sym5__ <= N; ++sym5__) {
-      for (int sym6__ = 1; sym6__ <= N; ++sym6__) {
+    for (int sym9__ = 1; sym9__ <= N; ++sym9__) {
+      for (int sym10__ = 1; sym10__ <= N; ++sym10__) {
         param_names__.emplace_back(std::string() + "X" + '.' +
-          std::to_string(sym6__) + '.' + std::to_string(sym5__));
+          std::to_string(sym10__) + '.' + std::to_string(sym9__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -3539,24 +4867,17 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(N * N)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3877,6 +5198,10 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
 }
 class copy_fail_model final : public model_base_crtp<copy_fail_model> {
  private:
+  int lcm_sym121__;
+  int lcm_sym120__;
+  int lcm_sym119__;
+  int lcm_sym118__;
   int lcm_sym117__;
   int lcm_sym116__;
   int lcm_sym115__;
@@ -3886,10 +5211,6 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   int lcm_sym111__;
   int lcm_sym110__;
   int lcm_sym109__;
-  int lcm_sym108__;
-  int lcm_sym107__;
-  int lcm_sym106__;
-  int lcm_sym105__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -3954,8 +5275,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         pos__ = 1;
         current_statement__ = 37;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym106__ = stan::math::logical_gte(nind, 1);
-          if (lcm_sym106__) {
+          lcm_sym110__ = stan::math::logical_gte(nind, 1);
+          if (lcm_sym110__) {
             current_statement__ = 37;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -3974,7 +5295,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 37;
-            if (lcm_sym106__) {
+            if (lcm_sym110__) {
               current_statement__ = 37;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -3992,7 +5313,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             }
           }
         } else {
-          lcm_sym106__ = stan::math::logical_gte(nind, 1);
+          lcm_sym110__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 37;
@@ -4009,15 +5330,15 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::math::check_greater_or_equal(function__, "max_age", max_age, 1);
       current_statement__ = 39;
       stan::math::validate_non_negative_index("x", "nind", nind);
-      lcm_sym108__ = (n_occasions - 1);
+      lcm_sym112__ = (n_occasions - 1);
       stan::math::validate_non_negative_index("x", "n_occasions - 1",
-        lcm_sym108__);
+        lcm_sym112__);
       current_statement__ = 40;
       context__.validate_dims("data initialization", "x", "int",
         std::vector<size_t>{static_cast<size_t>(nind),
-          static_cast<size_t>(lcm_sym108__)});
+          static_cast<size_t>(lcm_sym112__)});
       x = std::vector<std::vector<int>>(nind,
-            std::vector<int>(lcm_sym108__, std::numeric_limits<int>::min()));
+            std::vector<int>(lcm_sym112__, std::numeric_limits<int>::min()));
       {
         std::vector<int> x_flat__;
         current_statement__ = 40;
@@ -4025,9 +5346,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         current_statement__ = 40;
         pos__ = 1;
         current_statement__ = 40;
-        if (stan::math::logical_gte(lcm_sym108__, 1)) {
+        if (stan::math::logical_gte(lcm_sym112__, 1)) {
           current_statement__ = 40;
-          if (lcm_sym106__) {
+          if (lcm_sym110__) {
             current_statement__ = 40;
             stan::model::assign(x,
               stan::model::rvalue(x_flat__, "x_flat__",
@@ -4044,9 +5365,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               pos__ = (pos__ + 1);
             }
           }
-          for (int sym1__ = 2; sym1__ <= lcm_sym108__; ++sym1__) {
+          for (int sym1__ = 2; sym1__ <= lcm_sym112__; ++sym1__) {
             current_statement__ = 40;
-            if (lcm_sym106__) {
+            if (lcm_sym110__) {
               current_statement__ = 40;
               stan::model::assign(x, x_flat__[(pos__ - 1)],
                 "assigning variable x", stan::model::index_uni(1),
@@ -4072,7 +5393,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 41;
       n_occ_minus_1 = std::numeric_limits<int>::min();
       current_statement__ = 41;
-      n_occ_minus_1 = lcm_sym108__;
+      n_occ_minus_1 = lcm_sym112__;
       current_statement__ = 42;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 43;
@@ -4082,7 +5403,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 45;
       last = std::vector<int>(nind, std::numeric_limits<int>::min());
       current_statement__ = 47;
-      if (lcm_sym106__) {
+      if (lcm_sym110__) {
         current_statement__ = 46;
         stan::model::assign(first,
           first_capture(
@@ -4098,7 +5419,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         }
       }
       current_statement__ = 49;
-      if (lcm_sym106__) {
+      if (lcm_sym110__) {
         current_statement__ = 48;
         stan::model::assign(last,
           last_capture(
@@ -4127,12 +5448,12 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 52;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-        lcm_sym108__);
+        lcm_sym112__);
       current_statement__ = 53;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-        lcm_sym108__);
+        lcm_sym112__);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 56;
@@ -4170,11 +5491,15 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym104__;
-      int lcm_sym103__;
-      int lcm_sym102__;
-      int lcm_sym101__;
-      int lcm_sym100__;
+      double lcm_sym108__;
+      int lcm_sym107__;
+      int lcm_sym106__;
+      int lcm_sym105__;
+      int lcm_sym104__;
+      double lcm_sym103__;
+      double lcm_sym102__;
+      double lcm_sym101__;
+      double lcm_sym100__;
       double lcm_sym99__;
       double lcm_sym98__;
       double lcm_sym97__;
@@ -4189,10 +5514,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       double lcm_sym88__;
       double lcm_sym87__;
       double lcm_sym86__;
-      double lcm_sym85__;
-      double lcm_sym84__;
-      double lcm_sym83__;
-      double lcm_sym82__;
+      int lcm_sym85__;
+      int lcm_sym84__;
+      int lcm_sym83__;
+      int lcm_sym82__;
       int lcm_sym81__;
       int lcm_sym80__;
       int lcm_sym79__;
@@ -4209,10 +5534,6 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       int lcm_sym68__;
       int lcm_sym67__;
       int lcm_sym66__;
-      int lcm_sym65__;
-      int lcm_sym64__;
-      int lcm_sym63__;
-      int lcm_sym62__;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -4231,18 +5552,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       Eigen::Matrix<local_scalar_t__,-1,-1> chi =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
           DUMMY_VAR__);
-      lcm_sym62__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym62__) {
-        lcm_sym101__ = stan::model::rvalue(first, "first",
+      lcm_sym66__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym66__) {
+        lcm_sym105__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym75__ = (lcm_sym101__ - 1);
-        if (stan::math::logical_gte(lcm_sym75__, 1)) {
+        lcm_sym79__ = (lcm_sym105__ - 1);
+        if (stan::math::logical_gte(lcm_sym79__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym75__; ++t) {
+          for (int t = 2; t <= lcm_sym79__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -4251,20 +5572,20 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym73__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym73__, lcm_sym101__)) {
+        lcm_sym77__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym77__, lcm_sym105__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym101__)))),
+                  stan::model::index_uni(lcm_sym105__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym101__));
-          lcm_sym81__ = (lcm_sym101__ + 1);
+            stan::model::index_uni(lcm_sym105__));
+          lcm_sym85__ = (lcm_sym105__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
-          for (int t = lcm_sym81__; t <= lcm_sym73__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym105__));
+          for (int t = lcm_sym85__; t <= lcm_sym77__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -4278,16 +5599,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym100__ = stan::model::rvalue(first, "first",
+          lcm_sym104__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym74__ = (lcm_sym100__ - 1);
-          if (stan::math::logical_gte(lcm_sym74__, 1)) {
+          lcm_sym78__ = (lcm_sym104__ - 1);
+          if (stan::math::logical_gte(lcm_sym78__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym74__; ++t) {
+            for (int t = 2; t <= lcm_sym78__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -4297,19 +5618,19 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym73__, lcm_sym100__)) {
+          if (stan::math::logical_gte(lcm_sym77__, lcm_sym104__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym100__)))),
+                    stan::model::index_uni(lcm_sym104__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym100__));
-            lcm_sym80__ = (lcm_sym100__ + 1);
+              stan::model::index_uni(lcm_sym104__));
+            lcm_sym84__ = (lcm_sym104__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
-            for (int t = lcm_sym80__; t <= lcm_sym73__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym104__));
+            for (int t = lcm_sym84__; t <= lcm_sym77__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -4337,58 +5658,58 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym62__) {
+        if (lcm_sym66__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym9__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym9__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym73__ = (n_occasions - 1);
-          lcm_sym63__ = stan::math::logical_gte(lcm_sym73__, 1);
-          if (lcm_sym63__) {
+          lcm_sym77__ = (n_occasions - 1);
+          lcm_sym67__ = stan::math::logical_gte(lcm_sym77__, 1);
+          if (lcm_sym67__) {
             int inline_prob_uncaptured_t_curr_sym10__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym11__ =
               std::numeric_limits<int>::min();
-            lcm_sym77__ = (lcm_sym73__ + 1);
+            lcm_sym81__ = (lcm_sym77__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym9__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym73__)) * (1 -
+                   stan::model::index_uni(lcm_sym77__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym77__ - 1))))),
+                  stan::model::index_uni((lcm_sym81__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                   "inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym77__)), (1 -
+                  stan::model::index_uni(lcm_sym81__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym73__)))),
+                  stan::model::index_uni(lcm_sym77__)))),
               "assigning variable inline_prob_uncaptured_chi_sym9__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym73__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym77__));
             for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                 <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
+                 <= lcm_sym77__; ++inline_prob_uncaptured_t_sym12__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
-              lcm_sym72__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
+              lcm_sym76__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym76__ = (lcm_sym72__ + 1);
+              lcm_sym80__ = (lcm_sym76__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym72__)) * (1 -
+                     stan::model::index_uni(lcm_sym76__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym76__ - 1))))),
+                    stan::model::index_uni((lcm_sym80__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym76__)), (1 -
+                    stan::model::index_uni(lcm_sym80__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym72__)))),
+                    stan::model::index_uni(lcm_sym76__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym72__));
+                stan::model::index_uni(lcm_sym76__));
             }
           }
           for (int inline_prob_uncaptured_i_sym13__ = 2; inline_prob_uncaptured_i_sym13__
@@ -4399,60 +5720,60 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym63__) {
+            if (lcm_sym67__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym77__ = (lcm_sym73__ + 1);
+              lcm_sym81__ = (lcm_sym77__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                     stan::model::index_uni(lcm_sym73__)) * (1 -
+                     stan::model::index_uni(lcm_sym77__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni((lcm_sym77__ - 1))))),
+                    stan::model::index_uni((lcm_sym81__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym77__)), (1 -
+                    stan::model::index_uni(lcm_sym81__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym73__)))),
+                    stan::model::index_uni(lcm_sym77__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                stan::model::index_uni(lcm_sym73__));
+                stan::model::index_uni(lcm_sym77__));
               for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                   <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
+                   <= lcm_sym77__; ++inline_prob_uncaptured_t_sym12__) {
                 int inline_prob_uncaptured_t_curr_sym10__ =
                   std::numeric_limits<int>::min();
-                lcm_sym72__ = (n_occasions -
+                lcm_sym76__ = (n_occasions -
                   inline_prob_uncaptured_t_sym12__);
                 int inline_prob_uncaptured_t_next_sym11__ =
                   std::numeric_limits<int>::min();
-                lcm_sym76__ = (lcm_sym72__ + 1);
+                lcm_sym80__ = (lcm_sym76__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym13__),
-                       stan::model::index_uni(lcm_sym72__)) * (1 -
+                       stan::model::index_uni(lcm_sym76__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni((lcm_sym76__ - 1))))),
+                      stan::model::index_uni((lcm_sym80__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                       "inline_prob_uncaptured_chi_sym9__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym76__)), (1 -
+                      stan::model::index_uni(lcm_sym80__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym72__)))),
+                      stan::model::index_uni(lcm_sym76__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                  stan::model::index_uni(lcm_sym72__));
+                  stan::model::index_uni(lcm_sym76__));
               }
             }
           }
@@ -4480,28 +5801,28 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         inline_prob_uncaptured_return_sym8__, 1);
       {
         current_statement__ = 32;
-        if (lcm_sym62__) {
-          lcm_sym101__ = stan::model::rvalue(first, "first",
+        if (lcm_sym66__) {
+          lcm_sym105__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym101__, 0)) {
-            lcm_sym103__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym105__, 0)) {
+            lcm_sym107__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym81__ = (lcm_sym101__ + 1);
-            if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
+            lcm_sym85__ = (lcm_sym105__ + 1);
+            if (stan::math::logical_gte(lcm_sym107__, lcm_sym85__)) {
               current_statement__ = 26;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym81__ - 1)))));
-              lcm_sym79__ = (lcm_sym81__ + 1);
+                                 stan::model::index_uni((lcm_sym85__ - 1)))));
+              lcm_sym83__ = (lcm_sym85__ + 1);
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                stan::model::rvalue(y, "y",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym81__)),
+                                 stan::model::index_uni(lcm_sym85__)),
                                stan::model::rvalue(p, "p",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym81__ - 1)))));
-              for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
+                                 stan::model::index_uni((lcm_sym85__ - 1)))));
+              for (int t = lcm_sym83__; t <= lcm_sym107__; ++t) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
@@ -4523,30 +5844,30 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                                inline_prob_uncaptured_return_sym8__,
                                "inline_prob_uncaptured_return_sym8__",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(lcm_sym103__))));
+                               stan::model::index_uni(lcm_sym107__))));
           }
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym100__ = stan::model::rvalue(first, "first",
+            lcm_sym104__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym100__, 0)) {
-              lcm_sym102__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym104__, 0)) {
+              lcm_sym106__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym80__ = (lcm_sym100__ + 1);
-              if (stan::math::logical_gte(lcm_sym102__, lcm_sym80__)) {
+              lcm_sym84__ = (lcm_sym104__ + 1);
+              if (stan::math::logical_gte(lcm_sym106__, lcm_sym84__)) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym80__ - 1)))));
-                lcm_sym78__ = (lcm_sym80__ + 1);
+                                   stan::model::index_uni((lcm_sym84__ - 1)))));
+                lcm_sym82__ = (lcm_sym84__ + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni(lcm_sym80__)),
+                                   stan::model::index_uni(lcm_sym84__)),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym80__ - 1)))));
-                for (int t = lcm_sym78__; t <= lcm_sym102__; ++t) {
+                                   stan::model::index_uni((lcm_sym84__ - 1)))));
+                for (int t = lcm_sym82__; t <= lcm_sym106__; ++t) {
                   current_statement__ = 26;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -4568,7 +5889,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                                  inline_prob_uncaptured_return_sym8__,
                                  "inline_prob_uncaptured_return_sym8__",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(lcm_sym102__))));
+                                 stan::model::index_uni(lcm_sym106__))));
             }
           }
         }
@@ -4610,17 +5931,21 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym65__;
+      int lcm_sym64__;
+      int lcm_sym63__;
+      double lcm_sym62__;
       double lcm_sym61__;
-      int lcm_sym60__;
-      int lcm_sym59__;
+      double lcm_sym60__;
+      double lcm_sym59__;
       double lcm_sym58__;
       double lcm_sym57__;
       double lcm_sym56__;
       double lcm_sym55__;
-      double lcm_sym54__;
-      double lcm_sym53__;
-      double lcm_sym52__;
-      double lcm_sym51__;
+      int lcm_sym54__;
+      int lcm_sym53__;
+      int lcm_sym52__;
+      int lcm_sym51__;
       int lcm_sym50__;
       int lcm_sym49__;
       int lcm_sym48__;
@@ -4633,10 +5958,6 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       int lcm_sym41__;
       int lcm_sym40__;
       int lcm_sym39__;
-      int lcm_sym38__;
-      int lcm_sym37__;
-      int lcm_sym36__;
-      int lcm_sym35__;
       double mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -4662,18 +5983,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym35__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym35__) {
-        lcm_sym60__ = stan::model::rvalue(first, "first",
+      lcm_sym39__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym39__) {
+        lcm_sym64__ = stan::model::rvalue(first, "first",
                         stan::model::index_uni(1));
-        lcm_sym44__ = (lcm_sym60__ - 1);
-        if (stan::math::logical_gte(lcm_sym44__, 1)) {
+        lcm_sym48__ = (lcm_sym64__ - 1);
+        if (stan::math::logical_gte(lcm_sym48__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym44__; ++t) {
+          for (int t = 2; t <= lcm_sym48__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -4682,20 +6003,20 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym42__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym42__, lcm_sym60__)) {
+        lcm_sym46__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym46__, lcm_sym64__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym60__)))),
+                  stan::model::index_uni(lcm_sym64__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym60__));
-          lcm_sym50__ = (lcm_sym60__ + 1);
+            stan::model::index_uni(lcm_sym64__));
+          lcm_sym54__ = (lcm_sym64__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
-          for (int t = lcm_sym50__; t <= lcm_sym42__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym64__));
+          for (int t = lcm_sym54__; t <= lcm_sym46__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -4709,16 +6030,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym59__ = stan::model::rvalue(first, "first",
+          lcm_sym63__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym43__ = (lcm_sym59__ - 1);
-          if (stan::math::logical_gte(lcm_sym43__, 1)) {
+          lcm_sym47__ = (lcm_sym63__ - 1);
+          if (stan::math::logical_gte(lcm_sym47__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym43__; ++t) {
+            for (int t = 2; t <= lcm_sym47__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -4728,19 +6049,19 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym42__, lcm_sym59__)) {
+          if (stan::math::logical_gte(lcm_sym46__, lcm_sym63__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym59__)))),
+                    stan::model::index_uni(lcm_sym63__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym59__));
-            lcm_sym49__ = (lcm_sym59__ + 1);
+              stan::model::index_uni(lcm_sym63__));
+            lcm_sym53__ = (lcm_sym63__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
-            for (int t = lcm_sym49__; t <= lcm_sym42__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym63__));
+            for (int t = lcm_sym53__; t <= lcm_sym46__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -4767,58 +6088,58 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym35__) {
+        if (lcm_sym39__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym2__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym2__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym42__ = (n_occasions - 1);
-          lcm_sym36__ = stan::math::logical_gte(lcm_sym42__, 1);
-          if (lcm_sym36__) {
+          lcm_sym46__ = (n_occasions - 1);
+          lcm_sym40__ = stan::math::logical_gte(lcm_sym46__, 1);
+          if (lcm_sym40__) {
             int inline_prob_uncaptured_t_curr_sym3__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym4__ =
               std::numeric_limits<int>::min();
-            lcm_sym48__ = (lcm_sym42__ + 1);
+            lcm_sym52__ = (lcm_sym46__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym2__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym42__)) * (1 -
+                   stan::model::index_uni(lcm_sym46__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym48__ - 1))))),
+                  stan::model::index_uni((lcm_sym52__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                   "inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym48__)), (1 -
+                  stan::model::index_uni(lcm_sym52__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym42__)))),
+                  stan::model::index_uni(lcm_sym46__)))),
               "assigning variable inline_prob_uncaptured_chi_sym2__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym42__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym46__));
             for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                 <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
+                 <= lcm_sym46__; ++inline_prob_uncaptured_t_sym5__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
-              lcm_sym41__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
+              lcm_sym45__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym47__ = (lcm_sym41__ + 1);
+              lcm_sym51__ = (lcm_sym45__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym41__)) * (1 -
+                     stan::model::index_uni(lcm_sym45__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym47__ - 1))))),
+                    stan::model::index_uni((lcm_sym51__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym47__)), (1 -
+                    stan::model::index_uni(lcm_sym51__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym41__)))),
+                    stan::model::index_uni(lcm_sym45__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym41__));
+                stan::model::index_uni(lcm_sym45__));
             }
           }
           for (int inline_prob_uncaptured_i_sym6__ = 2; inline_prob_uncaptured_i_sym6__
@@ -4829,59 +6150,59 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym36__) {
+            if (lcm_sym40__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym48__ = (lcm_sym42__ + 1);
+              lcm_sym52__ = (lcm_sym46__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                     stan::model::index_uni(lcm_sym42__)) * (1 -
+                     stan::model::index_uni(lcm_sym46__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni((lcm_sym48__ - 1))))),
+                    stan::model::index_uni((lcm_sym52__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym48__)), (1 -
+                    stan::model::index_uni(lcm_sym52__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym42__)))),
+                    stan::model::index_uni(lcm_sym46__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                stan::model::index_uni(lcm_sym42__));
+                stan::model::index_uni(lcm_sym46__));
               for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                   <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
+                   <= lcm_sym46__; ++inline_prob_uncaptured_t_sym5__) {
                 int inline_prob_uncaptured_t_curr_sym3__ =
                   std::numeric_limits<int>::min();
-                lcm_sym41__ = (n_occasions -
+                lcm_sym45__ = (n_occasions -
                   inline_prob_uncaptured_t_sym5__);
                 int inline_prob_uncaptured_t_next_sym4__ =
                   std::numeric_limits<int>::min();
-                lcm_sym47__ = (lcm_sym41__ + 1);
+                lcm_sym51__ = (lcm_sym45__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                       stan::model::index_uni(lcm_sym41__)) * (1 -
+                       stan::model::index_uni(lcm_sym45__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni((lcm_sym47__ - 1))))),
+                      stan::model::index_uni((lcm_sym51__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                       "inline_prob_uncaptured_chi_sym2__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym47__)), (1 -
+                      stan::model::index_uni(lcm_sym51__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym41__)))),
+                      stan::model::index_uni(lcm_sym45__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                  stan::model::index_uni(lcm_sym41__));
+                  stan::model::index_uni(lcm_sym45__));
               }
             }
           }
@@ -4923,8 +6244,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4942,6 +6263,50 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::model::assign(beta,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
         "assigning variable beta");
+      out__.write_free_lub(0, 1, beta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym38__;
+      double lcm_sym37__;
+      int lcm_sym36__;
+      int lcm_sym35__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
+      {
+        std::vector<double> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        if (stan::math::logical_gte(max_age, 1)) {
+          stan::model::assign(beta,
+            stan::model::rvalue(beta_flat__, "beta_flat__",
+              stan::model::index_uni(1)), "assigning variable beta",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4983,27 +6348,27 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
+    for (int sym122__ = 1; sym122__ <= max_age; ++sym122__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym118__));
+        std::to_string(sym122__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occasions; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
     }
@@ -5014,27 +6379,27 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
+    for (int sym122__ = 1; sym122__ <= max_age; ++sym122__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym118__));
+        std::to_string(sym122__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occasions; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
     }
@@ -5106,24 +6471,17 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -5216,10 +6574,10 @@ static constexpr std::array<const char*, 66> locations_array__ =
   " (in 'dce-fail.stan', line 37, column 9 to column 16)"};
 class dce_fail_model final : public model_base_crtp<dce_fail_model> {
  private:
-  double lcm_sym28__;
-  double lcm_sym27__;
-  int lcm_sym26__;
-  int lcm_sym25__;
+  double lcm_sym43__;
+  double lcm_sym42__;
+  int lcm_sym41__;
+  int lcm_sym40__;
   int N;
   int n_age;
   int n_edu;
@@ -5458,28 +6816,28 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym39__;
+      double lcm_sym38__;
+      double lcm_sym37__;
+      double lcm_sym36__;
+      double lcm_sym35__;
+      double lcm_sym34__;
+      double lcm_sym33__;
+      double lcm_sym32__;
+      double lcm_sym31__;
+      double lcm_sym30__;
+      double lcm_sym29__;
+      double lcm_sym28__;
+      double lcm_sym27__;
+      double lcm_sym26__;
+      double lcm_sym25__;
       double lcm_sym24__;
       double lcm_sym23__;
       double lcm_sym22__;
-      double lcm_sym21__;
-      double lcm_sym20__;
-      double lcm_sym19__;
-      double lcm_sym18__;
-      double lcm_sym17__;
-      double lcm_sym16__;
-      double lcm_sym15__;
-      double lcm_sym14__;
-      double lcm_sym13__;
-      double lcm_sym12__;
-      double lcm_sym11__;
-      double lcm_sym10__;
-      double lcm_sym9__;
-      double lcm_sym8__;
-      double lcm_sym7__;
-      int lcm_sym6__;
-      int lcm_sym5__;
-      int lcm_sym4__;
-      int lcm_sym3__;
+      int lcm_sym21__;
+      int lcm_sym20__;
+      int lcm_sym19__;
+      int lcm_sym18__;
       local_scalar_t__ sigma;
       current_statement__ = 1;
       sigma = in__.template read_constrain_lb<local_scalar_t__,
@@ -5566,8 +6924,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                          sigma_region));
         current_statement__ = 31;
         if (stan::math::logical_gte(n_age, 1)) {
-          lcm_sym5__ = stan::math::logical_gte(n_edu, 1);
-          if (lcm_sym5__) {
+          lcm_sym20__ = stan::math::logical_gte(n_edu, 1);
+          if (lcm_sym20__) {
             current_statement__ = 28;
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
@@ -5583,7 +6941,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           }
           for (int j = 2; j <= n_age; ++j) {
             current_statement__ = 29;
-            if (lcm_sym5__) {
+            if (lcm_sym20__) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(b_age_edu, "b_age_edu",
@@ -5746,8 +7104,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym2__;
-      int lcm_sym1__;
+      int lcm_sym17__;
+      int lcm_sym16__;
       double sigma;
       current_statement__ = 1;
       sigma = in__.template read_constrain_lb<local_scalar_t__,
@@ -5837,8 +7195,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -5911,6 +7269,192 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
   }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym15__;
+      double lcm_sym14__;
+      double lcm_sym13__;
+      double lcm_sym12__;
+      double lcm_sym11__;
+      double lcm_sym10__;
+      double lcm_sym9__;
+      double lcm_sym8__;
+      double lcm_sym7__;
+      double lcm_sym6__;
+      int lcm_sym5__;
+      int lcm_sym4__;
+      int lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ sigma_age;
+      sigma_age = context__.vals_r("sigma_age")[(1 - 1)];
+      out__.write_free_lb(0, sigma_age);
+      local_scalar_t__ sigma_edu;
+      sigma_edu = context__.vals_r("sigma_edu")[(1 - 1)];
+      out__.write_free_lb(0, sigma_edu);
+      local_scalar_t__ sigma_state;
+      sigma_state = context__.vals_r("sigma_state")[(1 - 1)];
+      out__.write_free_lb(0, sigma_state);
+      local_scalar_t__ sigma_region;
+      sigma_region = context__.vals_r("sigma_region")[(1 - 1)];
+      out__.write_free_lb(0, sigma_region);
+      local_scalar_t__ sigma_age_edu;
+      sigma_age_edu = context__.vals_r("sigma_age_edu")[(1 - 1)];
+      out__.write_free_lb(0, sigma_age_edu);
+      local_scalar_t__ b_0;
+      b_0 = context__.vals_r("b_0")[(1 - 1)];
+      out__.write(b_0);
+      local_scalar_t__ b_female;
+      b_female = context__.vals_r("b_female")[(1 - 1)];
+      out__.write(b_female);
+      local_scalar_t__ b_black;
+      b_black = context__.vals_r("b_black")[(1 - 1)];
+      out__.write(b_black);
+      local_scalar_t__ b_female_black;
+      b_female_black = context__.vals_r("b_female_black")[(1 - 1)];
+      out__.write(b_female_black);
+      local_scalar_t__ b_v_prev;
+      b_v_prev = context__.vals_r("b_v_prev")[(1 - 1)];
+      out__.write(b_v_prev);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_age =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
+      {
+        std::vector<double> b_age_flat__;
+        b_age_flat__ = context__.vals_r("b_age");
+        pos__ = 1;
+        lcm_sym1__ = stan::math::logical_gte(n_age, 1);
+        if (lcm_sym1__) {
+          stan::model::assign(b_age,
+            stan::model::rvalue(b_age_flat__, "b_age_flat__",
+              stan::model::index_uni(1)), "assigning variable b_age",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
+            stan::model::assign(b_age, b_age_flat__[(pos__ - 1)],
+              "assigning variable b_age", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b_age);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_edu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
+      {
+        std::vector<double> b_edu_flat__;
+        b_edu_flat__ = context__.vals_r("b_edu");
+        pos__ = 1;
+        lcm_sym2__ = stan::math::logical_gte(n_edu, 1);
+        if (lcm_sym2__) {
+          stan::model::assign(b_edu,
+            stan::model::rvalue(b_edu_flat__, "b_edu_flat__",
+              stan::model::index_uni(1)), "assigning variable b_edu",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
+            stan::model::assign(b_edu, b_edu_flat__[(pos__ - 1)],
+              "assigning variable b_edu", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b_edu);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_region =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region, DUMMY_VAR__);
+      {
+        std::vector<double> b_region_flat__;
+        b_region_flat__ = context__.vals_r("b_region");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_region, 1)) {
+          stan::model::assign(b_region,
+            stan::model::rvalue(b_region_flat__, "b_region_flat__",
+              stan::model::index_uni(1)), "assigning variable b_region",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_region; ++sym1__) {
+            stan::model::assign(b_region, b_region_flat__[(pos__ - 1)],
+              "assigning variable b_region", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b_region);
+      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_age, n_edu,
+          DUMMY_VAR__);
+      {
+        std::vector<double> b_age_edu_flat__;
+        b_age_edu_flat__ = context__.vals_r("b_age_edu");
+        pos__ = 1;
+        if (lcm_sym2__) {
+          if (lcm_sym1__) {
+            stan::model::assign(b_age_edu,
+              stan::model::rvalue(b_age_edu_flat__, "b_age_edu_flat__",
+                stan::model::index_uni(1)), "assigning variable b_age_edu",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            for (int sym2__ = 2; sym2__ <= n_age; ++sym2__) {
+              stan::model::assign(b_age_edu, b_age_edu_flat__[(pos__ - 1)],
+                "assigning variable b_age_edu",
+                stan::model::index_uni(sym2__), stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
+            if (lcm_sym1__) {
+              stan::model::assign(b_age_edu, b_age_edu_flat__[(pos__ - 1)],
+                "assigning variable b_age_edu", stan::model::index_uni(1),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= n_age; ++sym2__) {
+                stan::model::assign(b_age_edu, b_age_edu_flat__[(pos__ - 1)],
+                  "assigning variable b_age_edu",
+                  stan::model::index_uni(sym2__),
+                  stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+        }
+      }
+      out__.write(b_age_edu);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_hat =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
+      {
+        std::vector<double> b_hat_flat__;
+        b_hat_flat__ = context__.vals_r("b_hat");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_state, 1)) {
+          stan::model::assign(b_hat,
+            stan::model::rvalue(b_hat_flat__, "b_hat_flat__",
+              stan::model::index_uni(1)), "assigning variable b_hat",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
+            stan::model::assign(b_hat, b_hat_flat__[(pos__ - 1)],
+              "assigning variable b_hat", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b_hat);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
                   emit_transformed_parameters__ = true, const bool
@@ -5956,27 +7500,27 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     param_names__.emplace_back(std::string() + "b_black");
     param_names__.emplace_back(std::string() + "b_female_black");
     param_names__.emplace_back(std::string() + "b_v_prev");
-    for (int sym29__ = 1; sym29__ <= n_age; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_age; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_age" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
-    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_edu; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_edu" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
-    for (int sym29__ = 1; sym29__ <= n_region; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_region; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_region" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
-    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
-      for (int sym30__ = 1; sym30__ <= n_age; ++sym30__) {
+    for (int sym44__ = 1; sym44__ <= n_edu; ++sym44__) {
+      for (int sym45__ = 1; sym45__ <= n_age; ++sym45__) {
         param_names__.emplace_back(std::string() + "b_age_edu" + '.' +
-          std::to_string(sym30__) + '.' + std::to_string(sym29__));
+          std::to_string(sym45__) + '.' + std::to_string(sym44__));
       }
     }
-    for (int sym29__ = 1; sym29__ <= n_state; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_state; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_hat" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -5996,27 +7540,27 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     param_names__.emplace_back(std::string() + "b_black");
     param_names__.emplace_back(std::string() + "b_female_black");
     param_names__.emplace_back(std::string() + "b_v_prev");
-    for (int sym29__ = 1; sym29__ <= n_age; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_age; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_age" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
-    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_edu; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_edu" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
-    for (int sym29__ = 1; sym29__ <= n_region; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_region; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_region" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
-    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
-      for (int sym30__ = 1; sym30__ <= n_age; ++sym30__) {
+    for (int sym44__ = 1; sym44__ <= n_edu; ++sym44__) {
+      for (int sym45__ = 1; sym45__ <= n_age; ++sym45__) {
         param_names__.emplace_back(std::string() + "b_age_edu" + '.' +
-          std::to_string(sym30__) + '.' + std::to_string(sym29__));
+          std::to_string(sym45__) + '.' + std::to_string(sym44__));
       }
     }
-    for (int sym29__ = 1; sym29__ <= n_state; ++sym29__) {
+    for (int sym44__ = 1; sym44__ <= n_state; ++sym44__) {
       param_names__.emplace_back(std::string() + "b_hat" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym44__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -6089,30 +7633,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16>
-      names__{"sigma", "sigma_age", "sigma_edu", "sigma_state",
-              "sigma_region", "sigma_age_edu", "b_0", "b_female", "b_black",
-              "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
-              "b_age_edu", "b_hat"};
-    const std::array<Eigen::Index, 16>
-      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu,
-                              n_region, (n_age * n_edu), n_state};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -6287,10 +7818,27 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -6397,24 +7945,17 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -6586,10 +8127,27 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -6696,24 +8254,17 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -6752,10 +8303,10 @@ static constexpr std::array<const char*, 12> locations_array__ =
   " (in 'expr-prop-fail.stan', line 3, column 2 to column 14)"};
 class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> {
  private:
-  double lcm_sym12__;
-  double lcm_sym11__;
-  int lcm_sym10__;
-  int lcm_sym9__;
+  double lcm_sym15__;
+  double lcm_sym14__;
+  int lcm_sym13__;
+  int lcm_sym12__;
   int N;
   Eigen::Matrix<double,-1,1> y_data__;
   Eigen::Map<Eigen::Matrix<double,-1,1>> y{nullptr, 0};
@@ -6852,12 +8403,12 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym11__;
+      double lcm_sym10__;
+      double lcm_sym9__;
       double lcm_sym8__;
       double lcm_sym7__;
-      double lcm_sym6__;
-      double lcm_sym5__;
-      double lcm_sym4__;
-      int lcm_sym3__;
+      int lcm_sym6__;
       Eigen::Matrix<local_scalar_t__,-1,1> mu;
       current_statement__ = 1;
       mu = in__.template read_constrain_ordered<
@@ -6953,8 +8504,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym2__;
-      int lcm_sym1__;
+      int lcm_sym5__;
+      int lcm_sym4__;
       Eigen::Matrix<double,-1,1> mu;
       current_statement__ = 1;
       mu = in__.template read_constrain_ordered<
@@ -6987,8 +8538,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7006,15 +8557,59 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       out__.write_free_ordered(mu);
       std::vector<local_scalar_t__> sigma =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      {
-        sigma[(1 - 1)] = in__.read<local_scalar_t__>();
-        {
-          sigma[(2 - 1)] = in__.read<local_scalar_t__>();
-        }
+      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+        sigma[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
       out__.write_free_lb(0, sigma);
       local_scalar_t__ theta;
       theta = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 1, theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym3__;
+      double lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> mu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<double> mu_flat__;
+        mu_flat__ = context__.vals_r("mu");
+        pos__ = 1;
+        {
+          stan::model::assign(mu,
+            stan::model::rvalue(mu_flat__, "mu_flat__",
+              stan::model::index_uni(1)), "assigning variable mu",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          {
+            stan::model::assign(mu, mu_flat__[(pos__ - 1)],
+              "assigning variable mu", stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_ordered(mu);
+      std::vector<local_scalar_t__> sigma =
+        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
+      sigma = context__.vals_r("sigma");
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ theta;
+      theta = context__.vals_r("theta")[(1 - 1)];
       out__.write_free_lub(0, 1, theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7043,13 +8638,13 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (int sym16__ = 1; sym16__ <= 2; ++sym16__) {
       param_names__.emplace_back(std::string() + "mu" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym16__));
     }
-    for (int sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (int sym16__ = 1; sym16__ <= 2; ++sym16__) {
       param_names__.emplace_back(std::string() + "sigma" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym16__));
     }
     param_names__.emplace_back(std::string() + "theta");
     if (emit_transformed_parameters__) {}
@@ -7059,13 +8654,13 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (int sym16__ = 1; sym16__ <= 2; ++sym16__) {
       param_names__.emplace_back(std::string() + "mu" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym16__));
     }
-    for (int sym13__ = 1; sym13__ <= 2; ++sym13__) {
+    for (int sym16__ = 1; sym16__ <= 2; ++sym16__) {
       param_names__.emplace_back(std::string() + "sigma" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym16__));
     }
     param_names__.emplace_back(std::string() + "theta");
     if (emit_transformed_parameters__) {}
@@ -7135,24 +8730,17 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "sigma", "theta"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{2, 2, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -7276,8 +8864,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym5__;
       double lcm_sym4__;
+      double lcm_sym3__;
       local_scalar_t__ mu;
       current_statement__ = 1;
       mu = in__.template read<local_scalar_t__>();
@@ -7332,8 +8920,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym3__;
       int lcm_sym2__;
+      int lcm_sym1__;
       double mu;
       current_statement__ = 1;
       mu = in__.template read<local_scalar_t__>();
@@ -7364,8 +8952,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7374,7 +8962,6 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mu;
@@ -7382,15 +8969,39 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       out__.write(mu);
       std::vector<local_scalar_t__> theta =
         std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      if (stan::math::logical_gte(J, 1)) {
-        theta[(1 - 1)] = in__.read<local_scalar_t__>();
-        for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
-          theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-        }
+      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
       out__.write(theta);
       local_scalar_t__ tau;
       tau = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, tau);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mu;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      std::vector<local_scalar_t__> theta =
+        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
+      theta = context__.vals_r("theta");
+      out__.write(theta);
+      local_scalar_t__ tau;
+      tau = context__.vals_r("tau")[(1 - 1)];
       out__.write_free_lb(0, tau);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7419,9 +9030,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mu");
-    for (int sym6__ = 1; sym6__ <= J; ++sym6__) {
+    for (int sym5__ = 1; sym5__ <= J; ++sym5__) {
       param_names__.emplace_back(std::string() + "theta" + '.' +
-        std::to_string(sym6__));
+        std::to_string(sym5__));
     }
     param_names__.emplace_back(std::string() + "tau");
     if (emit_transformed_parameters__) {}
@@ -7432,9 +9043,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mu");
-    for (int sym6__ = 1; sym6__ <= J; ++sym6__) {
+    for (int sym5__ = 1; sym5__ <= J; ++sym5__) {
       param_names__.emplace_back(std::string() + "theta" + '.' +
-        std::to_string(sym6__));
+        std::to_string(sym5__));
     }
     param_names__.emplace_back(std::string() + "tau");
     if (emit_transformed_parameters__) {}
@@ -7504,24 +9115,17 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "theta", "tau"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, J, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -7600,14 +9204,14 @@ static constexpr std::array<const char*, 52> locations_array__ =
   " (in 'expr-prop-fail3.stan', line 32, column 9 to column 10)"};
 class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model> {
  private:
-  double lcm_sym23__;
-  double lcm_sym22__;
-  double lcm_sym21__;
-  double lcm_sym20__;
-  double lcm_sym19__;
-  double lcm_sym18__;
-  int lcm_sym17__;
-  int lcm_sym16__;
+  double lcm_sym41__;
+  double lcm_sym40__;
+  double lcm_sym39__;
+  double lcm_sym38__;
+  double lcm_sym37__;
+  double lcm_sym36__;
+  int lcm_sym35__;
+  int lcm_sym34__;
   int N;
   int n_age;
   int n_age_edu;
@@ -7737,8 +9341,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         black_flat__ = context__.vals_r("black");
         current_statement__ = 33;
         pos__ = 1;
-        lcm_sym16__ = stan::math::logical_gte(N, 1);
-        if (lcm_sym16__) {
+        lcm_sym34__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym34__) {
           current_statement__ = 33;
           stan::model::assign(black,
             stan::model::rvalue(black_flat__, "black_flat__",
@@ -7787,7 +9391,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 37;
         pos__ = 1;
         current_statement__ = 37;
-        if (lcm_sym16__) {
+        if (lcm_sym34__) {
           current_statement__ = 37;
           stan::model::assign(female,
             stan::model::rvalue(female_flat__, "female_flat__",
@@ -7850,7 +9454,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 43;
         pos__ = 1;
         current_statement__ = 43;
-        if (lcm_sym16__) {
+        if (lcm_sym34__) {
           current_statement__ = 43;
           stan::model::assign(v_prev_full,
             stan::model::rvalue(v_prev_full_flat__, "v_prev_full_flat__",
@@ -7926,16 +9530,16 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym15__;
-      double lcm_sym14__;
-      double lcm_sym13__;
-      double lcm_sym12__;
-      double lcm_sym11__;
-      double lcm_sym10__;
-      double lcm_sym9__;
-      double lcm_sym8__;
-      double lcm_sym7__;
-      int lcm_sym6__;
+      double lcm_sym33__;
+      double lcm_sym32__;
+      double lcm_sym31__;
+      double lcm_sym30__;
+      double lcm_sym29__;
+      double lcm_sym28__;
+      double lcm_sym27__;
+      double lcm_sym26__;
+      double lcm_sym25__;
+      int lcm_sym24__;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age);
@@ -8126,11 +9730,11 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym5__;
-      double lcm_sym4__;
-      int lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
+      double lcm_sym23__;
+      double lcm_sym22__;
+      int lcm_sym21__;
+      int lcm_sym20__;
+      int lcm_sym19__;
       Eigen::Matrix<double,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age);
@@ -8299,8 +9903,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -8360,6 +9964,193 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
   }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym18__;
+      double lcm_sym17__;
+      double lcm_sym16__;
+      double lcm_sym15__;
+      double lcm_sym14__;
+      double lcm_sym13__;
+      double lcm_sym12__;
+      double lcm_sym11__;
+      double lcm_sym10__;
+      double lcm_sym9__;
+      double lcm_sym8__;
+      double lcm_sym7__;
+      int lcm_sym6__;
+      int lcm_sym5__;
+      int lcm_sym4__;
+      int lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
+      {
+        std::vector<double> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_age, 1)) {
+          stan::model::assign(a,
+            stan::model::rvalue(a_flat__, "a_flat__",
+              stan::model::index_uni(1)), "assigning variable a",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
+            stan::model::assign(a, a_flat__[(pos__ - 1)],
+              "assigning variable a", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> b =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
+      {
+        std::vector<double> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_edu, 1)) {
+          stan::model::assign(b,
+            stan::model::rvalue(b_flat__, "b_flat__",
+              stan::model::index_uni(1)), "assigning variable b",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
+            stan::model::assign(b, b_flat__[(pos__ - 1)],
+              "assigning variable b", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b);
+      Eigen::Matrix<local_scalar_t__,-1,1> c =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age_edu,
+          DUMMY_VAR__);
+      {
+        std::vector<double> c_flat__;
+        c_flat__ = context__.vals_r("c");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_age_edu, 1)) {
+          stan::model::assign(c,
+            stan::model::rvalue(c_flat__, "c_flat__",
+              stan::model::index_uni(1)), "assigning variable c",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_age_edu; ++sym1__) {
+            stan::model::assign(c, c_flat__[(pos__ - 1)],
+              "assigning variable c", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(c);
+      Eigen::Matrix<local_scalar_t__,-1,1> d =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
+      {
+        std::vector<double> d_flat__;
+        d_flat__ = context__.vals_r("d");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_state, 1)) {
+          stan::model::assign(d,
+            stan::model::rvalue(d_flat__, "d_flat__",
+              stan::model::index_uni(1)), "assigning variable d",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
+            stan::model::assign(d, d_flat__[(pos__ - 1)],
+              "assigning variable d", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(d);
+      Eigen::Matrix<local_scalar_t__,-1,1> e =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region_full,
+          DUMMY_VAR__);
+      {
+        std::vector<double> e_flat__;
+        e_flat__ = context__.vals_r("e");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_region_full, 1)) {
+          stan::model::assign(e,
+            stan::model::rvalue(e_flat__, "e_flat__",
+              stan::model::index_uni(1)), "assigning variable e",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_region_full; ++sym1__) {
+            stan::model::assign(e, e_flat__[(pos__ - 1)],
+              "assigning variable e", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(e);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<double> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        {
+          stan::model::assign(beta,
+            stan::model::rvalue(beta_flat__, "beta_flat__",
+              stan::model::index_uni(1)), "assigning variable beta",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(beta);
+      local_scalar_t__ sigma_a;
+      sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a);
+      local_scalar_t__ sigma_b;
+      sigma_b = context__.vals_r("sigma_b")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_b);
+      local_scalar_t__ sigma_c;
+      sigma_c = context__.vals_r("sigma_c")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_c);
+      local_scalar_t__ sigma_d;
+      sigma_d = context__.vals_r("sigma_d")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_d);
+      local_scalar_t__ sigma_e;
+      sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_e);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
                   emit_transformed_parameters__ = true, const bool
@@ -8400,29 +10191,29 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym24__ = 1; sym24__ <= n_age; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_age; ++sym42__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_edu; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_edu; ++sym42__) {
       param_names__.emplace_back(std::string() + "b" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_age_edu; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_age_edu; ++sym42__) {
       param_names__.emplace_back(std::string() + "c" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_state; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_state; ++sym42__) {
       param_names__.emplace_back(std::string() + "d" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_region_full; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_region_full; ++sym42__) {
       param_names__.emplace_back(std::string() + "e" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= 5; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= 5; ++sym42__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_b");
@@ -8430,9 +10221,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     param_names__.emplace_back(std::string() + "sigma_d");
     param_names__.emplace_back(std::string() + "sigma_e");
     if (emit_transformed_parameters__) {
-      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
+      for (int sym42__ = 1; sym42__ <= N; ++sym42__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym24__));
+          std::to_string(sym42__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -8441,29 +10232,29 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym24__ = 1; sym24__ <= n_age; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_age; ++sym42__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_edu; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_edu; ++sym42__) {
       param_names__.emplace_back(std::string() + "b" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_age_edu; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_age_edu; ++sym42__) {
       param_names__.emplace_back(std::string() + "c" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_state; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_state; ++sym42__) {
       param_names__.emplace_back(std::string() + "d" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= n_region_full; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= n_region_full; ++sym42__) {
       param_names__.emplace_back(std::string() + "e" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
-    for (int sym24__ = 1; sym24__ <= 5; ++sym24__) {
+    for (int sym42__ = 1; sym42__ <= 5; ++sym42__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym42__));
     }
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_b");
@@ -8471,9 +10262,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     param_names__.emplace_back(std::string() + "sigma_d");
     param_names__.emplace_back(std::string() + "sigma_e");
     if (emit_transformed_parameters__) {
-      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
+      for (int sym42__ = 1; sym42__ <= N; ++sym42__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym24__));
+          std::to_string(sym42__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -8544,28 +10335,17 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 11>
-      names__{"a", "b", "c", "d", "e", "beta", "sigma_a", "sigma_b",
-              "sigma_c", "sigma_d", "sigma_e"};
-    const std::array<Eigen::Index, 11>
-      constrain_param_sizes__{n_age, n_edu, n_age_edu, n_state,
-                              n_region_full, 5, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -8635,12 +10415,12 @@ static constexpr std::array<const char*, 43> locations_array__ =
   " (in 'expr-prop-fail4.stan', line 35, column 8 to column 9)"};
 class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model> {
  private:
-  double lcm_sym26__;
-  double lcm_sym25__;
-  Eigen::Matrix<double,-1,1> lcm_sym24___data__;
-  int lcm_sym23__;
-  int lcm_sym22__;
-  int lcm_sym21__;
+  double lcm_sym30__;
+  double lcm_sym29__;
+  Eigen::Matrix<double,-1,1> lcm_sym28___data__;
+  int lcm_sym27__;
+  int lcm_sym26__;
+  int lcm_sym25__;
   int N;
   int N_edges;
   std::vector<int> node1;
@@ -8648,7 +10428,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   Eigen::Matrix<double,-1,1> E_data__;
   Eigen::Matrix<double,-1,1> log_E_data__;
   int phi_std_raw_1dim__;
-  Eigen::Map<Eigen::Matrix<double,-1,1>> lcm_sym24__{nullptr, 0};
+  Eigen::Map<Eigen::Matrix<double,-1,1>> lcm_sym28__{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> E{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> log_E{nullptr, 0};
  public:
@@ -8758,11 +10538,11 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         "assigning variable log_E");
       current_statement__ = 37;
       phi_std_raw_1dim__ = std::numeric_limits<int>::min();
-      lcm_sym22__ = (N - 1);
-      phi_std_raw_1dim__ = lcm_sym22__;
+      lcm_sym26__ = (N - 1);
+      phi_std_raw_1dim__ = lcm_sym26__;
       current_statement__ = 37;
       stan::math::validate_non_negative_index("phi_std_raw", "N - 1",
-        lcm_sym22__);
+        lcm_sym26__);
       current_statement__ = 38;
       stan::math::validate_non_negative_index("phi", "N", N);
       current_statement__ = 39;
@@ -8805,12 +10585,12 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) function__;
     try {
-      local_scalar_t__ lcm_sym19__;
-      double lcm_sym18__;
-      double lcm_sym17__;
-      Eigen::Matrix<double,-1,1> lcm_sym16__;
-      double lcm_sym15__;
-      int lcm_sym20__;
+      local_scalar_t__ lcm_sym23__;
+      double lcm_sym22__;
+      double lcm_sym21__;
+      Eigen::Matrix<double,-1,1> lcm_sym20__;
+      double lcm_sym19__;
+      int lcm_sym24__;
       local_scalar_t__ tau_phi;
       current_statement__ = 1;
       tau_phi = in__.template read_constrain_lb<local_scalar_t__,
@@ -8822,13 +10602,13 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                                                   - 1),
                                                   std::numeric_limits<double>::quiet_NaN(
                                                     )));
-      lcm_sym20__ = (N - 1);
+      lcm_sym24__ = (N - 1);
       phi_std_raw = in__.template read<
                       stan::conditional_var_value_t<local_scalar_t__,
-                        Eigen::Matrix<local_scalar_t__,-1,1>>>(lcm_sym20__);
+                        Eigen::Matrix<local_scalar_t__,-1,1>>>(lcm_sym24__);
       local_scalar_t__ sigma_phi = DUMMY_VAR__;
-      lcm_sym19__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym19__;
+      lcm_sym23__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym23__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,1>> phi =
         stan::conditional_var_value_t<local_scalar_t__,
@@ -8837,17 +10617,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                                                     )));
       current_statement__ = 5;
       stan::model::assign(phi, phi_std_raw, "assigning variable phi",
-        stan::model::index_min_max(1, lcm_sym20__));
+        stan::model::index_min_max(1, lcm_sym24__));
       current_statement__ = 6;
       stan::model::assign(phi, -stan::math::sum(phi_std_raw),
         "assigning variable phi", stan::model::index_uni(N));
       current_statement__ = 7;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym19__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym23__),
         "assigning variable phi");
       current_statement__ = 3;
       stan::math::check_greater_or_equal(function__, "sigma_phi",
-        lcm_sym19__, 0);
+        lcm_sym23__, 0);
       {
         current_statement__ = 25;
         lp_accum__.add((-0.5 *
@@ -8895,17 +10675,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym10__;
-      double lcm_sym9__;
-      Eigen::Matrix<double,-1,1> lcm_sym8__;
-      Eigen::Matrix<double,-1,1> lcm_sym7__;
-      double lcm_sym12__;
-      double lcm_sym11__;
+      double lcm_sym14__;
+      double lcm_sym13__;
+      Eigen::Matrix<double,-1,1> lcm_sym12__;
+      Eigen::Matrix<double,-1,1> lcm_sym11__;
+      double lcm_sym16__;
+      double lcm_sym15__;
+      int lcm_sym10__;
+      int lcm_sym9__;
+      double lcm_sym8__;
+      int lcm_sym17__;
       int lcm_sym6__;
-      int lcm_sym5__;
-      double lcm_sym4__;
-      int lcm_sym13__;
-      int lcm_sym2__;
       double tau_phi;
       current_statement__ = 1;
       tau_phi = in__.template read_constrain_lb<local_scalar_t__,
@@ -8913,9 +10693,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       Eigen::Matrix<double,-1,1> phi_std_raw =
         Eigen::Matrix<double,-1,1>::Constant((N - 1),
           std::numeric_limits<double>::quiet_NaN());
-      lcm_sym13__ = (N - 1);
+      lcm_sym17__ = (N - 1);
       phi_std_raw = in__.template read<
-                      Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym13__);
+                      Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym17__);
       double sigma_phi = std::numeric_limits<double>::quiet_NaN();
       Eigen::Matrix<double,-1,1> phi =
         Eigen::Matrix<double,-1,1>::Constant(N,
@@ -8927,23 +10707,23 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym9__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym9__;
+      lcm_sym13__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym13__;
       current_statement__ = 5;
       stan::model::assign(phi, phi_std_raw, "assigning variable phi",
-        stan::model::index_min_max(1, lcm_sym13__));
+        stan::model::index_min_max(1, lcm_sym17__));
       current_statement__ = 6;
       stan::model::assign(phi, -stan::math::sum(phi_std_raw),
         "assigning variable phi", stan::model::index_uni(N));
       current_statement__ = 7;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym9__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym13__),
         "assigning variable phi");
       current_statement__ = 3;
-      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym9__,
-        0);
+      stan::math::check_greater_or_equal(function__, "sigma_phi",
+        lcm_sym13__, 0);
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym9__);
+        out__.write(lcm_sym13__);
         out__.write(phi);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -8968,8 +10748,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       beta0 = stan::math::normal_rng(0, 1, base_rng__);
       current_statement__ = 17;
       beta1 = stan::math::normal_rng(0, 1, base_rng__);
-      lcm_sym2__ = stan::math::logical_gte(N, 1);
-      if (lcm_sym2__) {
+      lcm_sym6__ = stan::math::logical_gte(N, 1);
+      if (lcm_sym6__) {
         current_statement__ = 18;
         stan::model::assign(theta_std,
           stan::math::normal_rng(0, 1, base_rng__),
@@ -8983,14 +10763,14 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       }
       current_statement__ = 20;
       tau_theta = stan::math::gamma_rng(3.2761, 1.81, base_rng__);
-      lcm_sym10__ = stan::math::inv_sqrt(tau_theta);
-      sigma_theta = lcm_sym10__;
-      stan::model::assign(lcm_sym8__,
-        stan::math::multiply(theta_std, lcm_sym10__),
-        "assigning variable lcm_sym8__");
-      stan::model::assign(theta, lcm_sym8__, "assigning variable theta");
+      lcm_sym14__ = stan::math::inv_sqrt(tau_theta);
+      sigma_theta = lcm_sym14__;
+      stan::model::assign(lcm_sym12__,
+        stan::math::multiply(theta_std, lcm_sym14__),
+        "assigning variable lcm_sym12__");
+      stan::model::assign(theta, lcm_sym12__, "assigning variable theta");
       current_statement__ = 24;
-      if (lcm_sym2__) {
+      if (lcm_sym6__) {
         current_statement__ = 21;
         stan::model::assign(x, stan::math::normal_rng(0, 1, base_rng__),
           "assigning variable x", stan::model::index_uni(1));
@@ -9002,7 +10782,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                 (stan::model::rvalue(stan::math::log(E), "log(E)",
                    stan::model::index_uni(1)) + beta0)) +
             stan::model::rvalue(phi, "phi", stan::model::index_uni(1))) +
-            stan::model::rvalue(lcm_sym8__, "lcm_sym8__",
+            stan::model::rvalue(lcm_sym12__, "lcm_sym12__",
               stan::model::index_uni(1))), base_rng__),
           "assigning variable y", stan::model::index_uni(1));
         for (int i = 2; i <= N; ++i) {
@@ -9017,7 +10797,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                   (stan::model::rvalue(stan::math::log(E), "log(E)",
                      stan::model::index_uni(i)) + beta0)) +
               stan::model::rvalue(phi, "phi", stan::model::index_uni(i))) +
-              stan::model::rvalue(lcm_sym8__, "lcm_sym8__",
+              stan::model::rvalue(lcm_sym12__, "lcm_sym12__",
                 stan::model::index_uni(i))), base_rng__),
             "assigning variable y", stan::model::index_uni(i));
         }
@@ -9027,12 +10807,12 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         0);
       current_statement__ = 11;
       stan::math::check_greater_or_equal(function__, "sigma_theta",
-        lcm_sym10__, 0);
+        lcm_sym14__, 0);
       out__.write(beta0);
       out__.write(beta1);
       out__.write(tau_theta);
-      out__.write(lcm_sym10__);
-      out__.write(lcm_sym8__);
+      out__.write(lcm_sym14__);
+      out__.write(lcm_sym12__);
       out__.write(theta_std);
       out__.write(x);
       out__.write(y);
@@ -9044,8 +10824,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -9054,7 +10834,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ tau_phi;
@@ -9062,8 +10841,55 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       out__.write_free_lb(0, tau_phi);
       Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw;
       stan::model::assign(phi_std_raw,
-        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>((N - 1)),
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(phi_std_raw_1dim__),
         "assigning variable phi_std_raw");
+      out__.write(phi_std_raw);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym5__;
+      double lcm_sym4__;
+      int lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ tau_phi;
+      tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      out__.write_free_lb(0, tau_phi);
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant((N - 1), DUMMY_VAR__);
+      {
+        std::vector<double> phi_std_raw_flat__;
+        phi_std_raw_flat__ = context__.vals_r("phi_std_raw");
+        pos__ = 1;
+        lcm_sym2__ = (N - 1);
+        if (stan::math::logical_gte(lcm_sym2__, 1)) {
+          stan::model::assign(phi_std_raw,
+            stan::model::rvalue(phi_std_raw_flat__, "phi_std_raw_flat__",
+              stan::model::index_uni(1)), "assigning variable phi_std_raw",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= lcm_sym2__; ++sym1__) {
+            stan::model::assign(phi_std_raw, phi_std_raw_flat__[(pos__ - 1)],
+              "assigning variable phi_std_raw",
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9117,15 +10943,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym27__ = 1; sym27__ <= phi_std_raw_1dim__; ++sym27__) {
+    for (int sym31__ = 1; sym31__ <= phi_std_raw_1dim__; ++sym31__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym27__));
+        std::to_string(sym31__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
     }
     if (emit_generated_quantities__) {
@@ -9133,21 +10959,21 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       param_names__.emplace_back(std::string() + "beta1");
       param_names__.emplace_back(std::string() + "tau_theta");
       param_names__.emplace_back(std::string() + "sigma_theta");
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "theta" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "theta_std" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "x" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "y" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
     }
   }
@@ -9156,15 +10982,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym27__ = 1; sym27__ <= phi_std_raw_1dim__; ++sym27__) {
+    for (int sym31__ = 1; sym31__ <= phi_std_raw_1dim__; ++sym31__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym27__));
+        std::to_string(sym31__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
     }
     if (emit_generated_quantities__) {
@@ -9172,21 +10998,21 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       param_names__.emplace_back(std::string() + "beta1");
       param_names__.emplace_back(std::string() + "tau_theta");
       param_names__.emplace_back(std::string() + "sigma_theta");
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "theta" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "theta_std" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "x" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym31__ = 1; sym31__ <= N; ++sym31__) {
         param_names__.emplace_back(std::string() + "y" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym31__));
       }
     }
   }
@@ -9256,25 +11082,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{1, phi_std_raw_1dim__};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -9597,16 +11415,16 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
 }
 class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model> {
  private:
+  int lcm_sym118__;
+  int lcm_sym117__;
+  int lcm_sym116__;
+  int lcm_sym115__;
   int lcm_sym114__;
   int lcm_sym113__;
   int lcm_sym112__;
   int lcm_sym111__;
   int lcm_sym110__;
   int lcm_sym109__;
-  int lcm_sym108__;
-  int lcm_sym107__;
-  int lcm_sym106__;
-  int lcm_sym105__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -9669,8 +11487,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         pos__ = 1;
         current_statement__ = 42;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym106__ = stan::math::logical_gte(nind, 1);
-          if (lcm_sym106__) {
+          lcm_sym110__ = stan::math::logical_gte(nind, 1);
+          if (lcm_sym110__) {
             current_statement__ = 42;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -9689,7 +11507,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 42;
-            if (lcm_sym106__) {
+            if (lcm_sym110__) {
               current_statement__ = 42;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -9707,7 +11525,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
         } else {
-          lcm_sym106__ = stan::math::logical_gte(nind, 1);
+          lcm_sym110__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 42;
@@ -9716,8 +11534,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::check_less_or_equal(function__, "y", y, 1);
       current_statement__ = 43;
       n_occ_minus_1 = std::numeric_limits<int>::min();
-      lcm_sym107__ = (n_occasions - 1);
-      n_occ_minus_1 = lcm_sym107__;
+      lcm_sym111__ = (n_occasions - 1);
+      n_occ_minus_1 = lcm_sym111__;
       current_statement__ = 44;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 45;
@@ -9727,7 +11545,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 47;
       last = std::vector<int>(nind, std::numeric_limits<int>::min());
       current_statement__ = 49;
-      if (lcm_sym106__) {
+      if (lcm_sym110__) {
         current_statement__ = 48;
         stan::model::assign(first,
           first_capture(
@@ -9743,7 +11561,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         }
       }
       current_statement__ = 51;
-      if (lcm_sym106__) {
+      if (lcm_sym110__) {
         current_statement__ = 50;
         stan::model::assign(last,
           last_capture(
@@ -9772,12 +11590,12 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-        lcm_sym107__);
+        lcm_sym111__);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 56;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-        lcm_sym107__);
+        lcm_sym111__);
       current_statement__ = 57;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 58;
@@ -9815,15 +11633,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym104__;
-      int lcm_sym103__;
-      int lcm_sym102__;
-      int lcm_sym101__;
-      int lcm_sym100__;
+      double lcm_sym108__;
+      int lcm_sym107__;
+      int lcm_sym106__;
+      int lcm_sym105__;
+      int lcm_sym104__;
+      double lcm_sym103__;
+      local_scalar_t__ lcm_sym102__;
+      local_scalar_t__ lcm_sym101__;
+      local_scalar_t__ lcm_sym100__;
       double lcm_sym99__;
-      local_scalar_t__ lcm_sym98__;
-      local_scalar_t__ lcm_sym97__;
-      local_scalar_t__ lcm_sym96__;
+      double lcm_sym98__;
+      double lcm_sym97__;
+      double lcm_sym96__;
       double lcm_sym95__;
       double lcm_sym94__;
       double lcm_sym93__;
@@ -9834,10 +11656,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       double lcm_sym88__;
       double lcm_sym87__;
       double lcm_sym86__;
-      double lcm_sym85__;
-      double lcm_sym84__;
-      double lcm_sym83__;
-      double lcm_sym82__;
+      int lcm_sym85__;
+      int lcm_sym84__;
+      int lcm_sym83__;
+      int lcm_sym82__;
       int lcm_sym81__;
       int lcm_sym80__;
       int lcm_sym79__;
@@ -9854,10 +11676,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       int lcm_sym68__;
       int lcm_sym67__;
       int lcm_sym66__;
-      int lcm_sym65__;
-      int lcm_sym64__;
-      int lcm_sym63__;
-      int lcm_sym62__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -9884,20 +11702,20 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
           DUMMY_VAR__);
       local_scalar_t__ mu = DUMMY_VAR__;
-      lcm_sym98__ = stan::math::logit(mean_phi);
-      mu = lcm_sym98__;
-      lcm_sym62__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym62__) {
-        lcm_sym101__ = stan::model::rvalue(first, "first",
+      lcm_sym102__ = stan::math::logit(mean_phi);
+      mu = lcm_sym102__;
+      lcm_sym66__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym66__) {
+        lcm_sym105__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym75__ = (lcm_sym101__ - 1);
-        if (stan::math::logical_gte(lcm_sym75__, 1)) {
+        lcm_sym79__ = (lcm_sym105__ - 1);
+        if (stan::math::logical_gte(lcm_sym79__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 9;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym75__; ++t) {
+          for (int t = 2; t <= lcm_sym79__; ++t) {
             current_statement__ = 10;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -9906,19 +11724,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym73__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym73__, lcm_sym101__)) {
-          lcm_sym97__ = stan::math::inv_logit((lcm_sym98__ +
-                          stan::model::rvalue(epsilon, "epsilon",
-                            stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym97__, "assigning variable phi",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
-          lcm_sym81__ = (lcm_sym101__ + 1);
+        lcm_sym77__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym77__, lcm_sym105__)) {
+          lcm_sym101__ = stan::math::inv_logit((lcm_sym102__ +
+                           stan::model::rvalue(epsilon, "epsilon",
+                             stan::model::index_uni(1))));
+          stan::model::assign(phi, lcm_sym101__, "assigning variable phi",
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym105__));
+          lcm_sym85__ = (lcm_sym105__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
-          for (int t = lcm_sym81__; t <= lcm_sym73__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym105__));
+          for (int t = lcm_sym85__; t <= lcm_sym77__; ++t) {
             current_statement__ = 12;
-            stan::model::assign(phi, lcm_sym97__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym101__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             current_statement__ = 13;
             stan::model::assign(p, mean_p, "assigning variable p",
@@ -9926,16 +11744,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym100__ = stan::model::rvalue(first, "first",
+          lcm_sym104__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym74__ = (lcm_sym100__ - 1);
-          if (stan::math::logical_gte(lcm_sym74__, 1)) {
+          lcm_sym78__ = (lcm_sym104__ - 1);
+          if (stan::math::logical_gte(lcm_sym78__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 9;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym74__; ++t) {
+            for (int t = 2; t <= lcm_sym78__; ++t) {
               current_statement__ = 10;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -9945,19 +11763,20 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
           current_statement__ = 15;
-          if (stan::math::logical_gte(lcm_sym73__, lcm_sym100__)) {
-            lcm_sym96__ = stan::math::inv_logit((lcm_sym98__ +
-                            stan::model::rvalue(epsilon, "epsilon",
-                              stan::model::index_uni(i))));
-            stan::model::assign(phi, lcm_sym96__, "assigning variable phi",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
-            lcm_sym80__ = (lcm_sym100__ + 1);
+          if (stan::math::logical_gte(lcm_sym77__, lcm_sym104__)) {
+            lcm_sym100__ = stan::math::inv_logit((lcm_sym102__ +
+                             stan::model::rvalue(epsilon, "epsilon",
+                               stan::model::index_uni(i))));
+            stan::model::assign(phi, lcm_sym100__, "assigning variable phi",
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym104__));
+            lcm_sym84__ = (lcm_sym104__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
-            for (int t = lcm_sym80__; t <= lcm_sym73__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym104__));
+            for (int t = lcm_sym84__; t <= lcm_sym77__; ++t) {
               current_statement__ = 12;
-              stan::model::assign(phi, lcm_sym96__, "assigning variable phi",
-                stan::model::index_uni(i), stan::model::index_uni(t));
+              stan::model::assign(phi, lcm_sym100__,
+                "assigning variable phi", stan::model::index_uni(i),
+                stan::model::index_uni(t));
               current_statement__ = 13;
               stan::model::assign(p, mean_p, "assigning variable p",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -9978,58 +11797,58 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 27;
-        if (lcm_sym62__) {
+        if (lcm_sym66__) {
           current_statement__ = 20;
           stan::model::assign(inline_prob_uncaptured_chi_sym9__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym9__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym73__ = (n_occasions - 1);
-          lcm_sym63__ = stan::math::logical_gte(lcm_sym73__, 1);
-          if (lcm_sym63__) {
+          lcm_sym77__ = (n_occasions - 1);
+          lcm_sym67__ = stan::math::logical_gte(lcm_sym77__, 1);
+          if (lcm_sym67__) {
             int inline_prob_uncaptured_t_curr_sym10__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym11__ =
               std::numeric_limits<int>::min();
-            lcm_sym77__ = (lcm_sym73__ + 1);
+            lcm_sym81__ = (lcm_sym77__ + 1);
             current_statement__ = 23;
             stan::model::assign(inline_prob_uncaptured_chi_sym9__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym73__)) * (1 -
+                   stan::model::index_uni(lcm_sym77__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym77__ - 1))))),
+                  stan::model::index_uni((lcm_sym81__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                   "inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym77__)), (1 -
+                  stan::model::index_uni(lcm_sym81__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym73__)))),
+                  stan::model::index_uni(lcm_sym77__)))),
               "assigning variable inline_prob_uncaptured_chi_sym9__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym73__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym77__));
             for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                 <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
+                 <= lcm_sym77__; ++inline_prob_uncaptured_t_sym12__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym72__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
-              lcm_sym76__ = (lcm_sym72__ + 1);
+              lcm_sym76__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
+              lcm_sym80__ = (lcm_sym76__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym72__)) * (1 -
+                     stan::model::index_uni(lcm_sym76__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym76__ - 1))))),
+                    stan::model::index_uni((lcm_sym80__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym76__)), (1 -
+                    stan::model::index_uni(lcm_sym80__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym72__)))),
+                    stan::model::index_uni(lcm_sym76__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym72__));
+                stan::model::index_uni(lcm_sym76__));
             }
           }
           for (int inline_prob_uncaptured_i_sym13__ = 2; inline_prob_uncaptured_i_sym13__
@@ -10040,60 +11859,60 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 25;
-            if (lcm_sym63__) {
+            if (lcm_sym67__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym77__ = (lcm_sym73__ + 1);
+              lcm_sym81__ = (lcm_sym77__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                     stan::model::index_uni(lcm_sym73__)) * (1 -
+                     stan::model::index_uni(lcm_sym77__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni((lcm_sym77__ - 1))))),
+                    stan::model::index_uni((lcm_sym81__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym77__)), (1 -
+                    stan::model::index_uni(lcm_sym81__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym73__)))),
+                    stan::model::index_uni(lcm_sym77__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                stan::model::index_uni(lcm_sym73__));
+                stan::model::index_uni(lcm_sym77__));
               for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                   <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
+                   <= lcm_sym77__; ++inline_prob_uncaptured_t_sym12__) {
                 int inline_prob_uncaptured_t_curr_sym10__ =
                   std::numeric_limits<int>::min();
                 int inline_prob_uncaptured_t_next_sym11__ =
                   std::numeric_limits<int>::min();
-                lcm_sym72__ = (n_occasions -
+                lcm_sym76__ = (n_occasions -
                   inline_prob_uncaptured_t_sym12__);
-                lcm_sym76__ = (lcm_sym72__ + 1);
+                lcm_sym80__ = (lcm_sym76__ + 1);
                 current_statement__ = 23;
                 stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym13__),
-                       stan::model::index_uni(lcm_sym72__)) * (1 -
+                       stan::model::index_uni(lcm_sym76__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni((lcm_sym76__ - 1))))),
+                      stan::model::index_uni((lcm_sym80__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                       "inline_prob_uncaptured_chi_sym9__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym76__)), (1 -
+                      stan::model::index_uni(lcm_sym80__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym72__)))),
+                      stan::model::index_uni(lcm_sym76__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                  stan::model::index_uni(lcm_sym72__));
+                  stan::model::index_uni(lcm_sym76__));
               }
             }
           }
@@ -10123,28 +11942,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         current_statement__ = 30;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
         current_statement__ = 37;
-        if (lcm_sym62__) {
-          lcm_sym101__ = stan::model::rvalue(first, "first",
+        if (lcm_sym66__) {
+          lcm_sym105__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym101__, 0)) {
-            lcm_sym103__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym105__, 0)) {
+            lcm_sym107__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym81__ = (lcm_sym101__ + 1);
-            if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
+            lcm_sym85__ = (lcm_sym105__ + 1);
+            if (stan::math::logical_gte(lcm_sym107__, lcm_sym85__)) {
               current_statement__ = 31;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym81__ - 1)))));
-              lcm_sym79__ = (lcm_sym81__ + 1);
+                                 stan::model::index_uni((lcm_sym85__ - 1)))));
+              lcm_sym83__ = (lcm_sym85__ + 1);
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                stan::model::rvalue(y, "y",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym81__)),
+                                 stan::model::index_uni(lcm_sym85__)),
                                stan::model::rvalue(p, "p",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym81__ - 1)))));
-              for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
+                                 stan::model::index_uni((lcm_sym85__ - 1)))));
+              for (int t = lcm_sym83__; t <= lcm_sym107__; ++t) {
                 current_statement__ = 31;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
@@ -10166,30 +11985,30 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                                inline_prob_uncaptured_return_sym8__,
                                "inline_prob_uncaptured_return_sym8__",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(lcm_sym103__))));
+                               stan::model::index_uni(lcm_sym107__))));
           }
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym100__ = stan::model::rvalue(first, "first",
+            lcm_sym104__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym100__, 0)) {
-              lcm_sym102__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym104__, 0)) {
+              lcm_sym106__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym80__ = (lcm_sym100__ + 1);
-              if (stan::math::logical_gte(lcm_sym102__, lcm_sym80__)) {
+              lcm_sym84__ = (lcm_sym104__ + 1);
+              if (stan::math::logical_gte(lcm_sym106__, lcm_sym84__)) {
                 current_statement__ = 31;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym80__ - 1)))));
-                lcm_sym78__ = (lcm_sym80__ + 1);
+                                   stan::model::index_uni((lcm_sym84__ - 1)))));
+                lcm_sym82__ = (lcm_sym84__ + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni(lcm_sym80__)),
+                                   stan::model::index_uni(lcm_sym84__)),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym80__ - 1)))));
-                for (int t = lcm_sym78__; t <= lcm_sym102__; ++t) {
+                                   stan::model::index_uni((lcm_sym84__ - 1)))));
+                for (int t = lcm_sym82__; t <= lcm_sym106__; ++t) {
                   current_statement__ = 31;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -10211,7 +12030,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                                  inline_prob_uncaptured_return_sym8__,
                                  "inline_prob_uncaptured_return_sym8__",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(lcm_sym102__))));
+                                 stan::model::index_uni(lcm_sym106__))));
             }
           }
         }
@@ -10253,17 +12072,21 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym65__;
+      int lcm_sym64__;
+      int lcm_sym63__;
+      double lcm_sym62__;
       double lcm_sym61__;
-      int lcm_sym60__;
-      int lcm_sym59__;
+      local_scalar_t__ lcm_sym60__;
+      local_scalar_t__ lcm_sym59__;
       double lcm_sym58__;
       double lcm_sym57__;
-      local_scalar_t__ lcm_sym56__;
-      local_scalar_t__ lcm_sym55__;
-      double lcm_sym54__;
-      double lcm_sym53__;
-      double lcm_sym52__;
-      double lcm_sym51__;
+      double lcm_sym56__;
+      double lcm_sym55__;
+      int lcm_sym54__;
+      int lcm_sym53__;
+      int lcm_sym52__;
+      int lcm_sym51__;
       int lcm_sym50__;
       int lcm_sym49__;
       int lcm_sym48__;
@@ -10276,10 +12099,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       int lcm_sym41__;
       int lcm_sym40__;
       int lcm_sym39__;
-      int lcm_sym38__;
-      int lcm_sym37__;
-      int lcm_sym36__;
-      int lcm_sym35__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -10315,20 +12134,20 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym57__ = stan::math::logit(mean_phi);
-      mu = lcm_sym57__;
-      lcm_sym35__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym35__) {
-        lcm_sym60__ = stan::model::rvalue(first, "first",
+      lcm_sym61__ = stan::math::logit(mean_phi);
+      mu = lcm_sym61__;
+      lcm_sym39__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym39__) {
+        lcm_sym64__ = stan::model::rvalue(first, "first",
                         stan::model::index_uni(1));
-        lcm_sym44__ = (lcm_sym60__ - 1);
-        if (stan::math::logical_gte(lcm_sym44__, 1)) {
+        lcm_sym48__ = (lcm_sym64__ - 1);
+        if (stan::math::logical_gte(lcm_sym48__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 9;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym44__; ++t) {
+          for (int t = 2; t <= lcm_sym48__; ++t) {
             current_statement__ = 10;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -10337,19 +12156,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym42__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym42__, lcm_sym60__)) {
-          lcm_sym56__ = stan::math::inv_logit((lcm_sym57__ +
+        lcm_sym46__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym46__, lcm_sym64__)) {
+          lcm_sym60__ = stan::math::inv_logit((lcm_sym61__ +
                           stan::model::rvalue(epsilon, "epsilon",
                             stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym56__, "assigning variable phi",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
-          lcm_sym50__ = (lcm_sym60__ + 1);
+          stan::model::assign(phi, lcm_sym60__, "assigning variable phi",
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym64__));
+          lcm_sym54__ = (lcm_sym64__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
-          for (int t = lcm_sym50__; t <= lcm_sym42__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym64__));
+          for (int t = lcm_sym54__; t <= lcm_sym46__; ++t) {
             current_statement__ = 12;
-            stan::model::assign(phi, lcm_sym56__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym60__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             current_statement__ = 13;
             stan::model::assign(p, mean_p, "assigning variable p",
@@ -10357,16 +12176,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym59__ = stan::model::rvalue(first, "first",
+          lcm_sym63__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym43__ = (lcm_sym59__ - 1);
-          if (stan::math::logical_gte(lcm_sym43__, 1)) {
+          lcm_sym47__ = (lcm_sym63__ - 1);
+          if (stan::math::logical_gte(lcm_sym47__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 9;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym43__; ++t) {
+            for (int t = 2; t <= lcm_sym47__; ++t) {
               current_statement__ = 10;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -10376,18 +12195,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
           current_statement__ = 15;
-          if (stan::math::logical_gte(lcm_sym42__, lcm_sym59__)) {
-            lcm_sym55__ = stan::math::inv_logit((lcm_sym57__ +
+          if (stan::math::logical_gte(lcm_sym46__, lcm_sym63__)) {
+            lcm_sym59__ = stan::math::inv_logit((lcm_sym61__ +
                             stan::model::rvalue(epsilon, "epsilon",
                               stan::model::index_uni(i))));
-            stan::model::assign(phi, lcm_sym55__, "assigning variable phi",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
-            lcm_sym49__ = (lcm_sym59__ + 1);
+            stan::model::assign(phi, lcm_sym59__, "assigning variable phi",
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym63__));
+            lcm_sym53__ = (lcm_sym63__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
-            for (int t = lcm_sym49__; t <= lcm_sym42__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym63__));
+            for (int t = lcm_sym53__; t <= lcm_sym46__; ++t) {
               current_statement__ = 12;
-              stan::model::assign(phi, lcm_sym55__, "assigning variable phi",
+              stan::model::assign(phi, lcm_sym59__, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
               current_statement__ = 13;
               stan::model::assign(p, mean_p, "assigning variable p",
@@ -10408,58 +12227,58 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 27;
-        if (lcm_sym35__) {
+        if (lcm_sym39__) {
           current_statement__ = 20;
           stan::model::assign(inline_prob_uncaptured_chi_sym2__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym2__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym42__ = (n_occasions - 1);
-          lcm_sym36__ = stan::math::logical_gte(lcm_sym42__, 1);
-          if (lcm_sym36__) {
+          lcm_sym46__ = (n_occasions - 1);
+          lcm_sym40__ = stan::math::logical_gte(lcm_sym46__, 1);
+          if (lcm_sym40__) {
             int inline_prob_uncaptured_t_curr_sym3__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym4__ =
               std::numeric_limits<int>::min();
-            lcm_sym48__ = (lcm_sym42__ + 1);
+            lcm_sym52__ = (lcm_sym46__ + 1);
             current_statement__ = 23;
             stan::model::assign(inline_prob_uncaptured_chi_sym2__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym42__)) * (1 -
+                   stan::model::index_uni(lcm_sym46__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym48__ - 1))))),
+                  stan::model::index_uni((lcm_sym52__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                   "inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym48__)), (1 -
+                  stan::model::index_uni(lcm_sym52__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym42__)))),
+                  stan::model::index_uni(lcm_sym46__)))),
               "assigning variable inline_prob_uncaptured_chi_sym2__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym42__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym46__));
             for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                 <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
+                 <= lcm_sym46__; ++inline_prob_uncaptured_t_sym5__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym41__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
-              lcm_sym47__ = (lcm_sym41__ + 1);
+              lcm_sym45__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
+              lcm_sym51__ = (lcm_sym45__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym41__)) * (1 -
+                     stan::model::index_uni(lcm_sym45__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym47__ - 1))))),
+                    stan::model::index_uni((lcm_sym51__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym47__)), (1 -
+                    stan::model::index_uni(lcm_sym51__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym41__)))),
+                    stan::model::index_uni(lcm_sym45__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym41__));
+                stan::model::index_uni(lcm_sym45__));
             }
           }
           for (int inline_prob_uncaptured_i_sym6__ = 2; inline_prob_uncaptured_i_sym6__
@@ -10470,59 +12289,59 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 25;
-            if (lcm_sym36__) {
+            if (lcm_sym40__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym48__ = (lcm_sym42__ + 1);
+              lcm_sym52__ = (lcm_sym46__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                     stan::model::index_uni(lcm_sym42__)) * (1 -
+                     stan::model::index_uni(lcm_sym46__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni((lcm_sym48__ - 1))))),
+                    stan::model::index_uni((lcm_sym52__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym48__)), (1 -
+                    stan::model::index_uni(lcm_sym52__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym42__)))),
+                    stan::model::index_uni(lcm_sym46__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                stan::model::index_uni(lcm_sym42__));
+                stan::model::index_uni(lcm_sym46__));
               for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                   <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
+                   <= lcm_sym46__; ++inline_prob_uncaptured_t_sym5__) {
                 int inline_prob_uncaptured_t_curr_sym3__ =
                   std::numeric_limits<int>::min();
                 int inline_prob_uncaptured_t_next_sym4__ =
                   std::numeric_limits<int>::min();
-                lcm_sym41__ = (n_occasions -
+                lcm_sym45__ = (n_occasions -
                   inline_prob_uncaptured_t_sym5__);
-                lcm_sym47__ = (lcm_sym41__ + 1);
+                lcm_sym51__ = (lcm_sym45__ + 1);
                 current_statement__ = 23;
                 stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                       stan::model::index_uni(lcm_sym41__)) * (1 -
+                       stan::model::index_uni(lcm_sym45__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni((lcm_sym47__ - 1))))),
+                      stan::model::index_uni((lcm_sym51__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                       "inline_prob_uncaptured_chi_sym2__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym47__)), (1 -
+                      stan::model::index_uni(lcm_sym51__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym41__)))),
+                      stan::model::index_uni(lcm_sym45__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                  stan::model::index_uni(lcm_sym41__));
+                  stan::model::index_uni(lcm_sym45__));
               }
             }
           }
@@ -10552,17 +12371,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         out__.write(phi);
         out__.write(p);
         out__.write(inline_prob_uncaptured_return_sym1__);
-        out__.write(lcm_sym57__);
+        out__.write(lcm_sym61__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
         return ;
       }
       double sigma2 = std::numeric_limits<double>::quiet_NaN();
-      lcm_sym58__ = stan::math::square(sigma);
-      sigma2 = lcm_sym58__;
+      lcm_sym62__ = stan::math::square(sigma);
+      sigma2 = lcm_sym62__;
       current_statement__ = 29;
-      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym58__, 0);
-      out__.write(lcm_sym58__);
+      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym62__, 0);
+      out__.write(lcm_sym62__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10571,8 +12390,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -10596,6 +12415,56 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym38__;
+      double lcm_sym37__;
+      int lcm_sym36__;
+      int lcm_sym35__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(nind, DUMMY_VAR__);
+      {
+        std::vector<double> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        if (stan::math::logical_gte(nind, 1)) {
+          stan::model::assign(epsilon,
+            stan::model::rvalue(epsilon_flat__, "epsilon_flat__",
+              stan::model::index_uni(1)), "assigning variable epsilon",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
+            stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+              "assigning variable epsilon", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10649,28 +12518,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym115__ = 1; sym115__ <= nind; ++sym115__) {
+    for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym115__));
+        std::to_string(sym119__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
-        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
+        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym116__) + '.' + std::to_string(sym115__));
+            std::to_string(sym120__) + '.' + std::to_string(sym119__));
         }
       }
-      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
-        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
+        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym116__) + '.' + std::to_string(sym115__));
+            std::to_string(sym120__) + '.' + std::to_string(sym119__));
         }
       }
-      for (int sym115__ = 1; sym115__ <= n_occasions; ++sym115__) {
-        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+      for (int sym119__ = 1; sym119__ <= n_occasions; ++sym119__) {
+        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym116__) + '.' + std::to_string(sym115__));
+            std::to_string(sym120__) + '.' + std::to_string(sym119__));
         }
       }
       param_names__.emplace_back(std::string() + "mu");
@@ -10685,28 +12554,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym115__ = 1; sym115__ <= nind; ++sym115__) {
+    for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym115__));
+        std::to_string(sym119__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
-        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
+        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym116__) + '.' + std::to_string(sym115__));
+            std::to_string(sym120__) + '.' + std::to_string(sym119__));
         }
       }
-      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
-        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
+        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym116__) + '.' + std::to_string(sym115__));
+            std::to_string(sym120__) + '.' + std::to_string(sym119__));
         }
       }
-      for (int sym115__ = 1; sym115__ <= n_occasions; ++sym115__) {
-        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+      for (int sym119__ = 1; sym119__ <= n_occasions; ++sym119__) {
+        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym116__) + '.' + std::to_string(sym115__));
+            std::to_string(sym120__) + '.' + std::to_string(sym119__));
         }
       }
       param_names__.emplace_back(std::string() + "mu");
@@ -10781,25 +12650,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"mean_phi", "mean_p", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, nind, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -11761,16 +13622,16 @@ js_super_lp(const std::vector<std::vector<int>>& y, const std::vector<int>&
 }
 class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model> {
  private:
+  int lcm_sym253__;
+  int lcm_sym252__;
+  int lcm_sym251__;
+  int lcm_sym250__;
+  int lcm_sym249__;
+  int lcm_sym248__;
+  int lcm_sym247__;
   int lcm_sym246__;
   int lcm_sym245__;
   int lcm_sym244__;
-  int lcm_sym243__;
-  int lcm_sym242__;
-  int lcm_sym241__;
-  int lcm_sym240__;
-  int lcm_sym239__;
-  int lcm_sym238__;
-  int lcm_sym237__;
   int M;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -11833,8 +13694,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         pos__ = 1;
         current_statement__ = 115;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym237__ = stan::math::logical_gte(M, 1);
-          if (lcm_sym237__) {
+          lcm_sym244__ = stan::math::logical_gte(M, 1);
+          if (lcm_sym244__) {
             current_statement__ = 115;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -11853,7 +13714,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 115;
-            if (lcm_sym237__) {
+            if (lcm_sym244__) {
               current_statement__ = 115;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -11871,7 +13732,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             }
           }
         } else {
-          lcm_sym237__ = stan::math::logical_gte(M, 1);
+          lcm_sym244__ = stan::math::logical_gte(M, 1);
         }
       }
       current_statement__ = 115;
@@ -11887,7 +13748,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       current_statement__ = 119;
       last = std::vector<int>(M, std::numeric_limits<int>::min());
       current_statement__ = 121;
-      if (lcm_sym237__) {
+      if (lcm_sym244__) {
         current_statement__ = 120;
         stan::model::assign(first,
           first_capture(
@@ -11903,7 +13764,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         }
       }
       current_statement__ = 123;
-      if (lcm_sym237__) {
+      if (lcm_sym244__) {
         current_statement__ = 122;
         stan::model::assign(last,
           last_capture(
@@ -11935,11 +13796,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::validate_non_negative_index("phi", "M", M);
       current_statement__ = 127;
       phi_2dim__ = std::numeric_limits<int>::min();
-      lcm_sym239__ = (n_occasions - 1);
-      phi_2dim__ = lcm_sym239__;
+      lcm_sym246__ = (n_occasions - 1);
+      phi_2dim__ = lcm_sym246__;
       current_statement__ = 127;
       stan::math::validate_non_negative_index("phi", "n_occasions - 1",
-        lcm_sym239__);
+        lcm_sym246__);
       current_statement__ = 128;
       stan::math::validate_non_negative_index("p", "M", M);
       current_statement__ = 129;
@@ -11994,24 +13855,31 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) function__;
     try {
+      int lcm_sym243__;
+      int lcm_sym242__;
+      local_scalar_t__ lcm_sym241__;
+      int lcm_sym240__;
+      int lcm_sym239__;
+      int lcm_sym238__;
+      int lcm_sym237__;
       int lcm_sym236__;
-      int lcm_sym235__;
-      local_scalar_t__ lcm_sym234__;
-      int lcm_sym233__;
-      int lcm_sym232__;
-      int lcm_sym231__;
-      int lcm_sym230__;
-      int lcm_sym229__;
-      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym228__;
+      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym235__;
+      double lcm_sym234__;
+      double lcm_sym233__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym232__;
+      double lcm_sym231__;
+      double lcm_sym230__;
+      double lcm_sym229__;
+      double lcm_sym228__;
       double lcm_sym227__;
-      double lcm_sym226__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym225__;
+      int lcm_sym226__;
+      double lcm_sym225__;
       double lcm_sym224__;
       double lcm_sym223__;
       double lcm_sym222__;
       double lcm_sym221__;
       double lcm_sym220__;
-      int lcm_sym219__;
+      double lcm_sym219__;
       double lcm_sym218__;
       double lcm_sym217__;
       double lcm_sym216__;
@@ -12019,17 +13887,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       double lcm_sym214__;
       double lcm_sym213__;
       double lcm_sym212__;
-      double lcm_sym211__;
+      int lcm_sym211__;
       double lcm_sym210__;
-      double lcm_sym209__;
-      double lcm_sym208__;
+      int lcm_sym209__;
+      int lcm_sym208__;
       double lcm_sym207__;
       double lcm_sym206__;
       double lcm_sym205__;
-      int lcm_sym204__;
+      double lcm_sym204__;
       double lcm_sym203__;
-      int lcm_sym202__;
-      int lcm_sym201__;
+      double lcm_sym202__;
+      double lcm_sym201__;
       double lcm_sym200__;
       double lcm_sym199__;
       double lcm_sym198__;
@@ -12037,39 +13905,32 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       double lcm_sym196__;
       double lcm_sym195__;
       double lcm_sym194__;
-      double lcm_sym193__;
-      double lcm_sym192__;
+      int lcm_sym193__;
+      int lcm_sym192__;
       double lcm_sym191__;
-      double lcm_sym190__;
-      double lcm_sym189__;
-      double lcm_sym188__;
-      double lcm_sym187__;
-      int lcm_sym186__;
-      int lcm_sym185__;
-      double lcm_sym184__;
+      int lcm_sym190__;
+      int lcm_sym189__;
+      int lcm_sym188__;
+      int lcm_sym187__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym186__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym185__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym184__;
       int lcm_sym183__;
       int lcm_sym182__;
       int lcm_sym181__;
       int lcm_sym180__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym179__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym178__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym177__;
+      int lcm_sym179__;
+      int lcm_sym178__;
+      int lcm_sym177__;
       int lcm_sym176__;
       int lcm_sym175__;
       int lcm_sym174__;
       int lcm_sym173__;
       int lcm_sym172__;
       int lcm_sym171__;
-      int lcm_sym170__;
-      int lcm_sym169__;
-      int lcm_sym168__;
-      int lcm_sym167__;
-      int lcm_sym166__;
-      int lcm_sym165__;
-      int lcm_sym164__;
-      double lcm_sym163__;
-      double lcm_sym162__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym161__;
+      double lcm_sym170__;
+      double lcm_sym169__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym168__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -12109,56 +13970,56 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       Eigen::Matrix<local_scalar_t__,-1,-1> chi =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, n_occasions,
           DUMMY_VAR__);
-      lcm_sym176__ = (n_occasions - 1);
-      stan::model::assign(lcm_sym228__,
-        stan::math::rep_matrix(mean_phi, M, lcm_sym176__),
-        "assigning variable lcm_sym228__");
-      stan::model::assign(phi, lcm_sym228__, "assigning variable phi");
+      lcm_sym183__ = (n_occasions - 1);
+      stan::model::assign(lcm_sym235__,
+        stan::math::rep_matrix(mean_phi, M, lcm_sym183__),
+        "assigning variable lcm_sym235__");
+      stan::model::assign(phi, lcm_sym235__, "assigning variable phi");
       current_statement__ = 76;
       if (stan::math::logical_gte(n_occasions, 1)) {
-        stan::model::assign(lcm_sym225__,
+        stan::model::assign(lcm_sym232__,
           stan::math::inv_logit(
             stan::math::add(stan::math::logit(mean_p), epsilon)),
-          "assigning variable lcm_sym225__");
-        stan::model::assign(p, lcm_sym225__, "assigning variable p",
+          "assigning variable lcm_sym232__");
+        stan::model::assign(p, lcm_sym232__, "assigning variable p",
           stan::model::index_omni(), stan::model::index_uni(1));
         for (int t = 2; t <= n_occasions; ++t) {
           current_statement__ = 12;
-          stan::model::assign(p, lcm_sym225__, "assigning variable p",
+          stan::model::assign(p, lcm_sym232__, "assigning variable p",
             stan::model::index_omni(), stan::model::index_uni(t));
         }
       }
-      stan::model::assign(lcm_sym161__,
+      stan::model::assign(lcm_sym168__,
         stan::math::divide(beta, stan::math::sum(beta)),
-        "assigning variable lcm_sym161__");
-      stan::model::assign(b, lcm_sym161__, "assigning variable b");
+        "assigning variable lcm_sym168__");
+      stan::model::assign(b, lcm_sym168__, "assigning variable b");
       {
         local_scalar_t__ cum_b = DUMMY_VAR__;
-        lcm_sym234__ = stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
+        lcm_sym241__ = stan::model::rvalue(lcm_sym168__, "lcm_sym168__",
                          stan::model::index_uni(1));
         current_statement__ = 14;
-        stan::model::assign(nu, lcm_sym234__, "assigning variable nu",
+        stan::model::assign(nu, lcm_sym241__, "assigning variable nu",
           stan::model::index_uni(1));
         current_statement__ = 18;
-        if (stan::math::logical_gte(lcm_sym176__, 2)) {
+        if (stan::math::logical_gte(lcm_sym183__, 2)) {
           current_statement__ = 15;
           stan::model::assign(nu,
-            (stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
-               stan::model::index_uni(2)) / (1.0 - lcm_sym234__)),
+            (stan::model::rvalue(lcm_sym168__, "lcm_sym168__",
+               stan::model::index_uni(2)) / (1.0 - lcm_sym241__)),
             "assigning variable nu", stan::model::index_uni(2));
           current_statement__ = 16;
-          cum_b = (lcm_sym234__ +
-            stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
+          cum_b = (lcm_sym241__ +
+            stan::model::rvalue(lcm_sym168__, "lcm_sym168__",
               stan::model::index_uni(2)));
-          for (int t = 3; t <= lcm_sym176__; ++t) {
+          for (int t = 3; t <= lcm_sym183__; ++t) {
             current_statement__ = 15;
             stan::model::assign(nu,
-              (stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
+              (stan::model::rvalue(lcm_sym168__, "lcm_sym168__",
                  stan::model::index_uni(t)) / (1.0 - cum_b)),
               "assigning variable nu", stan::model::index_uni(t));
             current_statement__ = 16;
             cum_b = (cum_b +
-              stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
+              stan::model::rvalue(lcm_sym168__, "lcm_sym168__",
                 stan::model::index_uni(t)));
           }
         }
@@ -12171,141 +14032,141 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       {
         int inline_prob_uncaptured_n_ind_sym15__ =
           std::numeric_limits<int>::min();
-        lcm_sym229__ = stan::math::rows(p);
+        lcm_sym236__ = stan::math::rows(p);
         int inline_prob_uncaptured_n_occasions_sym16__ =
           std::numeric_limits<int>::min();
-        lcm_sym219__ = stan::math::cols(p);
+        lcm_sym226__ = stan::math::cols(p);
         current_statement__ = 23;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym229__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym236__);
         current_statement__ = 24;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym219__);
+          lcm_sym226__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym17__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym229__,
-            lcm_sym219__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym236__,
+            lcm_sym226__, DUMMY_VAR__);
         current_statement__ = 33;
-        if (stan::math::logical_gte(lcm_sym229__, 1)) {
+        if (stan::math::logical_gte(lcm_sym236__, 1)) {
           current_statement__ = 26;
           stan::model::assign(inline_prob_uncaptured_chi_sym17__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym17__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym219__));
-          lcm_sym181__ = (lcm_sym219__ - 1);
-          lcm_sym168__ = stan::math::logical_gte(lcm_sym181__, 1);
-          if (lcm_sym168__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym226__));
+          lcm_sym188__ = (lcm_sym226__ - 1);
+          lcm_sym175__ = stan::math::logical_gte(lcm_sym188__, 1);
+          if (lcm_sym175__) {
             int inline_prob_uncaptured_t_curr_sym18__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym19__ =
               std::numeric_limits<int>::min();
-            lcm_sym186__ = (lcm_sym181__ + 1);
+            lcm_sym193__ = (lcm_sym188__ + 1);
             current_statement__ = 29;
             stan::model::assign(inline_prob_uncaptured_chi_sym17__,
               stan::math::fma(
-                (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                (stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                    stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym181__)) * (1 -
+                   stan::model::index_uni(lcm_sym188__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym186__)))),
+                  stan::model::index_uni(lcm_sym193__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                   "inline_prob_uncaptured_chi_sym17__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym186__)), (1 -
-                stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                  stan::model::index_uni(lcm_sym193__)), (1 -
+                stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym181__)))),
+                  stan::model::index_uni(lcm_sym188__)))),
               "assigning variable inline_prob_uncaptured_chi_sym17__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym181__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym188__));
             for (int inline_prob_uncaptured_t_sym20__ = 2; inline_prob_uncaptured_t_sym20__
-                 <= lcm_sym181__; ++inline_prob_uncaptured_t_sym20__) {
+                 <= lcm_sym188__; ++inline_prob_uncaptured_t_sym20__) {
               int inline_prob_uncaptured_t_curr_sym18__ =
                 std::numeric_limits<int>::min();
-              lcm_sym180__ = (lcm_sym219__ -
+              lcm_sym187__ = (lcm_sym226__ -
                 inline_prob_uncaptured_t_sym20__);
               int inline_prob_uncaptured_t_next_sym19__ =
                 std::numeric_limits<int>::min();
-              lcm_sym185__ = (lcm_sym180__ + 1);
+              lcm_sym192__ = (lcm_sym187__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym17__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                  (stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                      stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym180__)) * (1 -
+                     stan::model::index_uni(lcm_sym187__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym185__)))),
+                    stan::model::index_uni(lcm_sym192__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                     "inline_prob_uncaptured_chi_sym17__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym185__)), (1 -
-                  stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                    stan::model::index_uni(lcm_sym192__)), (1 -
+                  stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym180__)))),
+                    stan::model::index_uni(lcm_sym187__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym17__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym180__));
+                stan::model::index_uni(lcm_sym187__));
             }
           }
           for (int inline_prob_uncaptured_i_sym21__ = 2; inline_prob_uncaptured_i_sym21__
-               <= lcm_sym229__; ++inline_prob_uncaptured_i_sym21__) {
+               <= lcm_sym236__; ++inline_prob_uncaptured_i_sym21__) {
             current_statement__ = 26;
             stan::model::assign(inline_prob_uncaptured_chi_sym17__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym17__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-              stan::model::index_uni(lcm_sym219__));
+              stan::model::index_uni(lcm_sym226__));
             current_statement__ = 31;
-            if (lcm_sym168__) {
+            if (lcm_sym175__) {
               int inline_prob_uncaptured_t_curr_sym18__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym19__ =
                 std::numeric_limits<int>::min();
-              lcm_sym186__ = (lcm_sym181__ + 1);
+              lcm_sym193__ = (lcm_sym188__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym17__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                  (stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                     stan::model::index_uni(lcm_sym181__)) * (1 -
+                     stan::model::index_uni(lcm_sym188__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                    stan::model::index_uni(lcm_sym186__)))),
+                    stan::model::index_uni(lcm_sym193__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                     "inline_prob_uncaptured_chi_sym17__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                    stan::model::index_uni(lcm_sym186__)), (1 -
-                  stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                    stan::model::index_uni(lcm_sym193__)), (1 -
+                  stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                    stan::model::index_uni(lcm_sym181__)))),
+                    stan::model::index_uni(lcm_sym188__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym17__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                stan::model::index_uni(lcm_sym181__));
+                stan::model::index_uni(lcm_sym188__));
               for (int inline_prob_uncaptured_t_sym20__ = 2; inline_prob_uncaptured_t_sym20__
-                   <= lcm_sym181__; ++inline_prob_uncaptured_t_sym20__) {
+                   <= lcm_sym188__; ++inline_prob_uncaptured_t_sym20__) {
                 int inline_prob_uncaptured_t_curr_sym18__ =
                   std::numeric_limits<int>::min();
-                lcm_sym180__ = (lcm_sym219__ -
+                lcm_sym187__ = (lcm_sym226__ -
                   inline_prob_uncaptured_t_sym20__);
                 int inline_prob_uncaptured_t_next_sym19__ =
                   std::numeric_limits<int>::min();
-                lcm_sym185__ = (lcm_sym180__ + 1);
+                lcm_sym192__ = (lcm_sym187__ + 1);
                 current_statement__ = 29;
                 stan::model::assign(inline_prob_uncaptured_chi_sym17__,
                   stan::math::fma(
-                    (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                    (stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym21__),
-                       stan::model::index_uni(lcm_sym180__)) * (1 -
+                       stan::model::index_uni(lcm_sym187__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                      stan::model::index_uni(lcm_sym185__)))),
+                      stan::model::index_uni(lcm_sym192__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                       "inline_prob_uncaptured_chi_sym17__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                      stan::model::index_uni(lcm_sym185__)), (1 -
-                    stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                      stan::model::index_uni(lcm_sym192__)), (1 -
+                    stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                      stan::model::index_uni(lcm_sym180__)))),
+                      stan::model::index_uni(lcm_sym187__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym17__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                  stan::model::index_uni(lcm_sym180__));
+                  stan::model::index_uni(lcm_sym187__));
               }
             }
           }
@@ -12318,15 +14179,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::model::assign(chi, inline_prob_uncaptured_return_sym14__,
         "assigning variable chi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "phi", lcm_sym228__, 0);
+      stan::math::check_greater_or_equal(function__, "phi", lcm_sym235__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "phi", lcm_sym228__, 1);
+      stan::math::check_less_or_equal(function__, "phi", lcm_sym235__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "p", p, 0);
       current_statement__ = 8;
       stan::math::check_less_or_equal(function__, "p", p, 1);
       current_statement__ = 9;
-      stan::math::check_simplex(function__, "b", lcm_sym161__);
+      stan::math::check_simplex(function__, "b", lcm_sym168__);
       current_statement__ = 10;
       stan::math::check_greater_or_equal(function__, "nu", nu, 0);
       current_statement__ = 10;
@@ -12345,40 +14206,40 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         {
           int inline_js_super_lp_n_ind_sym23__ =
             std::numeric_limits<int>::min();
-          lcm_sym235__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym242__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(1));
           int inline_js_super_lp_n_occasions_sym24__ =
             std::numeric_limits<int>::min();
-          lcm_sym236__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym243__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(2));
           current_statement__ = 81;
           stan::math::validate_non_negative_index("qnu", "n_occasions",
-            lcm_sym236__);
+            lcm_sym243__);
           Eigen::Matrix<double,-1,1> inline_js_super_lp_qnu_sym25__ =
-            Eigen::Matrix<double,-1,1>::Constant(lcm_sym236__,
+            Eigen::Matrix<double,-1,1>::Constant(lcm_sym243__,
               std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym177__, stan::math::subtract(1.0, nu),
-            "assigning variable lcm_sym177__");
+          stan::model::assign(lcm_sym184__, stan::math::subtract(1.0, nu),
+            "assigning variable lcm_sym184__");
           current_statement__ = 109;
-          if (stan::math::logical_gte(lcm_sym235__, 1)) {
+          if (stan::math::logical_gte(lcm_sym242__, 1)) {
             current_statement__ = 83;
             stan::math::validate_non_negative_index("qp", "n_occasions",
-              lcm_sym236__);
+              lcm_sym243__);
             Eigen::Matrix<double,-1,1> inline_js_super_lp_qp_sym26__ =
-              Eigen::Matrix<double,-1,1>::Constant(lcm_sym236__,
+              Eigen::Matrix<double,-1,1>::Constant(lcm_sym243__,
                 std::numeric_limits<double>::quiet_NaN());
-            stan::model::assign(lcm_sym179__,
+            stan::model::assign(lcm_sym186__,
               stan::math::subtract(1.0,
                 stan::math::transpose(
                   stan::model::rvalue(p, "p", stan::model::index_uni(1)))),
-              "assigning variable lcm_sym179__");
-            lcm_sym231__ = stan::model::rvalue(first, "first",
+              "assigning variable lcm_sym186__");
+            lcm_sym238__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(1));
-            if (lcm_sym231__) {
+            if (lcm_sym238__) {
               current_statement__ = 92;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1, psi));
               current_statement__ = 102;
-              if (stan::math::logical_eq(lcm_sym231__, 1)) {
+              if (stan::math::logical_eq(lcm_sym238__, 1)) {
                 current_statement__ = 100;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  (stan::model::rvalue(nu, "nu",
@@ -12389,84 +14250,84 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               } else {
                 current_statement__ = 93;
                 stan::math::validate_non_negative_index("lp", "first[i]",
-                  lcm_sym231__);
+                  lcm_sym238__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_js_super_lp_lp_sym27__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym231__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym238__,
                     DUMMY_VAR__);
-                lcm_sym183__ = (lcm_sym231__ - 1);
+                lcm_sym190__ = (lcm_sym238__ - 1);
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::model::rvalue(nu, "nu",
                          stan::model::index_uni(1))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
-                        stan::model::index_min_max(1, lcm_sym183__))))) +
+                      stan::model::rvalue(lcm_sym186__, "lcm_sym186__",
+                        stan::model::index_min_max(1, lcm_sym190__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                      stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                         stan::model::index_uni(1),
-                        stan::model::index_min_max(1, lcm_sym183__))))) +
+                        stan::model::index_min_max(1, lcm_sym190__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym231__)))),
+                      stan::model::index_uni(lcm_sym238__)))),
                   "assigning variable inline_js_super_lp_lp_sym27__",
                   stan::model::index_uni(1));
                 current_statement__ = 96;
-                if (stan::math::logical_gte(lcm_sym183__, 2)) {
+                if (stan::math::logical_gte(lcm_sym190__, 2)) {
                   current_statement__ = 95;
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((((stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                            stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
                               stan::model::index_min_max(1, 1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(nu, "nu", stan::model::index_uni(2))))
                     +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
-                          stan::model::index_min_max(2, lcm_sym183__))))) +
+                        stan::model::rvalue(lcm_sym186__, "lcm_sym186__",
+                          stan::model::index_min_max(2, lcm_sym190__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                        stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                           stan::model::index_uni(1),
-                          stan::model::index_min_max(2, lcm_sym183__))))) +
+                          stan::model::index_min_max(2, lcm_sym190__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                        stan::model::index_uni(lcm_sym231__)))),
+                        stan::model::index_uni(lcm_sym238__)))),
                     "assigning variable inline_js_super_lp_lp_sym27__",
                     stan::model::index_uni(2));
                   for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                       <= lcm_sym183__; ++inline_js_super_lp_t_sym28__) {
+                       <= lcm_sym190__; ++inline_js_super_lp_t_sym28__) {
                     current_statement__ = 95;
                     stan::model::assign(inline_js_super_lp_lp_sym27__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym177__,
-                                "lcm_sym177__",
+                              stan::model::rvalue(lcm_sym184__,
+                                "lcm_sym184__",
                                 stan::model::index_min_max(1,
                                   (inline_js_super_lp_t_sym28__ - 1))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         nu[(inline_js_super_lp_t_sym28__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                          stan::model::rvalue(lcm_sym186__, "lcm_sym186__",
                             stan::model::index_min_max(
-                              inline_js_super_lp_t_sym28__, lcm_sym183__)))))
+                              inline_js_super_lp_t_sym28__, lcm_sym190__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                          stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                             stan::model::index_uni(1),
                             stan::model::index_min_max(
-                              inline_js_super_lp_t_sym28__, lcm_sym183__)))))
+                              inline_js_super_lp_t_sym28__, lcm_sym190__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(p, "p",
                           stan::model::index_uni(1),
-                          stan::model::index_uni(lcm_sym231__)))),
+                          stan::model::index_uni(lcm_sym238__)))),
                       "assigning variable inline_js_super_lp_lp_sym27__",
                       stan::model::index_uni(inline_js_super_lp_t_sym28__));
                   }
@@ -12475,42 +14336,42 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   ((stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
-                          stan::model::index_min_max(1, lcm_sym183__)))) +
-                  stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym231__ - 1)]))
+                        stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
+                          stan::model::index_min_max(1, lcm_sym190__)))) +
+                  stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym238__ - 1)]))
                   +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym231__)))),
+                      stan::model::index_uni(lcm_sym238__)))),
                   "assigning variable inline_js_super_lp_lp_sym27__",
-                  stan::model::index_uni(lcm_sym231__));
+                  stan::model::index_uni(lcm_sym238__));
                 current_statement__ = 98;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_js_super_lp_lp_sym27__));
               }
-              lcm_sym233__ = stan::model::rvalue(last, "last",
+              lcm_sym240__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(1));
-              if (stan::math::logical_gte(lcm_sym233__, (lcm_sym231__ + 1))) {
+              if (stan::math::logical_gte(lcm_sym240__, (lcm_sym238__ + 1))) {
                 current_statement__ = 103;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                 stan::model::rvalue(lcm_sym228__,
-                                   "lcm_sym228__", stan::model::index_uni(1),
-                                   stan::model::index_uni(((lcm_sym231__ + 1)
+                                 stan::model::rvalue(lcm_sym235__,
+                                   "lcm_sym235__", stan::model::index_uni(1),
+                                   stan::model::index_uni(((lcm_sym238__ + 1)
                                      - 1)))));
-                lcm_sym202__ = ((lcm_sym231__ + 1) + 1);
+                lcm_sym209__ = ((lcm_sym238__ + 1) + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym231__ + 1))),
+                                   stan::model::index_uni((lcm_sym238__ + 1))),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym231__ + 1)))));
-                for (int inline_js_super_lp_t_sym28__ = lcm_sym202__; inline_js_super_lp_t_sym28__
-                     <= lcm_sym233__; ++inline_js_super_lp_t_sym28__) {
+                                   stan::model::index_uni((lcm_sym238__ + 1)))));
+                for (int inline_js_super_lp_t_sym28__ = lcm_sym209__; inline_js_super_lp_t_sym28__
+                     <= lcm_sym240__; ++inline_js_super_lp_t_sym28__) {
                   current_statement__ = 103;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                   stan::model::rvalue(lcm_sym228__,
-                                     "lcm_sym228__",
+                                   stan::model::rvalue(lcm_sym235__,
+                                     "lcm_sym235__",
                                      stan::model::index_uni(1),
                                      stan::model::index_uni(
                                        (inline_js_super_lp_t_sym28__ - 1)))));
@@ -12532,14 +14393,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                                  inline_prob_uncaptured_return_sym14__,
                                  "inline_prob_uncaptured_return_sym14__",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym233__))));
+                                 stan::model::index_uni(lcm_sym240__))));
             } else {
-              lcm_sym204__ = (lcm_sym236__ + 1);
+              lcm_sym211__ = (lcm_sym243__ + 1);
               stan::math::validate_non_negative_index("lp",
-                "n_occasions + 1", lcm_sym204__);
+                "n_occasions + 1", lcm_sym211__);
               Eigen::Matrix<local_scalar_t__,-1,1>
                 inline_js_super_lp_lp_sym27__ =
-                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym204__,
+                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym211__,
                   DUMMY_VAR__);
               current_statement__ = 86;
               stan::model::assign(inline_js_super_lp_lp_sym27__,
@@ -12557,13 +14418,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 "assigning variable inline_js_super_lp_lp_sym27__",
                 stan::model::index_uni(1));
               current_statement__ = 88;
-              if (stan::math::logical_gte(lcm_sym236__, 2)) {
+              if (stan::math::logical_gte(lcm_sym243__, 2)) {
                 current_statement__ = 87;
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                      stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
                         stan::model::index_min_max(1, 1))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(nu, "nu", stan::model::index_uni(2))))
@@ -12579,13 +14440,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   "assigning variable inline_js_super_lp_lp_sym27__",
                   stan::model::index_uni(2));
                 for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                     <= lcm_sym236__; ++inline_js_super_lp_t_sym28__) {
+                     <= lcm_sym243__; ++inline_js_super_lp_t_sym28__) {
                   current_statement__ = 87;
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                        stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
                           stan::model::index_min_max(1,
                             (inline_js_super_lp_t_sym28__ - 1)))))) +
                     stan::math::bernoulli_lpmf<false>(1,
@@ -12608,31 +14469,31 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::model::assign(inline_js_super_lp_lp_sym27__,
                 stan::math::bernoulli_lpmf<false>(0, psi),
                 "assigning variable inline_js_super_lp_lp_sym27__",
-                stan::model::index_uni(lcm_sym204__));
+                stan::model::index_uni(lcm_sym211__));
               current_statement__ = 90;
               lp_accum__.add(stan::math::log_sum_exp(
                                inline_js_super_lp_lp_sym27__));
             }
             for (int inline_js_super_lp_i_sym29__ = 2; inline_js_super_lp_i_sym29__
-                 <= lcm_sym235__; ++inline_js_super_lp_i_sym29__) {
+                 <= lcm_sym242__; ++inline_js_super_lp_i_sym29__) {
               current_statement__ = 83;
               stan::math::validate_non_negative_index("qp", "n_occasions",
-                lcm_sym236__);
+                lcm_sym243__);
               Eigen::Matrix<double,-1,1> inline_js_super_lp_qp_sym26__ =
-                Eigen::Matrix<double,-1,1>::Constant(lcm_sym236__,
+                Eigen::Matrix<double,-1,1>::Constant(lcm_sym243__,
                   std::numeric_limits<double>::quiet_NaN());
-              stan::model::assign(lcm_sym178__,
+              stan::model::assign(lcm_sym185__,
                 stan::math::subtract(1.0,
                   stan::math::transpose(
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_js_super_lp_i_sym29__)))),
-                "assigning variable lcm_sym178__");
-              lcm_sym230__ = first[(inline_js_super_lp_i_sym29__ - 1)];
-              if (lcm_sym230__) {
+                "assigning variable lcm_sym185__");
+              lcm_sym237__ = first[(inline_js_super_lp_i_sym29__ - 1)];
+              if (lcm_sym237__) {
                 current_statement__ = 92;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1, psi));
                 current_statement__ = 102;
-                if (stan::math::logical_eq(lcm_sym230__, 1)) {
+                if (stan::math::logical_eq(lcm_sym237__, 1)) {
                   current_statement__ = 100;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    (stan::model::rvalue(nu, "nu",
@@ -12644,90 +14505,90 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 } else {
                   current_statement__ = 93;
                   stan::math::validate_non_negative_index("lp", "first[i]",
-                    lcm_sym230__);
+                    lcm_sym237__);
                   Eigen::Matrix<local_scalar_t__,-1,1>
                     inline_js_super_lp_lp_sym27__ =
-                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym230__,
+                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym237__,
                       DUMMY_VAR__);
-                  lcm_sym182__ = (lcm_sym230__ - 1);
+                  lcm_sym189__ = (lcm_sym237__ - 1);
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::model::rvalue(nu, "nu",
                            stan::model::index_uni(1))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym178__, "lcm_sym178__",
-                          stan::model::index_min_max(1, lcm_sym182__))))) +
+                        stan::model::rvalue(lcm_sym185__, "lcm_sym185__",
+                          stan::model::index_min_max(1, lcm_sym189__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                        stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                           stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                          stan::model::index_min_max(1, lcm_sym182__))))) +
+                          stan::model::index_min_max(1, lcm_sym189__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                        stan::model::index_uni(lcm_sym230__)))),
+                        stan::model::index_uni(lcm_sym237__)))),
                     "assigning variable inline_js_super_lp_lp_sym27__",
                     stan::model::index_uni(1));
                   current_statement__ = 96;
-                  if (stan::math::logical_gte(lcm_sym182__, 2)) {
+                  if (stan::math::logical_gte(lcm_sym189__, 2)) {
                     current_statement__ = 95;
                     stan::model::assign(inline_js_super_lp_lp_sym27__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym177__,
-                                "lcm_sym177__",
+                              stan::model::rvalue(lcm_sym184__,
+                                "lcm_sym184__",
                                 stan::model::index_min_max(1, 1)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(nu, "nu",
                           stan::model::index_uni(2)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym178__, "lcm_sym178__",
-                            stan::model::index_min_max(2, lcm_sym182__))))) +
+                          stan::model::rvalue(lcm_sym185__, "lcm_sym185__",
+                            stan::model::index_min_max(2, lcm_sym189__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                          stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                             stan::model::index_uni(
                               inline_js_super_lp_i_sym29__),
-                            stan::model::index_min_max(2, lcm_sym182__))))) +
+                            stan::model::index_min_max(2, lcm_sym189__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(p, "p",
                           stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                          stan::model::index_uni(lcm_sym230__)))),
+                          stan::model::index_uni(lcm_sym237__)))),
                       "assigning variable inline_js_super_lp_lp_sym27__",
                       stan::model::index_uni(2));
                     for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                         <= lcm_sym182__; ++inline_js_super_lp_t_sym28__) {
+                         <= lcm_sym189__; ++inline_js_super_lp_t_sym28__) {
                       current_statement__ = 95;
                       stan::model::assign(inline_js_super_lp_lp_sym27__,
                         ((((stan::math::bernoulli_lpmf<false>(1,
                               stan::math::prod(
-                                stan::model::rvalue(lcm_sym177__,
-                                  "lcm_sym177__",
+                                stan::model::rvalue(lcm_sym184__,
+                                  "lcm_sym184__",
                                   stan::model::index_min_max(1,
                                     (inline_js_super_lp_t_sym28__ - 1))))) +
                         stan::math::bernoulli_lpmf<false>(1,
                           nu[(inline_js_super_lp_t_sym28__ - 1)])) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym178__, "lcm_sym178__",
+                            stan::model::rvalue(lcm_sym185__, "lcm_sym185__",
                               stan::model::index_min_max(
-                                inline_js_super_lp_t_sym28__, lcm_sym182__)))))
+                                inline_js_super_lp_t_sym28__, lcm_sym189__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
+                            stan::model::rvalue(lcm_sym235__, "lcm_sym235__",
                               stan::model::index_uni(
                                 inline_js_super_lp_i_sym29__),
                               stan::model::index_min_max(
-                                inline_js_super_lp_t_sym28__, lcm_sym182__)))))
+                                inline_js_super_lp_t_sym28__, lcm_sym189__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::model::rvalue(p, "p",
                             stan::model::index_uni(
                               inline_js_super_lp_i_sym29__),
-                            stan::model::index_uni(lcm_sym230__)))),
+                            stan::model::index_uni(lcm_sym237__)))),
                         "assigning variable inline_js_super_lp_lp_sym27__",
                         stan::model::index_uni(inline_js_super_lp_t_sym28__));
                     }
@@ -12736,48 +14597,48 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
-                            stan::model::index_min_max(1, lcm_sym182__)))) +
-                    stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym230__ -
+                          stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
+                            stan::model::index_min_max(1, lcm_sym189__)))) +
+                    stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym237__ -
                       1)])) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                        stan::model::index_uni(lcm_sym230__)))),
+                        stan::model::index_uni(lcm_sym237__)))),
                     "assigning variable inline_js_super_lp_lp_sym27__",
-                    stan::model::index_uni(lcm_sym230__));
+                    stan::model::index_uni(lcm_sym237__));
                   current_statement__ = 98;
                   lp_accum__.add(stan::math::log_sum_exp(
                                    inline_js_super_lp_lp_sym27__));
                 }
-                lcm_sym232__ = last[(inline_js_super_lp_i_sym29__ - 1)];
-                if (stan::math::logical_gte(lcm_sym232__, (lcm_sym230__ + 1))) {
+                lcm_sym239__ = last[(inline_js_super_lp_i_sym29__ - 1)];
+                if (stan::math::logical_gte(lcm_sym239__, (lcm_sym237__ + 1))) {
                   current_statement__ = 103;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                   stan::model::rvalue(lcm_sym228__,
-                                     "lcm_sym228__",
+                                   stan::model::rvalue(lcm_sym235__,
+                                     "lcm_sym235__",
                                      stan::model::index_uni(
                                        inline_js_super_lp_i_sym29__),
-                                     stan::model::index_uni(((lcm_sym230__ +
+                                     stan::model::index_uni(((lcm_sym237__ +
                                        1) - 1)))));
-                  lcm_sym201__ = ((lcm_sym230__ + 1) + 1);
+                  lcm_sym208__ = ((lcm_sym237__ + 1) + 1);
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                    stan::model::rvalue(y, "y",
                                      stan::model::index_uni(
                                        inline_js_super_lp_i_sym29__),
-                                     stan::model::index_uni((lcm_sym230__ +
+                                     stan::model::index_uni((lcm_sym237__ +
                                        1))),
                                    stan::model::rvalue(p, "p",
                                      stan::model::index_uni(
                                        inline_js_super_lp_i_sym29__),
-                                     stan::model::index_uni((lcm_sym230__ +
+                                     stan::model::index_uni((lcm_sym237__ +
                                        1)))));
-                  for (int inline_js_super_lp_t_sym28__ = lcm_sym201__; inline_js_super_lp_t_sym28__
-                       <= lcm_sym232__; ++inline_js_super_lp_t_sym28__) {
+                  for (int inline_js_super_lp_t_sym28__ = lcm_sym208__; inline_js_super_lp_t_sym28__
+                       <= lcm_sym239__; ++inline_js_super_lp_t_sym28__) {
                     current_statement__ = 103;
                     lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                     stan::model::rvalue(lcm_sym228__,
-                                       "lcm_sym228__",
+                                     stan::model::rvalue(lcm_sym235__,
+                                       "lcm_sym235__",
                                        stan::model::index_uni(
                                          inline_js_super_lp_i_sym29__),
                                        stan::model::index_uni(
@@ -12800,14 +14661,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                                    "inline_prob_uncaptured_return_sym14__",
                                    stan::model::index_uni(
                                      inline_js_super_lp_i_sym29__),
-                                   stan::model::index_uni(lcm_sym232__))));
+                                   stan::model::index_uni(lcm_sym239__))));
               } else {
-                lcm_sym204__ = (lcm_sym236__ + 1);
+                lcm_sym211__ = (lcm_sym243__ + 1);
                 stan::math::validate_non_negative_index("lp",
-                  "n_occasions + 1", lcm_sym204__);
+                  "n_occasions + 1", lcm_sym211__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_js_super_lp_lp_sym27__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym204__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym211__,
                     DUMMY_VAR__);
                 current_statement__ = 86;
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
@@ -12828,13 +14689,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   "assigning variable inline_js_super_lp_lp_sym27__",
                   stan::model::index_uni(1));
                 current_statement__ = 88;
-                if (stan::math::logical_gte(lcm_sym236__, 2)) {
+                if (stan::math::logical_gte(lcm_sym243__, 2)) {
                   current_statement__ = 87;
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                        stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
                           stan::model::index_min_max(1, 1))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(nu, "nu", stan::model::index_uni(2))))
@@ -12852,13 +14713,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     "assigning variable inline_js_super_lp_lp_sym27__",
                     stan::model::index_uni(2));
                   for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                       <= lcm_sym236__; ++inline_js_super_lp_t_sym28__) {
+                       <= lcm_sym243__; ++inline_js_super_lp_t_sym28__) {
                     current_statement__ = 87;
                     stan::model::assign(inline_js_super_lp_lp_sym27__,
                       ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                          stan::model::rvalue(lcm_sym184__, "lcm_sym184__",
                             stan::model::index_min_max(1,
                               (inline_js_super_lp_t_sym28__ - 1)))))) +
                       stan::math::bernoulli_lpmf<false>(1,
@@ -12882,7 +14743,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   stan::math::bernoulli_lpmf<false>(0, psi),
                   "assigning variable inline_js_super_lp_lp_sym27__",
-                  stan::model::index_uni(lcm_sym204__));
+                  stan::model::index_uni(lcm_sym211__));
                 current_statement__ = 90;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_js_super_lp_lp_sym27__));
@@ -12928,46 +14789,53 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) function__;
     try {
+      int lcm_sym167__;
+      int lcm_sym166__;
+      local_scalar_t__ lcm_sym165__;
+      int lcm_sym164__;
+      int lcm_sym163__;
+      int lcm_sym162__;
+      int lcm_sym161__;
+      double lcm_sym140__;
       int lcm_sym160__;
       int lcm_sym159__;
-      local_scalar_t__ lcm_sym158__;
+      int lcm_sym158__;
       int lcm_sym157__;
       int lcm_sym156__;
       int lcm_sym155__;
       int lcm_sym154__;
-      double lcm_sym133__;
-      int lcm_sym153__;
+      double lcm_sym153__;
       int lcm_sym152__;
       int lcm_sym151__;
       int lcm_sym150__;
-      int lcm_sym149__;
-      int lcm_sym148__;
-      int lcm_sym147__;
-      double lcm_sym146__;
-      int lcm_sym145__;
-      int lcm_sym144__;
-      int lcm_sym143__;
-      Eigen::Matrix<double,-1,-1> lcm_sym142__;
-      std::vector<int> lcm_sym141__;
-      std::vector<std::vector<int>> lcm_sym140__;
-      Eigen::Matrix<double,-1,1> lcm_sym139__;
-      double lcm_sym132__;
-      double lcm_sym131__;
-      double lcm_sym130__;
-      double lcm_sym129__;
+      Eigen::Matrix<double,-1,-1> lcm_sym149__;
+      std::vector<int> lcm_sym148__;
+      std::vector<std::vector<int>> lcm_sym147__;
+      Eigen::Matrix<double,-1,1> lcm_sym146__;
+      double lcm_sym139__;
       double lcm_sym138__;
       double lcm_sym137__;
       double lcm_sym136__;
-      double lcm_sym135__;
+      double lcm_sym145__;
+      double lcm_sym144__;
+      double lcm_sym143__;
+      double lcm_sym142__;
+      int lcm_sym141__;
+      int lcm_sym135__;
       int lcm_sym134__;
-      int lcm_sym128__;
+      int lcm_sym133__;
+      int lcm_sym132__;
+      double lcm_sym131__;
+      int lcm_sym130__;
+      int lcm_sym129__;
+      double lcm_sym128__;
       int lcm_sym127__;
       int lcm_sym126__;
       int lcm_sym125__;
-      double lcm_sym124__;
+      int lcm_sym124__;
       int lcm_sym123__;
       int lcm_sym122__;
-      double lcm_sym121__;
+      int lcm_sym121__;
       int lcm_sym120__;
       int lcm_sym119__;
       int lcm_sym118__;
@@ -12975,16 +14843,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       int lcm_sym116__;
       int lcm_sym115__;
       int lcm_sym114__;
-      int lcm_sym113__;
-      int lcm_sym112__;
-      int lcm_sym111__;
-      int lcm_sym110__;
-      int lcm_sym109__;
-      int lcm_sym108__;
-      int lcm_sym107__;
-      double lcm_sym106__;
-      double lcm_sym105__;
-      Eigen::Matrix<double,-1,1> lcm_sym104__;
+      double lcm_sym113__;
+      double lcm_sym112__;
+      Eigen::Matrix<double,-1,1> lcm_sym111__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -13035,56 +14896,56 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym116__ = (n_occasions - 1);
-      stan::model::assign(lcm_sym142__,
-        stan::math::rep_matrix(mean_phi, M, lcm_sym116__),
-        "assigning variable lcm_sym142__");
-      stan::model::assign(phi, lcm_sym142__, "assigning variable phi");
-      lcm_sym108__ = stan::math::logical_gte(n_occasions, 1);
-      if (lcm_sym108__) {
-        stan::model::assign(lcm_sym139__,
+      lcm_sym123__ = (n_occasions - 1);
+      stan::model::assign(lcm_sym149__,
+        stan::math::rep_matrix(mean_phi, M, lcm_sym123__),
+        "assigning variable lcm_sym149__");
+      stan::model::assign(phi, lcm_sym149__, "assigning variable phi");
+      lcm_sym115__ = stan::math::logical_gte(n_occasions, 1);
+      if (lcm_sym115__) {
+        stan::model::assign(lcm_sym146__,
           stan::math::inv_logit(
             stan::math::add(stan::math::logit(mean_p), epsilon)),
-          "assigning variable lcm_sym139__");
-        stan::model::assign(p, lcm_sym139__, "assigning variable p",
+          "assigning variable lcm_sym146__");
+        stan::model::assign(p, lcm_sym146__, "assigning variable p",
           stan::model::index_omni(), stan::model::index_uni(1));
         for (int t = 2; t <= n_occasions; ++t) {
           current_statement__ = 12;
-          stan::model::assign(p, lcm_sym139__, "assigning variable p",
+          stan::model::assign(p, lcm_sym146__, "assigning variable p",
             stan::model::index_omni(), stan::model::index_uni(t));
         }
       }
-      stan::model::assign(lcm_sym104__,
+      stan::model::assign(lcm_sym111__,
         stan::math::divide(beta, stan::math::sum(beta)),
-        "assigning variable lcm_sym104__");
-      stan::model::assign(b, lcm_sym104__, "assigning variable b");
+        "assigning variable lcm_sym111__");
+      stan::model::assign(b, lcm_sym111__, "assigning variable b");
       {
         double cum_b = std::numeric_limits<double>::quiet_NaN();
-        lcm_sym158__ = stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
+        lcm_sym165__ = stan::model::rvalue(lcm_sym111__, "lcm_sym111__",
                          stan::model::index_uni(1));
         current_statement__ = 14;
-        stan::model::assign(nu, lcm_sym158__, "assigning variable nu",
+        stan::model::assign(nu, lcm_sym165__, "assigning variable nu",
           stan::model::index_uni(1));
         current_statement__ = 18;
-        if (stan::math::logical_gte(lcm_sym116__, 2)) {
+        if (stan::math::logical_gte(lcm_sym123__, 2)) {
           current_statement__ = 15;
           stan::model::assign(nu,
-            (stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
-               stan::model::index_uni(2)) / (1.0 - lcm_sym158__)),
+            (stan::model::rvalue(lcm_sym111__, "lcm_sym111__",
+               stan::model::index_uni(2)) / (1.0 - lcm_sym165__)),
             "assigning variable nu", stan::model::index_uni(2));
           current_statement__ = 16;
-          cum_b = (lcm_sym158__ +
-            stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
+          cum_b = (lcm_sym165__ +
+            stan::model::rvalue(lcm_sym111__, "lcm_sym111__",
               stan::model::index_uni(2)));
-          for (int t = 3; t <= lcm_sym116__; ++t) {
+          for (int t = 3; t <= lcm_sym123__; ++t) {
             current_statement__ = 15;
             stan::model::assign(nu,
-              (stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
+              (stan::model::rvalue(lcm_sym111__, "lcm_sym111__",
                  stan::model::index_uni(t)) / (1.0 - cum_b)),
               "assigning variable nu", stan::model::index_uni(t));
             current_statement__ = 16;
             cum_b = (cum_b +
-              stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
+              stan::model::rvalue(lcm_sym111__, "lcm_sym111__",
                 stan::model::index_uni(t)));
           }
         }
@@ -13096,140 +14957,140 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       {
         int inline_prob_uncaptured_n_ind_sym2__ =
           std::numeric_limits<int>::min();
-        lcm_sym143__ = stan::math::rows(p);
+        lcm_sym150__ = stan::math::rows(p);
         int inline_prob_uncaptured_n_occasions_sym3__ =
           std::numeric_limits<int>::min();
-        lcm_sym134__ = stan::math::cols(p);
+        lcm_sym141__ = stan::math::cols(p);
         current_statement__ = 23;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym143__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym150__);
         current_statement__ = 24;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym134__);
+          lcm_sym141__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym4__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym143__,
-            lcm_sym134__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym150__,
+            lcm_sym141__, DUMMY_VAR__);
         current_statement__ = 33;
-        if (stan::math::logical_gte(lcm_sym143__, 1)) {
+        if (stan::math::logical_gte(lcm_sym150__, 1)) {
           current_statement__ = 26;
           stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym4__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym134__));
-          lcm_sym118__ = (lcm_sym134__ - 1);
-          lcm_sym111__ = stan::math::logical_gte(lcm_sym118__, 1);
-          if (lcm_sym111__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym141__));
+          lcm_sym125__ = (lcm_sym141__ - 1);
+          lcm_sym118__ = stan::math::logical_gte(lcm_sym125__, 1);
+          if (lcm_sym118__) {
             int inline_prob_uncaptured_t_curr_sym5__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym6__ =
               std::numeric_limits<int>::min();
-            lcm_sym123__ = (lcm_sym118__ + 1);
+            lcm_sym130__ = (lcm_sym125__ + 1);
             current_statement__ = 29;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__,
               stan::math::fma(
-                (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                (stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                    stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym118__)) * (1 -
+                   stan::model::index_uni(lcm_sym125__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym123__)))),
+                  stan::model::index_uni(lcm_sym130__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                   "inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym123__)), (1 -
-                stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                  stan::model::index_uni(lcm_sym130__)), (1 -
+                stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym118__)))),
+                  stan::model::index_uni(lcm_sym125__)))),
               "assigning variable inline_prob_uncaptured_chi_sym4__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym118__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym125__));
             for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                 <= lcm_sym118__; ++inline_prob_uncaptured_t_sym7__) {
+                 <= lcm_sym125__; ++inline_prob_uncaptured_t_sym7__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
-              lcm_sym117__ = (lcm_sym134__ -
+              lcm_sym124__ = (lcm_sym141__ -
                 inline_prob_uncaptured_t_sym7__);
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym122__ = (lcm_sym117__ + 1);
+              lcm_sym129__ = (lcm_sym124__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                  (stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                      stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym117__)) * (1 -
+                     stan::model::index_uni(lcm_sym124__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym122__)))),
+                    stan::model::index_uni(lcm_sym129__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym122__)), (1 -
-                  stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                    stan::model::index_uni(lcm_sym129__)), (1 -
+                  stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym117__)))),
+                    stan::model::index_uni(lcm_sym124__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym117__));
+                stan::model::index_uni(lcm_sym124__));
             }
           }
           for (int inline_prob_uncaptured_i_sym8__ = 2; inline_prob_uncaptured_i_sym8__
-               <= lcm_sym143__; ++inline_prob_uncaptured_i_sym8__) {
+               <= lcm_sym150__; ++inline_prob_uncaptured_i_sym8__) {
             current_statement__ = 26;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym4__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-              stan::model::index_uni(lcm_sym134__));
+              stan::model::index_uni(lcm_sym141__));
             current_statement__ = 31;
-            if (lcm_sym111__) {
+            if (lcm_sym118__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym123__ = (lcm_sym118__ + 1);
+              lcm_sym130__ = (lcm_sym125__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                  (stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                     stan::model::index_uni(lcm_sym118__)) * (1 -
+                     stan::model::index_uni(lcm_sym125__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym123__)))),
+                    stan::model::index_uni(lcm_sym130__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym123__)), (1 -
-                  stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                    stan::model::index_uni(lcm_sym130__)), (1 -
+                  stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym118__)))),
+                    stan::model::index_uni(lcm_sym125__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                stan::model::index_uni(lcm_sym118__));
+                stan::model::index_uni(lcm_sym125__));
               for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                   <= lcm_sym118__; ++inline_prob_uncaptured_t_sym7__) {
+                   <= lcm_sym125__; ++inline_prob_uncaptured_t_sym7__) {
                 int inline_prob_uncaptured_t_curr_sym5__ =
                   std::numeric_limits<int>::min();
-                lcm_sym117__ = (lcm_sym134__ -
+                lcm_sym124__ = (lcm_sym141__ -
                   inline_prob_uncaptured_t_sym7__);
                 int inline_prob_uncaptured_t_next_sym6__ =
                   std::numeric_limits<int>::min();
-                lcm_sym122__ = (lcm_sym117__ + 1);
+                lcm_sym129__ = (lcm_sym124__ + 1);
                 current_statement__ = 29;
                 stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                   stan::math::fma(
-                    (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                    (stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                       stan::model::index_uni(lcm_sym117__)) * (1 -
+                       stan::model::index_uni(lcm_sym124__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym122__)))),
+                      stan::model::index_uni(lcm_sym129__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                       "inline_prob_uncaptured_chi_sym4__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym122__)), (1 -
-                    stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                      stan::model::index_uni(lcm_sym129__)), (1 -
+                    stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym117__)))),
+                      stan::model::index_uni(lcm_sym124__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                  stan::model::index_uni(lcm_sym117__));
+                  stan::model::index_uni(lcm_sym124__));
               }
             }
           }
@@ -13242,15 +15103,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::model::assign(chi, inline_prob_uncaptured_return_sym1__,
         "assigning variable chi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "phi", lcm_sym142__, 0);
+      stan::math::check_greater_or_equal(function__, "phi", lcm_sym149__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "phi", lcm_sym142__, 1);
+      stan::math::check_less_or_equal(function__, "phi", lcm_sym149__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "p", p, 0);
       current_statement__ = 8;
       stan::math::check_less_or_equal(function__, "p", p, 1);
       current_statement__ = 9;
-      stan::math::check_simplex(function__, "b", lcm_sym104__);
+      stan::math::check_simplex(function__, "b", lcm_sym111__);
       current_statement__ = 10;
       stan::math::check_greater_or_equal(function__, "nu", nu, 0);
       current_statement__ = 10;
@@ -13262,9 +15123,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_less_or_equal(function__, "chi",
         inline_prob_uncaptured_return_sym1__, 1);
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym142__);
+        out__.write(lcm_sym149__);
         out__.write(p);
-        out__.write(lcm_sym104__);
+        out__.write(lcm_sym111__);
         out__.write(nu);
         out__.write(inline_prob_uncaptured_return_sym1__);
       }
@@ -13280,10 +15141,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       std::vector<std::vector<int>> z =
         std::vector<std::vector<int>>(M,
           std::vector<int>(n_occasions, std::numeric_limits<int>::min()));
-      lcm_sym146__ = stan::math::square(sigma);
-      sigma2 = lcm_sym146__;
-      lcm_sym107__ = stan::math::logical_gte(M, 1);
-      if (lcm_sym107__) {
+      lcm_sym153__ = stan::math::square(sigma);
+      sigma2 = lcm_sym153__;
+      lcm_sym114__ = stan::math::logical_gte(M, 1);
+      if (lcm_sym114__) {
         int q = std::numeric_limits<int>::min();
         current_statement__ = 49;
         if (stan::math::bernoulli_rng(psi, base_rng__)) {
@@ -13295,18 +15156,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::model::index_uni(1));
           current_statement__ = 47;
           if (stan::math::logical_gte(n_occasions, 2)) {
-            lcm_sym157__ = stan::model::rvalue(z, "z",
+            lcm_sym164__ = stan::model::rvalue(z, "z",
                              stan::model::index_uni(1),
                              stan::model::index_uni(1));
-            lcm_sym128__ = (1 * (1 - lcm_sym157__));
-            q = lcm_sym128__;
+            lcm_sym135__ = (1 * (1 - lcm_sym164__));
+            q = lcm_sym135__;
             current_statement__ = 44;
             stan::model::assign(z,
               stan::math::bernoulli_rng(
-                stan::math::fma(lcm_sym157__,
-                  stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                stan::math::fma(lcm_sym164__,
+                  stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                     stan::model::index_uni(1), stan::model::index_uni(1)),
-                  (lcm_sym128__ *
+                  (lcm_sym135__ *
                   stan::model::rvalue(nu, "nu", stan::model::index_uni(2)))),
                 base_rng__), "assigning variable z",
               stan::model::index_uni(1), stan::model::index_uni(2));
@@ -13321,7 +15182,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   stan::math::fma(
                     stan::model::rvalue(z, "z", stan::model::index_uni(1),
                       stan::model::index_uni((t - 1))),
-                    stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                    stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                       stan::model::index_uni(1),
                       stan::model::index_uni((t - 1))), (q *
                     stan::model::rvalue(nu, "nu", stan::model::index_uni(t)))),
@@ -13347,19 +15208,19 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 47;
             if (stan::math::logical_gte(n_occasions, 2)) {
-              lcm_sym127__ = (1 * (1 -
+              lcm_sym134__ = (1 * (1 -
                 stan::model::rvalue(z, "z", stan::model::index_uni(i),
                   stan::model::index_uni(1))));
-              q = lcm_sym127__;
+              q = lcm_sym134__;
               current_statement__ = 44;
               stan::model::assign(z,
                 stan::math::bernoulli_rng(
                   stan::math::fma(
                     stan::model::rvalue(z, "z", stan::model::index_uni(i),
                       stan::model::index_uni(1)),
-                    stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                    stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                       stan::model::index_uni(i), stan::model::index_uni(1)),
-                    (lcm_sym127__ *
+                    (lcm_sym134__ *
                     stan::model::rvalue(nu, "nu", stan::model::index_uni(2)))),
                   base_rng__), "assigning variable z",
                 stan::model::index_uni(i), stan::model::index_uni(2));
@@ -13374,7 +15235,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     stan::math::fma(
                       stan::model::rvalue(z, "z", stan::model::index_uni(i),
                         stan::model::index_uni((t - 1))),
-                      stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
+                      stan::model::rvalue(lcm_sym149__, "lcm_sym149__",
                         stan::model::index_uni(i),
                         stan::model::index_uni((t - 1))), (q *
                       stan::model::rvalue(nu, "nu", stan::model::index_uni(t)))),
@@ -13412,18 +15273,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         std::vector<int> Nalive =
           std::vector<int>(M, std::numeric_limits<int>::min());
         current_statement__ = 65;
-        if (lcm_sym107__) {
+        if (lcm_sym114__) {
           int f = std::numeric_limits<int>::min();
           int inline_first_capture_return_sym10__;
           int inline_first_capture_early_ret_check_sym12__;
           inline_first_capture_early_ret_check_sym12__ = 0;
           for (int inline_first_capture_iterator_sym13__ = 1; inline_first_capture_iterator_sym13__
                <= 1; ++inline_first_capture_iterator_sym13__) {
-            lcm_sym145__ = stan::math::size(
+            lcm_sym152__ = stan::math::size(
                              stan::model::rvalue(z, "z",
                                stan::model::index_uni(1)));
             for (int inline_first_capture_k_sym11__ = 1; inline_first_capture_k_sym11__
-                 <= lcm_sym145__; ++inline_first_capture_k_sym11__) {
+                 <= lcm_sym152__; ++inline_first_capture_k_sym11__) {
               current_statement__ = 60;
               if (stan::model::rvalue(z, "z", stan::model::index_uni(1),
                     stan::model::index_uni(inline_first_capture_k_sym11__))) {
@@ -13453,11 +15314,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             inline_first_capture_early_ret_check_sym12__ = 0;
             for (int inline_first_capture_iterator_sym13__ = 1; inline_first_capture_iterator_sym13__
                  <= 1; ++inline_first_capture_iterator_sym13__) {
-              lcm_sym144__ = stan::math::size(
+              lcm_sym151__ = stan::math::size(
                                stan::model::rvalue(z, "z",
                                  stan::model::index_uni(i)));
               for (int inline_first_capture_k_sym11__ = 1; inline_first_capture_k_sym11__
-                   <= lcm_sym144__; ++inline_first_capture_k_sym11__) {
+                   <= lcm_sym151__; ++inline_first_capture_k_sym11__) {
                 current_statement__ = 60;
                 if (stan::model::rvalue(z, "z", stan::model::index_uni(i),
                       stan::model::index_uni(inline_first_capture_k_sym11__))) {
@@ -13483,7 +15344,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
         }
         current_statement__ = 69;
-        if (lcm_sym108__) {
+        if (lcm_sym115__) {
           current_statement__ = 66;
           stan::model::assign(N,
             stan::math::sum(
@@ -13512,7 +15373,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
         }
         current_statement__ = 73;
-        if (lcm_sym107__) {
+        if (lcm_sym114__) {
           current_statement__ = 70;
           stan::model::assign(Nind,
             stan::math::sum(
@@ -13540,7 +15401,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         Nsuper = stan::math::sum(Nalive);
       }
       current_statement__ = 35;
-      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym146__,
+      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym153__,
         0);
       current_statement__ = 36;
       stan::math::check_greater_or_equal(function__, "Nsuper", Nsuper, 0);
@@ -13552,12 +15413,12 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_greater_or_equal(function__, "z", z, 0);
       current_statement__ = 39;
       stan::math::check_less_or_equal(function__, "z", z, 1);
-      out__.write(lcm_sym146__);
+      out__.write(lcm_sym153__);
       out__.write(Nsuper);
       out__.write(N);
       out__.write(B);
-      if (lcm_sym108__) {
-        if (lcm_sym107__) {
+      if (lcm_sym115__) {
+        if (lcm_sym114__) {
           out__.write(stan::model::rvalue(z, "z", stan::model::index_uni(1),
                         stan::model::index_uni(1)));
           for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
@@ -13567,7 +15428,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
         }
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          if (lcm_sym107__) {
+          if (lcm_sym114__) {
             out__.write(stan::model::rvalue(z, "z",
                           stan::model::index_uni(1),
                           stan::model::index_uni(sym1__)));
@@ -13585,8 +15446,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -13618,6 +15479,83 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym110__;
+      double lcm_sym109__;
+      double lcm_sym108__;
+      double lcm_sym107__;
+      int lcm_sym106__;
+      int lcm_sym105__;
+      int lcm_sym104__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      local_scalar_t__ psi;
+      psi = context__.vals_r("psi")[(1 - 1)];
+      out__.write_free_lub(0, 1, psi);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
+          DUMMY_VAR__);
+      {
+        std::vector<double> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_occasions, 1)) {
+          stan::model::assign(beta,
+            stan::model::rvalue(beta_flat__, "beta_flat__",
+              stan::model::index_uni(1)), "assigning variable beta",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_lb(0, beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<double> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        if (stan::math::logical_gte(M, 1)) {
+          stan::model::assign(epsilon,
+            stan::model::rvalue(epsilon_flat__, "epsilon_flat__",
+              stan::model::index_uni(1)), "assigning variable epsilon",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
+            stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+              "assigning variable epsilon", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13680,58 +15618,58 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
     param_names__.emplace_back(std::string() + "psi");
-    for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+    for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym247__));
+        std::to_string(sym254__));
     }
-    for (int sym247__ = 1; sym247__ <= M; ++sym247__) {
+    for (int sym254__ = 1; sym254__ <= M; ++sym254__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym247__));
+        std::to_string(sym254__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym247__ = 1; sym247__ <= phi_2dim__; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= phi_2dim__; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "nu" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
     }
@@ -13743,58 +15681,58 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
     param_names__.emplace_back(std::string() + "psi");
-    for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+    for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym247__));
+        std::to_string(sym254__));
     }
-    for (int sym247__ = 1; sym247__ <= M; ++sym247__) {
+    for (int sym254__ = 1; sym254__ <= M; ++sym254__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym247__));
+        std::to_string(sym254__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym247__ = 1; sym247__ <= phi_2dim__; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= phi_2dim__; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
-      for (int sym247__ = 1; sym247__ <= (n_occasions - 1); ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= (n_occasions - 1); ++sym254__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "nu" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym247__));
+          std::to_string(sym254__));
       }
-      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
-        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
+      for (int sym254__ = 1; sym254__ <= n_occasions; ++sym254__) {
+        for (int sym255__ = 1; sym255__ <= M; ++sym255__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym248__) + '.' + std::to_string(sym247__));
+            std::to_string(sym255__) + '.' + std::to_string(sym254__));
         }
       }
     }
@@ -13869,26 +15807,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"mean_phi", "mean_p", "psi", "beta", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, n_occasions, M, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -13952,16 +15881,16 @@ static constexpr std::array<const char*, 37> locations_array__ =
   " (in 'expr-prop-fail7.stan', line 40, column 18 to column 19)"};
 class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model> {
  private:
-  int lcm_sym49__;
+  int lcm_sym54__;
+  int lcm_sym53__;
+  double lcm_sym52__;
+  double lcm_sym51__;
+  double lcm_sym50__;
+  double lcm_sym49__;
   int lcm_sym48__;
-  double lcm_sym47__;
-  double lcm_sym46__;
-  double lcm_sym45__;
-  double lcm_sym44__;
-  int lcm_sym43__;
-  int lcm_sym42__;
-  int lcm_sym41__;
-  int lcm_sym40__;
+  int lcm_sym47__;
+  int lcm_sym46__;
+  int lcm_sym45__;
   int K;
   int I;
   int J;
@@ -14031,8 +15960,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         pos__ = 1;
         current_statement__ = 25;
         if (stan::math::logical_gte(J, 1)) {
-          lcm_sym40__ = stan::math::logical_gte(I, 1);
-          if (lcm_sym40__) {
+          lcm_sym45__ = stan::math::logical_gte(I, 1);
+          if (lcm_sym45__) {
             current_statement__ = 25;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -14051,7 +15980,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           }
           for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
             current_statement__ = 25;
-            if (lcm_sym40__) {
+            if (lcm_sym45__) {
               current_statement__ = 25;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -14089,8 +16018,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         alpha_flat__ = context__.vals_r("alpha");
         current_statement__ = 27;
         pos__ = 1;
-        lcm_sym42__ = stan::math::logical_gte(K, 1);
-        if (lcm_sym42__) {
+        lcm_sym47__ = stan::math::logical_gte(K, 1);
+        if (lcm_sym47__) {
           current_statement__ = 27;
           stan::model::assign(alpha,
             stan::model::rvalue(alpha_flat__, "alpha_flat__",
@@ -14126,9 +16055,9 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         current_statement__ = 30;
         pos__ = 1;
         current_statement__ = 30;
-        if (lcm_sym42__) {
+        if (lcm_sym47__) {
           current_statement__ = 30;
-          if (lcm_sym42__) {
+          if (lcm_sym47__) {
             current_statement__ = 30;
             stan::model::assign(beta,
               stan::model::rvalue(beta_flat__, "beta_flat__",
@@ -14147,7 +16076,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           }
           for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
             current_statement__ = 30;
-            if (lcm_sym42__) {
+            if (lcm_sym47__) {
               current_statement__ = 30;
               stan::model::assign(beta, beta_flat__[(pos__ - 1)],
                 "assigning variable beta", stan::model::index_uni(1),
@@ -14212,20 +16141,20 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym44__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym43__;
+      double lcm_sym42__;
+      double lcm_sym41__;
+      double lcm_sym40__;
       double lcm_sym39__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym38__;
-      double lcm_sym37__;
-      double lcm_sym36__;
-      double lcm_sym35__;
-      double lcm_sym34__;
-      double lcm_sym33__;
-      Eigen::Matrix<double,-1,1> lcm_sym32__;
-      Eigen::Matrix<double,-1,1> lcm_sym31__;
-      Eigen::Matrix<double,-1,1> lcm_sym30__;
-      Eigen::Matrix<double,-1,1> lcm_sym29__;
-      int lcm_sym28__;
-      int lcm_sym27__;
-      int lcm_sym26__;
+      double lcm_sym38__;
+      Eigen::Matrix<double,-1,1> lcm_sym37__;
+      Eigen::Matrix<double,-1,1> lcm_sym36__;
+      Eigen::Matrix<double,-1,1> lcm_sym35__;
+      Eigen::Matrix<double,-1,1> lcm_sym34__;
+      int lcm_sym33__;
+      int lcm_sym32__;
+      int lcm_sym31__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,1>> pi;
       current_statement__ = 1;
@@ -14244,10 +16173,10 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       {
         current_statement__ = 10;
         lp_accum__.add(stan::math::dirichlet_lpdf<propto__>(pi, alpha));
-        lcm_sym27__ = stan::math::logical_gte(J, 1);
-        if (lcm_sym27__) {
-          lcm_sym28__ = stan::math::logical_gte(K, 1);
-          if (lcm_sym28__) {
+        lcm_sym32__ = stan::math::logical_gte(J, 1);
+        if (lcm_sym32__) {
+          lcm_sym33__ = stan::math::logical_gte(K, 1);
+          if (lcm_sym33__) {
             current_statement__ = 11;
             lp_accum__.add(stan::math::dirichlet_lpdf<propto__>(
                              stan::model::rvalue(theta, "theta",
@@ -14267,7 +16196,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           }
           for (int j = 2; j <= J; ++j) {
             current_statement__ = 12;
-            if (lcm_sym28__) {
+            if (lcm_sym33__) {
               current_statement__ = 11;
               lp_accum__.add(stan::math::dirichlet_lpdf<propto__>(
                                stan::model::rvalue(theta, "theta",
@@ -14297,14 +16226,14 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               Eigen::Matrix<local_scalar_t__,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(K,
                                                       std::numeric_limits<double>::quiet_NaN(
                                                         )));
-          stan::model::assign(lcm_sym38__, stan::math::log(pi),
-            "assigning variable lcm_sym38__");
-          stan::model::assign(log_q, lcm_sym38__, "assigning variable log_q");
+          stan::model::assign(lcm_sym43__, stan::math::log(pi),
+            "assigning variable lcm_sym43__");
+          stan::model::assign(log_q, lcm_sym43__, "assigning variable log_q");
           current_statement__ = 16;
-          if (lcm_sym27__) {
+          if (lcm_sym32__) {
             current_statement__ = 15;
             stan::model::assign(log_q,
-              stan::math::add(lcm_sym38__,
+              stan::math::add(lcm_sym43__,
                 stan::math::to_vector(
                   stan::math::log(
                     stan::model::rvalue(theta, "theta",
@@ -14337,13 +16266,13 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             stan::conditional_var_value_t<local_scalar_t__,
               Eigen::Matrix<local_scalar_t__,-1,1>> log_q;
             current_statement__ = 14;
-            stan::model::assign(log_q, lcm_sym38__,
+            stan::model::assign(log_q, lcm_sym43__,
               "assigning variable log_q");
             current_statement__ = 16;
-            if (lcm_sym27__) {
+            if (lcm_sym32__) {
               current_statement__ = 15;
               stan::model::assign(log_q,
-                stan::math::add(lcm_sym38__,
+                stan::math::add(lcm_sym43__,
                   stan::math::to_vector(
                     stan::math::log(
                       stan::model::rvalue(theta, "theta",
@@ -14411,6 +16340,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym30__;
+      double lcm_sym29__;
+      double lcm_sym28__;
+      double lcm_sym27__;
+      double lcm_sym26__;
       double lcm_sym25__;
       double lcm_sym24__;
       double lcm_sym23__;
@@ -14418,22 +16352,17 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       double lcm_sym21__;
       double lcm_sym20__;
       double lcm_sym19__;
-      double lcm_sym18__;
-      double lcm_sym17__;
-      double lcm_sym16__;
-      double lcm_sym15__;
-      double lcm_sym14__;
-      Eigen::Matrix<double,-1,1> lcm_sym13__;
-      Eigen::Matrix<double,-1,1> lcm_sym12__;
+      Eigen::Matrix<double,-1,1> lcm_sym18__;
+      Eigen::Matrix<double,-1,1> lcm_sym17__;
+      Eigen::Matrix<double,-1,1> lcm_sym16__;
+      Eigen::Matrix<double,-1,1> lcm_sym15__;
+      Eigen::Matrix<double,-1,1> lcm_sym14__;
+      int lcm_sym13__;
+      int lcm_sym12__;
       Eigen::Matrix<double,-1,1> lcm_sym11__;
-      Eigen::Matrix<double,-1,1> lcm_sym10__;
-      Eigen::Matrix<double,-1,1> lcm_sym9__;
+      int lcm_sym10__;
+      int lcm_sym9__;
       int lcm_sym8__;
-      int lcm_sym7__;
-      Eigen::Matrix<double,-1,1> lcm_sym6__;
-      int lcm_sym5__;
-      int lcm_sym4__;
-      int lcm_sym3__;
       Eigen::Matrix<double,-1,1> pi;
       current_statement__ = 1;
       pi = in__.template read_constrain_simplex<
@@ -14449,11 +16378,11 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                   std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>,
                 jacobian__>(lp__, J, K, K);
       out__.write(pi);
-      lcm_sym5__ = stan::math::logical_gte(K, 1);
-      if (lcm_sym5__) {
-        if (lcm_sym5__) {
-          lcm_sym4__ = stan::math::logical_gte(J, 1);
-          if (lcm_sym4__) {
+      lcm_sym10__ = stan::math::logical_gte(K, 1);
+      if (lcm_sym10__) {
+        if (lcm_sym10__) {
+          lcm_sym9__ = stan::math::logical_gte(J, 1);
+          if (lcm_sym9__) {
             out__.write(stan::model::rvalue(theta, "theta",
                           stan::model::index_uni(1),
                           stan::model::index_uni(1),
@@ -14466,7 +16395,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             }
           }
           for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
-            if (lcm_sym4__) {
+            if (lcm_sym9__) {
               out__.write(stan::model::rvalue(theta, "theta",
                             stan::model::index_uni(1),
                             stan::model::index_uni(sym2__),
@@ -14481,9 +16410,9 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           }
         }
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
-          if (lcm_sym5__) {
-            lcm_sym4__ = stan::math::logical_gte(J, 1);
-            if (lcm_sym4__) {
+          if (lcm_sym10__) {
+            lcm_sym9__ = stan::math::logical_gte(J, 1);
+            if (lcm_sym9__) {
               out__.write(stan::model::rvalue(theta, "theta",
                             stan::model::index_uni(1),
                             stan::model::index_uni(1),
@@ -14496,7 +16425,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               }
             }
             for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
-              if (lcm_sym4__) {
+              if (lcm_sym9__) {
                 out__.write(stan::model::rvalue(theta, "theta",
                               stan::model::index_uni(1),
                               stan::model::index_uni(sym2__),
@@ -14522,21 +16451,21 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         std::vector<Eigen::Matrix<double,-1,1>>(I,
           Eigen::Matrix<double,-1,1>::Constant(K,
             std::numeric_limits<double>::quiet_NaN()));
-      lcm_sym3__ = stan::math::logical_gte(I, 1);
-      if (lcm_sym3__) {
+      lcm_sym8__ = stan::math::logical_gte(I, 1);
+      if (lcm_sym8__) {
         current_statement__ = 4;
         stan::math::validate_non_negative_index("log_q", "K", K);
         Eigen::Matrix<double,-1,1> log_q =
           Eigen::Matrix<double,-1,1>::Constant(K,
             std::numeric_limits<double>::quiet_NaN());
-        stan::model::assign(lcm_sym13__, stan::math::log(pi),
-          "assigning variable lcm_sym13__");
-        stan::model::assign(log_q, lcm_sym13__, "assigning variable log_q");
-        lcm_sym4__ = stan::math::logical_gte(J, 1);
-        if (lcm_sym4__) {
+        stan::model::assign(lcm_sym18__, stan::math::log(pi),
+          "assigning variable lcm_sym18__");
+        stan::model::assign(log_q, lcm_sym18__, "assigning variable log_q");
+        lcm_sym9__ = stan::math::logical_gte(J, 1);
+        if (lcm_sym9__) {
           current_statement__ = 6;
           stan::model::assign(log_q,
-            stan::math::add(lcm_sym13__,
+            stan::math::add(lcm_sym18__,
               stan::math::to_vector(
                 stan::math::log(
                   stan::model::rvalue(theta, "theta",
@@ -14569,12 +16498,12 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           stan::math::validate_non_negative_index("log_q", "K", K);
           Eigen::Matrix<double,-1,1> log_q;
           current_statement__ = 5;
-          stan::model::assign(log_q, lcm_sym13__, "assigning variable log_q");
+          stan::model::assign(log_q, lcm_sym18__, "assigning variable log_q");
           current_statement__ = 8;
-          if (lcm_sym4__) {
+          if (lcm_sym9__) {
             current_statement__ = 6;
             stan::model::assign(log_q,
-              stan::math::add(lcm_sym13__,
+              stan::math::add(lcm_sym18__,
                 stan::math::to_vector(
                   stan::math::log(
                     stan::model::rvalue(theta, "theta",
@@ -14605,8 +16534,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             "assigning variable log_Pr_z", stan::model::index_uni(i));
         }
       }
-      if (lcm_sym5__) {
-        if (lcm_sym3__) {
+      if (lcm_sym10__) {
+        if (lcm_sym8__) {
           out__.write(stan::model::rvalue(log_Pr_z, "log_Pr_z",
                         stan::model::index_uni(1), stan::model::index_uni(1)));
           for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
@@ -14616,7 +16545,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           }
         }
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
-          if (lcm_sym3__) {
+          if (lcm_sym8__) {
             out__.write(stan::model::rvalue(log_Pr_z, "log_Pr_z",
                           stan::model::index_uni(1),
                           stan::model::index_uni(sym1__)));
@@ -14634,8 +16563,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -14644,8 +16573,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym2__;
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> pi;
@@ -14657,31 +16584,134 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
-      if (stan::math::logical_gte(K, 1)) {
-        lcm_sym1__ = stan::math::logical_gte(J, 1);
-        if (lcm_sym1__) {
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= J; ++sym2__) {
           stan::model::assign(theta,
             in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-            "assigning variable theta", stan::model::index_uni(1),
+            "assigning variable theta", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
+      }
+      out__.write_free_simplex(theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym7__;
+      double lcm_sym6__;
+      double lcm_sym5__;
+      double lcm_sym4__;
+      int lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> pi =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
+      {
+        std::vector<double> pi_flat__;
+        pi_flat__ = context__.vals_r("pi");
+        pos__ = 1;
+        lcm_sym2__ = stan::math::logical_gte(K, 1);
+        if (lcm_sym2__) {
+          stan::model::assign(pi,
+            stan::model::rvalue(pi_flat__, "pi_flat__",
+              stan::model::index_uni(1)), "assigning variable pi",
             stan::model::index_uni(1));
-          for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
-            stan::model::assign(theta,
-              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-              "assigning variable theta", stan::model::index_uni(sym2__),
-              stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
+            stan::model::assign(pi, pi_flat__[(pos__ - 1)],
+              "assigning variable pi", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
           }
         }
-        for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
-          if (lcm_sym1__) {
-            stan::model::assign(theta,
-              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-              "assigning variable theta", stan::model::index_uni(1),
-              stan::model::index_uni(sym1__));
-            for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
+      }
+      out__.write_free_simplex(pi);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> theta =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
+      {
+        std::vector<double> theta_flat__;
+        theta_flat__ = context__.vals_r("theta");
+        pos__ = 1;
+        if (lcm_sym2__) {
+          if (lcm_sym2__) {
+            lcm_sym1__ = stan::math::logical_gte(J, 1);
+            if (lcm_sym1__) {
               stan::model::assign(theta,
-                in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-                "assigning variable theta", stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
+                stan::model::rvalue(theta_flat__, "theta_flat__",
+                  stan::model::index_uni(1)), "assigning variable theta",
+                stan::model::index_uni(1), stan::model::index_uni(1),
+                stan::model::index_uni(1));
+              pos__ = 2;
+              for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
+                stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                  "assigning variable theta", stan::model::index_uni(sym3__),
+                  stan::model::index_uni(1), stan::model::index_uni(1));
+                pos__ = (pos__ + 1);
+              }
+            }
+            for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
+              if (lcm_sym1__) {
+                stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                  "assigning variable theta", stan::model::index_uni(1),
+                  stan::model::index_uni(sym2__), stan::model::index_uni(1));
+                pos__ = (pos__ + 1);
+                for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
+                  stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                    "assigning variable theta",
+                    stan::model::index_uni(sym3__),
+                    stan::model::index_uni(sym2__), stan::model::index_uni(1));
+                  pos__ = (pos__ + 1);
+                }
+              }
+            }
+          }
+          for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
+            if (lcm_sym2__) {
+              lcm_sym1__ = stan::math::logical_gte(J, 1);
+              if (lcm_sym1__) {
+                stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                  "assigning variable theta", stan::model::index_uni(1),
+                  stan::model::index_uni(1), stan::model::index_uni(sym1__));
+                pos__ = (pos__ + 1);
+                for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
+                  stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                    "assigning variable theta",
+                    stan::model::index_uni(sym3__),
+                    stan::model::index_uni(1), stan::model::index_uni(sym1__));
+                  pos__ = (pos__ + 1);
+                }
+              }
+              for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
+                if (lcm_sym1__) {
+                  stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                    "assigning variable theta", stan::model::index_uni(1),
+                    stan::model::index_uni(sym2__),
+                    stan::model::index_uni(sym1__));
+                  pos__ = (pos__ + 1);
+                  for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
+                    stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                      "assigning variable theta",
+                      stan::model::index_uni(sym3__),
+                      stan::model::index_uni(sym2__),
+                      stan::model::index_uni(sym1__));
+                    pos__ = (pos__ + 1);
+                  }
+                }
+              }
             }
           }
         }
@@ -14724,25 +16754,25 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym50__ = 1; sym50__ <= K; ++sym50__) {
+    for (int sym55__ = 1; sym55__ <= K; ++sym55__) {
       param_names__.emplace_back(std::string() + "pi" + '.' +
-        std::to_string(sym50__));
+        std::to_string(sym55__));
     }
-    for (int sym50__ = 1; sym50__ <= K; ++sym50__) {
-      for (int sym51__ = 1; sym51__ <= K; ++sym51__) {
-        for (int sym52__ = 1; sym52__ <= J; ++sym52__) {
+    for (int sym55__ = 1; sym55__ <= K; ++sym55__) {
+      for (int sym56__ = 1; sym56__ <= K; ++sym56__) {
+        for (int sym57__ = 1; sym57__ <= J; ++sym57__) {
           param_names__.emplace_back(std::string() + "theta" + '.' +
-            std::to_string(sym52__) + '.' + std::to_string(sym51__) + '.' +
-            std::to_string(sym50__));
+            std::to_string(sym57__) + '.' + std::to_string(sym56__) + '.' +
+            std::to_string(sym55__));
         }
       }
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {
-      for (int sym50__ = 1; sym50__ <= K; ++sym50__) {
-        for (int sym51__ = 1; sym51__ <= I; ++sym51__) {
+      for (int sym55__ = 1; sym55__ <= K; ++sym55__) {
+        for (int sym56__ = 1; sym56__ <= I; ++sym56__) {
           param_names__.emplace_back(std::string() + "log_Pr_z" + '.' +
-            std::to_string(sym51__) + '.' + std::to_string(sym50__));
+            std::to_string(sym56__) + '.' + std::to_string(sym55__));
         }
       }
     }
@@ -14751,25 +16781,25 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym50__ = 1; sym50__ <= (K - 1); ++sym50__) {
+    for (int sym55__ = 1; sym55__ <= (K - 1); ++sym55__) {
       param_names__.emplace_back(std::string() + "pi" + '.' +
-        std::to_string(sym50__));
+        std::to_string(sym55__));
     }
-    for (int sym50__ = 1; sym50__ <= (K - 1); ++sym50__) {
-      for (int sym51__ = 1; sym51__ <= K; ++sym51__) {
-        for (int sym52__ = 1; sym52__ <= J; ++sym52__) {
+    for (int sym55__ = 1; sym55__ <= (K - 1); ++sym55__) {
+      for (int sym56__ = 1; sym56__ <= K; ++sym56__) {
+        for (int sym57__ = 1; sym57__ <= J; ++sym57__) {
           param_names__.emplace_back(std::string() + "theta" + '.' +
-            std::to_string(sym52__) + '.' + std::to_string(sym51__) + '.' +
-            std::to_string(sym50__));
+            std::to_string(sym57__) + '.' + std::to_string(sym56__) + '.' +
+            std::to_string(sym55__));
         }
       }
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {
-      for (int sym50__ = 1; sym50__ <= K; ++sym50__) {
-        for (int sym51__ = 1; sym51__ <= I; ++sym51__) {
+      for (int sym55__ = 1; sym55__ <= K; ++sym55__) {
+        for (int sym56__ = 1; sym56__ <= I; ++sym56__) {
           param_names__.emplace_back(std::string() + "log_Pr_z" + '.' +
-            std::to_string(sym51__) + '.' + std::to_string(sym50__));
+            std::to_string(sym56__) + '.' + std::to_string(sym55__));
         }
       }
     }
@@ -14838,24 +16868,17 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"pi", "theta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{K, (J * K * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -14907,10 +16930,10 @@ static constexpr std::array<const char*, 25> locations_array__ =
   " (in 'expr-prop-fail8.stan', line 22, column 9 to column 10)"};
 class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model> {
  private:
-  double lcm_sym11__;
-  double lcm_sym10__;
-  int lcm_sym9__;
-  int lcm_sym8__;
+  double lcm_sym17__;
+  double lcm_sym16__;
+  int lcm_sym15__;
+  int lcm_sym14__;
   int N;
   int N_edges;
   std::vector<int> node1;
@@ -15059,9 +17082,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) function__;
     try {
-      local_scalar_t__ lcm_sym7__;
-      double lcm_sym6__;
-      Eigen::Matrix<double,-1,1> lcm_sym5__;
+      local_scalar_t__ lcm_sym13__;
+      double lcm_sym12__;
+      Eigen::Matrix<double,-1,1> lcm_sym11__;
       local_scalar_t__ beta0;
       current_statement__ = 1;
       beta0 = in__.template read<local_scalar_t__>();
@@ -15089,8 +17112,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                       stan::conditional_var_value_t<local_scalar_t__,
                         Eigen::Matrix<local_scalar_t__,-1,1>>>(N);
       local_scalar_t__ sigma_phi = DUMMY_VAR__;
-      lcm_sym7__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym7__;
+      lcm_sym13__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym13__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,1>> phi =
         stan::conditional_var_value_t<local_scalar_t__,
@@ -15102,11 +17125,11 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         stan::model::index_min_max(1, N));
       current_statement__ = 10;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym7__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym13__),
         "assigning variable phi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym7__,
-        0);
+      stan::math::check_greater_or_equal(function__, "sigma_phi",
+        lcm_sym13__, 0);
       {
         current_statement__ = 11;
         lp_accum__.add(stan::math::dot_self(
@@ -15150,10 +17173,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym4__;
-      Eigen::Matrix<double,-1,1> lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
+      double lcm_sym10__;
+      Eigen::Matrix<double,-1,1> lcm_sym9__;
+      int lcm_sym8__;
+      int lcm_sym7__;
       double beta0;
       current_statement__ = 1;
       beta0 = in__.template read<local_scalar_t__>();
@@ -15190,20 +17213,20 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym4__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym4__;
+      lcm_sym10__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym10__;
       current_statement__ = 9;
       stan::model::assign(phi, phi_std_raw, "assigning variable phi",
         stan::model::index_min_max(1, N));
       current_statement__ = 10;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym4__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym10__),
         "assigning variable phi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym4__,
-        0);
+      stan::math::check_greater_or_equal(function__, "sigma_phi",
+        lcm_sym10__, 0);
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym4__);
+        out__.write(lcm_sym10__);
         out__.write(phi);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -15217,8 +17240,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -15250,6 +17273,83 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       stan::model::assign(phi_std_raw,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
         "assigning variable phi_std_raw");
+      out__.write(phi_std_raw);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym6__;
+      double lcm_sym5__;
+      double lcm_sym4__;
+      double lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ beta0;
+      beta0 = context__.vals_r("beta0")[(1 - 1)];
+      out__.write(beta0);
+      local_scalar_t__ beta1;
+      beta1 = context__.vals_r("beta1")[(1 - 1)];
+      out__.write(beta1);
+      local_scalar_t__ tau_theta;
+      tau_theta = context__.vals_r("tau_theta")[(1 - 1)];
+      out__.write_free_lb(0, tau_theta);
+      local_scalar_t__ tau_phi;
+      tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      out__.write_free_lb(0, tau_phi);
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_std =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<double> theta_std_flat__;
+        theta_std_flat__ = context__.vals_r("theta_std");
+        pos__ = 1;
+        lcm_sym1__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym1__) {
+          stan::model::assign(theta_std,
+            stan::model::rvalue(theta_std_flat__, "theta_std_flat__",
+              stan::model::index_uni(1)), "assigning variable theta_std",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
+            stan::model::assign(theta_std, theta_std_flat__[(pos__ - 1)],
+              "assigning variable theta_std", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(theta_std);
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<double> phi_std_raw_flat__;
+        phi_std_raw_flat__ = context__.vals_r("phi_std_raw");
+        pos__ = 1;
+        if (lcm_sym1__) {
+          stan::model::assign(phi_std_raw,
+            stan::model::rvalue(phi_std_raw_flat__, "phi_std_raw_flat__",
+              stan::model::index_uni(1)), "assigning variable phi_std_raw",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
+            stan::model::assign(phi_std_raw, phi_std_raw_flat__[(pos__ - 1)],
+              "assigning variable phi_std_raw",
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15294,19 +17394,19 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     param_names__.emplace_back(std::string() + "beta1");
     param_names__.emplace_back(std::string() + "tau_theta");
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
+    for (int sym18__ = 1; sym18__ <= N; ++sym18__) {
       param_names__.emplace_back(std::string() + "theta_std" + '.' +
-        std::to_string(sym12__));
+        std::to_string(sym18__));
     }
-    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
+    for (int sym18__ = 1; sym18__ <= N; ++sym18__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym12__));
+        std::to_string(sym18__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
+      for (int sym18__ = 1; sym18__ <= N; ++sym18__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym12__));
+          std::to_string(sym18__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -15319,19 +17419,19 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     param_names__.emplace_back(std::string() + "beta1");
     param_names__.emplace_back(std::string() + "tau_theta");
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
+    for (int sym18__ = 1; sym18__ <= N; ++sym18__) {
       param_names__.emplace_back(std::string() + "theta_std" + '.' +
-        std::to_string(sym12__));
+        std::to_string(sym18__));
     }
-    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
+    for (int sym18__ = 1; sym18__ <= N; ++sym18__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym12__));
+        std::to_string(sym18__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
+      for (int sym18__ = 1; sym18__ <= N; ++sym18__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym12__));
+          std::to_string(sym18__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -15400,27 +17500,17 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"beta0", "beta1", "tau_theta", "tau_phi", "theta_std",
-              "phi_std_raw"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, N, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -15741,6 +17831,10 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
 }
 class fails_test_model final : public model_base_crtp<fails_test_model> {
  private:
+  int lcm_sym121__;
+  int lcm_sym120__;
+  int lcm_sym119__;
+  int lcm_sym118__;
   int lcm_sym117__;
   int lcm_sym116__;
   int lcm_sym115__;
@@ -15750,10 +17844,6 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   int lcm_sym111__;
   int lcm_sym110__;
   int lcm_sym109__;
-  int lcm_sym108__;
-  int lcm_sym107__;
-  int lcm_sym106__;
-  int lcm_sym105__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -15818,8 +17908,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         pos__ = 1;
         current_statement__ = 37;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym106__ = stan::math::logical_gte(nind, 1);
-          if (lcm_sym106__) {
+          lcm_sym110__ = stan::math::logical_gte(nind, 1);
+          if (lcm_sym110__) {
             current_statement__ = 37;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -15838,7 +17928,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 37;
-            if (lcm_sym106__) {
+            if (lcm_sym110__) {
               current_statement__ = 37;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -15856,7 +17946,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             }
           }
         } else {
-          lcm_sym106__ = stan::math::logical_gte(nind, 1);
+          lcm_sym110__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 37;
@@ -15873,15 +17963,15 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::math::check_greater_or_equal(function__, "max_age", max_age, 1);
       current_statement__ = 39;
       stan::math::validate_non_negative_index("x", "nind", nind);
-      lcm_sym108__ = (n_occasions - 1);
+      lcm_sym112__ = (n_occasions - 1);
       stan::math::validate_non_negative_index("x", "n_occasions - 1",
-        lcm_sym108__);
+        lcm_sym112__);
       current_statement__ = 40;
       context__.validate_dims("data initialization", "x", "int",
         std::vector<size_t>{static_cast<size_t>(nind),
-          static_cast<size_t>(lcm_sym108__)});
+          static_cast<size_t>(lcm_sym112__)});
       x = std::vector<std::vector<int>>(nind,
-            std::vector<int>(lcm_sym108__, std::numeric_limits<int>::min()));
+            std::vector<int>(lcm_sym112__, std::numeric_limits<int>::min()));
       {
         std::vector<int> x_flat__;
         current_statement__ = 40;
@@ -15889,9 +17979,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         current_statement__ = 40;
         pos__ = 1;
         current_statement__ = 40;
-        if (stan::math::logical_gte(lcm_sym108__, 1)) {
+        if (stan::math::logical_gte(lcm_sym112__, 1)) {
           current_statement__ = 40;
-          if (lcm_sym106__) {
+          if (lcm_sym110__) {
             current_statement__ = 40;
             stan::model::assign(x,
               stan::model::rvalue(x_flat__, "x_flat__",
@@ -15908,9 +17998,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               pos__ = (pos__ + 1);
             }
           }
-          for (int sym1__ = 2; sym1__ <= lcm_sym108__; ++sym1__) {
+          for (int sym1__ = 2; sym1__ <= lcm_sym112__; ++sym1__) {
             current_statement__ = 40;
-            if (lcm_sym106__) {
+            if (lcm_sym110__) {
               current_statement__ = 40;
               stan::model::assign(x, x_flat__[(pos__ - 1)],
                 "assigning variable x", stan::model::index_uni(1),
@@ -15936,7 +18026,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 41;
       n_occ_minus_1 = std::numeric_limits<int>::min();
       current_statement__ = 41;
-      n_occ_minus_1 = lcm_sym108__;
+      n_occ_minus_1 = lcm_sym112__;
       current_statement__ = 42;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 43;
@@ -15946,7 +18036,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 45;
       last = std::vector<int>(nind, std::numeric_limits<int>::min());
       current_statement__ = 47;
-      if (lcm_sym106__) {
+      if (lcm_sym110__) {
         current_statement__ = 46;
         stan::model::assign(first,
           first_capture(
@@ -15962,7 +18052,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         }
       }
       current_statement__ = 49;
-      if (lcm_sym106__) {
+      if (lcm_sym110__) {
         current_statement__ = 48;
         stan::model::assign(last,
           last_capture(
@@ -15991,12 +18081,12 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 52;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-        lcm_sym108__);
+        lcm_sym112__);
       current_statement__ = 53;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-        lcm_sym108__);
+        lcm_sym112__);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 56;
@@ -16034,11 +18124,15 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym104__;
-      int lcm_sym103__;
-      int lcm_sym102__;
-      int lcm_sym101__;
-      int lcm_sym100__;
+      double lcm_sym108__;
+      int lcm_sym107__;
+      int lcm_sym106__;
+      int lcm_sym105__;
+      int lcm_sym104__;
+      double lcm_sym103__;
+      double lcm_sym102__;
+      double lcm_sym101__;
+      double lcm_sym100__;
       double lcm_sym99__;
       double lcm_sym98__;
       double lcm_sym97__;
@@ -16053,10 +18147,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       double lcm_sym88__;
       double lcm_sym87__;
       double lcm_sym86__;
-      double lcm_sym85__;
-      double lcm_sym84__;
-      double lcm_sym83__;
-      double lcm_sym82__;
+      int lcm_sym85__;
+      int lcm_sym84__;
+      int lcm_sym83__;
+      int lcm_sym82__;
       int lcm_sym81__;
       int lcm_sym80__;
       int lcm_sym79__;
@@ -16073,10 +18167,6 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       int lcm_sym68__;
       int lcm_sym67__;
       int lcm_sym66__;
-      int lcm_sym65__;
-      int lcm_sym64__;
-      int lcm_sym63__;
-      int lcm_sym62__;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -16095,18 +18185,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       Eigen::Matrix<local_scalar_t__,-1,-1> chi =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
           DUMMY_VAR__);
-      lcm_sym62__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym62__) {
-        lcm_sym101__ = stan::model::rvalue(first, "first",
+      lcm_sym66__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym66__) {
+        lcm_sym105__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym75__ = (lcm_sym101__ - 1);
-        if (stan::math::logical_gte(lcm_sym75__, 1)) {
+        lcm_sym79__ = (lcm_sym105__ - 1);
+        if (stan::math::logical_gte(lcm_sym79__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym75__; ++t) {
+          for (int t = 2; t <= lcm_sym79__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -16115,20 +18205,20 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym73__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym73__, lcm_sym101__)) {
+        lcm_sym77__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym77__, lcm_sym105__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym101__)))),
+                  stan::model::index_uni(lcm_sym105__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym101__));
-          lcm_sym81__ = (lcm_sym101__ + 1);
+            stan::model::index_uni(lcm_sym105__));
+          lcm_sym85__ = (lcm_sym105__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
-          for (int t = lcm_sym81__; t <= lcm_sym73__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym105__));
+          for (int t = lcm_sym85__; t <= lcm_sym77__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -16142,16 +18232,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym100__ = stan::model::rvalue(first, "first",
+          lcm_sym104__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym74__ = (lcm_sym100__ - 1);
-          if (stan::math::logical_gte(lcm_sym74__, 1)) {
+          lcm_sym78__ = (lcm_sym104__ - 1);
+          if (stan::math::logical_gte(lcm_sym78__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym74__; ++t) {
+            for (int t = 2; t <= lcm_sym78__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -16161,19 +18251,19 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym73__, lcm_sym100__)) {
+          if (stan::math::logical_gte(lcm_sym77__, lcm_sym104__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym100__)))),
+                    stan::model::index_uni(lcm_sym104__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym100__));
-            lcm_sym80__ = (lcm_sym100__ + 1);
+              stan::model::index_uni(lcm_sym104__));
+            lcm_sym84__ = (lcm_sym104__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
-            for (int t = lcm_sym80__; t <= lcm_sym73__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym104__));
+            for (int t = lcm_sym84__; t <= lcm_sym77__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -16201,58 +18291,58 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym62__) {
+        if (lcm_sym66__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym9__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym9__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym73__ = (n_occasions - 1);
-          lcm_sym63__ = stan::math::logical_gte(lcm_sym73__, 1);
-          if (lcm_sym63__) {
+          lcm_sym77__ = (n_occasions - 1);
+          lcm_sym67__ = stan::math::logical_gte(lcm_sym77__, 1);
+          if (lcm_sym67__) {
             int inline_prob_uncaptured_t_curr_sym10__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym11__ =
               std::numeric_limits<int>::min();
-            lcm_sym77__ = (lcm_sym73__ + 1);
+            lcm_sym81__ = (lcm_sym77__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym9__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym73__)) * (1 -
+                   stan::model::index_uni(lcm_sym77__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym77__ - 1))))),
+                  stan::model::index_uni((lcm_sym81__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                   "inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym77__)), (1 -
+                  stan::model::index_uni(lcm_sym81__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym73__)))),
+                  stan::model::index_uni(lcm_sym77__)))),
               "assigning variable inline_prob_uncaptured_chi_sym9__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym73__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym77__));
             for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                 <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
+                 <= lcm_sym77__; ++inline_prob_uncaptured_t_sym12__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
-              lcm_sym72__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
+              lcm_sym76__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym76__ = (lcm_sym72__ + 1);
+              lcm_sym80__ = (lcm_sym76__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym72__)) * (1 -
+                     stan::model::index_uni(lcm_sym76__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym76__ - 1))))),
+                    stan::model::index_uni((lcm_sym80__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym76__)), (1 -
+                    stan::model::index_uni(lcm_sym80__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym72__)))),
+                    stan::model::index_uni(lcm_sym76__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym72__));
+                stan::model::index_uni(lcm_sym76__));
             }
           }
           for (int inline_prob_uncaptured_i_sym13__ = 2; inline_prob_uncaptured_i_sym13__
@@ -16263,60 +18353,60 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym63__) {
+            if (lcm_sym67__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym77__ = (lcm_sym73__ + 1);
+              lcm_sym81__ = (lcm_sym77__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                     stan::model::index_uni(lcm_sym73__)) * (1 -
+                     stan::model::index_uni(lcm_sym77__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni((lcm_sym77__ - 1))))),
+                    stan::model::index_uni((lcm_sym81__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym77__)), (1 -
+                    stan::model::index_uni(lcm_sym81__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym73__)))),
+                    stan::model::index_uni(lcm_sym77__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                stan::model::index_uni(lcm_sym73__));
+                stan::model::index_uni(lcm_sym77__));
               for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                   <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
+                   <= lcm_sym77__; ++inline_prob_uncaptured_t_sym12__) {
                 int inline_prob_uncaptured_t_curr_sym10__ =
                   std::numeric_limits<int>::min();
-                lcm_sym72__ = (n_occasions -
+                lcm_sym76__ = (n_occasions -
                   inline_prob_uncaptured_t_sym12__);
                 int inline_prob_uncaptured_t_next_sym11__ =
                   std::numeric_limits<int>::min();
-                lcm_sym76__ = (lcm_sym72__ + 1);
+                lcm_sym80__ = (lcm_sym76__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym13__),
-                       stan::model::index_uni(lcm_sym72__)) * (1 -
+                       stan::model::index_uni(lcm_sym76__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni((lcm_sym76__ - 1))))),
+                      stan::model::index_uni((lcm_sym80__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                       "inline_prob_uncaptured_chi_sym9__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym76__)), (1 -
+                      stan::model::index_uni(lcm_sym80__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym72__)))),
+                      stan::model::index_uni(lcm_sym76__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                  stan::model::index_uni(lcm_sym72__));
+                  stan::model::index_uni(lcm_sym76__));
               }
             }
           }
@@ -16344,28 +18434,28 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         inline_prob_uncaptured_return_sym8__, 1);
       {
         current_statement__ = 32;
-        if (lcm_sym62__) {
-          lcm_sym101__ = stan::model::rvalue(first, "first",
+        if (lcm_sym66__) {
+          lcm_sym105__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym101__, 0)) {
-            lcm_sym103__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym105__, 0)) {
+            lcm_sym107__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym81__ = (lcm_sym101__ + 1);
-            if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
+            lcm_sym85__ = (lcm_sym105__ + 1);
+            if (stan::math::logical_gte(lcm_sym107__, lcm_sym85__)) {
               current_statement__ = 26;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym81__ - 1)))));
-              lcm_sym79__ = (lcm_sym81__ + 1);
+                                 stan::model::index_uni((lcm_sym85__ - 1)))));
+              lcm_sym83__ = (lcm_sym85__ + 1);
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                stan::model::rvalue(y, "y",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym81__)),
+                                 stan::model::index_uni(lcm_sym85__)),
                                stan::model::rvalue(p, "p",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym81__ - 1)))));
-              for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
+                                 stan::model::index_uni((lcm_sym85__ - 1)))));
+              for (int t = lcm_sym83__; t <= lcm_sym107__; ++t) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
@@ -16387,30 +18477,30 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                                inline_prob_uncaptured_return_sym8__,
                                "inline_prob_uncaptured_return_sym8__",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(lcm_sym103__))));
+                               stan::model::index_uni(lcm_sym107__))));
           }
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym100__ = stan::model::rvalue(first, "first",
+            lcm_sym104__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym100__, 0)) {
-              lcm_sym102__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym104__, 0)) {
+              lcm_sym106__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym80__ = (lcm_sym100__ + 1);
-              if (stan::math::logical_gte(lcm_sym102__, lcm_sym80__)) {
+              lcm_sym84__ = (lcm_sym104__ + 1);
+              if (stan::math::logical_gte(lcm_sym106__, lcm_sym84__)) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym80__ - 1)))));
-                lcm_sym78__ = (lcm_sym80__ + 1);
+                                   stan::model::index_uni((lcm_sym84__ - 1)))));
+                lcm_sym82__ = (lcm_sym84__ + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni(lcm_sym80__)),
+                                   stan::model::index_uni(lcm_sym84__)),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym80__ - 1)))));
-                for (int t = lcm_sym78__; t <= lcm_sym102__; ++t) {
+                                   stan::model::index_uni((lcm_sym84__ - 1)))));
+                for (int t = lcm_sym82__; t <= lcm_sym106__; ++t) {
                   current_statement__ = 26;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -16432,7 +18522,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                                  inline_prob_uncaptured_return_sym8__,
                                  "inline_prob_uncaptured_return_sym8__",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(lcm_sym102__))));
+                                 stan::model::index_uni(lcm_sym106__))));
             }
           }
         }
@@ -16474,17 +18564,21 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym65__;
+      int lcm_sym64__;
+      int lcm_sym63__;
+      double lcm_sym62__;
       double lcm_sym61__;
-      int lcm_sym60__;
-      int lcm_sym59__;
+      double lcm_sym60__;
+      double lcm_sym59__;
       double lcm_sym58__;
       double lcm_sym57__;
       double lcm_sym56__;
       double lcm_sym55__;
-      double lcm_sym54__;
-      double lcm_sym53__;
-      double lcm_sym52__;
-      double lcm_sym51__;
+      int lcm_sym54__;
+      int lcm_sym53__;
+      int lcm_sym52__;
+      int lcm_sym51__;
       int lcm_sym50__;
       int lcm_sym49__;
       int lcm_sym48__;
@@ -16497,10 +18591,6 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       int lcm_sym41__;
       int lcm_sym40__;
       int lcm_sym39__;
-      int lcm_sym38__;
-      int lcm_sym37__;
-      int lcm_sym36__;
-      int lcm_sym35__;
       double mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -16526,18 +18616,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym35__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym35__) {
-        lcm_sym60__ = stan::model::rvalue(first, "first",
+      lcm_sym39__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym39__) {
+        lcm_sym64__ = stan::model::rvalue(first, "first",
                         stan::model::index_uni(1));
-        lcm_sym44__ = (lcm_sym60__ - 1);
-        if (stan::math::logical_gte(lcm_sym44__, 1)) {
+        lcm_sym48__ = (lcm_sym64__ - 1);
+        if (stan::math::logical_gte(lcm_sym48__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym44__; ++t) {
+          for (int t = 2; t <= lcm_sym48__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -16546,20 +18636,20 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym42__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym42__, lcm_sym60__)) {
+        lcm_sym46__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym46__, lcm_sym64__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym60__)))),
+                  stan::model::index_uni(lcm_sym64__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym60__));
-          lcm_sym50__ = (lcm_sym60__ + 1);
+            stan::model::index_uni(lcm_sym64__));
+          lcm_sym54__ = (lcm_sym64__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
-          for (int t = lcm_sym50__; t <= lcm_sym42__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym64__));
+          for (int t = lcm_sym54__; t <= lcm_sym46__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -16573,16 +18663,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym59__ = stan::model::rvalue(first, "first",
+          lcm_sym63__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym43__ = (lcm_sym59__ - 1);
-          if (stan::math::logical_gte(lcm_sym43__, 1)) {
+          lcm_sym47__ = (lcm_sym63__ - 1);
+          if (stan::math::logical_gte(lcm_sym47__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym43__; ++t) {
+            for (int t = 2; t <= lcm_sym47__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -16592,19 +18682,19 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym42__, lcm_sym59__)) {
+          if (stan::math::logical_gte(lcm_sym46__, lcm_sym63__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym59__)))),
+                    stan::model::index_uni(lcm_sym63__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym59__));
-            lcm_sym49__ = (lcm_sym59__ + 1);
+              stan::model::index_uni(lcm_sym63__));
+            lcm_sym53__ = (lcm_sym63__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
-            for (int t = lcm_sym49__; t <= lcm_sym42__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym63__));
+            for (int t = lcm_sym53__; t <= lcm_sym46__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -16631,58 +18721,58 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym35__) {
+        if (lcm_sym39__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym2__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym2__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym42__ = (n_occasions - 1);
-          lcm_sym36__ = stan::math::logical_gte(lcm_sym42__, 1);
-          if (lcm_sym36__) {
+          lcm_sym46__ = (n_occasions - 1);
+          lcm_sym40__ = stan::math::logical_gte(lcm_sym46__, 1);
+          if (lcm_sym40__) {
             int inline_prob_uncaptured_t_curr_sym3__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym4__ =
               std::numeric_limits<int>::min();
-            lcm_sym48__ = (lcm_sym42__ + 1);
+            lcm_sym52__ = (lcm_sym46__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym2__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym42__)) * (1 -
+                   stan::model::index_uni(lcm_sym46__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym48__ - 1))))),
+                  stan::model::index_uni((lcm_sym52__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                   "inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym48__)), (1 -
+                  stan::model::index_uni(lcm_sym52__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym42__)))),
+                  stan::model::index_uni(lcm_sym46__)))),
               "assigning variable inline_prob_uncaptured_chi_sym2__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym42__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym46__));
             for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                 <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
+                 <= lcm_sym46__; ++inline_prob_uncaptured_t_sym5__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
-              lcm_sym41__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
+              lcm_sym45__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym47__ = (lcm_sym41__ + 1);
+              lcm_sym51__ = (lcm_sym45__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym41__)) * (1 -
+                     stan::model::index_uni(lcm_sym45__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym47__ - 1))))),
+                    stan::model::index_uni((lcm_sym51__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym47__)), (1 -
+                    stan::model::index_uni(lcm_sym51__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym41__)))),
+                    stan::model::index_uni(lcm_sym45__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym41__));
+                stan::model::index_uni(lcm_sym45__));
             }
           }
           for (int inline_prob_uncaptured_i_sym6__ = 2; inline_prob_uncaptured_i_sym6__
@@ -16693,59 +18783,59 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym36__) {
+            if (lcm_sym40__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym48__ = (lcm_sym42__ + 1);
+              lcm_sym52__ = (lcm_sym46__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                     stan::model::index_uni(lcm_sym42__)) * (1 -
+                     stan::model::index_uni(lcm_sym46__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni((lcm_sym48__ - 1))))),
+                    stan::model::index_uni((lcm_sym52__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym48__)), (1 -
+                    stan::model::index_uni(lcm_sym52__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym42__)))),
+                    stan::model::index_uni(lcm_sym46__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                stan::model::index_uni(lcm_sym42__));
+                stan::model::index_uni(lcm_sym46__));
               for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                   <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
+                   <= lcm_sym46__; ++inline_prob_uncaptured_t_sym5__) {
                 int inline_prob_uncaptured_t_curr_sym3__ =
                   std::numeric_limits<int>::min();
-                lcm_sym41__ = (n_occasions -
+                lcm_sym45__ = (n_occasions -
                   inline_prob_uncaptured_t_sym5__);
                 int inline_prob_uncaptured_t_next_sym4__ =
                   std::numeric_limits<int>::min();
-                lcm_sym47__ = (lcm_sym41__ + 1);
+                lcm_sym51__ = (lcm_sym45__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                       stan::model::index_uni(lcm_sym41__)) * (1 -
+                       stan::model::index_uni(lcm_sym45__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni((lcm_sym47__ - 1))))),
+                      stan::model::index_uni((lcm_sym51__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                       "inline_prob_uncaptured_chi_sym2__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym47__)), (1 -
+                      stan::model::index_uni(lcm_sym51__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym41__)))),
+                      stan::model::index_uni(lcm_sym45__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                  stan::model::index_uni(lcm_sym41__));
+                  stan::model::index_uni(lcm_sym45__));
               }
             }
           }
@@ -16787,8 +18877,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -16806,6 +18896,50 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::model::assign(beta,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
         "assigning variable beta");
+      out__.write_free_lub(0, 1, beta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym38__;
+      double lcm_sym37__;
+      int lcm_sym36__;
+      int lcm_sym35__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
+      {
+        std::vector<double> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        if (stan::math::logical_gte(max_age, 1)) {
+          stan::model::assign(beta,
+            stan::model::rvalue(beta_flat__, "beta_flat__",
+              stan::model::index_uni(1)), "assigning variable beta",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16847,27 +18981,27 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
+    for (int sym122__ = 1; sym122__ <= max_age; ++sym122__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym118__));
+        std::to_string(sym122__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occasions; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
     }
@@ -16878,27 +19012,27 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
+    for (int sym122__ = 1; sym122__ <= max_age; ++sym122__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym118__));
+        std::to_string(sym122__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occ_minus_1; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
-      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
-        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
+      for (int sym122__ = 1; sym122__ <= n_occasions; ++sym122__) {
+        for (int sym123__ = 1; sym123__ <= nind; ++sym123__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym119__) + '.' + std::to_string(sym118__));
+            std::to_string(sym123__) + '.' + std::to_string(sym122__));
         }
       }
     }
@@ -16970,24 +19104,17 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -17287,10 +19414,27 @@ class function_in_function_inline_model final : public model_base_crtp<function_
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -17397,24 +19541,17 @@ class function_in_function_inline_model final : public model_base_crtp<function_
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -17716,10 +19853,27 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -17826,24 +19980,17 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18003,7 +20150,7 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym17__;
+      int lcm_sym22__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,1>> p_single_ret_vec;
       current_statement__ = 1;
@@ -18096,9 +20243,9 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym16__;
-      int lcm_sym15__;
-      int lcm_sym14__;
+      int lcm_sym21__;
+      int lcm_sym20__;
+      int lcm_sym19__;
       Eigen::Matrix<double,-1,1> p_single_ret_vec;
       current_statement__ = 1;
       p_single_ret_vec = in__.template read<
@@ -18164,8 +20311,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -18185,6 +20332,110 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       stan::model::assign(p_multi_ret_vec,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
         "assigning variable p_multi_ret_vec");
+      out__.write(p_multi_ret_vec);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym18__;
+      double lcm_sym17__;
+      double lcm_sym16__;
+      double lcm_sym15__;
+      int lcm_sym14__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<double> p_single_ret_vec_flat__;
+        p_single_ret_vec_flat__ = context__.vals_r("p_single_ret_vec");
+        pos__ = 1;
+        {
+          stan::model::assign(p_single_ret_vec,
+            stan::model::rvalue(p_single_ret_vec_flat__,
+              "p_single_ret_vec_flat__", stan::model::index_uni(1)),
+            "assigning variable p_single_ret_vec", stan::model::index_uni(1));
+          pos__ = 2;
+          {
+            stan::model::assign(p_single_ret_vec,
+              p_single_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_single_ret_vec",
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(p_single_ret_vec,
+              p_single_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_single_ret_vec",
+              stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(p_single_ret_vec,
+              p_single_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_single_ret_vec",
+              stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(p_single_ret_vec,
+              p_single_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_single_ret_vec",
+              stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_single_ret_vec);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<double> p_multi_ret_vec_flat__;
+        p_multi_ret_vec_flat__ = context__.vals_r("p_multi_ret_vec");
+        pos__ = 1;
+        {
+          stan::model::assign(p_multi_ret_vec,
+            stan::model::rvalue(p_multi_ret_vec_flat__,
+              "p_multi_ret_vec_flat__", stan::model::index_uni(1)),
+            "assigning variable p_multi_ret_vec", stan::model::index_uni(1));
+          pos__ = 2;
+          {
+            stan::model::assign(p_multi_ret_vec,
+              p_multi_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_multi_ret_vec", stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(p_multi_ret_vec,
+              p_multi_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_multi_ret_vec", stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(p_multi_ret_vec,
+              p_multi_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_multi_ret_vec", stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+          }
+          {
+            stan::model::assign(p_multi_ret_vec,
+              p_multi_ret_vec_flat__[(pos__ - 1)],
+              "assigning variable p_multi_ret_vec", stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(p_multi_ret_vec);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18222,22 +20473,22 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+    for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
       param_names__.emplace_back(std::string() + "p_single_ret_vec" + '.' +
-        std::to_string(sym18__));
+        std::to_string(sym23__));
     }
-    for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+    for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
       param_names__.emplace_back(std::string() + "p_multi_ret_vec" + '.' +
-        std::to_string(sym18__));
+        std::to_string(sym23__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+      for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
         param_names__.emplace_back(std::string() + "tp_single_ret_vec" + '.'
-          + std::to_string(sym18__));
+          + std::to_string(sym23__));
       }
-      for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+      for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
         param_names__.emplace_back(std::string() + "tp_multi_ret_vec" + '.' +
-          std::to_string(sym18__));
+          std::to_string(sym23__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -18246,22 +20497,22 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+    for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
       param_names__.emplace_back(std::string() + "p_single_ret_vec" + '.' +
-        std::to_string(sym18__));
+        std::to_string(sym23__));
     }
-    for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+    for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
       param_names__.emplace_back(std::string() + "p_multi_ret_vec" + '.' +
-        std::to_string(sym18__));
+        std::to_string(sym23__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+      for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
         param_names__.emplace_back(std::string() + "tp_single_ret_vec" + '.'
-          + std::to_string(sym18__));
+          + std::to_string(sym23__));
       }
-      for (int sym18__ = 1; sym18__ <= 5; ++sym18__) {
+      for (int sym23__ = 1; sym23__ <= 5; ++sym23__) {
         param_names__.emplace_back(std::string() + "tp_multi_ret_vec" + '.' +
-          std::to_string(sym18__));
+          std::to_string(sym23__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -18330,25 +20581,17 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2>
-      names__{"p_single_ret_vec", "p_multi_ret_vec"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{5, 5};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18554,8 +20797,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -18568,6 +20811,26 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       pos__ = 1;
       local_scalar_t__ alpha;
       alpha = in__.read<local_scalar_t__>();
+      out__.write(alpha);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ alpha;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
       out__.write(alpha);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18669,24 +20932,17 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"alpha"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18919,10 +21175,27 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -19057,24 +21330,17 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20097,16 +22363,16 @@ seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
 }
 class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> {
  private:
+  int lcm_sym270__;
+  int lcm_sym269__;
+  int lcm_sym268__;
+  int lcm_sym267__;
+  int lcm_sym266__;
+  int lcm_sym265__;
+  int lcm_sym264__;
   int lcm_sym263__;
   int lcm_sym262__;
   int lcm_sym261__;
-  int lcm_sym260__;
-  int lcm_sym259__;
-  int lcm_sym258__;
-  int lcm_sym257__;
-  int lcm_sym256__;
-  int lcm_sym255__;
-  int lcm_sym254__;
   int M;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -20170,8 +22436,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         pos__ = 1;
         current_statement__ = 114;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym254__ = stan::math::logical_gte(M, 1);
-          if (lcm_sym254__) {
+          lcm_sym261__ = stan::math::logical_gte(M, 1);
+          if (lcm_sym261__) {
             current_statement__ = 114;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -20190,7 +22456,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 114;
-            if (lcm_sym254__) {
+            if (lcm_sym261__) {
               current_statement__ = 114;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -20208,7 +22474,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             }
           }
         } else {
-          lcm_sym254__ = stan::math::logical_gte(M, 1);
+          lcm_sym261__ = stan::math::logical_gte(M, 1);
         }
       }
       current_statement__ = 114;
@@ -20224,7 +22490,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 118;
       last = std::vector<int>(M, std::numeric_limits<int>::min());
       current_statement__ = 120;
-      if (lcm_sym254__) {
+      if (lcm_sym261__) {
         current_statement__ = 119;
         stan::model::assign(first,
           first_capture(
@@ -20240,7 +22506,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         }
       }
       current_statement__ = 122;
-      if (lcm_sym254__) {
+      if (lcm_sym261__) {
         current_statement__ = 121;
         stan::model::assign(last,
           last_capture(
@@ -20268,20 +22534,20 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         n_occasions);
       current_statement__ = 124;
       epsilon_1dim__ = std::numeric_limits<int>::min();
-      lcm_sym256__ = (n_occasions - 1);
-      epsilon_1dim__ = lcm_sym256__;
+      lcm_sym263__ = (n_occasions - 1);
+      epsilon_1dim__ = lcm_sym263__;
       current_statement__ = 124;
       stan::math::validate_non_negative_index("epsilon", "n_occasions - 1",
-        lcm_sym256__);
+        lcm_sym263__);
       current_statement__ = 125;
       stan::math::validate_non_negative_index("phi", "M", M);
       current_statement__ = 126;
       phi_2dim__ = std::numeric_limits<int>::min();
       current_statement__ = 126;
-      phi_2dim__ = lcm_sym256__;
+      phi_2dim__ = lcm_sym263__;
       current_statement__ = 126;
       stan::math::validate_non_negative_index("phi", "n_occasions - 1",
-        lcm_sym256__);
+        lcm_sym263__);
       current_statement__ = 127;
       stan::math::validate_non_negative_index("p", "M", M);
       current_statement__ = 128;
@@ -20333,39 +22599,46 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) function__;
     try {
+      int lcm_sym260__;
+      int lcm_sym259__;
+      int lcm_sym258__;
+      int lcm_sym257__;
+      int lcm_sym256__;
+      int lcm_sym255__;
       int lcm_sym253__;
-      int lcm_sym252__;
-      int lcm_sym251__;
-      int lcm_sym250__;
-      int lcm_sym249__;
-      int lcm_sym248__;
-      int lcm_sym246__;
-      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym245__;
+      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym252__;
+      double lcm_sym251__;
+      double lcm_sym250__;
+      local_scalar_t__ lcm_sym249__;
+      local_scalar_t__ lcm_sym248__;
+      double lcm_sym247__;
+      double lcm_sym246__;
+      double lcm_sym245__;
       double lcm_sym244__;
-      double lcm_sym243__;
-      local_scalar_t__ lcm_sym242__;
-      local_scalar_t__ lcm_sym241__;
+      int lcm_sym243__;
+      double lcm_sym242__;
+      double lcm_sym241__;
       double lcm_sym240__;
       double lcm_sym239__;
       double lcm_sym238__;
       double lcm_sym237__;
-      int lcm_sym236__;
+      double lcm_sym236__;
       double lcm_sym235__;
       double lcm_sym234__;
       double lcm_sym233__;
       double lcm_sym232__;
       double lcm_sym231__;
       double lcm_sym230__;
-      double lcm_sym229__;
-      double lcm_sym228__;
-      double lcm_sym227__;
+      int lcm_sym229__;
+      int lcm_sym228__;
+      int lcm_sym227__;
       double lcm_sym226__;
       double lcm_sym225__;
       double lcm_sym224__;
       double lcm_sym223__;
-      int lcm_sym222__;
-      int lcm_sym221__;
-      int lcm_sym220__;
+      double lcm_sym222__;
+      double lcm_sym221__;
+      double lcm_sym220__;
       double lcm_sym219__;
       double lcm_sym218__;
       double lcm_sym217__;
@@ -20373,35 +22646,28 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       double lcm_sym215__;
       double lcm_sym214__;
       double lcm_sym213__;
-      double lcm_sym212__;
-      double lcm_sym211__;
-      double lcm_sym210__;
-      double lcm_sym209__;
-      double lcm_sym208__;
-      double lcm_sym207__;
-      double lcm_sym206__;
-      int lcm_sym205__;
-      int lcm_sym204__;
-      int lcm_sym203__;
+      int lcm_sym212__;
+      int lcm_sym211__;
+      int lcm_sym210__;
+      int lcm_sym209__;
+      int lcm_sym208__;
+      int lcm_sym207__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym206__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym205__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym204__;
+      int lcm_sym254__;
       int lcm_sym202__;
       int lcm_sym201__;
       int lcm_sym200__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym199__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym198__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym197__;
-      int lcm_sym247__;
+      int lcm_sym199__;
+      int lcm_sym198__;
+      int lcm_sym197__;
+      int lcm_sym196__;
       int lcm_sym195__;
       int lcm_sym194__;
       int lcm_sym193__;
       int lcm_sym192__;
       int lcm_sym191__;
-      int lcm_sym190__;
-      int lcm_sym189__;
-      int lcm_sym188__;
-      int lcm_sym187__;
-      int lcm_sym186__;
-      int lcm_sym185__;
-      int lcm_sym184__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -20418,15 +22684,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant((n_occasions - 1),
           DUMMY_VAR__);
-      lcm_sym247__ = (n_occasions - 1);
+      lcm_sym254__ = (n_occasions - 1);
       epsilon = in__.template read<
-                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym247__);
+                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym254__);
       local_scalar_t__ sigma;
       current_statement__ = 5;
       sigma = in__.template read_constrain_lub<local_scalar_t__,
                 jacobian__>(0, 5, lp__);
       Eigen::Matrix<local_scalar_t__,-1,-1> phi =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, lcm_sym247__,
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, lcm_sym254__,
           DUMMY_VAR__);
       Eigen::Matrix<local_scalar_t__,-1,-1> p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, n_occasions,
@@ -20435,180 +22701,180 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, n_occasions,
           DUMMY_VAR__);
       current_statement__ = 11;
-      if (stan::math::logical_gte(lcm_sym247__, 1)) {
-        lcm_sym186__ = stan::math::logical_gte(M, 1);
-        if (lcm_sym186__) {
-          lcm_sym242__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
+      if (stan::math::logical_gte(lcm_sym254__, 1)) {
+        lcm_sym193__ = stan::math::logical_gte(M, 1);
+        if (lcm_sym193__) {
+          lcm_sym249__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
                            stan::model::rvalue(epsilon, "epsilon",
                              stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym242__, "assigning variable phi",
+          stan::model::assign(phi, lcm_sym249__, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 9;
-            stan::model::assign(phi, lcm_sym242__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym249__, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
           }
         }
-        for (int t = 2; t <= lcm_sym247__; ++t) {
+        for (int t = 2; t <= lcm_sym254__; ++t) {
           current_statement__ = 10;
-          if (lcm_sym186__) {
-            lcm_sym241__ = stan::math::inv_logit((stan::math::logit(mean_phi)
+          if (lcm_sym193__) {
+            lcm_sym248__ = stan::math::inv_logit((stan::math::logit(mean_phi)
                              +
                              stan::model::rvalue(epsilon, "epsilon",
                                stan::model::index_uni(t))));
-            stan::model::assign(phi, lcm_sym241__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym248__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             for (int i = 2; i <= M; ++i) {
               current_statement__ = 9;
-              stan::model::assign(phi, lcm_sym241__,
+              stan::model::assign(phi, lcm_sym248__,
                 "assigning variable phi", stan::model::index_uni(i),
                 stan::model::index_uni(t));
             }
           }
         }
       }
-      stan::model::assign(lcm_sym245__,
+      stan::model::assign(lcm_sym252__,
         stan::math::rep_matrix(mean_p, M, n_occasions),
-        "assigning variable lcm_sym245__");
-      stan::model::assign(p, lcm_sym245__, "assigning variable p");
+        "assigning variable lcm_sym252__");
+      stan::model::assign(p, lcm_sym252__, "assigning variable p");
       Eigen::Matrix<local_scalar_t__,-1,-1>
         inline_prob_uncaptured_return_sym20__;
       {
         int inline_prob_uncaptured_n_ind_sym21__ =
           std::numeric_limits<int>::min();
-        lcm_sym246__ = stan::math::rows(lcm_sym245__);
+        lcm_sym253__ = stan::math::rows(lcm_sym252__);
         int inline_prob_uncaptured_n_occasions_sym22__ =
           std::numeric_limits<int>::min();
-        lcm_sym236__ = stan::math::cols(lcm_sym245__);
+        lcm_sym243__ = stan::math::cols(lcm_sym252__);
         current_statement__ = 14;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym246__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym253__);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym236__);
+          lcm_sym243__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym23__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym246__,
-            lcm_sym236__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym253__,
+            lcm_sym243__, DUMMY_VAR__);
         current_statement__ = 24;
-        if (stan::math::logical_gte(lcm_sym246__, 1)) {
+        if (stan::math::logical_gte(lcm_sym253__, 1)) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym23__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym23__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym236__));
-          lcm_sym201__ = (lcm_sym236__ - 1);
-          lcm_sym188__ = stan::math::logical_gte(lcm_sym201__, 1);
-          if (lcm_sym188__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym243__));
+          lcm_sym208__ = (lcm_sym243__ - 1);
+          lcm_sym195__ = stan::math::logical_gte(lcm_sym208__, 1);
+          if (lcm_sym195__) {
             int inline_prob_uncaptured_t_curr_sym24__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym25__ =
               std::numeric_limits<int>::min();
-            lcm_sym205__ = (lcm_sym201__ + 1);
+            lcm_sym212__ = (lcm_sym208__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym23__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym201__)) * (1 -
-                stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                   stan::model::index_uni(lcm_sym208__)) * (1 -
+                stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym205__)))),
+                  stan::model::index_uni(lcm_sym212__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                   "inline_prob_uncaptured_chi_sym23__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym205__)), (1 -
+                  stan::model::index_uni(lcm_sym212__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym201__)))),
+                  stan::model::index_uni(lcm_sym208__)))),
               "assigning variable inline_prob_uncaptured_chi_sym23__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym201__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym208__));
             for (int inline_prob_uncaptured_t_sym26__ = 2; inline_prob_uncaptured_t_sym26__
-                 <= lcm_sym201__; ++inline_prob_uncaptured_t_sym26__) {
+                 <= lcm_sym208__; ++inline_prob_uncaptured_t_sym26__) {
               int inline_prob_uncaptured_t_curr_sym24__ =
                 std::numeric_limits<int>::min();
-              lcm_sym200__ = (lcm_sym236__ -
+              lcm_sym207__ = (lcm_sym243__ -
                 inline_prob_uncaptured_t_sym26__);
               int inline_prob_uncaptured_t_next_sym25__ =
                 std::numeric_limits<int>::min();
-              lcm_sym204__ = (lcm_sym200__ + 1);
+              lcm_sym211__ = (lcm_sym207__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym23__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym200__)) * (1 -
-                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                     stan::model::index_uni(lcm_sym207__)) * (1 -
+                  stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym204__)))),
+                    stan::model::index_uni(lcm_sym211__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                     "inline_prob_uncaptured_chi_sym23__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym204__)), (1 -
+                    stan::model::index_uni(lcm_sym211__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym200__)))),
+                    stan::model::index_uni(lcm_sym207__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym23__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym200__));
+                stan::model::index_uni(lcm_sym207__));
             }
           }
           for (int inline_prob_uncaptured_i_sym27__ = 2; inline_prob_uncaptured_i_sym27__
-               <= lcm_sym246__; ++inline_prob_uncaptured_i_sym27__) {
+               <= lcm_sym253__; ++inline_prob_uncaptured_i_sym27__) {
             current_statement__ = 17;
             stan::model::assign(inline_prob_uncaptured_chi_sym23__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym23__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-              stan::model::index_uni(lcm_sym236__));
+              stan::model::index_uni(lcm_sym243__));
             current_statement__ = 22;
-            if (lcm_sym188__) {
+            if (lcm_sym195__) {
               int inline_prob_uncaptured_t_curr_sym24__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym25__ =
                 std::numeric_limits<int>::min();
-              lcm_sym205__ = (lcm_sym201__ + 1);
+              lcm_sym212__ = (lcm_sym208__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym23__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                     stan::model::index_uni(lcm_sym201__)) * (1 -
-                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                     stan::model::index_uni(lcm_sym208__)) * (1 -
+                  stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                    stan::model::index_uni(lcm_sym205__)))),
+                    stan::model::index_uni(lcm_sym212__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                     "inline_prob_uncaptured_chi_sym23__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                    stan::model::index_uni(lcm_sym205__)), (1 -
+                    stan::model::index_uni(lcm_sym212__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                    stan::model::index_uni(lcm_sym201__)))),
+                    stan::model::index_uni(lcm_sym208__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym23__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                stan::model::index_uni(lcm_sym201__));
+                stan::model::index_uni(lcm_sym208__));
               for (int inline_prob_uncaptured_t_sym26__ = 2; inline_prob_uncaptured_t_sym26__
-                   <= lcm_sym201__; ++inline_prob_uncaptured_t_sym26__) {
+                   <= lcm_sym208__; ++inline_prob_uncaptured_t_sym26__) {
                 int inline_prob_uncaptured_t_curr_sym24__ =
                   std::numeric_limits<int>::min();
-                lcm_sym200__ = (lcm_sym236__ -
+                lcm_sym207__ = (lcm_sym243__ -
                   inline_prob_uncaptured_t_sym26__);
                 int inline_prob_uncaptured_t_next_sym25__ =
                   std::numeric_limits<int>::min();
-                lcm_sym204__ = (lcm_sym200__ + 1);
+                lcm_sym211__ = (lcm_sym207__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym23__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym27__),
-                       stan::model::index_uni(lcm_sym200__)) * (1 -
-                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                       stan::model::index_uni(lcm_sym207__)) * (1 -
+                    stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                      stan::model::index_uni(lcm_sym204__)))),
+                      stan::model::index_uni(lcm_sym211__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                       "inline_prob_uncaptured_chi_sym23__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                      stan::model::index_uni(lcm_sym204__)), (1 -
+                      stan::model::index_uni(lcm_sym211__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                      stan::model::index_uni(lcm_sym200__)))),
+                      stan::model::index_uni(lcm_sym207__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym23__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                  stan::model::index_uni(lcm_sym200__));
+                  stan::model::index_uni(lcm_sym207__));
               }
             }
           }
@@ -20625,9 +22891,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 6;
       stan::math::check_less_or_equal(function__, "phi", phi, 1);
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "p", lcm_sym245__, 0);
+      stan::math::check_greater_or_equal(function__, "p", lcm_sym252__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "p", lcm_sym245__, 1);
+      stan::math::check_less_or_equal(function__, "p", lcm_sym252__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "chi",
         inline_prob_uncaptured_return_sym20__, 0);
@@ -20640,129 +22906,129 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         {
           int inline_jolly_seber_lp_n_ind_sym29__ =
             std::numeric_limits<int>::min();
-          lcm_sym252__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym259__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(1));
           int inline_jolly_seber_lp_n_occasions_sym30__ =
             std::numeric_limits<int>::min();
-          lcm_sym253__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym260__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(2));
           current_statement__ = 81;
           stan::math::validate_non_negative_index("qgamma", "n_occasions",
-            lcm_sym253__);
+            lcm_sym260__);
           Eigen::Matrix<double,-1,1> inline_jolly_seber_lp_qgamma_sym31__ =
-            Eigen::Matrix<double,-1,1>::Constant(lcm_sym253__,
+            Eigen::Matrix<double,-1,1>::Constant(lcm_sym260__,
               std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym197__, stan::math::subtract(1.0, gamma),
-            "assigning variable lcm_sym197__");
+          stan::model::assign(lcm_sym204__, stan::math::subtract(1.0, gamma),
+            "assigning variable lcm_sym204__");
           current_statement__ = 108;
-          if (stan::math::logical_gte(lcm_sym252__, 1)) {
+          if (stan::math::logical_gte(lcm_sym259__, 1)) {
             current_statement__ = 83;
             stan::math::validate_non_negative_index("qp", "n_occasions",
-              lcm_sym253__);
+              lcm_sym260__);
             Eigen::Matrix<double,-1,1> inline_jolly_seber_lp_qp_sym32__ =
-              Eigen::Matrix<double,-1,1>::Constant(lcm_sym253__,
+              Eigen::Matrix<double,-1,1>::Constant(lcm_sym260__,
                 std::numeric_limits<double>::quiet_NaN());
-            stan::model::assign(lcm_sym199__,
+            stan::model::assign(lcm_sym206__,
               stan::math::subtract(1.0,
                 stan::math::transpose(
-                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                  stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                     stan::model::index_uni(1)))),
-              "assigning variable lcm_sym199__");
-            lcm_sym249__ = stan::model::rvalue(first, "first",
+              "assigning variable lcm_sym206__");
+            lcm_sym256__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(1));
-            if (lcm_sym249__) {
+            if (lcm_sym256__) {
               current_statement__ = 101;
-              if (stan::math::logical_eq(lcm_sym249__, 1)) {
+              if (stan::math::logical_eq(lcm_sym256__, 1)) {
                 current_statement__ = 99;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  (stan::model::rvalue(gamma, "gamma",
                                     stan::model::index_uni(1)) *
-                                 stan::model::rvalue(lcm_sym245__,
-                                   "lcm_sym245__", stan::model::index_uni(1),
+                                 stan::model::rvalue(lcm_sym252__,
+                                   "lcm_sym252__", stan::model::index_uni(1),
                                    stan::model::index_uni(1)))));
               } else {
                 current_statement__ = 92;
                 stan::math::validate_non_negative_index("lp", "first[i]",
-                  lcm_sym249__);
+                  lcm_sym256__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_jolly_seber_lp_lp_sym33__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym249__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym256__,
                     DUMMY_VAR__);
-                lcm_sym203__ = (lcm_sym249__ - 1);
+                lcm_sym210__ = (lcm_sym256__ - 1);
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym199__, "lcm_sym199__",
-                        stan::model::index_min_max(1, lcm_sym203__))))) +
+                      stan::model::rvalue(lcm_sym206__, "lcm_sym206__",
+                        stan::model::index_min_max(1, lcm_sym210__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
                       stan::model::rvalue(phi, "phi",
                         stan::model::index_uni(1),
-                        stan::model::index_min_max(1, lcm_sym203__))))) +
+                        stan::model::index_min_max(1, lcm_sym210__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                    stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                       stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym249__)))),
+                      stan::model::index_uni(lcm_sym256__)))),
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
                   stan::model::index_uni(1));
                 current_statement__ = 95;
-                if (stan::math::logical_gte(lcm_sym203__, 2)) {
+                if (stan::math::logical_gte(lcm_sym210__, 2)) {
                   current_statement__ = 94;
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     ((((stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
+                            stan::model::rvalue(lcm_sym204__, "lcm_sym204__",
                               stan::model::index_min_max(1, 1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(2)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym199__, "lcm_sym199__",
-                          stan::model::index_min_max(2, lcm_sym203__))))) +
+                        stan::model::rvalue(lcm_sym206__, "lcm_sym206__",
+                          stan::model::index_min_max(2, lcm_sym210__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
                         stan::model::rvalue(phi, "phi",
                           stan::model::index_uni(1),
-                          stan::model::index_min_max(2, lcm_sym203__))))) +
+                          stan::model::index_min_max(2, lcm_sym210__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                      stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                         stan::model::index_uni(1),
-                        stan::model::index_uni(lcm_sym249__)))),
+                        stan::model::index_uni(lcm_sym256__)))),
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
                     stan::model::index_uni(2));
                   for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                       <= lcm_sym203__; ++inline_jolly_seber_lp_t_sym34__) {
+                       <= lcm_sym210__; ++inline_jolly_seber_lp_t_sym34__) {
                     current_statement__ = 94;
                     stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym197__,
-                                "lcm_sym197__",
+                              stan::model::rvalue(lcm_sym204__,
+                                "lcm_sym204__",
                                 stan::model::index_min_max(1,
                                   (inline_jolly_seber_lp_t_sym34__ - 1))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym199__, "lcm_sym199__",
+                          stan::model::rvalue(lcm_sym206__, "lcm_sym206__",
                             stan::model::index_min_max(
-                              inline_jolly_seber_lp_t_sym34__, lcm_sym203__)))))
+                              inline_jolly_seber_lp_t_sym34__, lcm_sym210__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
                           stan::model::rvalue(phi, "phi",
                             stan::model::index_uni(1),
                             stan::model::index_min_max(
-                              inline_jolly_seber_lp_t_sym34__, lcm_sym203__)))))
+                              inline_jolly_seber_lp_t_sym34__, lcm_sym210__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                        stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                           stan::model::index_uni(1),
-                          stan::model::index_uni(lcm_sym249__)))),
+                          stan::model::index_uni(lcm_sym256__)))),
                       "assigning variable inline_jolly_seber_lp_lp_sym33__",
                       stan::model::index_uni(inline_jolly_seber_lp_t_sym34__));
                   }
@@ -20771,39 +23037,39 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   ((stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
-                          stan::model::index_min_max(1, lcm_sym203__)))) +
-                  stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym249__ -
+                        stan::model::rvalue(lcm_sym204__, "lcm_sym204__",
+                          stan::model::index_min_max(1, lcm_sym210__)))) +
+                  stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym256__ -
                     1)])) +
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                    stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                       stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym249__)))),
+                      stan::model::index_uni(lcm_sym256__)))),
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                  stan::model::index_uni(lcm_sym249__));
+                  stan::model::index_uni(lcm_sym256__));
                 current_statement__ = 97;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_jolly_seber_lp_lp_sym33__));
               }
-              lcm_sym251__ = stan::model::rvalue(last, "last",
+              lcm_sym258__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(1));
-              if (stan::math::logical_gte(lcm_sym251__, (lcm_sym249__ + 1))) {
+              if (stan::math::logical_gte(lcm_sym258__, (lcm_sym256__ + 1))) {
                 current_statement__ = 102;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni(((lcm_sym249__ + 1)
+                                   stan::model::index_uni(((lcm_sym256__ + 1)
                                      - 1)))));
-                lcm_sym221__ = ((lcm_sym249__ + 1) + 1);
+                lcm_sym228__ = ((lcm_sym256__ + 1) + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym249__ + 1))),
-                                 stan::model::rvalue(lcm_sym245__,
-                                   "lcm_sym245__", stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym249__ + 1)))));
-                for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym221__; inline_jolly_seber_lp_t_sym34__
-                     <= lcm_sym251__; ++inline_jolly_seber_lp_t_sym34__) {
+                                   stan::model::index_uni((lcm_sym256__ + 1))),
+                                 stan::model::rvalue(lcm_sym252__,
+                                   "lcm_sym252__", stan::model::index_uni(1),
+                                   stan::model::index_uni((lcm_sym256__ + 1)))));
+                for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym228__; inline_jolly_seber_lp_t_sym34__
+                     <= lcm_sym258__; ++inline_jolly_seber_lp_t_sym34__) {
                   current_statement__ = 102;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -20816,8 +23082,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                      stan::model::index_uni(1),
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_t_sym34__)),
-                                   stan::model::rvalue(lcm_sym245__,
-                                     "lcm_sym245__",
+                                   stan::model::rvalue(lcm_sym252__,
+                                     "lcm_sym252__",
                                      stan::model::index_uni(1),
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_t_sym34__))));
@@ -20829,14 +23095,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                  inline_prob_uncaptured_return_sym20__,
                                  "inline_prob_uncaptured_return_sym20__",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym251__))));
+                                 stan::model::index_uni(lcm_sym258__))));
             } else {
-              lcm_sym222__ = (lcm_sym253__ + 1);
+              lcm_sym229__ = (lcm_sym260__ + 1);
               stan::math::validate_non_negative_index("lp",
-                "n_occasions + 1", lcm_sym222__);
+                "n_occasions + 1", lcm_sym229__);
               Eigen::Matrix<local_scalar_t__,-1,1>
                 inline_jolly_seber_lp_lp_sym33__ =
-                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym222__,
+                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym229__,
                   DUMMY_VAR__);
               current_statement__ = 86;
               stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
@@ -20844,7 +23110,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     stan::model::rvalue(gamma, "gamma",
                       stan::model::index_uni(1))) +
                 stan::math::bernoulli_lpmf<false>(0,
-                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                  stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                     stan::model::index_uni(1), stan::model::index_uni(1)))) +
                 stan::math::bernoulli_lpmf<false>(1,
                   stan::model::rvalue(inline_prob_uncaptured_return_sym20__,
@@ -20853,18 +23119,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 "assigning variable inline_jolly_seber_lp_lp_sym33__",
                 stan::model::index_uni(1));
               current_statement__ = 88;
-              if (stan::math::logical_gte(lcm_sym253__, 2)) {
+              if (stan::math::logical_gte(lcm_sym260__, 2)) {
                 current_statement__ = 87;
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::math::prod(
-                         stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
+                         stan::model::rvalue(lcm_sym204__, "lcm_sym204__",
                            stan::model::index_min_max(1, 1)))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(gamma, "gamma",
                       stan::model::index_uni(2)))) +
                   stan::math::bernoulli_lpmf<false>(0,
-                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                    stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                       stan::model::index_uni(1), stan::model::index_uni(2))))
                   +
                   stan::math::bernoulli_lpmf<false>(1,
@@ -20875,18 +23141,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
                   stan::model::index_uni(2));
                 for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                     <= lcm_sym253__; ++inline_jolly_seber_lp_t_sym34__) {
+                     <= lcm_sym260__; ++inline_jolly_seber_lp_t_sym34__) {
                   current_statement__ = 87;
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
-                           stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
+                           stan::model::rvalue(lcm_sym204__, "lcm_sym204__",
                              stan::model::index_min_max(1,
                                (inline_jolly_seber_lp_t_sym34__ - 1))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                     stan::math::bernoulli_lpmf<false>(0,
-                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                      stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                         stan::model::index_uni(1),
                         stan::model::index_uni(
                           inline_jolly_seber_lp_t_sym34__)))) +
@@ -20904,107 +23170,107 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               current_statement__ = 89;
               stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                 stan::math::bernoulli_lpmf<false>(1,
-                  stan::math::prod(lcm_sym197__)),
+                  stan::math::prod(lcm_sym204__)),
                 "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                stan::model::index_uni(lcm_sym222__));
+                stan::model::index_uni(lcm_sym229__));
               current_statement__ = 90;
               lp_accum__.add(stan::math::log_sum_exp(
                                inline_jolly_seber_lp_lp_sym33__));
             }
             for (int inline_jolly_seber_lp_i_sym35__ = 2; inline_jolly_seber_lp_i_sym35__
-                 <= lcm_sym252__; ++inline_jolly_seber_lp_i_sym35__) {
+                 <= lcm_sym259__; ++inline_jolly_seber_lp_i_sym35__) {
               current_statement__ = 83;
               stan::math::validate_non_negative_index("qp", "n_occasions",
-                lcm_sym253__);
+                lcm_sym260__);
               Eigen::Matrix<double,-1,1> inline_jolly_seber_lp_qp_sym32__ =
-                Eigen::Matrix<double,-1,1>::Constant(lcm_sym253__,
+                Eigen::Matrix<double,-1,1>::Constant(lcm_sym260__,
                   std::numeric_limits<double>::quiet_NaN());
-              stan::model::assign(lcm_sym198__,
+              stan::model::assign(lcm_sym205__,
                 stan::math::subtract(1.0,
                   stan::math::transpose(
-                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                    stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                       stan::model::index_uni(inline_jolly_seber_lp_i_sym35__)))),
-                "assigning variable lcm_sym198__");
-              lcm_sym248__ = first[(inline_jolly_seber_lp_i_sym35__ - 1)];
-              if (lcm_sym248__) {
+                "assigning variable lcm_sym205__");
+              lcm_sym255__ = first[(inline_jolly_seber_lp_i_sym35__ - 1)];
+              if (lcm_sym255__) {
                 current_statement__ = 101;
-                if (stan::math::logical_eq(lcm_sym248__, 1)) {
+                if (stan::math::logical_eq(lcm_sym255__, 1)) {
                   current_statement__ = 99;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    (stan::model::rvalue(gamma, "gamma",
                                       stan::model::index_uni(1)) *
-                                   stan::model::rvalue(lcm_sym245__,
-                                     "lcm_sym245__",
+                                   stan::model::rvalue(lcm_sym252__,
+                                     "lcm_sym252__",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
                                      stan::model::index_uni(1)))));
                 } else {
                   current_statement__ = 92;
                   stan::math::validate_non_negative_index("lp", "first[i]",
-                    lcm_sym248__);
+                    lcm_sym255__);
                   Eigen::Matrix<local_scalar_t__,-1,1>
                     inline_jolly_seber_lp_lp_sym33__ =
-                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym248__,
+                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym255__,
                       DUMMY_VAR__);
-                  lcm_sym202__ = (lcm_sym248__ - 1);
+                  lcm_sym209__ = (lcm_sym255__ - 1);
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::model::rvalue(gamma, "gamma",
                            stan::model::index_uni(1))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym198__, "lcm_sym198__",
-                          stan::model::index_min_max(1, lcm_sym202__))))) +
+                        stan::model::rvalue(lcm_sym205__, "lcm_sym205__",
+                          stan::model::index_min_max(1, lcm_sym209__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
                         stan::model::rvalue(phi, "phi",
                           stan::model::index_uni(
                             inline_jolly_seber_lp_i_sym35__),
-                          stan::model::index_min_max(1, lcm_sym202__))))) +
+                          stan::model::index_min_max(1, lcm_sym209__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                      stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_i_sym35__),
-                        stan::model::index_uni(lcm_sym248__)))),
+                        stan::model::index_uni(lcm_sym255__)))),
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
                     stan::model::index_uni(1));
                   current_statement__ = 95;
-                  if (stan::math::logical_gte(lcm_sym202__, 2)) {
+                  if (stan::math::logical_gte(lcm_sym209__, 2)) {
                     current_statement__ = 94;
                     stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym197__,
-                                "lcm_sym197__",
+                              stan::model::rvalue(lcm_sym204__,
+                                "lcm_sym204__",
                                 stan::model::index_min_max(1, 1)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(gamma, "gamma",
                           stan::model::index_uni(2)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym198__, "lcm_sym198__",
-                            stan::model::index_min_max(2, lcm_sym202__))))) +
+                          stan::model::rvalue(lcm_sym205__, "lcm_sym205__",
+                            stan::model::index_min_max(2, lcm_sym209__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
                           stan::model::rvalue(phi, "phi",
                             stan::model::index_uni(
                               inline_jolly_seber_lp_i_sym35__),
-                            stan::model::index_min_max(2, lcm_sym202__))))) +
+                            stan::model::index_min_max(2, lcm_sym209__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                        stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                           stan::model::index_uni(
                             inline_jolly_seber_lp_i_sym35__),
-                          stan::model::index_uni(lcm_sym248__)))),
+                          stan::model::index_uni(lcm_sym255__)))),
                       "assigning variable inline_jolly_seber_lp_lp_sym33__",
                       stan::model::index_uni(2));
                     for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                         <= lcm_sym202__; ++inline_jolly_seber_lp_t_sym34__) {
+                         <= lcm_sym209__; ++inline_jolly_seber_lp_t_sym34__) {
                       current_statement__ = 94;
                       stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                         ((((stan::math::bernoulli_lpmf<false>(1,
                               stan::math::prod(
-                                stan::model::rvalue(lcm_sym197__,
-                                  "lcm_sym197__",
+                                stan::model::rvalue(lcm_sym204__,
+                                  "lcm_sym204__",
                                   stan::model::index_min_max(1,
                                     (inline_jolly_seber_lp_t_sym34__ - 1)))))
                         +
@@ -21012,9 +23278,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                           gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym198__, "lcm_sym198__",
+                            stan::model::rvalue(lcm_sym205__, "lcm_sym205__",
                               stan::model::index_min_max(
-                                inline_jolly_seber_lp_t_sym34__, lcm_sym202__)))))
+                                inline_jolly_seber_lp_t_sym34__, lcm_sym209__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
@@ -21022,13 +23288,13 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                               stan::model::index_uni(
                                 inline_jolly_seber_lp_i_sym35__),
                               stan::model::index_min_max(
-                                inline_jolly_seber_lp_t_sym34__, lcm_sym202__)))))
+                                inline_jolly_seber_lp_t_sym34__, lcm_sym209__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
-                          stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                          stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                             stan::model::index_uni(
                               inline_jolly_seber_lp_i_sym35__),
-                            stan::model::index_uni(lcm_sym248__)))),
+                            stan::model::index_uni(lcm_sym255__)))),
                         "assigning variable inline_jolly_seber_lp_lp_sym33__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_t_sym34__));
@@ -21038,45 +23304,45 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     ((stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
-                            stan::model::index_min_max(1, lcm_sym202__)))) +
-                    stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym248__
+                          stan::model::rvalue(lcm_sym204__, "lcm_sym204__",
+                            stan::model::index_min_max(1, lcm_sym209__)))) +
+                    stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym255__
                       - 1)])) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                      stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_i_sym35__),
-                        stan::model::index_uni(lcm_sym248__)))),
+                        stan::model::index_uni(lcm_sym255__)))),
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                    stan::model::index_uni(lcm_sym248__));
+                    stan::model::index_uni(lcm_sym255__));
                   current_statement__ = 97;
                   lp_accum__.add(stan::math::log_sum_exp(
                                    inline_jolly_seber_lp_lp_sym33__));
                 }
-                lcm_sym250__ = last[(inline_jolly_seber_lp_i_sym35__ - 1)];
-                if (stan::math::logical_gte(lcm_sym250__, (lcm_sym248__ + 1))) {
+                lcm_sym257__ = last[(inline_jolly_seber_lp_i_sym35__ - 1)];
+                if (stan::math::logical_gte(lcm_sym257__, (lcm_sym255__ + 1))) {
                   current_statement__ = 102;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
-                                     stan::model::index_uni(((lcm_sym248__ +
+                                     stan::model::index_uni(((lcm_sym255__ +
                                        1) - 1)))));
-                  lcm_sym220__ = ((lcm_sym248__ + 1) + 1);
+                  lcm_sym227__ = ((lcm_sym255__ + 1) + 1);
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                    stan::model::rvalue(y, "y",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
-                                     stan::model::index_uni((lcm_sym248__ +
+                                     stan::model::index_uni((lcm_sym255__ +
                                        1))),
-                                   stan::model::rvalue(lcm_sym245__,
-                                     "lcm_sym245__",
+                                   stan::model::rvalue(lcm_sym252__,
+                                     "lcm_sym252__",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
-                                     stan::model::index_uni((lcm_sym248__ +
+                                     stan::model::index_uni((lcm_sym255__ +
                                        1)))));
-                  for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym220__; inline_jolly_seber_lp_t_sym34__
-                       <= lcm_sym250__; ++inline_jolly_seber_lp_t_sym34__) {
+                  for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym227__; inline_jolly_seber_lp_t_sym34__
+                       <= lcm_sym257__; ++inline_jolly_seber_lp_t_sym34__) {
                     current_statement__ = 102;
                     lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                      stan::model::rvalue(phi, "phi",
@@ -21090,8 +23356,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                      y[(inline_jolly_seber_lp_i_sym35__ -
                                      1)][(inline_jolly_seber_lp_t_sym34__ -
                                      1)],
-                                     stan::model::rvalue(lcm_sym245__,
-                                       "lcm_sym245__",
+                                     stan::model::rvalue(lcm_sym252__,
+                                       "lcm_sym252__",
                                        stan::model::index_uni(
                                          inline_jolly_seber_lp_i_sym35__),
                                        stan::model::index_uni(
@@ -21105,14 +23371,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                    "inline_prob_uncaptured_return_sym20__",
                                    stan::model::index_uni(
                                      inline_jolly_seber_lp_i_sym35__),
-                                   stan::model::index_uni(lcm_sym250__))));
+                                   stan::model::index_uni(lcm_sym257__))));
               } else {
-                lcm_sym222__ = (lcm_sym253__ + 1);
+                lcm_sym229__ = (lcm_sym260__ + 1);
                 stan::math::validate_non_negative_index("lp",
-                  "n_occasions + 1", lcm_sym222__);
+                  "n_occasions + 1", lcm_sym229__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_jolly_seber_lp_lp_sym33__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym222__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym229__,
                     DUMMY_VAR__);
                 current_statement__ = 86;
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
@@ -21120,7 +23386,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(1))) +
                   stan::math::bernoulli_lpmf<false>(0,
-                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                    stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                       stan::model::index_uni(inline_jolly_seber_lp_i_sym35__),
                       stan::model::index_uni(1)))) +
                   stan::math::bernoulli_lpmf<false>(1,
@@ -21132,18 +23398,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
                   stan::model::index_uni(1));
                 current_statement__ = 88;
-                if (stan::math::logical_gte(lcm_sym253__, 2)) {
+                if (stan::math::logical_gte(lcm_sym260__, 2)) {
                   current_statement__ = 87;
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
-                           stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
+                           stan::model::rvalue(lcm_sym204__, "lcm_sym204__",
                              stan::model::index_min_max(1, 1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(2)))) +
                     stan::math::bernoulli_lpmf<false>(0,
-                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                      stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_i_sym35__),
                         stan::model::index_uni(2)))) +
@@ -21157,19 +23423,19 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
                     stan::model::index_uni(2));
                   for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                       <= lcm_sym253__; ++inline_jolly_seber_lp_t_sym34__) {
+                       <= lcm_sym260__; ++inline_jolly_seber_lp_t_sym34__) {
                     current_statement__ = 87;
                     stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                       (((stan::math::bernoulli_lpmf<false>(1,
                            stan::math::prod(
-                             stan::model::rvalue(lcm_sym197__,
-                               "lcm_sym197__",
+                             stan::model::rvalue(lcm_sym204__,
+                               "lcm_sym204__",
                                stan::model::index_min_max(1,
                                  (inline_jolly_seber_lp_t_sym34__ - 1))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(0,
-                        stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
+                        stan::model::rvalue(lcm_sym252__, "lcm_sym252__",
                           stan::model::index_uni(
                             inline_jolly_seber_lp_i_sym35__),
                           stan::model::index_uni(
@@ -21189,9 +23455,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 89;
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::math::prod(lcm_sym197__)),
+                    stan::math::prod(lcm_sym204__)),
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                  stan::model::index_uni(lcm_sym222__));
+                  stan::model::index_uni(lcm_sym229__));
                 current_statement__ = 90;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_jolly_seber_lp_lp_sym33__));
@@ -21237,67 +23503,67 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym183__;
+      double lcm_sym190__;
+      int lcm_sym189__;
+      int lcm_sym188__;
+      int lcm_sym187__;
+      int lcm_sym186__;
+      int lcm_sym185__;
+      int lcm_sym184__;
+      double lcm_sym155__;
       int lcm_sym182__;
       int lcm_sym181__;
       int lcm_sym180__;
       int lcm_sym179__;
       int lcm_sym178__;
       int lcm_sym177__;
-      double lcm_sym148__;
+      double lcm_sym176__;
       int lcm_sym175__;
-      int lcm_sym174__;
+      double lcm_sym174__;
       int lcm_sym173__;
       int lcm_sym172__;
       int lcm_sym171__;
       int lcm_sym170__;
-      double lcm_sym169__;
-      int lcm_sym168__;
-      double lcm_sym167__;
-      int lcm_sym166__;
-      int lcm_sym165__;
-      int lcm_sym164__;
-      int lcm_sym163__;
-      Eigen::Matrix<double,-1,-1> lcm_sym162__;
-      std::vector<std::vector<int>> lcm_sym161__;
-      local_scalar_t__ lcm_sym160__;
-      local_scalar_t__ lcm_sym159__;
+      Eigen::Matrix<double,-1,-1> lcm_sym169__;
+      std::vector<std::vector<int>> lcm_sym168__;
+      local_scalar_t__ lcm_sym167__;
+      local_scalar_t__ lcm_sym166__;
+      double lcm_sym165__;
+      double lcm_sym164__;
+      double lcm_sym163__;
+      double lcm_sym162__;
+      double lcm_sym161__;
+      double lcm_sym160__;
+      double lcm_sym159__;
       double lcm_sym158__;
-      double lcm_sym157__;
-      double lcm_sym156__;
-      double lcm_sym155__;
-      double lcm_sym154__;
-      double lcm_sym153__;
-      double lcm_sym152__;
-      double lcm_sym151__;
-      Eigen::Matrix<double,-1,1> lcm_sym150__;
+      Eigen::Matrix<double,-1,1> lcm_sym157__;
+      int lcm_sym156__;
+      int lcm_sym150__;
       int lcm_sym149__;
+      int lcm_sym148__;
+      int lcm_sym147__;
+      double lcm_sym146__;
+      double lcm_sym145__;
+      double lcm_sym144__;
       int lcm_sym143__;
       int lcm_sym142__;
-      int lcm_sym141__;
+      double lcm_sym141__;
       int lcm_sym140__;
-      double lcm_sym139__;
-      double lcm_sym138__;
-      double lcm_sym137__;
+      int lcm_sym139__;
+      int lcm_sym138__;
+      int lcm_sym137__;
       int lcm_sym136__;
       int lcm_sym135__;
-      double lcm_sym134__;
+      int lcm_sym183__;
       int lcm_sym133__;
       int lcm_sym132__;
       int lcm_sym131__;
       int lcm_sym130__;
       int lcm_sym129__;
       int lcm_sym128__;
-      int lcm_sym176__;
+      int lcm_sym127__;
       int lcm_sym126__;
-      int lcm_sym125__;
-      int lcm_sym124__;
-      int lcm_sym123__;
-      int lcm_sym122__;
-      int lcm_sym121__;
-      int lcm_sym120__;
-      int lcm_sym119__;
-      Eigen::Matrix<double,-1,1> lcm_sym118__;
+      Eigen::Matrix<double,-1,1> lcm_sym125__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -21314,15 +23580,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<double,-1,1> epsilon =
         Eigen::Matrix<double,-1,1>::Constant((n_occasions - 1),
           std::numeric_limits<double>::quiet_NaN());
-      lcm_sym176__ = (n_occasions - 1);
+      lcm_sym183__ = (n_occasions - 1);
       epsilon = in__.template read<
-                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym176__);
+                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym183__);
       double sigma;
       current_statement__ = 5;
       sigma = in__.template read_constrain_lub<local_scalar_t__,
                 jacobian__>(0, 5, lp__);
       Eigen::Matrix<double,-1,-1> phi =
-        Eigen::Matrix<double,-1,-1>::Constant(M, lcm_sym176__,
+        Eigen::Matrix<double,-1,-1>::Constant(M, lcm_sym183__,
           std::numeric_limits<double>::quiet_NaN());
       Eigen::Matrix<double,-1,-1> p =
         Eigen::Matrix<double,-1,-1>::Constant(M, n_occasions,
@@ -21341,180 +23607,180 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         return ;
       }
       current_statement__ = 11;
-      if (stan::math::logical_gte(lcm_sym176__, 1)) {
-        lcm_sym119__ = stan::math::logical_gte(M, 1);
-        if (lcm_sym119__) {
-          lcm_sym160__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
+      if (stan::math::logical_gte(lcm_sym183__, 1)) {
+        lcm_sym126__ = stan::math::logical_gte(M, 1);
+        if (lcm_sym126__) {
+          lcm_sym167__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
                            stan::model::rvalue(epsilon, "epsilon",
                              stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym160__, "assigning variable phi",
+          stan::model::assign(phi, lcm_sym167__, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 9;
-            stan::model::assign(phi, lcm_sym160__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym167__, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
           }
         }
-        for (int t = 2; t <= lcm_sym176__; ++t) {
+        for (int t = 2; t <= lcm_sym183__; ++t) {
           current_statement__ = 10;
-          if (lcm_sym119__) {
-            lcm_sym159__ = stan::math::inv_logit((stan::math::logit(mean_phi)
+          if (lcm_sym126__) {
+            lcm_sym166__ = stan::math::inv_logit((stan::math::logit(mean_phi)
                              +
                              stan::model::rvalue(epsilon, "epsilon",
                                stan::model::index_uni(t))));
-            stan::model::assign(phi, lcm_sym159__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym166__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             for (int i = 2; i <= M; ++i) {
               current_statement__ = 9;
-              stan::model::assign(phi, lcm_sym159__,
+              stan::model::assign(phi, lcm_sym166__,
                 "assigning variable phi", stan::model::index_uni(i),
                 stan::model::index_uni(t));
             }
           }
         }
       } else {
-        lcm_sym119__ = stan::math::logical_gte(M, 1);
+        lcm_sym126__ = stan::math::logical_gte(M, 1);
       }
-      stan::model::assign(lcm_sym162__,
+      stan::model::assign(lcm_sym169__,
         stan::math::rep_matrix(mean_p, M, n_occasions),
-        "assigning variable lcm_sym162__");
-      stan::model::assign(p, lcm_sym162__, "assigning variable p");
+        "assigning variable lcm_sym169__");
+      stan::model::assign(p, lcm_sym169__, "assigning variable p");
       Eigen::Matrix<double,-1,-1> inline_prob_uncaptured_return_sym1__;
       {
         int inline_prob_uncaptured_n_ind_sym2__ =
           std::numeric_limits<int>::min();
-        lcm_sym164__ = stan::math::rows(lcm_sym162__);
+        lcm_sym171__ = stan::math::rows(lcm_sym169__);
         int inline_prob_uncaptured_n_occasions_sym3__ =
           std::numeric_limits<int>::min();
-        lcm_sym149__ = stan::math::cols(lcm_sym162__);
+        lcm_sym156__ = stan::math::cols(lcm_sym169__);
         current_statement__ = 14;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym164__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym171__);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym149__);
+          lcm_sym156__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym4__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym164__,
-            lcm_sym149__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym171__,
+            lcm_sym156__, DUMMY_VAR__);
         current_statement__ = 24;
-        if (stan::math::logical_gte(lcm_sym164__, 1)) {
+        if (stan::math::logical_gte(lcm_sym171__, 1)) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym4__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym149__));
-          lcm_sym131__ = (lcm_sym149__ - 1);
-          lcm_sym123__ = stan::math::logical_gte(lcm_sym131__, 1);
-          if (lcm_sym123__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym156__));
+          lcm_sym138__ = (lcm_sym156__ - 1);
+          lcm_sym130__ = stan::math::logical_gte(lcm_sym138__, 1);
+          if (lcm_sym130__) {
             int inline_prob_uncaptured_t_curr_sym5__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym6__ =
               std::numeric_limits<int>::min();
-            lcm_sym136__ = (lcm_sym131__ + 1);
+            lcm_sym143__ = (lcm_sym138__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym131__)) * (1 -
-                stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
+                   stan::model::index_uni(lcm_sym138__)) * (1 -
+                stan::model::rvalue(lcm_sym169__, "lcm_sym169__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym136__)))),
+                  stan::model::index_uni(lcm_sym143__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                   "inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym136__)), (1 -
+                  stan::model::index_uni(lcm_sym143__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym131__)))),
+                  stan::model::index_uni(lcm_sym138__)))),
               "assigning variable inline_prob_uncaptured_chi_sym4__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym131__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym138__));
             for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                 <= lcm_sym131__; ++inline_prob_uncaptured_t_sym7__) {
+                 <= lcm_sym138__; ++inline_prob_uncaptured_t_sym7__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
-              lcm_sym130__ = (lcm_sym149__ -
+              lcm_sym137__ = (lcm_sym156__ -
                 inline_prob_uncaptured_t_sym7__);
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym135__ = (lcm_sym130__ + 1);
+              lcm_sym142__ = (lcm_sym137__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym130__)) * (1 -
-                  stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
+                     stan::model::index_uni(lcm_sym137__)) * (1 -
+                  stan::model::rvalue(lcm_sym169__, "lcm_sym169__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym135__)))),
+                    stan::model::index_uni(lcm_sym142__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym135__)), (1 -
+                    stan::model::index_uni(lcm_sym142__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym130__)))),
+                    stan::model::index_uni(lcm_sym137__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym130__));
+                stan::model::index_uni(lcm_sym137__));
             }
           }
           for (int inline_prob_uncaptured_i_sym8__ = 2; inline_prob_uncaptured_i_sym8__
-               <= lcm_sym164__; ++inline_prob_uncaptured_i_sym8__) {
+               <= lcm_sym171__; ++inline_prob_uncaptured_i_sym8__) {
             current_statement__ = 17;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym4__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-              stan::model::index_uni(lcm_sym149__));
+              stan::model::index_uni(lcm_sym156__));
             current_statement__ = 22;
-            if (lcm_sym123__) {
+            if (lcm_sym130__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym136__ = (lcm_sym131__ + 1);
+              lcm_sym143__ = (lcm_sym138__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                     stan::model::index_uni(lcm_sym131__)) * (1 -
-                  stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
+                     stan::model::index_uni(lcm_sym138__)) * (1 -
+                  stan::model::rvalue(lcm_sym169__, "lcm_sym169__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym136__)))),
+                    stan::model::index_uni(lcm_sym143__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym136__)), (1 -
+                    stan::model::index_uni(lcm_sym143__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym131__)))),
+                    stan::model::index_uni(lcm_sym138__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                stan::model::index_uni(lcm_sym131__));
+                stan::model::index_uni(lcm_sym138__));
               for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                   <= lcm_sym131__; ++inline_prob_uncaptured_t_sym7__) {
+                   <= lcm_sym138__; ++inline_prob_uncaptured_t_sym7__) {
                 int inline_prob_uncaptured_t_curr_sym5__ =
                   std::numeric_limits<int>::min();
-                lcm_sym130__ = (lcm_sym149__ -
+                lcm_sym137__ = (lcm_sym156__ -
                   inline_prob_uncaptured_t_sym7__);
                 int inline_prob_uncaptured_t_next_sym6__ =
                   std::numeric_limits<int>::min();
-                lcm_sym135__ = (lcm_sym130__ + 1);
+                lcm_sym142__ = (lcm_sym137__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                       stan::model::index_uni(lcm_sym130__)) * (1 -
-                    stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
+                       stan::model::index_uni(lcm_sym137__)) * (1 -
+                    stan::model::rvalue(lcm_sym169__, "lcm_sym169__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym135__)))),
+                      stan::model::index_uni(lcm_sym142__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                       "inline_prob_uncaptured_chi_sym4__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym135__)), (1 -
+                      stan::model::index_uni(lcm_sym142__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym130__)))),
+                      stan::model::index_uni(lcm_sym137__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                  stan::model::index_uni(lcm_sym130__));
+                  stan::model::index_uni(lcm_sym137__));
               }
             }
           }
@@ -21531,9 +23797,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 6;
       stan::math::check_less_or_equal(function__, "phi", phi, 1);
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "p", lcm_sym162__, 0);
+      stan::math::check_greater_or_equal(function__, "p", lcm_sym169__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "p", lcm_sym162__, 1);
+      stan::math::check_less_or_equal(function__, "p", lcm_sym169__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "chi",
         inline_prob_uncaptured_return_sym1__, 0);
@@ -21542,7 +23808,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         inline_prob_uncaptured_return_sym1__, 1);
       if (emit_transformed_parameters__) {
         out__.write(phi);
-        out__.write(lcm_sym162__);
+        out__.write(lcm_sym169__);
         out__.write(inline_prob_uncaptured_return_sym1__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -21562,31 +23828,31 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         std::vector<std::vector<int>>(M,
           std::vector<int>(n_occasions, std::numeric_limits<int>::min()));
       current_statement__ = 41;
-      if (lcm_sym119__) {
+      if (lcm_sym126__) {
         int q = std::numeric_limits<int>::min();
         double mu2 = std::numeric_limits<double>::quiet_NaN();
-        lcm_sym148__ = stan::model::rvalue(gamma, "gamma",
+        lcm_sym155__ = stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1));
         stan::model::assign(z,
-          stan::math::bernoulli_rng(lcm_sym148__, base_rng__),
+          stan::math::bernoulli_rng(lcm_sym155__, base_rng__),
           "assigning variable z", stan::model::index_uni(1),
           stan::model::index_uni(1));
-        lcm_sym121__ = stan::math::logical_gte(n_occasions, 2);
-        if (lcm_sym121__) {
-          lcm_sym180__ = stan::model::rvalue(z, "z",
+        lcm_sym128__ = stan::math::logical_gte(n_occasions, 2);
+        if (lcm_sym128__) {
+          lcm_sym187__ = stan::model::rvalue(z, "z",
                            stan::model::index_uni(1),
                            stan::model::index_uni(1));
-          lcm_sym143__ = (1 * (1 - lcm_sym180__));
-          q = lcm_sym143__;
-          lcm_sym157__ = stan::math::fma(
+          lcm_sym150__ = (1 * (1 - lcm_sym187__));
+          q = lcm_sym150__;
+          lcm_sym164__ = stan::math::fma(
                            stan::model::rvalue(phi, "phi",
                              stan::model::index_uni(1),
-                             stan::model::index_uni(1)), lcm_sym180__,
+                             stan::model::index_uni(1)), lcm_sym187__,
                            (stan::model::rvalue(gamma, "gamma",
-                              stan::model::index_uni(2)) * lcm_sym143__));
+                              stan::model::index_uni(2)) * lcm_sym150__));
           current_statement__ = 35;
           stan::model::assign(z,
-            stan::math::bernoulli_rng(lcm_sym157__, base_rng__),
+            stan::math::bernoulli_rng(lcm_sym164__, base_rng__),
             "assigning variable z", stan::model::index_uni(1),
             stan::model::index_uni(2));
           for (int t = 3; t <= n_occasions; ++t) {
@@ -21594,7 +23860,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             q = (q * (1 -
               stan::model::rvalue(z, "z", stan::model::index_uni(1),
                 stan::model::index_uni((t - 1)))));
-            lcm_sym158__ = stan::math::fma(
+            lcm_sym165__ = stan::math::fma(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(1),
                                stan::model::index_uni((t - 1))),
@@ -21605,7 +23871,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                 stan::model::index_uni(t)) * q));
             current_statement__ = 35;
             stan::model::assign(z,
-              stan::math::bernoulli_rng(lcm_sym158__, base_rng__),
+              stan::math::bernoulli_rng(lcm_sym165__, base_rng__),
               "assigning variable z", stan::model::index_uni(1),
               stan::model::index_uni(t));
           }
@@ -21615,16 +23881,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           double mu2 = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 38;
           stan::model::assign(z,
-            stan::math::bernoulli_rng(lcm_sym148__, base_rng__),
+            stan::math::bernoulli_rng(lcm_sym155__, base_rng__),
             "assigning variable z", stan::model::index_uni(i),
             stan::model::index_uni(1));
           current_statement__ = 39;
-          if (lcm_sym121__) {
-            lcm_sym142__ = (1 * (1 -
+          if (lcm_sym128__) {
+            lcm_sym149__ = (1 * (1 -
               stan::model::rvalue(z, "z", stan::model::index_uni(i),
                 stan::model::index_uni(1))));
-            q = lcm_sym142__;
-            lcm_sym155__ = stan::math::fma(
+            q = lcm_sym149__;
+            lcm_sym162__ = stan::math::fma(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(i),
                                stan::model::index_uni(1)),
@@ -21632,10 +23898,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                stan::model::index_uni(i),
                                stan::model::index_uni(1)),
                              (stan::model::rvalue(gamma, "gamma",
-                                stan::model::index_uni(2)) * lcm_sym142__));
+                                stan::model::index_uni(2)) * lcm_sym149__));
             current_statement__ = 35;
             stan::model::assign(z,
-              stan::math::bernoulli_rng(lcm_sym155__, base_rng__),
+              stan::math::bernoulli_rng(lcm_sym162__, base_rng__),
               "assigning variable z", stan::model::index_uni(i),
               stan::model::index_uni(2));
             for (int t = 3; t <= n_occasions; ++t) {
@@ -21643,7 +23909,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               q = (q * (1 -
                 stan::model::rvalue(z, "z", stan::model::index_uni(i),
                   stan::model::index_uni((t - 1)))));
-              lcm_sym156__ = stan::math::fma(
+              lcm_sym163__ = stan::math::fma(
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(i),
                                  stan::model::index_uni((t - 1))),
@@ -21654,7 +23920,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                   stan::model::index_uni(t)) * q));
               current_statement__ = 35;
               stan::model::assign(z,
-                stan::math::bernoulli_rng(lcm_sym156__, base_rng__),
+                stan::math::bernoulli_rng(lcm_sym163__, base_rng__),
                 "assigning variable z", stan::model::index_uni(i),
                 stan::model::index_uni(t));
             }
@@ -21671,29 +23937,29 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         Eigen::Matrix<double,-1,1> inline_seq_cprob_return_sym10__;
         {
           int inline_seq_cprob_N_sym11__ = std::numeric_limits<int>::min();
-          lcm_sym163__ = stan::math::rows(gamma);
+          lcm_sym170__ = stan::math::rows(gamma);
           current_statement__ = 45;
           stan::math::validate_non_negative_index("log_cprob", "N",
-            lcm_sym163__);
+            lcm_sym170__);
           Eigen::Matrix<local_scalar_t__,-1,1>
             inline_seq_cprob_log_cprob_sym12__ =
-            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym163__,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym170__,
               DUMMY_VAR__);
           local_scalar_t__ inline_seq_cprob_log_residual_prob_sym13__ =
             DUMMY_VAR__;
           current_statement__ = 51;
-          if (stan::math::logical_gte(lcm_sym163__, 1)) {
-            lcm_sym148__ = stan::model::rvalue(gamma, "gamma",
+          if (stan::math::logical_gte(lcm_sym170__, 1)) {
+            lcm_sym155__ = stan::model::rvalue(gamma, "gamma",
                              stan::model::index_uni(1));
             stan::model::assign(inline_seq_cprob_log_cprob_sym12__,
-              (stan::math::log(lcm_sym148__) + 0),
+              (stan::math::log(lcm_sym155__) + 0),
               "assigning variable inline_seq_cprob_log_cprob_sym12__",
               stan::model::index_uni(1));
             current_statement__ = 48;
             inline_seq_cprob_log_residual_prob_sym13__ = (0 +
-              stan::math::log1m(lcm_sym148__));
+              stan::math::log1m(lcm_sym155__));
             for (int inline_seq_cprob_n_sym14__ = 2; inline_seq_cprob_n_sym14__
-                 <= lcm_sym163__; ++inline_seq_cprob_n_sym14__) {
+                 <= lcm_sym170__; ++inline_seq_cprob_n_sym14__) {
               current_statement__ = 49;
               stan::model::assign(inline_seq_cprob_log_cprob_sym12__,
                 (stan::math::log(gamma[(inline_seq_cprob_n_sym14__ - 1)]) +
@@ -21731,27 +23997,27 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         stan::math::validate_non_negative_index("Nalive", "M", M);
         std::vector<int> Nalive =
           std::vector<int>(M, std::numeric_limits<int>::min());
-        lcm_sym167__ = stan::math::square(sigma);
-        sigma2 = lcm_sym167__;
-        lcm_sym169__ = stan::math::sum(inline_seq_cprob_return_sym10__);
-        psi = lcm_sym169__;
+        lcm_sym174__ = stan::math::square(sigma);
+        sigma2 = lcm_sym174__;
+        lcm_sym176__ = stan::math::sum(inline_seq_cprob_return_sym10__);
+        psi = lcm_sym176__;
         current_statement__ = 60;
         stan::model::assign(b,
-          stan::math::divide(inline_seq_cprob_return_sym10__, lcm_sym169__),
+          stan::math::divide(inline_seq_cprob_return_sym10__, lcm_sym176__),
           "assigning variable b");
         current_statement__ = 68;
-        if (lcm_sym119__) {
+        if (lcm_sym126__) {
           int f = std::numeric_limits<int>::min();
           int inline_first_capture_return_sym16__;
           int inline_first_capture_early_ret_check_sym18__;
           inline_first_capture_early_ret_check_sym18__ = 0;
           for (int inline_first_capture_iterator_sym19__ = 1; inline_first_capture_iterator_sym19__
                <= 1; ++inline_first_capture_iterator_sym19__) {
-            lcm_sym166__ = stan::math::size(
+            lcm_sym173__ = stan::math::size(
                              stan::model::rvalue(z, "z",
                                stan::model::index_uni(1)));
             for (int inline_first_capture_k_sym17__ = 1; inline_first_capture_k_sym17__
-                 <= lcm_sym166__; ++inline_first_capture_k_sym17__) {
+                 <= lcm_sym173__; ++inline_first_capture_k_sym17__) {
               current_statement__ = 63;
               if (stan::model::rvalue(z, "z", stan::model::index_uni(1),
                     stan::model::index_uni(inline_first_capture_k_sym17__))) {
@@ -21781,11 +24047,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             inline_first_capture_early_ret_check_sym18__ = 0;
             for (int inline_first_capture_iterator_sym19__ = 1; inline_first_capture_iterator_sym19__
                  <= 1; ++inline_first_capture_iterator_sym19__) {
-              lcm_sym165__ = stan::math::size(
+              lcm_sym172__ = stan::math::size(
                                stan::model::rvalue(z, "z",
                                  stan::model::index_uni(i)));
               for (int inline_first_capture_k_sym17__ = 1; inline_first_capture_k_sym17__
-                   <= lcm_sym165__; ++inline_first_capture_k_sym17__) {
+                   <= lcm_sym172__; ++inline_first_capture_k_sym17__) {
                 current_statement__ = 63;
                 if (stan::model::rvalue(z, "z", stan::model::index_uni(i),
                       stan::model::index_uni(inline_first_capture_k_sym17__))) {
@@ -21810,8 +24076,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             }
           }
         }
-        lcm_sym120__ = stan::math::logical_gte(n_occasions, 1);
-        if (lcm_sym120__) {
+        lcm_sym127__ = stan::math::logical_gte(n_occasions, 1);
+        if (lcm_sym127__) {
           current_statement__ = 69;
           stan::model::assign(N,
             stan::math::sum(
@@ -21840,7 +24106,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         }
         current_statement__ = 75;
-        if (lcm_sym119__) {
+        if (lcm_sym126__) {
           current_statement__ = 72;
           stan::model::assign(Nind,
             stan::math::sum(
@@ -21867,14 +24133,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 76;
         Nsuper = stan::math::sum(Nalive);
       }
-      out__.write(lcm_sym167__);
+      out__.write(lcm_sym174__);
       out__.write(psi);
       out__.write(b);
       out__.write(Nsuper);
       out__.write(N);
       out__.write(B);
-      if (lcm_sym120__) {
-        if (lcm_sym119__) {
+      if (lcm_sym127__) {
+        if (lcm_sym126__) {
           out__.write(stan::model::rvalue(z, "z", stan::model::index_uni(1),
                         stan::model::index_uni(1)));
           for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
@@ -21884,7 +24150,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         }
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          if (lcm_sym119__) {
+          if (lcm_sym126__) {
             out__.write(stan::model::rvalue(z, "z",
                           stan::model::index_uni(1),
                           stan::model::index_uni(sym1__)));
@@ -21902,8 +24168,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -21912,7 +24178,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym117__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mean_phi;
@@ -21928,11 +24193,88 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       out__.write_free_lub(0, 1, gamma);
       Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
       stan::model::assign(epsilon,
-        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>((n_occasions - 1)),
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(epsilon_1dim__),
         "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym124__;
+      double lcm_sym123__;
+      double lcm_sym122__;
+      double lcm_sym121__;
+      int lcm_sym120__;
+      int lcm_sym119__;
+      int lcm_sym118__;
+      int lcm_sym117__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> gamma =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
+          DUMMY_VAR__);
+      {
+        std::vector<double> gamma_flat__;
+        gamma_flat__ = context__.vals_r("gamma");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_occasions, 1)) {
+          stan::model::assign(gamma,
+            stan::model::rvalue(gamma_flat__, "gamma_flat__",
+              stan::model::index_uni(1)), "assigning variable gamma",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
+            stan::model::assign(gamma, gamma_flat__[(pos__ - 1)],
+              "assigning variable gamma", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_lub(0, 1, gamma);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant((n_occasions - 1),
+          DUMMY_VAR__);
+      {
+        std::vector<double> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        lcm_sym119__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym119__, 1)) {
+          stan::model::assign(epsilon,
+            stan::model::rvalue(epsilon_flat__, "epsilon_flat__",
+              stan::model::index_uni(1)), "assigning variable epsilon",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= lcm_sym119__; ++sym1__) {
+            stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+              "assigning variable epsilon", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21995,55 +24337,55 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+    for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
       param_names__.emplace_back(std::string() + "gamma" + '.' +
-        std::to_string(sym264__));
+        std::to_string(sym271__));
     }
-    for (int sym264__ = 1; sym264__ <= epsilon_1dim__; ++sym264__) {
+    for (int sym271__ = 1; sym271__ <= epsilon_1dim__; ++sym271__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym264__));
+        std::to_string(sym271__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym264__ = 1; sym264__ <= phi_2dim__; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= phi_2dim__; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "psi");
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym264__));
+          std::to_string(sym271__));
       }
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym264__));
+          std::to_string(sym271__));
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym264__));
+          std::to_string(sym271__));
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
     }
@@ -22054,55 +24396,55 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+    for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
       param_names__.emplace_back(std::string() + "gamma" + '.' +
-        std::to_string(sym264__));
+        std::to_string(sym271__));
     }
-    for (int sym264__ = 1; sym264__ <= epsilon_1dim__; ++sym264__) {
+    for (int sym271__ = 1; sym271__ <= epsilon_1dim__; ++sym271__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym264__));
+        std::to_string(sym271__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym264__ = 1; sym264__ <= phi_2dim__; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= phi_2dim__; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "psi");
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym264__));
+          std::to_string(sym271__));
       }
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym264__));
+          std::to_string(sym271__));
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym264__));
+          std::to_string(sym271__));
       }
-      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
-        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
+      for (int sym271__ = 1; sym271__ <= n_occasions; ++sym271__) {
+        for (int sym272__ = 1; sym272__ <= M; ++sym272__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym265__) + '.' + std::to_string(sym264__));
+            std::to_string(sym272__) + '.' + std::to_string(sym271__));
         }
       }
     }
@@ -22179,26 +24521,17 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"mean_phi", "mean_p", "gamma", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{1, 1, n_occasions, epsilon_1dim__, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22369,10 +24702,27 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -22479,24 +24829,17 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22664,8 +25007,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -22678,6 +25021,26 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       pos__ = 1;
       local_scalar_t__ x;
       x = in__.read<local_scalar_t__>();
+      out__.write(x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ x;
+      x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22779,24 +25142,17 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"x"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22903,7 +25259,7 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym4__;
+      double lcm_sym3__;
       std::vector<local_scalar_t__> theta =
         std::vector<local_scalar_t__>(J, DUMMY_VAR__);
       current_statement__ = 1;
@@ -22949,8 +25305,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym3__;
       int lcm_sym2__;
+      int lcm_sym1__;
       std::vector<double> theta =
         std::vector<double>(J, std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 1;
@@ -22972,8 +25328,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -22982,17 +25338,34 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       std::vector<local_scalar_t__> theta =
         std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      if (stan::math::logical_gte(J, 1)) {
-        theta[(1 - 1)] = in__.read<local_scalar_t__>();
-        for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
-          theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-        }
+      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      std::vector<local_scalar_t__> theta =
+        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
+      theta = context__.vals_r("theta");
       out__.write(theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -23019,9 +25392,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym5__ = 1; sym5__ <= J; ++sym5__) {
+    for (int sym4__ = 1; sym4__ <= J; ++sym4__) {
       param_names__.emplace_back(std::string() + "theta" + '.' +
-        std::to_string(sym5__));
+        std::to_string(sym4__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -23030,9 +25403,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym5__ = 1; sym5__ <= J; ++sym5__) {
+    for (int sym4__ = 1; sym4__ <= J; ++sym4__) {
       param_names__.emplace_back(std::string() + "theta" + '.' +
-        std::to_string(sym5__));
+        std::to_string(sym4__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -23101,24 +25474,17 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"theta"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{J};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -24358,8 +26724,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -24375,6 +26741,29 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       out__.write_free_lub(0, 1, mean_phi);
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 1, mean_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
       out__.write_free_lub(0, 1, mean_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -24533,24 +26922,17 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_phi", "mean_p"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -24834,8 +27216,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -24848,6 +27230,26 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       pos__ = 1;
       local_scalar_t__ mu;
       mu = in__.read<local_scalar_t__>();
+      out__.write(mu);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mu;
+      mu = context__.vals_r("mu")[(1 - 1)];
       out__.write(mu);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -24976,24 +27378,17 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"mu"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -25600,8 +27995,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -25623,6 +28018,35 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       out__.write(alpha_p);
       local_scalar_t__ beta_p;
       beta_p = in__.read<local_scalar_t__>();
+      out__.write(beta_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ alpha_occ;
+      alpha_occ = context__.vals_r("alpha_occ")[(1 - 1)];
+      out__.write(alpha_occ);
+      local_scalar_t__ beta_occ;
+      beta_occ = context__.vals_r("beta_occ")[(1 - 1)];
+      out__.write(beta_occ);
+      local_scalar_t__ alpha_p;
+      alpha_p = context__.vals_r("alpha_p")[(1 - 1)];
+      out__.write(alpha_p);
+      local_scalar_t__ beta_p;
+      beta_p = context__.vals_r("beta_p")[(1 - 1)];
       out__.write(beta_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -25801,25 +28225,17 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"alpha_occ", "beta_occ", "alpha_p", "beta_p"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -25881,14 +28297,14 @@ static constexpr std::array<const char*, 35> locations_array__ =
   " (in 'off-small.stan', line 22, column 9 to column 10)"};
 class off_small_model final : public model_base_crtp<off_small_model> {
  private:
-  double lcm_sym26__;
-  double lcm_sym25__;
-  double lcm_sym24__;
-  double lcm_sym23__;
-  double lcm_sym22__;
-  double lcm_sym21__;
-  int lcm_sym20__;
-  int lcm_sym19__;
+  double lcm_sym32__;
+  double lcm_sym31__;
+  double lcm_sym30__;
+  double lcm_sym29__;
+  double lcm_sym28__;
+  double lcm_sym27__;
+  int lcm_sym26__;
+  int lcm_sym25__;
   int J;
   int N;
   std::vector<int> person;
@@ -25962,8 +28378,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         time_flat__ = context__.vals_r("time");
         current_statement__ = 25;
         pos__ = 1;
-        lcm_sym19__ = stan::math::logical_gte(N, 1);
-        if (lcm_sym19__) {
+        lcm_sym25__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym25__) {
           current_statement__ = 25;
           stan::model::assign(time,
             stan::model::rvalue(time_flat__, "time_flat__",
@@ -25996,7 +28412,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         current_statement__ = 27;
         pos__ = 1;
         current_statement__ = 27;
-        if (lcm_sym19__) {
+        if (lcm_sym25__) {
           current_statement__ = 27;
           stan::model::assign(treatment,
             stan::model::rvalue(treatment_flat__, "treatment_flat__",
@@ -26028,7 +28444,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         current_statement__ = 29;
         pos__ = 1;
         current_statement__ = 29;
-        if (lcm_sym19__) {
+        if (lcm_sym25__) {
           current_statement__ = 29;
           stan::model::assign(y,
             stan::model::rvalue(y_flat__, "y_flat__",
@@ -26087,17 +28503,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym18__;
+      double lcm_sym24__;
+      double lcm_sym23__;
+      double lcm_sym22__;
+      double lcm_sym21__;
+      double lcm_sym20__;
+      double lcm_sym19__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym18__;
       double lcm_sym17__;
       double lcm_sym16__;
-      double lcm_sym15__;
-      double lcm_sym14__;
-      double lcm_sym13__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym12__;
-      double lcm_sym11__;
-      double lcm_sym10__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym9__;
-      int lcm_sym8__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym15__;
+      int lcm_sym14__;
       local_scalar_t__ beta;
       current_statement__ = 1;
       beta = in__.template read<local_scalar_t__>();
@@ -26131,20 +28547,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
       Eigen::Matrix<local_scalar_t__,-1,1> y_hat =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      stan::model::assign(lcm_sym12__,
+      stan::model::assign(lcm_sym18__,
         stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable lcm_sym12__");
-      stan::model::assign(a1, lcm_sym12__, "assigning variable a1");
-      stan::model::assign(lcm_sym9__,
+        "assigning variable lcm_sym18__");
+      stan::model::assign(a1, lcm_sym18__, "assigning variable a1");
+      stan::model::assign(lcm_sym15__,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
-        "assigning variable lcm_sym9__");
-      stan::model::assign(a2, lcm_sym9__, "assigning variable a2");
+        "assigning variable lcm_sym15__");
+      stan::model::assign(a2, lcm_sym15__, "assigning variable a2");
       current_statement__ = 13;
       if (stan::math::logical_gte(N, 1)) {
         current_statement__ = 12;
         stan::model::assign(y_hat,
           stan::math::fma(
-            stan::model::rvalue(lcm_sym9__, "lcm_sym9__",
+            stan::model::rvalue(lcm_sym15__, "lcm_sym15__",
               stan::model::index_uni(
                 stan::model::rvalue(person, "person",
                   stan::model::index_uni(1)))),
@@ -26153,7 +28569,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
               stan::model::rvalue(time, "time", stan::model::index_uni(1))),
               stan::model::rvalue(treatment, "treatment",
                 stan::model::index_uni(1)),
-              stan::model::rvalue(lcm_sym12__, "lcm_sym12__",
+              stan::model::rvalue(lcm_sym18__, "lcm_sym18__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(1)))))),
@@ -26162,7 +28578,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
           current_statement__ = 12;
           stan::model::assign(y_hat,
             stan::math::fma(
-              stan::model::rvalue(lcm_sym9__, "lcm_sym9__",
+              stan::model::rvalue(lcm_sym15__, "lcm_sym15__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(i)))),
@@ -26171,7 +28587,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                 stan::model::rvalue(time, "time", stan::model::index_uni(i))),
                 stan::model::rvalue(treatment, "treatment",
                   stan::model::index_uni(i)),
-                stan::model::rvalue(lcm_sym12__, "lcm_sym12__",
+                stan::model::rvalue(lcm_sym18__, "lcm_sym18__",
                   stan::model::index_uni(
                     stan::model::rvalue(person, "person",
                       stan::model::index_uni(i)))))),
@@ -26229,13 +28645,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      Eigen::Matrix<double,-1,1> lcm_sym7__;
-      double lcm_sym6__;
-      double lcm_sym5__;
-      Eigen::Matrix<double,-1,1> lcm_sym4__;
-      int lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
+      Eigen::Matrix<double,-1,1> lcm_sym13__;
+      double lcm_sym12__;
+      double lcm_sym11__;
+      Eigen::Matrix<double,-1,1> lcm_sym10__;
+      int lcm_sym9__;
+      int lcm_sym8__;
+      int lcm_sym7__;
       double beta;
       current_statement__ = 1;
       beta = in__.template read<local_scalar_t__>();
@@ -26285,20 +28701,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      stan::model::assign(lcm_sym7__,
+      stan::model::assign(lcm_sym13__,
         stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable lcm_sym7__");
-      stan::model::assign(a1, lcm_sym7__, "assigning variable a1");
-      stan::model::assign(lcm_sym4__,
+        "assigning variable lcm_sym13__");
+      stan::model::assign(a1, lcm_sym13__, "assigning variable a1");
+      stan::model::assign(lcm_sym10__,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
-        "assigning variable lcm_sym4__");
-      stan::model::assign(a2, lcm_sym4__, "assigning variable a2");
+        "assigning variable lcm_sym10__");
+      stan::model::assign(a2, lcm_sym10__, "assigning variable a2");
       current_statement__ = 13;
       if (stan::math::logical_gte(N, 1)) {
         current_statement__ = 12;
         stan::model::assign(y_hat,
           stan::math::fma(
-            stan::model::rvalue(lcm_sym4__, "lcm_sym4__",
+            stan::model::rvalue(lcm_sym10__, "lcm_sym10__",
               stan::model::index_uni(
                 stan::model::rvalue(person, "person",
                   stan::model::index_uni(1)))),
@@ -26307,7 +28723,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
               stan::model::rvalue(time, "time", stan::model::index_uni(1))),
               stan::model::rvalue(treatment, "treatment",
                 stan::model::index_uni(1)),
-              stan::model::rvalue(lcm_sym7__, "lcm_sym7__",
+              stan::model::rvalue(lcm_sym13__, "lcm_sym13__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(1)))))),
@@ -26316,7 +28732,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
           current_statement__ = 12;
           stan::model::assign(y_hat,
             stan::math::fma(
-              stan::model::rvalue(lcm_sym4__, "lcm_sym4__",
+              stan::model::rvalue(lcm_sym10__, "lcm_sym10__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(i)))),
@@ -26325,7 +28741,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                 stan::model::rvalue(time, "time", stan::model::index_uni(i))),
                 stan::model::rvalue(treatment, "treatment",
                   stan::model::index_uni(i)),
-                stan::model::rvalue(lcm_sym7__, "lcm_sym7__",
+                stan::model::rvalue(lcm_sym13__, "lcm_sym13__",
                   stan::model::index_uni(
                     stan::model::rvalue(person, "person",
                       stan::model::index_uni(i)))))),
@@ -26333,8 +28749,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         }
       }
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym7__);
-        out__.write(lcm_sym4__);
+        out__.write(lcm_sym13__);
+        out__.write(lcm_sym10__);
         out__.write(y_hat);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -26348,8 +28764,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -26387,6 +28803,88 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       out__.write_free_lub(0, 100, sigma_a2);
       local_scalar_t__ sigma_y;
       sigma_y = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym6__;
+      double lcm_sym5__;
+      double lcm_sym4__;
+      double lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ beta;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write(beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> eta1 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<double> eta1_flat__;
+        eta1_flat__ = context__.vals_r("eta1");
+        pos__ = 1;
+        lcm_sym1__ = stan::math::logical_gte(J, 1);
+        if (lcm_sym1__) {
+          stan::model::assign(eta1,
+            stan::model::rvalue(eta1_flat__, "eta1_flat__",
+              stan::model::index_uni(1)), "assigning variable eta1",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
+            stan::model::assign(eta1, eta1_flat__[(pos__ - 1)],
+              "assigning variable eta1", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(eta1);
+      Eigen::Matrix<local_scalar_t__,-1,1> eta2 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<double> eta2_flat__;
+        eta2_flat__ = context__.vals_r("eta2");
+        pos__ = 1;
+        if (lcm_sym1__) {
+          stan::model::assign(eta2,
+            stan::model::rvalue(eta2_flat__, "eta2_flat__",
+              stan::model::index_uni(1)), "assigning variable eta2",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
+            stan::model::assign(eta2, eta2_flat__[(pos__ - 1)],
+              "assigning variable eta2", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(eta2);
+      local_scalar_t__ mu_a1;
+      mu_a1 = context__.vals_r("mu_a1")[(1 - 1)];
+      out__.write(mu_a1);
+      local_scalar_t__ mu_a2;
+      mu_a2 = context__.vals_r("mu_a2")[(1 - 1)];
+      out__.write(mu_a2);
+      local_scalar_t__ sigma_a1;
+      sigma_a1 = context__.vals_r("sigma_a1")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a1);
+      local_scalar_t__ sigma_a2;
+      sigma_a2 = context__.vals_r("sigma_a2")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a2);
+      local_scalar_t__ sigma_y;
+      sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -26430,13 +28928,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "beta");
-    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+    for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
       param_names__.emplace_back(std::string() + "eta1" + '.' +
-        std::to_string(sym27__));
+        std::to_string(sym33__));
     }
-    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+    for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
       param_names__.emplace_back(std::string() + "eta2" + '.' +
-        std::to_string(sym27__));
+        std::to_string(sym33__));
     }
     param_names__.emplace_back(std::string() + "mu_a1");
     param_names__.emplace_back(std::string() + "mu_a2");
@@ -26444,17 +28942,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     param_names__.emplace_back(std::string() + "sigma_a2");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+      for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
         param_names__.emplace_back(std::string() + "a1" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym33__));
       }
-      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+      for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
         param_names__.emplace_back(std::string() + "a2" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym33__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym33__ = 1; sym33__ <= N; ++sym33__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym33__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -26464,13 +28962,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "beta");
-    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+    for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
       param_names__.emplace_back(std::string() + "eta1" + '.' +
-        std::to_string(sym27__));
+        std::to_string(sym33__));
     }
-    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+    for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
       param_names__.emplace_back(std::string() + "eta2" + '.' +
-        std::to_string(sym27__));
+        std::to_string(sym33__));
     }
     param_names__.emplace_back(std::string() + "mu_a1");
     param_names__.emplace_back(std::string() + "mu_a2");
@@ -26478,17 +28976,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     param_names__.emplace_back(std::string() + "sigma_a2");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+      for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
         param_names__.emplace_back(std::string() + "a1" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym33__));
       }
-      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
+      for (int sym33__ = 1; sym33__ <= J; ++sym33__) {
         param_names__.emplace_back(std::string() + "a2" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym33__));
       }
-      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
+      for (int sym33__ = 1; sym33__ <= N; ++sym33__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym27__));
+          std::to_string(sym33__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -26559,27 +29057,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8>
-      names__{"beta", "eta1", "eta2", "mu_a1", "mu_a2", "sigma_a1",
-              "sigma_a2", "sigma_y"};
-    const std::array<Eigen::Index, 8>
-      constrain_param_sizes__{1, J, J, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -26830,30 +29318,30 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym64__;
+      double lcm_sym63__;
+      double lcm_sym62__;
+      double lcm_sym61__;
+      double lcm_sym60__;
+      double lcm_sym59__;
+      double lcm_sym58__;
       double lcm_sym57__;
       double lcm_sym56__;
       double lcm_sym55__;
       double lcm_sym54__;
-      double lcm_sym53__;
-      double lcm_sym52__;
-      double lcm_sym51__;
-      double lcm_sym50__;
-      double lcm_sym49__;
-      double lcm_sym48__;
-      double lcm_sym47__;
+      int lcm_sym53__;
+      int lcm_sym52__;
+      int lcm_sym51__;
+      int lcm_sym50__;
+      int lcm_sym49__;
+      int lcm_sym48__;
+      int lcm_sym47__;
       int lcm_sym46__;
       int lcm_sym45__;
       int lcm_sym44__;
       int lcm_sym43__;
       int lcm_sym42__;
       int lcm_sym41__;
-      int lcm_sym40__;
-      int lcm_sym39__;
-      int lcm_sym38__;
-      int lcm_sym37__;
-      int lcm_sym36__;
-      int lcm_sym35__;
-      int lcm_sym34__;
       local_scalar_t__ theta;
       current_statement__ = 1;
       theta = in__.template read<local_scalar_t__>();
@@ -26967,19 +29455,19 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           }
           int inline_rfun_early_ret_check_sym12__ =
             std::numeric_limits<int>::min();
-          lcm_sym43__ = (inline_rfun_return_sym8__ + 1);
+          lcm_sym50__ = (inline_rfun_return_sym8__ + 1);
           for (int inline_rfun_iterator_sym13__ = 1; inline_rfun_iterator_sym13__
                <= 1; ++inline_rfun_iterator_sym13__) {
             {
               inline_rfun_return_sym11__ = 29;
-              lcm_sym43__ = (inline_rfun_return_sym8__ + 1);
+              lcm_sym50__ = (inline_rfun_return_sym8__ + 1);
               break;
             }
             inline_rfun_return_sym11__ = 7;
-            lcm_sym43__ = (inline_rfun_return_sym8__ + 1);
+            lcm_sym50__ = (inline_rfun_return_sym8__ + 1);
             break;
           }
-          for (int i = lcm_sym43__; i <= inline_rfun_return_sym11__; ++i) {
+          for (int i = lcm_sym50__; i <= inline_rfun_return_sym11__; ++i) {
             {
               int inline_rfun_return_sym14__;
               int inline_rfun_early_ret_check_sym15__ =
@@ -27043,22 +29531,22 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
               }
             }
             {
-              lcm_sym46__ = (2 * 2);
-              if (stan::math::logical_gte(lcm_sym46__, 2)) {
-                lcm_sym44__ = (2 + 1);
+              lcm_sym53__ = (2 * 2);
+              if (stan::math::logical_gte(lcm_sym53__, 2)) {
+                lcm_sym51__ = (2 + 1);
                 lp_accum__.add(53);
-                for (int k = lcm_sym44__; k <= lcm_sym46__; ++k) {
+                for (int k = lcm_sym51__; k <= lcm_sym53__; ++k) {
                   current_statement__ = 16;
                   lp_accum__.add(53);
                 }
               }
             }
             {
-              lcm_sym46__ = (3 * 2);
-              if (stan::math::logical_gte(lcm_sym46__, 3)) {
-                lcm_sym44__ = (3 + 1);
+              lcm_sym53__ = (3 * 2);
+              if (stan::math::logical_gte(lcm_sym53__, 3)) {
+                lcm_sym51__ = (3 + 1);
                 lp_accum__.add(53);
-                for (int k = lcm_sym44__; k <= lcm_sym46__; ++k) {
+                for (int k = lcm_sym51__; k <= lcm_sym53__; ++k) {
                   current_statement__ = 16;
                   lp_accum__.add(53);
                 }
@@ -27066,25 +29554,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             }
           }
           {
-            lcm_sym42__ = (2 + 2);
-            if (stan::math::logical_gte(lcm_sym42__, 2)) {
-              lcm_sym45__ = (2 * 2);
-              if (stan::math::logical_gte(lcm_sym45__, 2)) {
-                lcm_sym41__ = (2 + 1);
+            lcm_sym49__ = (2 + 2);
+            if (stan::math::logical_gte(lcm_sym49__, 2)) {
+              lcm_sym52__ = (2 * 2);
+              if (stan::math::logical_gte(lcm_sym52__, 2)) {
+                lcm_sym48__ = (2 + 1);
                 lp_accum__.add(53);
-                for (int k = lcm_sym41__; k <= lcm_sym45__; ++k) {
+                for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
                   current_statement__ = 16;
                   lp_accum__.add(53);
                 }
               } else {
-                lcm_sym41__ = (2 + 1);
+                lcm_sym48__ = (2 + 1);
               }
-              for (int j = lcm_sym41__; j <= lcm_sym42__; ++j) {
-                lcm_sym46__ = (j * 2);
-                if (stan::math::logical_gte(lcm_sym46__, j)) {
-                  lcm_sym44__ = (j + 1);
+              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+                lcm_sym53__ = (j * 2);
+                if (stan::math::logical_gte(lcm_sym53__, j)) {
+                  lcm_sym51__ = (j + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym44__; k <= lcm_sym46__; ++k) {
+                  for (int k = lcm_sym51__; k <= lcm_sym53__; ++k) {
                     current_statement__ = 16;
                     lp_accum__.add(53);
                   }
@@ -27093,25 +29581,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             }
           }
           {
-            lcm_sym42__ = (3 + 2);
-            if (stan::math::logical_gte(lcm_sym42__, 3)) {
-              lcm_sym45__ = (3 * 2);
-              if (stan::math::logical_gte(lcm_sym45__, 3)) {
-                lcm_sym41__ = (3 + 1);
+            lcm_sym49__ = (3 + 2);
+            if (stan::math::logical_gte(lcm_sym49__, 3)) {
+              lcm_sym52__ = (3 * 2);
+              if (stan::math::logical_gte(lcm_sym52__, 3)) {
+                lcm_sym48__ = (3 + 1);
                 lp_accum__.add(53);
-                for (int k = lcm_sym41__; k <= lcm_sym45__; ++k) {
+                for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
                   current_statement__ = 16;
                   lp_accum__.add(53);
                 }
               } else {
-                lcm_sym41__ = (3 + 1);
+                lcm_sym48__ = (3 + 1);
               }
-              for (int j = lcm_sym41__; j <= lcm_sym42__; ++j) {
-                lcm_sym46__ = (j * 2);
-                if (stan::math::logical_gte(lcm_sym46__, j)) {
-                  lcm_sym44__ = (j + 1);
+              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+                lcm_sym53__ = (j * 2);
+                if (stan::math::logical_gte(lcm_sym53__, j)) {
+                  lcm_sym51__ = (j + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym44__; k <= lcm_sym46__; ++k) {
+                  for (int k = lcm_sym51__; k <= lcm_sym53__; ++k) {
                     current_statement__ = 16;
                     lp_accum__.add(53);
                   }
@@ -27120,25 +29608,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             }
           }
           {
-            lcm_sym42__ = (4 + 2);
-            if (stan::math::logical_gte(lcm_sym42__, 4)) {
-              lcm_sym45__ = (4 * 2);
-              if (stan::math::logical_gte(lcm_sym45__, 4)) {
-                lcm_sym41__ = (4 + 1);
+            lcm_sym49__ = (4 + 2);
+            if (stan::math::logical_gte(lcm_sym49__, 4)) {
+              lcm_sym52__ = (4 * 2);
+              if (stan::math::logical_gte(lcm_sym52__, 4)) {
+                lcm_sym48__ = (4 + 1);
                 lp_accum__.add(53);
-                for (int k = lcm_sym41__; k <= lcm_sym45__; ++k) {
+                for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
                   current_statement__ = 16;
                   lp_accum__.add(53);
                 }
               } else {
-                lcm_sym41__ = (4 + 1);
+                lcm_sym48__ = (4 + 1);
               }
-              for (int j = lcm_sym41__; j <= lcm_sym42__; ++j) {
-                lcm_sym46__ = (j * 2);
-                if (stan::math::logical_gte(lcm_sym46__, j)) {
-                  lcm_sym44__ = (j + 1);
+              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+                lcm_sym53__ = (j * 2);
+                if (stan::math::logical_gte(lcm_sym53__, j)) {
+                  lcm_sym51__ = (j + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym44__; k <= lcm_sym46__; ++k) {
+                  for (int k = lcm_sym51__; k <= lcm_sym53__; ++k) {
                     current_statement__ = 16;
                     lp_accum__.add(53);
                   }
@@ -27147,25 +29635,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             }
           }
           {
-            lcm_sym42__ = (5 + 2);
-            if (stan::math::logical_gte(lcm_sym42__, 5)) {
-              lcm_sym45__ = (5 * 2);
-              if (stan::math::logical_gte(lcm_sym45__, 5)) {
-                lcm_sym41__ = (5 + 1);
+            lcm_sym49__ = (5 + 2);
+            if (stan::math::logical_gte(lcm_sym49__, 5)) {
+              lcm_sym52__ = (5 * 2);
+              if (stan::math::logical_gte(lcm_sym52__, 5)) {
+                lcm_sym48__ = (5 + 1);
                 lp_accum__.add(53);
-                for (int k = lcm_sym41__; k <= lcm_sym45__; ++k) {
+                for (int k = lcm_sym48__; k <= lcm_sym52__; ++k) {
                   current_statement__ = 16;
                   lp_accum__.add(53);
                 }
               } else {
-                lcm_sym41__ = (5 + 1);
+                lcm_sym48__ = (5 + 1);
               }
-              for (int j = lcm_sym41__; j <= lcm_sym42__; ++j) {
-                lcm_sym46__ = (j * 2);
-                if (stan::math::logical_gte(lcm_sym46__, j)) {
-                  lcm_sym44__ = (j + 1);
+              for (int j = lcm_sym48__; j <= lcm_sym49__; ++j) {
+                lcm_sym53__ = (j * 2);
+                if (stan::math::logical_gte(lcm_sym53__, j)) {
+                  lcm_sym51__ = (j + 1);
                   lp_accum__.add(53);
-                  for (int k = lcm_sym44__; k <= lcm_sym46__; ++k) {
+                  for (int k = lcm_sym51__; k <= lcm_sym53__; ++k) {
                     current_statement__ = 16;
                     lp_accum__.add(53);
                   }
@@ -27216,8 +29704,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         x = 576;
         current_statement__ = 40;
         lp_accum__.add(576);
-        lcm_sym40__ = stan::math::logical_gt(theta, 46);
-        if (lcm_sym40__) {
+        lcm_sym47__ = stan::math::logical_gt(theta, 46);
+        if (lcm_sym47__) {
           current_statement__ = 41;
           x = 5880;
         }
@@ -27229,7 +29717,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 45;
         lp_accum__.add(x);
         current_statement__ = 47;
-        if (lcm_sym40__) {
+        if (lcm_sym47__) {
           current_statement__ = 46;
           z = x;
         }
@@ -27382,8 +29870,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym33__;
-      int lcm_sym32__;
+      int lcm_sym40__;
+      int lcm_sym39__;
       double theta;
       current_statement__ = 1;
       theta = in__.template read<local_scalar_t__>();
@@ -27422,8 +29910,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -27459,6 +29947,138 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
   }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym38__;
+      double lcm_sym37__;
+      double lcm_sym36__;
+      double lcm_sym35__;
+      double lcm_sym34__;
+      double lcm_sym33__;
+      int lcm_sym32__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ theta;
+      theta = context__.vals_r("theta")[(1 - 1)];
+      out__.write(theta);
+      local_scalar_t__ phi;
+      phi = context__.vals_r("phi")[(1 - 1)];
+      out__.write(phi);
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 2, DUMMY_VAR__);
+      {
+        std::vector<double> x_matrix_flat__;
+        x_matrix_flat__ = context__.vals_r("x_matrix");
+        pos__ = 1;
+        {
+          {
+            stan::model::assign(x_matrix,
+              stan::model::rvalue(x_matrix_flat__, "x_matrix_flat__",
+                stan::model::index_uni(1)), "assigning variable x_matrix",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            {
+              stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+                "assigning variable x_matrix", stan::model::index_uni(2),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+                "assigning variable x_matrix", stan::model::index_uni(3),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+              "assigning variable x_matrix", stan::model::index_uni(1),
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+                "assigning variable x_matrix", stan::model::index_uni(2),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+                "assigning variable x_matrix", stan::model::index_uni(3),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(x_matrix);
+      Eigen::Matrix<local_scalar_t__,-1,1> x_vector =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<double> x_vector_flat__;
+        x_vector_flat__ = context__.vals_r("x_vector");
+        pos__ = 1;
+        {
+          stan::model::assign(x_vector,
+            stan::model::rvalue(x_vector_flat__, "x_vector_flat__",
+              stan::model::index_uni(1)), "assigning variable x_vector",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          {
+            stan::model::assign(x_vector, x_vector_flat__[(pos__ - 1)],
+              "assigning variable x_vector", stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(x_vector);
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
+      {
+        std::vector<double> x_cov_flat__;
+        x_cov_flat__ = context__.vals_r("x_cov");
+        pos__ = 1;
+        {
+          {
+            stan::model::assign(x_cov,
+              stan::model::rvalue(x_cov_flat__, "x_cov_flat__",
+                stan::model::index_uni(1)), "assigning variable x_cov",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            {
+              stan::model::assign(x_cov, x_cov_flat__[(pos__ - 1)],
+                "assigning variable x_cov", stan::model::index_uni(2),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(x_cov, x_cov_flat__[(pos__ - 1)],
+              "assigning variable x_cov", stan::model::index_uni(1),
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(x_cov, x_cov_flat__[(pos__ - 1)],
+                "assigning variable x_cov", stan::model::index_uni(2),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write_free_cov_matrix(x_cov);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
                   emit_transformed_parameters__ = true, const bool
@@ -27488,20 +30108,20 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "theta");
     param_names__.emplace_back(std::string() + "phi");
-    for (int sym58__ = 1; sym58__ <= 2; ++sym58__) {
-      for (int sym59__ = 1; sym59__ <= 3; ++sym59__) {
+    for (int sym65__ = 1; sym65__ <= 2; ++sym65__) {
+      for (int sym66__ = 1; sym66__ <= 3; ++sym66__) {
         param_names__.emplace_back(std::string() + "x_matrix" + '.' +
-          std::to_string(sym59__) + '.' + std::to_string(sym58__));
+          std::to_string(sym66__) + '.' + std::to_string(sym65__));
       }
     }
-    for (int sym58__ = 1; sym58__ <= 2; ++sym58__) {
+    for (int sym65__ = 1; sym65__ <= 2; ++sym65__) {
       param_names__.emplace_back(std::string() + "x_vector" + '.' +
-        std::to_string(sym58__));
+        std::to_string(sym65__));
     }
-    for (int sym58__ = 1; sym58__ <= 2; ++sym58__) {
-      for (int sym59__ = 1; sym59__ <= 2; ++sym59__) {
+    for (int sym65__ = 1; sym65__ <= 2; ++sym65__) {
+      for (int sym66__ = 1; sym66__ <= 2; ++sym66__) {
         param_names__.emplace_back(std::string() + "x_cov" + '.' +
-          std::to_string(sym59__) + '.' + std::to_string(sym58__));
+          std::to_string(sym66__) + '.' + std::to_string(sym65__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -27513,19 +30133,19 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "theta");
     param_names__.emplace_back(std::string() + "phi");
-    for (int sym58__ = 1; sym58__ <= 2; ++sym58__) {
-      for (int sym59__ = 1; sym59__ <= 3; ++sym59__) {
+    for (int sym65__ = 1; sym65__ <= 2; ++sym65__) {
+      for (int sym66__ = 1; sym66__ <= 3; ++sym66__) {
         param_names__.emplace_back(std::string() + "x_matrix" + '.' +
-          std::to_string(sym59__) + '.' + std::to_string(sym58__));
+          std::to_string(sym66__) + '.' + std::to_string(sym65__));
       }
     }
-    for (int sym58__ = 1; sym58__ <= 2; ++sym58__) {
+    for (int sym65__ = 1; sym65__ <= 2; ++sym65__) {
       param_names__.emplace_back(std::string() + "x_vector" + '.' +
-        std::to_string(sym58__));
+        std::to_string(sym65__));
     }
-    for (int sym58__ = 1; sym58__ <= 3; ++sym58__) {
+    for (int sym65__ = 1; sym65__ <= 3; ++sym65__) {
       param_names__.emplace_back(std::string() + "x_cov" + '.' +
-        std::to_string(sym58__));
+        std::to_string(sym65__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -27594,26 +30214,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"theta", "phi", "x_matrix", "x_vector", "x_cov"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{1, 1, (3 * 2), 2, (2 * 2)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -27803,10 +30414,27 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -27913,24 +30541,17 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -28154,10 +30775,27 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -28264,24 +30902,17 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -28336,14 +30967,14 @@ static constexpr std::array<const char*, 28> locations_array__ =
   " (in 'partial-eval.stan', line 17, column 9 to column 10)"};
 class partial_eval_model final : public model_base_crtp<partial_eval_model> {
  private:
-  double lcm_sym23__;
-  double lcm_sym22__;
-  double lcm_sym21__;
-  double lcm_sym20__;
-  double lcm_sym19__;
-  double lcm_sym18__;
-  int lcm_sym17__;
-  int lcm_sym16__;
+  double lcm_sym29__;
+  double lcm_sym28__;
+  double lcm_sym27__;
+  double lcm_sym26__;
+  double lcm_sym25__;
+  double lcm_sym24__;
+  int lcm_sym23__;
+  int lcm_sym22__;
   int N;
   int n_pair;
   std::vector<int> pair;
@@ -28417,8 +31048,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         pre_test_flat__ = context__.vals_r("pre_test");
         current_statement__ = 21;
         pos__ = 1;
-        lcm_sym16__ = stan::math::logical_gte(N, 1);
-        if (lcm_sym16__) {
+        lcm_sym22__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym22__) {
           current_statement__ = 21;
           stan::model::assign(pre_test,
             stan::model::rvalue(pre_test_flat__, "pre_test_flat__",
@@ -28451,7 +31082,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 23;
         pos__ = 1;
         current_statement__ = 23;
-        if (lcm_sym16__) {
+        if (lcm_sym22__) {
           current_statement__ = 23;
           stan::model::assign(treatment,
             stan::model::rvalue(treatment_flat__, "treatment_flat__",
@@ -28488,7 +31119,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 25;
         pos__ = 1;
         current_statement__ = 25;
-        if (lcm_sym16__) {
+        if (lcm_sym22__) {
           current_statement__ = 25;
           stan::model::assign(y,
             stan::model::rvalue(y_flat__, "y_flat__",
@@ -28541,16 +31172,16 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      std::complex<double> lcm_sym15__;
-      std::complex<double> lcm_sym14__;
+      std::complex<double> lcm_sym21__;
+      std::complex<double> lcm_sym20__;
+      double lcm_sym19__;
+      double lcm_sym18__;
+      double lcm_sym17__;
+      double lcm_sym16__;
+      double lcm_sym15__;
+      double lcm_sym14__;
       double lcm_sym13__;
-      double lcm_sym12__;
-      double lcm_sym11__;
-      double lcm_sym10__;
-      double lcm_sym9__;
-      double lcm_sym8__;
-      double lcm_sym7__;
-      int lcm_sym6__;
+      int lcm_sym12__;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair);
@@ -28617,15 +31248,15 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         std::complex<double> z =
           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
             std::numeric_limits<double>::quiet_NaN());
-        lcm_sym15__ = stan::math::to_complex(7, 5);
+        lcm_sym21__ = stan::math::to_complex(7, 5);
         current_statement__ = 14;
         if (pstream__) {
-          stan::math::stan_print(pstream__, lcm_sym15__);
+          stan::math::stan_print(pstream__, lcm_sym21__);
           *(pstream__) << std::endl;
         }
-        lcm_sym14__ = stan::math::to_complex(5, 4);
+        lcm_sym20__ = stan::math::to_complex(5, 4);
         current_statement__ = 15;
-        lp_accum__.add(stan::math::get_real(lcm_sym14__));
+        lp_accum__.add(stan::math::get_real(lcm_sym20__));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -28664,11 +31295,11 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym5__;
-      double lcm_sym4__;
-      int lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
+      double lcm_sym11__;
+      double lcm_sym10__;
+      int lcm_sym9__;
+      int lcm_sym8__;
+      int lcm_sym7__;
       Eigen::Matrix<double,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair);
@@ -28747,8 +31378,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -28777,6 +31408,78 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       out__.write_free_lub(0, 100, sigma_a);
       local_scalar_t__ sigma_y;
       sigma_y = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym6__;
+      double lcm_sym5__;
+      double lcm_sym4__;
+      double lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
+      {
+        std::vector<double> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        if (stan::math::logical_gte(n_pair, 1)) {
+          stan::model::assign(a,
+            stan::model::rvalue(a_flat__, "a_flat__",
+              stan::model::index_uni(1)), "assigning variable a",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          for (int sym1__ = 2; sym1__ <= n_pair; ++sym1__) {
+            stan::model::assign(a, a_flat__[(pos__ - 1)],
+              "assigning variable a", stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<double> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        {
+          stan::model::assign(beta,
+            stan::model::rvalue(beta_flat__, "beta_flat__",
+              stan::model::index_uni(1)), "assigning variable beta",
+            stan::model::index_uni(1));
+          pos__ = 2;
+          {
+            stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+              "assigning variable beta", stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(beta);
+      local_scalar_t__ mu_a;
+      mu_a = context__.vals_r("mu_a")[(1 - 1)];
+      out__.write(mu_a);
+      local_scalar_t__ sigma_a;
+      sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a);
+      local_scalar_t__ sigma_y;
+      sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -28817,21 +31520,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym24__ = 1; sym24__ <= n_pair; ++sym24__) {
+    for (int sym30__ = 1; sym30__ <= n_pair; ++sym30__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym30__));
     }
-    for (int sym24__ = 1; sym24__ <= 2; ++sym24__) {
+    for (int sym30__ = 1; sym30__ <= 2; ++sym30__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym30__));
     }
     param_names__.emplace_back(std::string() + "mu_a");
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
+      for (int sym30__ = 1; sym30__ <= N; ++sym30__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym24__));
+          std::to_string(sym30__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -28840,21 +31543,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym24__ = 1; sym24__ <= n_pair; ++sym24__) {
+    for (int sym30__ = 1; sym30__ <= n_pair; ++sym30__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym30__));
     }
-    for (int sym24__ = 1; sym24__ <= 2; ++sym24__) {
+    for (int sym30__ = 1; sym30__ <= 2; ++sym30__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym24__));
+        std::to_string(sym30__));
     }
     param_names__.emplace_back(std::string() + "mu_a");
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
+      for (int sym30__ = 1; sym30__ <= N; ++sym30__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym24__));
+          std::to_string(sym30__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -28923,26 +31626,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"a", "beta", "mu_a", "sigma_a", "sigma_y"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{n_pair, 2, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -28980,11 +31674,11 @@ static constexpr std::array<const char*, 11> locations_array__ =
   " (in 'partial_eval_multiply.stan', line 5, column 2 to column 20)"};
 class partial_eval_multiply_model final : public model_base_crtp<partial_eval_multiply_model> {
  private:
-  double lcm_sym10__;
-  double lcm_sym9__;
-  double lcm_sym8__;
-  double lcm_sym7__;
-  int lcm_sym6__;
+  double lcm_sym15__;
+  double lcm_sym14__;
+  double lcm_sym13__;
+  double lcm_sym12__;
+  int lcm_sym11__;
   Eigen::Matrix<double,-1,-1> m1_data__;
   Eigen::Matrix<double,-1,-1> m4_data__;
   std::vector<int> idx;
@@ -30690,9 +33384,9 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) function__;
     try {
-      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym5__;
-      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym4__;
-      double lcm_sym3__;
+      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym10__;
+      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym9__;
+      double lcm_sym8__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,-1>> m2;
       current_statement__ = 1;
@@ -30709,24 +33403,24 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
         Eigen::Matrix<double,-1,-1> m5 =
           Eigen::Matrix<double,-1,-1>::Constant(10, 10,
             std::numeric_limits<double>::quiet_NaN());
-        stan::model::assign(lcm_sym4__,
+        stan::model::assign(lcm_sym9__,
           stan::math::add(
             stan::math::multiply(m1,
               stan::math::elt_multiply(m2,
                 stan::model::rvalue(m3, "m3", stan::model::index_multi(idx),
                   stan::model::index_multi(idy)))), m4),
-          "assigning variable lcm_sym4__");
+          "assigning variable lcm_sym9__");
         Eigen::Matrix<double,-1,-1> m6 =
           Eigen::Matrix<double,-1,-1>::Constant(10, 10,
             std::numeric_limits<double>::quiet_NaN());
-        stan::model::assign(lcm_sym5__, stan::math::fma(m1, m2, m4),
-          "assigning variable lcm_sym5__");
+        stan::model::assign(lcm_sym10__, stan::math::fma(m1, m2, m4),
+          "assigning variable lcm_sym10__");
         Eigen::Matrix<double,-1,-1> m7 =
           Eigen::Matrix<double,-1,-1>::Constant(10, 10,
             std::numeric_limits<double>::quiet_NaN());
         current_statement__ = 6;
-        lp_accum__.add(((stan::math::sum(lcm_sym4__) +
-          stan::math::sum(lcm_sym5__)) + stan::math::sum(lcm_sym5__)));
+        lp_accum__.add(((stan::math::sum(lcm_sym9__) +
+          stan::math::sum(lcm_sym10__)) + stan::math::sum(lcm_sym10__)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -30765,8 +33459,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym2__;
-      int lcm_sym1__;
+      int lcm_sym7__;
+      int lcm_sym6__;
       Eigen::Matrix<double,-1,-1> m2;
       current_statement__ = 1;
       m2 = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10);
@@ -30791,8 +33485,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -30812,6 +33506,1250 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       stan::model::assign(m3,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable m3");
+      out__.write(m3);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym5__;
+      double lcm_sym4__;
+      double lcm_sym3__;
+      double lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<double> m2_flat__;
+        m2_flat__ = context__.vals_r("m2");
+        pos__ = 1;
+        {
+          {
+            stan::model::assign(m2,
+              stan::model::rvalue(m2_flat__, "m2_flat__",
+                stan::model::index_uni(1)), "assigning variable m2",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(6));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(7));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(8));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(9));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(1),
+              stan::model::index_uni(10));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(2),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(3),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(4),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(5),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(6),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(7),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(8),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(9),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+                "assigning variable m2", stan::model::index_uni(10),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
+      out__.write(m2);
+      Eigen::Matrix<local_scalar_t__,-1,-1> m3 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<double> m3_flat__;
+        m3_flat__ = context__.vals_r("m3");
+        pos__ = 1;
+        {
+          {
+            stan::model::assign(m3,
+              stan::model::rvalue(m3_flat__, "m3_flat__",
+                stan::model::index_uni(1)), "assigning variable m3",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(2));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(3));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(4));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(5));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(6));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(7));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(8));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(9));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(9));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(1),
+              stan::model::index_uni(10));
+            pos__ = (pos__ + 1);
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(2),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(3),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(4),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(5),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(6),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(7),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(8),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(9),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+            {
+              stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+                "assigning variable m3", stan::model::index_uni(10),
+                stan::model::index_uni(10));
+              pos__ = (pos__ + 1);
+            }
+          }
+        }
+      }
       out__.write(m3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -30842,16 +34780,16 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
-      for (int sym12__ = 1; sym12__ <= 10; ++sym12__) {
+    for (int sym16__ = 1; sym16__ <= 10; ++sym16__) {
+      for (int sym17__ = 1; sym17__ <= 10; ++sym17__) {
         param_names__.emplace_back(std::string() + "m2" + '.' +
-          std::to_string(sym12__) + '.' + std::to_string(sym11__));
+          std::to_string(sym17__) + '.' + std::to_string(sym16__));
       }
     }
-    for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
-      for (int sym12__ = 1; sym12__ <= 10; ++sym12__) {
+    for (int sym16__ = 1; sym16__ <= 10; ++sym16__) {
+      for (int sym17__ = 1; sym17__ <= 10; ++sym17__) {
         param_names__.emplace_back(std::string() + "m3" + '.' +
-          std::to_string(sym12__) + '.' + std::to_string(sym11__));
+          std::to_string(sym17__) + '.' + std::to_string(sym16__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -30861,16 +34799,16 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
-      for (int sym12__ = 1; sym12__ <= 10; ++sym12__) {
+    for (int sym16__ = 1; sym16__ <= 10; ++sym16__) {
+      for (int sym17__ = 1; sym17__ <= 10; ++sym17__) {
         param_names__.emplace_back(std::string() + "m2" + '.' +
-          std::to_string(sym12__) + '.' + std::to_string(sym11__));
+          std::to_string(sym17__) + '.' + std::to_string(sym16__));
       }
     }
-    for (int sym11__ = 1; sym11__ <= 10; ++sym11__) {
-      for (int sym12__ = 1; sym12__ <= 10; ++sym12__) {
+    for (int sym16__ = 1; sym16__ <= 10; ++sym16__) {
+      for (int sym17__ = 1; sym17__ <= 10; ++sym17__) {
         param_names__.emplace_back(std::string() + "m3" + '.' +
-          std::to_string(sym12__) + '.' + std::to_string(sym11__));
+          std::to_string(sym17__) + '.' + std::to_string(sym16__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -30940,25 +34878,17 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"m2", "m3"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(10 * 10), (10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -31018,13 +34948,13 @@ static constexpr std::array<const char*, 33> locations_array__ =
   " (in 'stalled1-failure.stan', line 32, column 18 to column 19)"};
 class stalled1_failure_model final : public model_base_crtp<stalled1_failure_model> {
  private:
+  double lcm_sym30__;
+  double lcm_sym29__;
+  double lcm_sym28__;
   double lcm_sym27__;
-  double lcm_sym26__;
-  double lcm_sym25__;
-  double lcm_sym24__;
-  int lcm_sym23__;
-  int lcm_sym22__;
-  Eigen::Matrix<double,-1,1> lcm_sym21___data__;
+  int lcm_sym26__;
+  int lcm_sym25__;
+  Eigen::Matrix<double,-1,1> lcm_sym24___data__;
   int I;
   std::vector<int> n;
   std::vector<int> N;
@@ -31032,7 +34962,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   Eigen::Matrix<double,-1,1> x2_data__;
   int K;
   Eigen::Matrix<double,-1,1> x1x2_data__;
-  Eigen::Map<Eigen::Matrix<double,-1,1>> lcm_sym21__{nullptr, 0};
+  Eigen::Map<Eigen::Matrix<double,-1,1>> lcm_sym24__{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> x1{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> x2{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> x1x2{nullptr, 0};
@@ -31099,8 +35029,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         x1_flat__ = context__.vals_r("x1");
         current_statement__ = 23;
         pos__ = 1;
-        lcm_sym22__ = stan::math::logical_gte(I, 1);
-        if (lcm_sym22__) {
+        lcm_sym25__ = stan::math::logical_gte(I, 1);
+        if (lcm_sym25__) {
           current_statement__ = 23;
           stan::model::assign(x1,
             stan::model::rvalue(x1_flat__, "x1_flat__",
@@ -31132,7 +35062,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         current_statement__ = 25;
         pos__ = 1;
         current_statement__ = 25;
-        if (lcm_sym22__) {
+        if (lcm_sym25__) {
           current_statement__ = 25;
           stan::model::assign(x2,
             stan::model::rvalue(x2_flat__, "x2_flat__",
@@ -31199,17 +35129,17 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym23__;
+      double lcm_sym22__;
+      double lcm_sym21__;
       double lcm_sym20__;
       double lcm_sym19__;
       double lcm_sym18__;
       double lcm_sym17__;
       double lcm_sym16__;
       double lcm_sym15__;
-      double lcm_sym14__;
-      double lcm_sym13__;
-      double lcm_sym12__;
-      int lcm_sym11__;
-      local_scalar_t__ lcm_sym10__;
+      int lcm_sym14__;
+      local_scalar_t__ lcm_sym13__;
       local_scalar_t__ alpha0;
       current_statement__ = 1;
       alpha0 = in__.template read<local_scalar_t__>();
@@ -31242,8 +35172,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
               stan::conditional_var_value_t<local_scalar_t__,
                 Eigen::Matrix<local_scalar_t__,-1,1>>>>(I, 8);
       local_scalar_t__ sigma = DUMMY_VAR__;
-      lcm_sym10__ = (1 / stan::math::sqrt(tau));
-      sigma = lcm_sym10__;
+      lcm_sym13__ = (1 / stan::math::sqrt(tau));
+      sigma = lcm_sym13__;
       {
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha0, 0.0, 1.0E3));
@@ -31260,7 +35190,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           current_statement__ = 13;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::model::rvalue(b, "b",
-                             stan::model::index_uni(1)), 0.0, lcm_sym10__));
+                             stan::model::index_uni(1)), 0.0, lcm_sym13__));
           current_statement__ = 14;
           lp_accum__.add(stan::math::binomial_logit_lpmf<propto__>(
                            stan::model::rvalue(n, "n",
@@ -31284,7 +35214,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
             current_statement__ = 13;
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b, "b",
-                               stan::model::index_uni(i)), 0.0, lcm_sym10__));
+                               stan::model::index_uni(i)), 0.0, lcm_sym13__));
             current_statement__ = 14;
             lp_accum__.add(stan::math::binomial_logit_lpmf<propto__>(
                              stan::model::rvalue(n, "n",
@@ -31344,14 +35274,14 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym12__;
+      double lcm_sym11__;
+      double lcm_sym10__;
       double lcm_sym9__;
-      double lcm_sym8__;
-      double lcm_sym7__;
-      double lcm_sym6__;
-      int lcm_sym5__;
-      int lcm_sym4__;
-      int lcm_sym3__;
-      double lcm_sym2__;
+      int lcm_sym8__;
+      int lcm_sym7__;
+      int lcm_sym6__;
+      double lcm_sym5__;
       double alpha0;
       current_statement__ = 1;
       alpha0 = in__.template read<local_scalar_t__>();
@@ -31382,8 +35312,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       out__.write(alpha12);
       out__.write(tau);
       {
-        lcm_sym3__ = stan::math::logical_gte(I, 1);
-        if (lcm_sym3__) {
+        lcm_sym6__ = stan::math::logical_gte(I, 1);
+        if (lcm_sym6__) {
           out__.write(stan::model::rvalue(b, "b", stan::model::index_uni(1),
                         stan::model::index_uni(1)));
           for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
@@ -31393,7 +35323,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(2)));
@@ -31405,7 +35335,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(3)));
@@ -31417,7 +35347,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(4)));
@@ -31429,7 +35359,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(5)));
@@ -31441,7 +35371,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(6)));
@@ -31453,7 +35383,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(7)));
@@ -31465,7 +35395,7 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
           }
         }
         {
-          if (lcm_sym3__) {
+          if (lcm_sym6__) {
             out__.write(stan::model::rvalue(b, "b",
                           stan::model::index_uni(1),
                           stan::model::index_uni(8)));
@@ -31482,10 +35412,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym2__ = (1 / stan::math::sqrt(tau));
-      sigma = lcm_sym2__;
+      lcm_sym5__ = (1 / stan::math::sqrt(tau));
+      sigma = lcm_sym5__;
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym2__);
+        out__.write(lcm_sym5__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
         return ;
@@ -31498,8 +35428,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -31508,7 +35438,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ alpha0;
@@ -31528,15 +35457,169 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       out__.write_free_lb(0, tau);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
-          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(8, DUMMY_VAR__));
-      if (stan::math::logical_gte(I, 1)) {
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
+      for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
         stan::model::assign(b,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(8),
-          "assigning variable b", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
-          stan::model::assign(b,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(8),
-            "assigning variable b", stan::model::index_uni(sym1__));
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+          "assigning variable b", stan::model::index_uni(sym1__));
+      }
+      out__.write(b);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      double lcm_sym4__;
+      double lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ alpha0;
+      alpha0 = context__.vals_r("alpha0")[(1 - 1)];
+      out__.write(alpha0);
+      local_scalar_t__ alpha1;
+      alpha1 = context__.vals_r("alpha1")[(1 - 1)];
+      out__.write(alpha1);
+      local_scalar_t__ alpha2;
+      alpha2 = context__.vals_r("alpha2")[(1 - 1)];
+      out__.write(alpha2);
+      local_scalar_t__ alpha12;
+      alpha12 = context__.vals_r("alpha12")[(1 - 1)];
+      out__.write(alpha12);
+      local_scalar_t__ tau;
+      tau = context__.vals_r("tau")[(1 - 1)];
+      out__.write_free_lb(0, tau);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(8, DUMMY_VAR__));
+      {
+        std::vector<double> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        {
+          lcm_sym1__ = stan::math::logical_gte(I, 1);
+          if (lcm_sym1__) {
+            stan::model::assign(b,
+              stan::model::rvalue(b_flat__, "b_flat__",
+                stan::model::index_uni(1)), "assigning variable b",
+              stan::model::index_uni(1), stan::model::index_uni(1));
+            pos__ = 2;
+            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(sym2__),
+                stan::model::index_uni(1));
+              pos__ = (pos__ + 1);
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(2));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(2));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(3));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(3));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(4));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(4));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(5));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(5));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(6));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(6));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(7));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(7));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
+          {
+            if (lcm_sym1__) {
+              stan::model::assign(b, b_flat__[(pos__ - 1)],
+                "assigning variable b", stan::model::index_uni(1),
+                stan::model::index_uni(8));
+              pos__ = (pos__ + 1);
+              for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
+                stan::model::assign(b, b_flat__[(pos__ - 1)],
+                  "assigning variable b", stan::model::index_uni(sym2__),
+                  stan::model::index_uni(8));
+                pos__ = (pos__ + 1);
+              }
+            }
+          }
         }
       }
       out__.write(b);
@@ -31582,10 +35665,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     param_names__.emplace_back(std::string() + "alpha2");
     param_names__.emplace_back(std::string() + "alpha12");
     param_names__.emplace_back(std::string() + "tau");
-    for (int sym28__ = 1; sym28__ <= K; ++sym28__) {
-      for (int sym29__ = 1; sym29__ <= I; ++sym29__) {
+    for (int sym31__ = 1; sym31__ <= K; ++sym31__) {
+      for (int sym32__ = 1; sym32__ <= I; ++sym32__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym29__) + '.' + std::to_string(sym28__));
+          std::to_string(sym32__) + '.' + std::to_string(sym31__));
       }
     }
     if (emit_transformed_parameters__) {
@@ -31602,10 +35685,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     param_names__.emplace_back(std::string() + "alpha2");
     param_names__.emplace_back(std::string() + "alpha12");
     param_names__.emplace_back(std::string() + "tau");
-    for (int sym28__ = 1; sym28__ <= K; ++sym28__) {
-      for (int sym29__ = 1; sym29__ <= I; ++sym29__) {
+    for (int sym31__ = 1; sym31__ <= K; ++sym31__) {
+      for (int sym32__ = 1; sym32__ <= I; ++sym32__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym29__) + '.' + std::to_string(sym28__));
+          std::to_string(sym32__) + '.' + std::to_string(sym31__));
       }
     }
     if (emit_transformed_parameters__) {
@@ -31677,26 +35760,17 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"alpha0", "alpha1", "alpha2", "alpha12", "tau", "b"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, 1, (I * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -32091,8 +36165,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -32105,6 +36179,26 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       pos__ = 1;
       local_scalar_t__ param;
       param = in__.read<local_scalar_t__>();
+      out__.write(param);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ param;
+      param = context__.vals_r("param")[(1 - 1)];
       out__.write(param);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -32230,24 +36324,17 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"param"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -32526,8 +36613,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -32540,6 +36627,26 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       pos__ = 1;
       local_scalar_t__ y;
       y = in__.read<local_scalar_t__>();
+      out__.write(y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ y;
+      y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -32670,24 +36777,17 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"y"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -33114,10 +37214,27 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -33236,24 +37353,17 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -8643,11 +8643,9 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
         "assigning variable mu");
       out__.write_free_ordered(mu);
-      std::vector<local_scalar_t__> sigma =
-        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        sigma[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      std::vector<local_scalar_t__> sigma;
+      stan::model::assign(sigma, in__.read<std::vector<local_scalar_t__>>(2),
+        "assigning variable sigma");
       out__.write_free_lb(0, sigma);
       local_scalar_t__ theta;
       theta = in__.read<local_scalar_t__>();
@@ -9066,11 +9064,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       local_scalar_t__ mu;
       mu = in__.read<local_scalar_t__>();
       out__.write(mu);
-      std::vector<local_scalar_t__> theta =
-        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      std::vector<local_scalar_t__> theta;
+      stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
+        "assigning variable theta");
       out__.write(theta);
       local_scalar_t__ tau;
       tau = in__.read<local_scalar_t__>();
@@ -16739,11 +16735,12 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= J; ++sym2__) {
-          stan::model::assign(theta,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-            "assigning variable theta", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
+            stan::model::assign(theta, in__.read<local_scalar_t__>(),
+              "assigning variable theta", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write_free_simplex(theta);
@@ -25615,11 +25612,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     try {
       int pos__;
       pos__ = 1;
-      std::vector<local_scalar_t__> theta =
-        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      std::vector<local_scalar_t__> theta;
+      stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
+        "assigning variable theta");
       out__.write(theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -35843,10 +35838,12 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
-        stan::model::assign(b,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-          "assigning variable b", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
+          stan::model::assign(b, in__.read<local_scalar_t__>(),
+            "assigning variable b", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(b);
     } catch (const std::exception& e) {

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1076,510 +1076,10 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      {
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(2));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(2));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(3));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(3));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(4));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(4));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(5));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(5));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(6));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(6));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(7));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(7));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(8));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(8));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(9));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(9));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(10));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(10));
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3527,510 +3027,10 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      {
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(2));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(2));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(3));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(3));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(4));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(4));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(5));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(5));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(6));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(6));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(7));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(7));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(8));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(8));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(9));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(9));
-          }
-        }
-        {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(1),
-            stan::model::index_uni(10));
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(2),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(3),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(4),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(5),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(6),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(7),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(8),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(9),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-              "assigning variable X_p", stan::model::index_uni(10),
-              stan::model::index_uni(10));
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4311,8 +3311,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) function__;
     try {
-      local_scalar_t__ lcm_sym5__;
-      Eigen::Matrix<local_scalar_t__,1,-1> lcm_sym4__;
+      local_scalar_t__ lcm_sym4__;
+      Eigen::Matrix<local_scalar_t__,1,-1> lcm_sym3__;
       Eigen::Matrix<local_scalar_t__,-1,-1> X;
       current_statement__ = 1;
       X = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N);
@@ -4331,11 +3331,11 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
           Eigen::Matrix<double,1,-1> vec2 =
             Eigen::Matrix<double,1,-1>::Constant(N,
               std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym4__, stan::math::columns_dot_self(X),
-            "assigning variable lcm_sym4__");
+          stan::model::assign(lcm_sym3__, stan::math::columns_dot_self(X),
+            "assigning variable lcm_sym3__");
         }
-        lcm_sym5__ = stan::math::sum(lcm_sym4__);
-        lp_accum__.add(lcm_sym5__);
+        lcm_sym4__ = stan::math::sum(lcm_sym3__);
+        lp_accum__.add(lcm_sym4__);
         current_statement__ = 7;
         stan::math::validate_non_negative_index("vec3", "N", N);
         Eigen::Matrix<double,1,-1> vec3 =
@@ -4349,7 +3349,7 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
               std::numeric_limits<double>::quiet_NaN());
         }
         current_statement__ = 12;
-        lp_accum__.add(lcm_sym5__);
+        lp_accum__.add(lcm_sym4__);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4388,8 +3388,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym3__;
       int lcm_sym2__;
+      int lcm_sym1__;
       Eigen::Matrix<double,-1,-1> X;
       current_statement__ = 1;
       X = in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N);
@@ -4420,36 +3420,12 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> X =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      lcm_sym1__ = stan::math::logical_gte(N, 1);
-      if (lcm_sym1__) {
-        if (lcm_sym1__) {
-          stan::model::assign(X, in__.read<local_scalar_t__>(),
-            "assigning variable X", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          for (int sym2__ = 2; sym2__ <= N; ++sym2__) {
-            stan::model::assign(X, in__.read<local_scalar_t__>(),
-              "assigning variable X", stan::model::index_uni(sym2__),
-              stan::model::index_uni(1));
-          }
-        }
-        for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
-          if (lcm_sym1__) {
-            stan::model::assign(X, in__.read<local_scalar_t__>(),
-              "assigning variable X", stan::model::index_uni(1),
-              stan::model::index_uni(sym1__));
-            for (int sym2__ = 2; sym2__ <= N; ++sym2__) {
-              stan::model::assign(X, in__.read<local_scalar_t__>(),
-                "assigning variable X", stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> X;
+      stan::model::assign(X,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable X");
       out__.write(X);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4477,10 +3453,10 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym6__ = 1; sym6__ <= N; ++sym6__) {
-      for (int sym7__ = 1; sym7__ <= N; ++sym7__) {
+    for (int sym5__ = 1; sym5__ <= N; ++sym5__) {
+      for (int sym6__ = 1; sym6__ <= N; ++sym6__) {
         param_names__.emplace_back(std::string() + "X" + '.' +
-          std::to_string(sym7__) + '.' + std::to_string(sym6__));
+          std::to_string(sym6__) + '.' + std::to_string(sym5__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -4490,10 +3466,10 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym6__ = 1; sym6__ <= N; ++sym6__) {
-      for (int sym7__ = 1; sym7__ <= N; ++sym7__) {
+    for (int sym5__ = 1; sym5__ <= N; ++sym5__) {
+      for (int sym6__ = 1; sym6__ <= N; ++sym6__) {
         param_names__.emplace_back(std::string() + "X" + '.' +
-          std::to_string(sym7__) + '.' + std::to_string(sym6__));
+          std::to_string(sym6__) + '.' + std::to_string(sym5__));
       }
     }
     if (emit_transformed_parameters__) {}
@@ -4901,7 +3877,6 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
 }
 class copy_fail_model final : public model_base_crtp<copy_fail_model> {
  private:
-  int lcm_sym118__;
   int lcm_sym117__;
   int lcm_sym116__;
   int lcm_sym115__;
@@ -4914,6 +3889,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   int lcm_sym108__;
   int lcm_sym107__;
   int lcm_sym106__;
+  int lcm_sym105__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -4978,8 +3954,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         pos__ = 1;
         current_statement__ = 37;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym107__ = stan::math::logical_gte(nind, 1);
-          if (lcm_sym107__) {
+          lcm_sym106__ = stan::math::logical_gte(nind, 1);
+          if (lcm_sym106__) {
             current_statement__ = 37;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -4998,7 +3974,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 37;
-            if (lcm_sym107__) {
+            if (lcm_sym106__) {
               current_statement__ = 37;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -5016,7 +3992,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             }
           }
         } else {
-          lcm_sym107__ = stan::math::logical_gte(nind, 1);
+          lcm_sym106__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 37;
@@ -5033,15 +4009,15 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::math::check_greater_or_equal(function__, "max_age", max_age, 1);
       current_statement__ = 39;
       stan::math::validate_non_negative_index("x", "nind", nind);
-      lcm_sym109__ = (n_occasions - 1);
+      lcm_sym108__ = (n_occasions - 1);
       stan::math::validate_non_negative_index("x", "n_occasions - 1",
-        lcm_sym109__);
+        lcm_sym108__);
       current_statement__ = 40;
       context__.validate_dims("data initialization", "x", "int",
         std::vector<size_t>{static_cast<size_t>(nind),
-          static_cast<size_t>(lcm_sym109__)});
+          static_cast<size_t>(lcm_sym108__)});
       x = std::vector<std::vector<int>>(nind,
-            std::vector<int>(lcm_sym109__, std::numeric_limits<int>::min()));
+            std::vector<int>(lcm_sym108__, std::numeric_limits<int>::min()));
       {
         std::vector<int> x_flat__;
         current_statement__ = 40;
@@ -5049,9 +4025,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         current_statement__ = 40;
         pos__ = 1;
         current_statement__ = 40;
-        if (stan::math::logical_gte(lcm_sym109__, 1)) {
+        if (stan::math::logical_gte(lcm_sym108__, 1)) {
           current_statement__ = 40;
-          if (lcm_sym107__) {
+          if (lcm_sym106__) {
             current_statement__ = 40;
             stan::model::assign(x,
               stan::model::rvalue(x_flat__, "x_flat__",
@@ -5068,9 +4044,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               pos__ = (pos__ + 1);
             }
           }
-          for (int sym1__ = 2; sym1__ <= lcm_sym109__; ++sym1__) {
+          for (int sym1__ = 2; sym1__ <= lcm_sym108__; ++sym1__) {
             current_statement__ = 40;
-            if (lcm_sym107__) {
+            if (lcm_sym106__) {
               current_statement__ = 40;
               stan::model::assign(x, x_flat__[(pos__ - 1)],
                 "assigning variable x", stan::model::index_uni(1),
@@ -5096,7 +4072,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 41;
       n_occ_minus_1 = std::numeric_limits<int>::min();
       current_statement__ = 41;
-      n_occ_minus_1 = lcm_sym109__;
+      n_occ_minus_1 = lcm_sym108__;
       current_statement__ = 42;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 43;
@@ -5106,7 +4082,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 45;
       last = std::vector<int>(nind, std::numeric_limits<int>::min());
       current_statement__ = 47;
-      if (lcm_sym107__) {
+      if (lcm_sym106__) {
         current_statement__ = 46;
         stan::model::assign(first,
           first_capture(
@@ -5122,7 +4098,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         }
       }
       current_statement__ = 49;
-      if (lcm_sym107__) {
+      if (lcm_sym106__) {
         current_statement__ = 48;
         stan::model::assign(last,
           last_capture(
@@ -5151,12 +4127,12 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 52;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-        lcm_sym109__);
+        lcm_sym108__);
       current_statement__ = 53;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-        lcm_sym109__);
+        lcm_sym108__);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 56;
@@ -5194,12 +4170,11 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym105__;
-      int lcm_sym104__;
+      double lcm_sym104__;
       int lcm_sym103__;
       int lcm_sym102__;
       int lcm_sym101__;
-      double lcm_sym100__;
+      int lcm_sym100__;
       double lcm_sym99__;
       double lcm_sym98__;
       double lcm_sym97__;
@@ -5217,7 +4192,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       double lcm_sym85__;
       double lcm_sym84__;
       double lcm_sym83__;
-      int lcm_sym82__;
+      double lcm_sym82__;
       int lcm_sym81__;
       int lcm_sym80__;
       int lcm_sym79__;
@@ -5237,6 +4212,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       int lcm_sym65__;
       int lcm_sym64__;
       int lcm_sym63__;
+      int lcm_sym62__;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -5255,18 +4231,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       Eigen::Matrix<local_scalar_t__,-1,-1> chi =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
           DUMMY_VAR__);
-      lcm_sym63__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym63__) {
-        lcm_sym102__ = stan::model::rvalue(first, "first",
+      lcm_sym62__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym62__) {
+        lcm_sym101__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym76__ = (lcm_sym102__ - 1);
-        if (stan::math::logical_gte(lcm_sym76__, 1)) {
+        lcm_sym75__ = (lcm_sym101__ - 1);
+        if (stan::math::logical_gte(lcm_sym75__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym76__; ++t) {
+          for (int t = 2; t <= lcm_sym75__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -5275,20 +4251,20 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym74__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym74__, lcm_sym102__)) {
+        lcm_sym73__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym73__, lcm_sym101__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym102__)))),
+                  stan::model::index_uni(lcm_sym101__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym102__));
-          lcm_sym82__ = (lcm_sym102__ + 1);
+            stan::model::index_uni(lcm_sym101__));
+          lcm_sym81__ = (lcm_sym101__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym102__));
-          for (int t = lcm_sym82__; t <= lcm_sym74__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
+          for (int t = lcm_sym81__; t <= lcm_sym73__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -5302,16 +4278,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym101__ = stan::model::rvalue(first, "first",
+          lcm_sym100__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym75__ = (lcm_sym101__ - 1);
-          if (stan::math::logical_gte(lcm_sym75__, 1)) {
+          lcm_sym74__ = (lcm_sym100__ - 1);
+          if (stan::math::logical_gte(lcm_sym74__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym75__; ++t) {
+            for (int t = 2; t <= lcm_sym74__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -5321,19 +4297,19 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym74__, lcm_sym101__)) {
+          if (stan::math::logical_gte(lcm_sym73__, lcm_sym100__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym101__)))),
+                    stan::model::index_uni(lcm_sym100__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym101__));
-            lcm_sym81__ = (lcm_sym101__ + 1);
+              stan::model::index_uni(lcm_sym100__));
+            lcm_sym80__ = (lcm_sym100__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym101__));
-            for (int t = lcm_sym81__; t <= lcm_sym74__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
+            for (int t = lcm_sym80__; t <= lcm_sym73__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -5361,58 +4337,58 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym63__) {
+        if (lcm_sym62__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym9__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym9__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym74__ = (n_occasions - 1);
-          lcm_sym64__ = stan::math::logical_gte(lcm_sym74__, 1);
-          if (lcm_sym64__) {
+          lcm_sym73__ = (n_occasions - 1);
+          lcm_sym63__ = stan::math::logical_gte(lcm_sym73__, 1);
+          if (lcm_sym63__) {
             int inline_prob_uncaptured_t_curr_sym10__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym11__ =
               std::numeric_limits<int>::min();
-            lcm_sym78__ = (lcm_sym74__ + 1);
+            lcm_sym77__ = (lcm_sym73__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym9__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym74__)) * (1 -
+                   stan::model::index_uni(lcm_sym73__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym78__ - 1))))),
+                  stan::model::index_uni((lcm_sym77__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                   "inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym78__)), (1 -
+                  stan::model::index_uni(lcm_sym77__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym74__)))),
+                  stan::model::index_uni(lcm_sym73__)))),
               "assigning variable inline_prob_uncaptured_chi_sym9__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym74__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym73__));
             for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                 <= lcm_sym74__; ++inline_prob_uncaptured_t_sym12__) {
+                 <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
-              lcm_sym73__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
+              lcm_sym72__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym77__ = (lcm_sym73__ + 1);
+              lcm_sym76__ = (lcm_sym72__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym73__)) * (1 -
+                     stan::model::index_uni(lcm_sym72__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym77__ - 1))))),
+                    stan::model::index_uni((lcm_sym76__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym77__)), (1 -
+                    stan::model::index_uni(lcm_sym76__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym73__)))),
+                    stan::model::index_uni(lcm_sym72__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym73__));
+                stan::model::index_uni(lcm_sym72__));
             }
           }
           for (int inline_prob_uncaptured_i_sym13__ = 2; inline_prob_uncaptured_i_sym13__
@@ -5423,60 +4399,60 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym64__) {
+            if (lcm_sym63__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym78__ = (lcm_sym74__ + 1);
+              lcm_sym77__ = (lcm_sym73__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                     stan::model::index_uni(lcm_sym74__)) * (1 -
+                     stan::model::index_uni(lcm_sym73__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni((lcm_sym78__ - 1))))),
+                    stan::model::index_uni((lcm_sym77__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym78__)), (1 -
+                    stan::model::index_uni(lcm_sym77__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym74__)))),
+                    stan::model::index_uni(lcm_sym73__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                stan::model::index_uni(lcm_sym74__));
+                stan::model::index_uni(lcm_sym73__));
               for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                   <= lcm_sym74__; ++inline_prob_uncaptured_t_sym12__) {
+                   <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
                 int inline_prob_uncaptured_t_curr_sym10__ =
                   std::numeric_limits<int>::min();
-                lcm_sym73__ = (n_occasions -
+                lcm_sym72__ = (n_occasions -
                   inline_prob_uncaptured_t_sym12__);
                 int inline_prob_uncaptured_t_next_sym11__ =
                   std::numeric_limits<int>::min();
-                lcm_sym77__ = (lcm_sym73__ + 1);
+                lcm_sym76__ = (lcm_sym72__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym13__),
-                       stan::model::index_uni(lcm_sym73__)) * (1 -
+                       stan::model::index_uni(lcm_sym72__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni((lcm_sym77__ - 1))))),
+                      stan::model::index_uni((lcm_sym76__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                       "inline_prob_uncaptured_chi_sym9__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym77__)), (1 -
+                      stan::model::index_uni(lcm_sym76__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym73__)))),
+                      stan::model::index_uni(lcm_sym72__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                  stan::model::index_uni(lcm_sym73__));
+                  stan::model::index_uni(lcm_sym72__));
               }
             }
           }
@@ -5504,28 +4480,28 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         inline_prob_uncaptured_return_sym8__, 1);
       {
         current_statement__ = 32;
-        if (lcm_sym63__) {
-          lcm_sym102__ = stan::model::rvalue(first, "first",
+        if (lcm_sym62__) {
+          lcm_sym101__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym102__, 0)) {
-            lcm_sym104__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym101__, 0)) {
+            lcm_sym103__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym82__ = (lcm_sym102__ + 1);
-            if (stan::math::logical_gte(lcm_sym104__, lcm_sym82__)) {
+            lcm_sym81__ = (lcm_sym101__ + 1);
+            if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
               current_statement__ = 26;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym82__ - 1)))));
-              lcm_sym80__ = (lcm_sym82__ + 1);
+                                 stan::model::index_uni((lcm_sym81__ - 1)))));
+              lcm_sym79__ = (lcm_sym81__ + 1);
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                stan::model::rvalue(y, "y",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym82__)),
+                                 stan::model::index_uni(lcm_sym81__)),
                                stan::model::rvalue(p, "p",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym82__ - 1)))));
-              for (int t = lcm_sym80__; t <= lcm_sym104__; ++t) {
+                                 stan::model::index_uni((lcm_sym81__ - 1)))));
+              for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
@@ -5547,30 +4523,30 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                                inline_prob_uncaptured_return_sym8__,
                                "inline_prob_uncaptured_return_sym8__",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(lcm_sym104__))));
+                               stan::model::index_uni(lcm_sym103__))));
           }
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym101__ = stan::model::rvalue(first, "first",
+            lcm_sym100__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym101__, 0)) {
-              lcm_sym103__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym100__, 0)) {
+              lcm_sym102__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym81__ = (lcm_sym101__ + 1);
-              if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
+              lcm_sym80__ = (lcm_sym100__ + 1);
+              if (stan::math::logical_gte(lcm_sym102__, lcm_sym80__)) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym81__ - 1)))));
-                lcm_sym79__ = (lcm_sym81__ + 1);
+                                   stan::model::index_uni((lcm_sym80__ - 1)))));
+                lcm_sym78__ = (lcm_sym80__ + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni(lcm_sym81__)),
+                                   stan::model::index_uni(lcm_sym80__)),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym81__ - 1)))));
-                for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
+                                   stan::model::index_uni((lcm_sym80__ - 1)))));
+                for (int t = lcm_sym78__; t <= lcm_sym102__; ++t) {
                   current_statement__ = 26;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -5592,7 +4568,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                                  inline_prob_uncaptured_return_sym8__,
                                  "inline_prob_uncaptured_return_sym8__",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(lcm_sym103__))));
+                                 stan::model::index_uni(lcm_sym102__))));
             }
           }
         }
@@ -5634,10 +4610,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym62__;
-      int lcm_sym61__;
+      double lcm_sym61__;
       int lcm_sym60__;
-      double lcm_sym59__;
+      int lcm_sym59__;
       double lcm_sym58__;
       double lcm_sym57__;
       double lcm_sym56__;
@@ -5645,7 +4620,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       double lcm_sym54__;
       double lcm_sym53__;
       double lcm_sym52__;
-      int lcm_sym51__;
+      double lcm_sym51__;
       int lcm_sym50__;
       int lcm_sym49__;
       int lcm_sym48__;
@@ -5661,6 +4636,7 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       int lcm_sym38__;
       int lcm_sym37__;
       int lcm_sym36__;
+      int lcm_sym35__;
       double mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -5686,18 +4662,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym36__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym36__) {
-        lcm_sym61__ = stan::model::rvalue(first, "first",
+      lcm_sym35__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym35__) {
+        lcm_sym60__ = stan::model::rvalue(first, "first",
                         stan::model::index_uni(1));
-        lcm_sym45__ = (lcm_sym61__ - 1);
-        if (stan::math::logical_gte(lcm_sym45__, 1)) {
+        lcm_sym44__ = (lcm_sym60__ - 1);
+        if (stan::math::logical_gte(lcm_sym44__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym45__; ++t) {
+          for (int t = 2; t <= lcm_sym44__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -5706,20 +4682,20 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym43__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym43__, lcm_sym61__)) {
+        lcm_sym42__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym42__, lcm_sym60__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym61__)))),
+                  stan::model::index_uni(lcm_sym60__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym61__));
-          lcm_sym51__ = (lcm_sym61__ + 1);
+            stan::model::index_uni(lcm_sym60__));
+          lcm_sym50__ = (lcm_sym60__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym61__));
-          for (int t = lcm_sym51__; t <= lcm_sym43__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
+          for (int t = lcm_sym50__; t <= lcm_sym42__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -5733,16 +4709,16 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym60__ = stan::model::rvalue(first, "first",
+          lcm_sym59__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym44__ = (lcm_sym60__ - 1);
-          if (stan::math::logical_gte(lcm_sym44__, 1)) {
+          lcm_sym43__ = (lcm_sym59__ - 1);
+          if (stan::math::logical_gte(lcm_sym43__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym44__; ++t) {
+            for (int t = 2; t <= lcm_sym43__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -5752,19 +4728,19 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym43__, lcm_sym60__)) {
+          if (stan::math::logical_gte(lcm_sym42__, lcm_sym59__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym60__)))),
+                    stan::model::index_uni(lcm_sym59__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym60__));
-            lcm_sym50__ = (lcm_sym60__ + 1);
+              stan::model::index_uni(lcm_sym59__));
+            lcm_sym49__ = (lcm_sym59__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym60__));
-            for (int t = lcm_sym50__; t <= lcm_sym43__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
+            for (int t = lcm_sym49__; t <= lcm_sym42__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -5791,58 +4767,58 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym36__) {
+        if (lcm_sym35__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym2__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym2__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym43__ = (n_occasions - 1);
-          lcm_sym37__ = stan::math::logical_gte(lcm_sym43__, 1);
-          if (lcm_sym37__) {
+          lcm_sym42__ = (n_occasions - 1);
+          lcm_sym36__ = stan::math::logical_gte(lcm_sym42__, 1);
+          if (lcm_sym36__) {
             int inline_prob_uncaptured_t_curr_sym3__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym4__ =
               std::numeric_limits<int>::min();
-            lcm_sym49__ = (lcm_sym43__ + 1);
+            lcm_sym48__ = (lcm_sym42__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym2__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym43__)) * (1 -
+                   stan::model::index_uni(lcm_sym42__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym49__ - 1))))),
+                  stan::model::index_uni((lcm_sym48__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                   "inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym49__)), (1 -
+                  stan::model::index_uni(lcm_sym48__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym43__)))),
+                  stan::model::index_uni(lcm_sym42__)))),
               "assigning variable inline_prob_uncaptured_chi_sym2__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym43__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym42__));
             for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                 <= lcm_sym43__; ++inline_prob_uncaptured_t_sym5__) {
+                 <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
-              lcm_sym42__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
+              lcm_sym41__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym48__ = (lcm_sym42__ + 1);
+              lcm_sym47__ = (lcm_sym41__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym42__)) * (1 -
+                     stan::model::index_uni(lcm_sym41__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym48__ - 1))))),
+                    stan::model::index_uni((lcm_sym47__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym48__)), (1 -
+                    stan::model::index_uni(lcm_sym47__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym42__)))),
+                    stan::model::index_uni(lcm_sym41__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym42__));
+                stan::model::index_uni(lcm_sym41__));
             }
           }
           for (int inline_prob_uncaptured_i_sym6__ = 2; inline_prob_uncaptured_i_sym6__
@@ -5853,59 +4829,59 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym37__) {
+            if (lcm_sym36__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym49__ = (lcm_sym43__ + 1);
+              lcm_sym48__ = (lcm_sym42__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                     stan::model::index_uni(lcm_sym43__)) * (1 -
+                     stan::model::index_uni(lcm_sym42__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni((lcm_sym49__ - 1))))),
+                    stan::model::index_uni((lcm_sym48__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym49__)), (1 -
+                    stan::model::index_uni(lcm_sym48__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym43__)))),
+                    stan::model::index_uni(lcm_sym42__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                stan::model::index_uni(lcm_sym43__));
+                stan::model::index_uni(lcm_sym42__));
               for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                   <= lcm_sym43__; ++inline_prob_uncaptured_t_sym5__) {
+                   <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
                 int inline_prob_uncaptured_t_curr_sym3__ =
                   std::numeric_limits<int>::min();
-                lcm_sym42__ = (n_occasions -
+                lcm_sym41__ = (n_occasions -
                   inline_prob_uncaptured_t_sym5__);
                 int inline_prob_uncaptured_t_next_sym4__ =
                   std::numeric_limits<int>::min();
-                lcm_sym48__ = (lcm_sym42__ + 1);
+                lcm_sym47__ = (lcm_sym41__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                       stan::model::index_uni(lcm_sym42__)) * (1 -
+                       stan::model::index_uni(lcm_sym41__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni((lcm_sym48__ - 1))))),
+                      stan::model::index_uni((lcm_sym47__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                       "inline_prob_uncaptured_chi_sym2__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym48__)), (1 -
+                      stan::model::index_uni(lcm_sym47__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym42__)))),
+                      stan::model::index_uni(lcm_sym41__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                  stan::model::index_uni(lcm_sym42__));
+                  stan::model::index_uni(lcm_sym41__));
               }
             }
           }
@@ -5957,22 +4933,15 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym35__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
-      if (stan::math::logical_gte(max_age, 1)) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
+        "assigning variable beta");
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6014,27 +4983,27 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym119__ = 1; sym119__ <= max_age; ++sym119__) {
+    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym119__));
+        std::to_string(sym118__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occasions; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
     }
@@ -6045,27 +5014,27 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym119__ = 1; sym119__ <= max_age; ++sym119__) {
+    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym119__));
+        std::to_string(sym118__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occasions; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
     }
@@ -6247,10 +5216,10 @@ static constexpr std::array<const char*, 66> locations_array__ =
   " (in 'dce-fail.stan', line 37, column 9 to column 16)"};
 class dce_fail_model final : public model_base_crtp<dce_fail_model> {
  private:
-  double lcm_sym32__;
-  double lcm_sym31__;
-  int lcm_sym30__;
-  int lcm_sym29__;
+  double lcm_sym28__;
+  double lcm_sym27__;
+  int lcm_sym26__;
+  int lcm_sym25__;
   int N;
   int n_age;
   int n_edu;
@@ -6489,10 +5458,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym28__;
-      double lcm_sym27__;
-      double lcm_sym26__;
-      double lcm_sym25__;
       double lcm_sym24__;
       double lcm_sym23__;
       double lcm_sym22__;
@@ -6507,10 +5472,14 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       double lcm_sym13__;
       double lcm_sym12__;
       double lcm_sym11__;
-      int lcm_sym10__;
-      int lcm_sym9__;
-      int lcm_sym8__;
-      int lcm_sym7__;
+      double lcm_sym10__;
+      double lcm_sym9__;
+      double lcm_sym8__;
+      double lcm_sym7__;
+      int lcm_sym6__;
+      int lcm_sym5__;
+      int lcm_sym4__;
+      int lcm_sym3__;
       local_scalar_t__ sigma;
       current_statement__ = 1;
       sigma = in__.template read_constrain_lb<local_scalar_t__,
@@ -6597,8 +5566,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                          sigma_region));
         current_statement__ = 31;
         if (stan::math::logical_gte(n_age, 1)) {
-          lcm_sym9__ = stan::math::logical_gte(n_edu, 1);
-          if (lcm_sym9__) {
+          lcm_sym5__ = stan::math::logical_gte(n_edu, 1);
+          if (lcm_sym5__) {
             current_statement__ = 28;
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
@@ -6614,7 +5583,7 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           }
           for (int j = 2; j <= n_age; ++j) {
             current_statement__ = 29;
-            if (lcm_sym9__) {
+            if (lcm_sym5__) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(b_age_edu, "b_age_edu",
@@ -6777,8 +5746,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym6__;
-      int lcm_sym5__;
+      int lcm_sym2__;
+      int lcm_sym1__;
       double sigma;
       current_statement__ = 1;
       sigma = in__.template read_constrain_lb<local_scalar_t__,
@@ -6878,10 +5847,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym4__;
-      int lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ sigma;
@@ -6917,80 +5882,30 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       local_scalar_t__ b_v_prev;
       b_v_prev = in__.read<local_scalar_t__>();
       out__.write(b_v_prev);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_age =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
-      lcm_sym1__ = stan::math::logical_gte(n_age, 1);
-      if (lcm_sym1__) {
-        stan::model::assign(b_age, in__.read<local_scalar_t__>(),
-          "assigning variable b_age", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
-          stan::model::assign(b_age, in__.read<local_scalar_t__>(),
-            "assigning variable b_age", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_age;
+      stan::model::assign(b_age,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age),
+        "assigning variable b_age");
       out__.write(b_age);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_edu =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
-      lcm_sym2__ = stan::math::logical_gte(n_edu, 1);
-      if (lcm_sym2__) {
-        stan::model::assign(b_edu, in__.read<local_scalar_t__>(),
-          "assigning variable b_edu", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
-          stan::model::assign(b_edu, in__.read<local_scalar_t__>(),
-            "assigning variable b_edu", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_edu;
+      stan::model::assign(b_edu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_edu),
+        "assigning variable b_edu");
       out__.write(b_edu);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_region =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region, DUMMY_VAR__);
-      if (stan::math::logical_gte(n_region, 1)) {
-        stan::model::assign(b_region, in__.read<local_scalar_t__>(),
-          "assigning variable b_region", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_region; ++sym1__) {
-          stan::model::assign(b_region, in__.read<local_scalar_t__>(),
-            "assigning variable b_region", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_region;
+      stan::model::assign(b_region,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_region),
+        "assigning variable b_region");
       out__.write(b_region);
-      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_age, n_edu,
-          DUMMY_VAR__);
-      if (lcm_sym2__) {
-        if (lcm_sym1__) {
-          stan::model::assign(b_age_edu, in__.read<local_scalar_t__>(),
-            "assigning variable b_age_edu", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          for (int sym2__ = 2; sym2__ <= n_age; ++sym2__) {
-            stan::model::assign(b_age_edu, in__.read<local_scalar_t__>(),
-              "assigning variable b_age_edu", stan::model::index_uni(sym2__),
-              stan::model::index_uni(1));
-          }
-        }
-        for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
-          if (lcm_sym1__) {
-            stan::model::assign(b_age_edu, in__.read<local_scalar_t__>(),
-              "assigning variable b_age_edu", stan::model::index_uni(1),
-              stan::model::index_uni(sym1__));
-            for (int sym2__ = 2; sym2__ <= n_age; ++sym2__) {
-              stan::model::assign(b_age_edu, in__.read<local_scalar_t__>(),
-                "assigning variable b_age_edu",
-                stan::model::index_uni(sym2__),
-                stan::model::index_uni(sym1__));
-            }
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu;
+      stan::model::assign(b_age_edu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n_age, n_edu),
+        "assigning variable b_age_edu");
       out__.write(b_age_edu);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_hat =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
-      if (stan::math::logical_gte(n_state, 1)) {
-        stan::model::assign(b_hat, in__.read<local_scalar_t__>(),
-          "assigning variable b_hat", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
-          stan::model::assign(b_hat, in__.read<local_scalar_t__>(),
-            "assigning variable b_hat", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_hat;
+      stan::model::assign(b_hat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
+        "assigning variable b_hat");
       out__.write(b_hat);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7041,27 +5956,27 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     param_names__.emplace_back(std::string() + "b_black");
     param_names__.emplace_back(std::string() + "b_female_black");
     param_names__.emplace_back(std::string() + "b_v_prev");
-    for (int sym33__ = 1; sym33__ <= n_age; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_age; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_age" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
-    for (int sym33__ = 1; sym33__ <= n_edu; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_edu" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
-    for (int sym33__ = 1; sym33__ <= n_region; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_region; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_region" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
-    for (int sym33__ = 1; sym33__ <= n_edu; ++sym33__) {
-      for (int sym34__ = 1; sym34__ <= n_age; ++sym34__) {
+    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
+      for (int sym30__ = 1; sym30__ <= n_age; ++sym30__) {
         param_names__.emplace_back(std::string() + "b_age_edu" + '.' +
-          std::to_string(sym34__) + '.' + std::to_string(sym33__));
+          std::to_string(sym30__) + '.' + std::to_string(sym29__));
       }
     }
-    for (int sym33__ = 1; sym33__ <= n_state; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_state; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_hat" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -7081,27 +5996,27 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     param_names__.emplace_back(std::string() + "b_black");
     param_names__.emplace_back(std::string() + "b_female_black");
     param_names__.emplace_back(std::string() + "b_v_prev");
-    for (int sym33__ = 1; sym33__ <= n_age; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_age; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_age" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
-    for (int sym33__ = 1; sym33__ <= n_edu; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_edu" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
-    for (int sym33__ = 1; sym33__ <= n_region; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_region; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_region" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
-    for (int sym33__ = 1; sym33__ <= n_edu; ++sym33__) {
-      for (int sym34__ = 1; sym34__ <= n_age; ++sym34__) {
+    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
+      for (int sym30__ = 1; sym30__ <= n_age; ++sym30__) {
         param_names__.emplace_back(std::string() + "b_age_edu" + '.' +
-          std::to_string(sym34__) + '.' + std::to_string(sym33__));
+          std::to_string(sym30__) + '.' + std::to_string(sym29__));
       }
     }
-    for (int sym33__ = 1; sym33__ <= n_state; ++sym33__) {
+    for (int sym29__ = 1; sym29__ <= n_state; ++sym29__) {
       param_names__.emplace_back(std::string() + "b_hat" + '.' +
-        std::to_string(sym33__));
+        std::to_string(sym29__));
     }
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
@@ -8084,16 +6999,10 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> mu =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      {
-        stan::model::assign(mu, in__.read<local_scalar_t__>(),
-          "assigning variable mu", stan::model::index_uni(1));
-        {
-          stan::model::assign(mu, in__.read<local_scalar_t__>(),
-            "assigning variable mu", stan::model::index_uni(2));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> mu;
+      stan::model::assign(mu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable mu");
       out__.write_free_ordered(mu);
       std::vector<local_scalar_t__> sigma =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
@@ -8691,14 +7600,14 @@ static constexpr std::array<const char*, 52> locations_array__ =
   " (in 'expr-prop-fail3.stan', line 32, column 9 to column 10)"};
 class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model> {
  private:
-  double lcm_sym28__;
-  double lcm_sym27__;
-  double lcm_sym26__;
-  double lcm_sym25__;
-  double lcm_sym24__;
   double lcm_sym23__;
-  int lcm_sym22__;
-  int lcm_sym21__;
+  double lcm_sym22__;
+  double lcm_sym21__;
+  double lcm_sym20__;
+  double lcm_sym19__;
+  double lcm_sym18__;
+  int lcm_sym17__;
+  int lcm_sym16__;
   int N;
   int n_age;
   int n_age_edu;
@@ -8828,8 +7737,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         black_flat__ = context__.vals_r("black");
         current_statement__ = 33;
         pos__ = 1;
-        lcm_sym21__ = stan::math::logical_gte(N, 1);
-        if (lcm_sym21__) {
+        lcm_sym16__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym16__) {
           current_statement__ = 33;
           stan::model::assign(black,
             stan::model::rvalue(black_flat__, "black_flat__",
@@ -8878,7 +7787,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 37;
         pos__ = 1;
         current_statement__ = 37;
-        if (lcm_sym21__) {
+        if (lcm_sym16__) {
           current_statement__ = 37;
           stan::model::assign(female,
             stan::model::rvalue(female_flat__, "female_flat__",
@@ -8941,7 +7850,7 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         current_statement__ = 43;
         pos__ = 1;
         current_statement__ = 43;
-        if (lcm_sym21__) {
+        if (lcm_sym16__) {
           current_statement__ = 43;
           stan::model::assign(v_prev_full,
             stan::model::rvalue(v_prev_full_flat__, "v_prev_full_flat__",
@@ -9017,16 +7926,16 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym20__;
-      double lcm_sym19__;
-      double lcm_sym18__;
-      double lcm_sym17__;
-      double lcm_sym16__;
       double lcm_sym15__;
       double lcm_sym14__;
       double lcm_sym13__;
       double lcm_sym12__;
-      int lcm_sym11__;
+      double lcm_sym11__;
+      double lcm_sym10__;
+      double lcm_sym9__;
+      double lcm_sym8__;
+      double lcm_sym7__;
+      int lcm_sym6__;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age);
@@ -9217,11 +8126,11 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym10__;
-      double lcm_sym9__;
-      int lcm_sym8__;
-      int lcm_sym7__;
-      int lcm_sym6__;
+      double lcm_sym5__;
+      double lcm_sym4__;
+      int lcm_sym3__;
+      int lcm_sym2__;
+      int lcm_sym1__;
       Eigen::Matrix<double,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age);
@@ -9400,92 +8309,37 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym5__;
-      int lcm_sym4__;
-      int lcm_sym3__;
-      int lcm_sym2__;
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> a =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
-      if (stan::math::logical_gte(n_age, 1)) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_age; ++sym1__) {
-          stan::model::assign(a, in__.read<local_scalar_t__>(),
-            "assigning variable a", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> a;
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age),
+        "assigning variable a");
       out__.write(a);
-      Eigen::Matrix<local_scalar_t__,-1,1> b =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
-      if (stan::math::logical_gte(n_edu, 1)) {
-        stan::model::assign(b, in__.read<local_scalar_t__>(),
-          "assigning variable b", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_edu; ++sym1__) {
-          stan::model::assign(b, in__.read<local_scalar_t__>(),
-            "assigning variable b", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b;
+      stan::model::assign(b,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_edu),
+        "assigning variable b");
       out__.write(b);
-      Eigen::Matrix<local_scalar_t__,-1,1> c =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age_edu,
-          DUMMY_VAR__);
-      if (stan::math::logical_gte(n_age_edu, 1)) {
-        stan::model::assign(c, in__.read<local_scalar_t__>(),
-          "assigning variable c", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_age_edu; ++sym1__) {
-          stan::model::assign(c, in__.read<local_scalar_t__>(),
-            "assigning variable c", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> c;
+      stan::model::assign(c,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age_edu),
+        "assigning variable c");
       out__.write(c);
-      Eigen::Matrix<local_scalar_t__,-1,1> d =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
-      if (stan::math::logical_gte(n_state, 1)) {
-        stan::model::assign(d, in__.read<local_scalar_t__>(),
-          "assigning variable d", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_state; ++sym1__) {
-          stan::model::assign(d, in__.read<local_scalar_t__>(),
-            "assigning variable d", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> d;
+      stan::model::assign(d,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
+        "assigning variable d");
       out__.write(d);
-      Eigen::Matrix<local_scalar_t__,-1,1> e =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region_full,
-          DUMMY_VAR__);
-      if (stan::math::logical_gte(n_region_full, 1)) {
-        stan::model::assign(e, in__.read<local_scalar_t__>(),
-          "assigning variable e", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_region_full; ++sym1__) {
-          stan::model::assign(e, in__.read<local_scalar_t__>(),
-            "assigning variable e", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> e;
+      stan::model::assign(e,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_region_full),
+        "assigning variable e");
       out__.write(e);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(1));
-        {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(2));
-        }
-        {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(3));
-        }
-        {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(4));
-        }
-        {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(5));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable beta");
       out__.write(beta);
       local_scalar_t__ sigma_a;
       sigma_a = in__.read<local_scalar_t__>();
@@ -9546,29 +8400,29 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym29__ = 1; sym29__ <= n_age; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_age; ++sym24__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_edu; ++sym24__) {
       param_names__.emplace_back(std::string() + "b" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_age_edu; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_age_edu; ++sym24__) {
       param_names__.emplace_back(std::string() + "c" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_state; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_state; ++sym24__) {
       param_names__.emplace_back(std::string() + "d" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_region_full; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_region_full; ++sym24__) {
       param_names__.emplace_back(std::string() + "e" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= 5; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= 5; ++sym24__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_b");
@@ -9576,9 +8430,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     param_names__.emplace_back(std::string() + "sigma_d");
     param_names__.emplace_back(std::string() + "sigma_e");
     if (emit_transformed_parameters__) {
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym24__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -9587,29 +8441,29 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym29__ = 1; sym29__ <= n_age; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_age; ++sym24__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_edu; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_edu; ++sym24__) {
       param_names__.emplace_back(std::string() + "b" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_age_edu; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_age_edu; ++sym24__) {
       param_names__.emplace_back(std::string() + "c" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_state; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_state; ++sym24__) {
       param_names__.emplace_back(std::string() + "d" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= n_region_full; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= n_region_full; ++sym24__) {
       param_names__.emplace_back(std::string() + "e" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
-    for (int sym29__ = 1; sym29__ <= 5; ++sym29__) {
+    for (int sym24__ = 1; sym24__ <= 5; ++sym24__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym24__));
     }
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_b");
@@ -9617,9 +8471,9 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     param_names__.emplace_back(std::string() + "sigma_d");
     param_names__.emplace_back(std::string() + "sigma_e");
     if (emit_transformed_parameters__) {
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym24__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -9781,12 +8635,12 @@ static constexpr std::array<const char*, 43> locations_array__ =
   " (in 'expr-prop-fail4.stan', line 35, column 8 to column 9)"};
 class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model> {
  private:
-  double lcm_sym28__;
-  double lcm_sym27__;
-  Eigen::Matrix<double,-1,1> lcm_sym26___data__;
-  int lcm_sym25__;
-  int lcm_sym24__;
+  double lcm_sym26__;
+  double lcm_sym25__;
+  Eigen::Matrix<double,-1,1> lcm_sym24___data__;
   int lcm_sym23__;
+  int lcm_sym22__;
+  int lcm_sym21__;
   int N;
   int N_edges;
   std::vector<int> node1;
@@ -9794,7 +8648,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   Eigen::Matrix<double,-1,1> E_data__;
   Eigen::Matrix<double,-1,1> log_E_data__;
   int phi_std_raw_1dim__;
-  Eigen::Map<Eigen::Matrix<double,-1,1>> lcm_sym26__{nullptr, 0};
+  Eigen::Map<Eigen::Matrix<double,-1,1>> lcm_sym24__{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> E{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> log_E{nullptr, 0};
  public:
@@ -9904,11 +8758,11 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         "assigning variable log_E");
       current_statement__ = 37;
       phi_std_raw_1dim__ = std::numeric_limits<int>::min();
-      lcm_sym24__ = (N - 1);
-      phi_std_raw_1dim__ = lcm_sym24__;
+      lcm_sym22__ = (N - 1);
+      phi_std_raw_1dim__ = lcm_sym22__;
       current_statement__ = 37;
       stan::math::validate_non_negative_index("phi_std_raw", "N - 1",
-        lcm_sym24__);
+        lcm_sym22__);
       current_statement__ = 38;
       stan::math::validate_non_negative_index("phi", "N", N);
       current_statement__ = 39;
@@ -9951,12 +8805,12 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) function__;
     try {
-      local_scalar_t__ lcm_sym21__;
-      double lcm_sym20__;
-      double lcm_sym19__;
-      Eigen::Matrix<double,-1,1> lcm_sym18__;
+      local_scalar_t__ lcm_sym19__;
+      double lcm_sym18__;
       double lcm_sym17__;
-      int lcm_sym22__;
+      Eigen::Matrix<double,-1,1> lcm_sym16__;
+      double lcm_sym15__;
+      int lcm_sym20__;
       local_scalar_t__ tau_phi;
       current_statement__ = 1;
       tau_phi = in__.template read_constrain_lb<local_scalar_t__,
@@ -9968,13 +8822,13 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                                                   - 1),
                                                   std::numeric_limits<double>::quiet_NaN(
                                                     )));
-      lcm_sym22__ = (N - 1);
+      lcm_sym20__ = (N - 1);
       phi_std_raw = in__.template read<
                       stan::conditional_var_value_t<local_scalar_t__,
-                        Eigen::Matrix<local_scalar_t__,-1,1>>>(lcm_sym22__);
+                        Eigen::Matrix<local_scalar_t__,-1,1>>>(lcm_sym20__);
       local_scalar_t__ sigma_phi = DUMMY_VAR__;
-      lcm_sym21__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym21__;
+      lcm_sym19__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym19__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,1>> phi =
         stan::conditional_var_value_t<local_scalar_t__,
@@ -9983,17 +8837,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                                                     )));
       current_statement__ = 5;
       stan::model::assign(phi, phi_std_raw, "assigning variable phi",
-        stan::model::index_min_max(1, lcm_sym22__));
+        stan::model::index_min_max(1, lcm_sym20__));
       current_statement__ = 6;
       stan::model::assign(phi, -stan::math::sum(phi_std_raw),
         "assigning variable phi", stan::model::index_uni(N));
       current_statement__ = 7;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym21__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym19__),
         "assigning variable phi");
       current_statement__ = 3;
       stan::math::check_greater_or_equal(function__, "sigma_phi",
-        lcm_sym21__, 0);
+        lcm_sym19__, 0);
       {
         current_statement__ = 25;
         lp_accum__.add((-0.5 *
@@ -10041,17 +8895,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) function__;
     try {
+      double lcm_sym10__;
+      double lcm_sym9__;
+      Eigen::Matrix<double,-1,1> lcm_sym8__;
+      Eigen::Matrix<double,-1,1> lcm_sym7__;
       double lcm_sym12__;
       double lcm_sym11__;
-      Eigen::Matrix<double,-1,1> lcm_sym10__;
-      Eigen::Matrix<double,-1,1> lcm_sym9__;
-      double lcm_sym14__;
-      double lcm_sym13__;
-      int lcm_sym8__;
-      int lcm_sym7__;
-      double lcm_sym6__;
-      int lcm_sym15__;
-      int lcm_sym4__;
+      int lcm_sym6__;
+      int lcm_sym5__;
+      double lcm_sym4__;
+      int lcm_sym13__;
+      int lcm_sym2__;
       double tau_phi;
       current_statement__ = 1;
       tau_phi = in__.template read_constrain_lb<local_scalar_t__,
@@ -10059,9 +8913,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       Eigen::Matrix<double,-1,1> phi_std_raw =
         Eigen::Matrix<double,-1,1>::Constant((N - 1),
           std::numeric_limits<double>::quiet_NaN());
-      lcm_sym15__ = (N - 1);
+      lcm_sym13__ = (N - 1);
       phi_std_raw = in__.template read<
-                      Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym15__);
+                      Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym13__);
       double sigma_phi = std::numeric_limits<double>::quiet_NaN();
       Eigen::Matrix<double,-1,1> phi =
         Eigen::Matrix<double,-1,1>::Constant(N,
@@ -10073,23 +8927,23 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym11__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym11__;
+      lcm_sym9__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym9__;
       current_statement__ = 5;
       stan::model::assign(phi, phi_std_raw, "assigning variable phi",
-        stan::model::index_min_max(1, lcm_sym15__));
+        stan::model::index_min_max(1, lcm_sym13__));
       current_statement__ = 6;
       stan::model::assign(phi, -stan::math::sum(phi_std_raw),
         "assigning variable phi", stan::model::index_uni(N));
       current_statement__ = 7;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym11__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym9__),
         "assigning variable phi");
       current_statement__ = 3;
-      stan::math::check_greater_or_equal(function__, "sigma_phi",
-        lcm_sym11__, 0);
+      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym9__,
+        0);
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym11__);
+        out__.write(lcm_sym9__);
         out__.write(phi);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -10114,8 +8968,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       beta0 = stan::math::normal_rng(0, 1, base_rng__);
       current_statement__ = 17;
       beta1 = stan::math::normal_rng(0, 1, base_rng__);
-      lcm_sym4__ = stan::math::logical_gte(N, 1);
-      if (lcm_sym4__) {
+      lcm_sym2__ = stan::math::logical_gte(N, 1);
+      if (lcm_sym2__) {
         current_statement__ = 18;
         stan::model::assign(theta_std,
           stan::math::normal_rng(0, 1, base_rng__),
@@ -10129,14 +8983,14 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       }
       current_statement__ = 20;
       tau_theta = stan::math::gamma_rng(3.2761, 1.81, base_rng__);
-      lcm_sym12__ = stan::math::inv_sqrt(tau_theta);
-      sigma_theta = lcm_sym12__;
-      stan::model::assign(lcm_sym10__,
-        stan::math::multiply(theta_std, lcm_sym12__),
-        "assigning variable lcm_sym10__");
-      stan::model::assign(theta, lcm_sym10__, "assigning variable theta");
+      lcm_sym10__ = stan::math::inv_sqrt(tau_theta);
+      sigma_theta = lcm_sym10__;
+      stan::model::assign(lcm_sym8__,
+        stan::math::multiply(theta_std, lcm_sym10__),
+        "assigning variable lcm_sym8__");
+      stan::model::assign(theta, lcm_sym8__, "assigning variable theta");
       current_statement__ = 24;
-      if (lcm_sym4__) {
+      if (lcm_sym2__) {
         current_statement__ = 21;
         stan::model::assign(x, stan::math::normal_rng(0, 1, base_rng__),
           "assigning variable x", stan::model::index_uni(1));
@@ -10148,7 +9002,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                 (stan::model::rvalue(stan::math::log(E), "log(E)",
                    stan::model::index_uni(1)) + beta0)) +
             stan::model::rvalue(phi, "phi", stan::model::index_uni(1))) +
-            stan::model::rvalue(lcm_sym10__, "lcm_sym10__",
+            stan::model::rvalue(lcm_sym8__, "lcm_sym8__",
               stan::model::index_uni(1))), base_rng__),
           "assigning variable y", stan::model::index_uni(1));
         for (int i = 2; i <= N; ++i) {
@@ -10163,7 +9017,7 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                   (stan::model::rvalue(stan::math::log(E), "log(E)",
                      stan::model::index_uni(i)) + beta0)) +
               stan::model::rvalue(phi, "phi", stan::model::index_uni(i))) +
-              stan::model::rvalue(lcm_sym10__, "lcm_sym10__",
+              stan::model::rvalue(lcm_sym8__, "lcm_sym8__",
                 stan::model::index_uni(i))), base_rng__),
             "assigning variable y", stan::model::index_uni(i));
         }
@@ -10173,12 +9027,12 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         0);
       current_statement__ = 11;
       stan::math::check_greater_or_equal(function__, "sigma_theta",
-        lcm_sym12__, 0);
+        lcm_sym10__, 0);
       out__.write(beta0);
       out__.write(beta1);
       out__.write(tau_theta);
-      out__.write(lcm_sym12__);
       out__.write(lcm_sym10__);
+      out__.write(lcm_sym8__);
       out__.write(theta_std);
       out__.write(x);
       out__.write(y);
@@ -10200,24 +9054,16 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym3__;
       int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ tau_phi;
       tau_phi = in__.read<local_scalar_t__>();
       out__.write_free_lb(0, tau_phi);
-      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant((N - 1), DUMMY_VAR__);
-      lcm_sym3__ = (N - 1);
-      if (stan::math::logical_gte(lcm_sym3__, 1)) {
-        stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-          "assigning variable phi_std_raw", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= lcm_sym3__; ++sym1__) {
-          stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-            "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw;
+      stan::model::assign(phi_std_raw,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>((N - 1)),
+        "assigning variable phi_std_raw");
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10271,15 +9117,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym29__ = 1; sym29__ <= phi_std_raw_1dim__; ++sym29__) {
+    for (int sym27__ = 1; sym27__ <= phi_std_raw_1dim__; ++sym27__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym27__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
     }
     if (emit_generated_quantities__) {
@@ -10287,21 +9133,21 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       param_names__.emplace_back(std::string() + "beta1");
       param_names__.emplace_back(std::string() + "tau_theta");
       param_names__.emplace_back(std::string() + "sigma_theta");
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "theta" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "theta_std" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "x" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "y" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
     }
   }
@@ -10310,15 +9156,15 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym29__ = 1; sym29__ <= phi_std_raw_1dim__; ++sym29__) {
+    for (int sym27__ = 1; sym27__ <= phi_std_raw_1dim__; ++sym27__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym29__));
+        std::to_string(sym27__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
     }
     if (emit_generated_quantities__) {
@@ -10326,21 +9172,21 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       param_names__.emplace_back(std::string() + "beta1");
       param_names__.emplace_back(std::string() + "tau_theta");
       param_names__.emplace_back(std::string() + "sigma_theta");
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "theta" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "theta_std" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "x" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
-      for (int sym29__ = 1; sym29__ <= N; ++sym29__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "y" + '.' +
-          std::to_string(sym29__));
+          std::to_string(sym27__));
       }
     }
   }
@@ -10751,7 +9597,6 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
 }
 class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model> {
  private:
-  int lcm_sym115__;
   int lcm_sym114__;
   int lcm_sym113__;
   int lcm_sym112__;
@@ -10761,6 +9606,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   int lcm_sym108__;
   int lcm_sym107__;
   int lcm_sym106__;
+  int lcm_sym105__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -10823,8 +9669,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         pos__ = 1;
         current_statement__ = 42;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym107__ = stan::math::logical_gte(nind, 1);
-          if (lcm_sym107__) {
+          lcm_sym106__ = stan::math::logical_gte(nind, 1);
+          if (lcm_sym106__) {
             current_statement__ = 42;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -10843,7 +9689,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 42;
-            if (lcm_sym107__) {
+            if (lcm_sym106__) {
               current_statement__ = 42;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -10861,7 +9707,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
         } else {
-          lcm_sym107__ = stan::math::logical_gte(nind, 1);
+          lcm_sym106__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 42;
@@ -10870,8 +9716,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::check_less_or_equal(function__, "y", y, 1);
       current_statement__ = 43;
       n_occ_minus_1 = std::numeric_limits<int>::min();
-      lcm_sym108__ = (n_occasions - 1);
-      n_occ_minus_1 = lcm_sym108__;
+      lcm_sym107__ = (n_occasions - 1);
+      n_occ_minus_1 = lcm_sym107__;
       current_statement__ = 44;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 45;
@@ -10881,7 +9727,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 47;
       last = std::vector<int>(nind, std::numeric_limits<int>::min());
       current_statement__ = 49;
-      if (lcm_sym107__) {
+      if (lcm_sym106__) {
         current_statement__ = 48;
         stan::model::assign(first,
           first_capture(
@@ -10897,7 +9743,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         }
       }
       current_statement__ = 51;
-      if (lcm_sym107__) {
+      if (lcm_sym106__) {
         current_statement__ = 50;
         stan::model::assign(last,
           last_capture(
@@ -10926,12 +9772,12 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-        lcm_sym108__);
+        lcm_sym107__);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 56;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-        lcm_sym108__);
+        lcm_sym107__);
       current_statement__ = 57;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 58;
@@ -10969,16 +9815,15 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym105__;
-      int lcm_sym104__;
+      double lcm_sym104__;
       int lcm_sym103__;
       int lcm_sym102__;
       int lcm_sym101__;
-      double lcm_sym100__;
-      local_scalar_t__ lcm_sym99__;
+      int lcm_sym100__;
+      double lcm_sym99__;
       local_scalar_t__ lcm_sym98__;
       local_scalar_t__ lcm_sym97__;
-      double lcm_sym96__;
+      local_scalar_t__ lcm_sym96__;
       double lcm_sym95__;
       double lcm_sym94__;
       double lcm_sym93__;
@@ -10992,7 +9837,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       double lcm_sym85__;
       double lcm_sym84__;
       double lcm_sym83__;
-      int lcm_sym82__;
+      double lcm_sym82__;
       int lcm_sym81__;
       int lcm_sym80__;
       int lcm_sym79__;
@@ -11012,6 +9857,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       int lcm_sym65__;
       int lcm_sym64__;
       int lcm_sym63__;
+      int lcm_sym62__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -11038,20 +9884,20 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
           DUMMY_VAR__);
       local_scalar_t__ mu = DUMMY_VAR__;
-      lcm_sym99__ = stan::math::logit(mean_phi);
-      mu = lcm_sym99__;
-      lcm_sym63__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym63__) {
-        lcm_sym102__ = stan::model::rvalue(first, "first",
+      lcm_sym98__ = stan::math::logit(mean_phi);
+      mu = lcm_sym98__;
+      lcm_sym62__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym62__) {
+        lcm_sym101__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym76__ = (lcm_sym102__ - 1);
-        if (stan::math::logical_gte(lcm_sym76__, 1)) {
+        lcm_sym75__ = (lcm_sym101__ - 1);
+        if (stan::math::logical_gte(lcm_sym75__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 9;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym76__; ++t) {
+          for (int t = 2; t <= lcm_sym75__; ++t) {
             current_statement__ = 10;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -11060,19 +9906,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym74__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym74__, lcm_sym102__)) {
-          lcm_sym98__ = stan::math::inv_logit((lcm_sym99__ +
+        lcm_sym73__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym73__, lcm_sym101__)) {
+          lcm_sym97__ = stan::math::inv_logit((lcm_sym98__ +
                           stan::model::rvalue(epsilon, "epsilon",
                             stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym98__, "assigning variable phi",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym102__));
-          lcm_sym82__ = (lcm_sym102__ + 1);
+          stan::model::assign(phi, lcm_sym97__, "assigning variable phi",
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
+          lcm_sym81__ = (lcm_sym101__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym102__));
-          for (int t = lcm_sym82__; t <= lcm_sym74__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
+          for (int t = lcm_sym81__; t <= lcm_sym73__; ++t) {
             current_statement__ = 12;
-            stan::model::assign(phi, lcm_sym98__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym97__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             current_statement__ = 13;
             stan::model::assign(p, mean_p, "assigning variable p",
@@ -11080,16 +9926,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym101__ = stan::model::rvalue(first, "first",
+          lcm_sym100__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym75__ = (lcm_sym101__ - 1);
-          if (stan::math::logical_gte(lcm_sym75__, 1)) {
+          lcm_sym74__ = (lcm_sym100__ - 1);
+          if (stan::math::logical_gte(lcm_sym74__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 9;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym75__; ++t) {
+            for (int t = 2; t <= lcm_sym74__; ++t) {
               current_statement__ = 10;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -11099,18 +9945,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
           current_statement__ = 15;
-          if (stan::math::logical_gte(lcm_sym74__, lcm_sym101__)) {
-            lcm_sym97__ = stan::math::inv_logit((lcm_sym99__ +
+          if (stan::math::logical_gte(lcm_sym73__, lcm_sym100__)) {
+            lcm_sym96__ = stan::math::inv_logit((lcm_sym98__ +
                             stan::model::rvalue(epsilon, "epsilon",
                               stan::model::index_uni(i))));
-            stan::model::assign(phi, lcm_sym97__, "assigning variable phi",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym101__));
-            lcm_sym81__ = (lcm_sym101__ + 1);
+            stan::model::assign(phi, lcm_sym96__, "assigning variable phi",
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
+            lcm_sym80__ = (lcm_sym100__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym101__));
-            for (int t = lcm_sym81__; t <= lcm_sym74__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
+            for (int t = lcm_sym80__; t <= lcm_sym73__; ++t) {
               current_statement__ = 12;
-              stan::model::assign(phi, lcm_sym97__, "assigning variable phi",
+              stan::model::assign(phi, lcm_sym96__, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
               current_statement__ = 13;
               stan::model::assign(p, mean_p, "assigning variable p",
@@ -11132,58 +9978,58 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 27;
-        if (lcm_sym63__) {
+        if (lcm_sym62__) {
           current_statement__ = 20;
           stan::model::assign(inline_prob_uncaptured_chi_sym9__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym9__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym74__ = (n_occasions - 1);
-          lcm_sym64__ = stan::math::logical_gte(lcm_sym74__, 1);
-          if (lcm_sym64__) {
+          lcm_sym73__ = (n_occasions - 1);
+          lcm_sym63__ = stan::math::logical_gte(lcm_sym73__, 1);
+          if (lcm_sym63__) {
             int inline_prob_uncaptured_t_curr_sym10__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym11__ =
               std::numeric_limits<int>::min();
-            lcm_sym78__ = (lcm_sym74__ + 1);
+            lcm_sym77__ = (lcm_sym73__ + 1);
             current_statement__ = 23;
             stan::model::assign(inline_prob_uncaptured_chi_sym9__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym74__)) * (1 -
+                   stan::model::index_uni(lcm_sym73__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym78__ - 1))))),
+                  stan::model::index_uni((lcm_sym77__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                   "inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym78__)), (1 -
+                  stan::model::index_uni(lcm_sym77__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym74__)))),
+                  stan::model::index_uni(lcm_sym73__)))),
               "assigning variable inline_prob_uncaptured_chi_sym9__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym74__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym73__));
             for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                 <= lcm_sym74__; ++inline_prob_uncaptured_t_sym12__) {
+                 <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym73__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
-              lcm_sym77__ = (lcm_sym73__ + 1);
+              lcm_sym72__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
+              lcm_sym76__ = (lcm_sym72__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym73__)) * (1 -
+                     stan::model::index_uni(lcm_sym72__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym77__ - 1))))),
+                    stan::model::index_uni((lcm_sym76__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym77__)), (1 -
+                    stan::model::index_uni(lcm_sym76__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym73__)))),
+                    stan::model::index_uni(lcm_sym72__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym73__));
+                stan::model::index_uni(lcm_sym72__));
             }
           }
           for (int inline_prob_uncaptured_i_sym13__ = 2; inline_prob_uncaptured_i_sym13__
@@ -11194,60 +10040,60 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 25;
-            if (lcm_sym64__) {
+            if (lcm_sym63__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym78__ = (lcm_sym74__ + 1);
+              lcm_sym77__ = (lcm_sym73__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                     stan::model::index_uni(lcm_sym74__)) * (1 -
+                     stan::model::index_uni(lcm_sym73__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni((lcm_sym78__ - 1))))),
+                    stan::model::index_uni((lcm_sym77__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym78__)), (1 -
+                    stan::model::index_uni(lcm_sym77__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym74__)))),
+                    stan::model::index_uni(lcm_sym73__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                stan::model::index_uni(lcm_sym74__));
+                stan::model::index_uni(lcm_sym73__));
               for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                   <= lcm_sym74__; ++inline_prob_uncaptured_t_sym12__) {
+                   <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
                 int inline_prob_uncaptured_t_curr_sym10__ =
                   std::numeric_limits<int>::min();
                 int inline_prob_uncaptured_t_next_sym11__ =
                   std::numeric_limits<int>::min();
-                lcm_sym73__ = (n_occasions -
+                lcm_sym72__ = (n_occasions -
                   inline_prob_uncaptured_t_sym12__);
-                lcm_sym77__ = (lcm_sym73__ + 1);
+                lcm_sym76__ = (lcm_sym72__ + 1);
                 current_statement__ = 23;
                 stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym13__),
-                       stan::model::index_uni(lcm_sym73__)) * (1 -
+                       stan::model::index_uni(lcm_sym72__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni((lcm_sym77__ - 1))))),
+                      stan::model::index_uni((lcm_sym76__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                       "inline_prob_uncaptured_chi_sym9__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym77__)), (1 -
+                      stan::model::index_uni(lcm_sym76__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym73__)))),
+                      stan::model::index_uni(lcm_sym72__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                  stan::model::index_uni(lcm_sym73__));
+                  stan::model::index_uni(lcm_sym72__));
               }
             }
           }
@@ -11277,28 +10123,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         current_statement__ = 30;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
         current_statement__ = 37;
-        if (lcm_sym63__) {
-          lcm_sym102__ = stan::model::rvalue(first, "first",
+        if (lcm_sym62__) {
+          lcm_sym101__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym102__, 0)) {
-            lcm_sym104__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym101__, 0)) {
+            lcm_sym103__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym82__ = (lcm_sym102__ + 1);
-            if (stan::math::logical_gte(lcm_sym104__, lcm_sym82__)) {
+            lcm_sym81__ = (lcm_sym101__ + 1);
+            if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
               current_statement__ = 31;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym82__ - 1)))));
-              lcm_sym80__ = (lcm_sym82__ + 1);
+                                 stan::model::index_uni((lcm_sym81__ - 1)))));
+              lcm_sym79__ = (lcm_sym81__ + 1);
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                stan::model::rvalue(y, "y",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym82__)),
+                                 stan::model::index_uni(lcm_sym81__)),
                                stan::model::rvalue(p, "p",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym82__ - 1)))));
-              for (int t = lcm_sym80__; t <= lcm_sym104__; ++t) {
+                                 stan::model::index_uni((lcm_sym81__ - 1)))));
+              for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
                 current_statement__ = 31;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
@@ -11320,30 +10166,30 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                                inline_prob_uncaptured_return_sym8__,
                                "inline_prob_uncaptured_return_sym8__",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(lcm_sym104__))));
+                               stan::model::index_uni(lcm_sym103__))));
           }
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym101__ = stan::model::rvalue(first, "first",
+            lcm_sym100__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym101__, 0)) {
-              lcm_sym103__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym100__, 0)) {
+              lcm_sym102__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym81__ = (lcm_sym101__ + 1);
-              if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
+              lcm_sym80__ = (lcm_sym100__ + 1);
+              if (stan::math::logical_gte(lcm_sym102__, lcm_sym80__)) {
                 current_statement__ = 31;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym81__ - 1)))));
-                lcm_sym79__ = (lcm_sym81__ + 1);
+                                   stan::model::index_uni((lcm_sym80__ - 1)))));
+                lcm_sym78__ = (lcm_sym80__ + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni(lcm_sym81__)),
+                                   stan::model::index_uni(lcm_sym80__)),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym81__ - 1)))));
-                for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
+                                   stan::model::index_uni((lcm_sym80__ - 1)))));
+                for (int t = lcm_sym78__; t <= lcm_sym102__; ++t) {
                   current_statement__ = 31;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -11365,7 +10211,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                                  inline_prob_uncaptured_return_sym8__,
                                  "inline_prob_uncaptured_return_sym8__",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(lcm_sym103__))));
+                                 stan::model::index_uni(lcm_sym102__))));
             }
           }
         }
@@ -11407,18 +10253,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym62__;
-      int lcm_sym61__;
+      double lcm_sym61__;
       int lcm_sym60__;
-      double lcm_sym59__;
+      int lcm_sym59__;
       double lcm_sym58__;
-      local_scalar_t__ lcm_sym57__;
+      double lcm_sym57__;
       local_scalar_t__ lcm_sym56__;
-      double lcm_sym55__;
+      local_scalar_t__ lcm_sym55__;
       double lcm_sym54__;
       double lcm_sym53__;
       double lcm_sym52__;
-      int lcm_sym51__;
+      double lcm_sym51__;
       int lcm_sym50__;
       int lcm_sym49__;
       int lcm_sym48__;
@@ -11434,6 +10279,7 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       int lcm_sym38__;
       int lcm_sym37__;
       int lcm_sym36__;
+      int lcm_sym35__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -11469,20 +10315,20 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym58__ = stan::math::logit(mean_phi);
-      mu = lcm_sym58__;
-      lcm_sym36__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym36__) {
-        lcm_sym61__ = stan::model::rvalue(first, "first",
+      lcm_sym57__ = stan::math::logit(mean_phi);
+      mu = lcm_sym57__;
+      lcm_sym35__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym35__) {
+        lcm_sym60__ = stan::model::rvalue(first, "first",
                         stan::model::index_uni(1));
-        lcm_sym45__ = (lcm_sym61__ - 1);
-        if (stan::math::logical_gte(lcm_sym45__, 1)) {
+        lcm_sym44__ = (lcm_sym60__ - 1);
+        if (stan::math::logical_gte(lcm_sym44__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 9;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym45__; ++t) {
+          for (int t = 2; t <= lcm_sym44__; ++t) {
             current_statement__ = 10;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -11491,19 +10337,19 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym43__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym43__, lcm_sym61__)) {
-          lcm_sym57__ = stan::math::inv_logit((lcm_sym58__ +
+        lcm_sym42__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym42__, lcm_sym60__)) {
+          lcm_sym56__ = stan::math::inv_logit((lcm_sym57__ +
                           stan::model::rvalue(epsilon, "epsilon",
                             stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym57__, "assigning variable phi",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym61__));
-          lcm_sym51__ = (lcm_sym61__ + 1);
+          stan::model::assign(phi, lcm_sym56__, "assigning variable phi",
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
+          lcm_sym50__ = (lcm_sym60__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym61__));
-          for (int t = lcm_sym51__; t <= lcm_sym43__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
+          for (int t = lcm_sym50__; t <= lcm_sym42__; ++t) {
             current_statement__ = 12;
-            stan::model::assign(phi, lcm_sym57__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym56__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             current_statement__ = 13;
             stan::model::assign(p, mean_p, "assigning variable p",
@@ -11511,16 +10357,16 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym60__ = stan::model::rvalue(first, "first",
+          lcm_sym59__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym44__ = (lcm_sym60__ - 1);
-          if (stan::math::logical_gte(lcm_sym44__, 1)) {
+          lcm_sym43__ = (lcm_sym59__ - 1);
+          if (stan::math::logical_gte(lcm_sym43__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 9;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym44__; ++t) {
+            for (int t = 2; t <= lcm_sym43__; ++t) {
               current_statement__ = 10;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -11530,18 +10376,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             }
           }
           current_statement__ = 15;
-          if (stan::math::logical_gte(lcm_sym43__, lcm_sym60__)) {
-            lcm_sym56__ = stan::math::inv_logit((lcm_sym58__ +
+          if (stan::math::logical_gte(lcm_sym42__, lcm_sym59__)) {
+            lcm_sym55__ = stan::math::inv_logit((lcm_sym57__ +
                             stan::model::rvalue(epsilon, "epsilon",
                               stan::model::index_uni(i))));
-            stan::model::assign(phi, lcm_sym56__, "assigning variable phi",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym60__));
-            lcm_sym50__ = (lcm_sym60__ + 1);
+            stan::model::assign(phi, lcm_sym55__, "assigning variable phi",
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
+            lcm_sym49__ = (lcm_sym59__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym60__));
-            for (int t = lcm_sym50__; t <= lcm_sym43__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
+            for (int t = lcm_sym49__; t <= lcm_sym42__; ++t) {
               current_statement__ = 12;
-              stan::model::assign(phi, lcm_sym56__, "assigning variable phi",
+              stan::model::assign(phi, lcm_sym55__, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
               current_statement__ = 13;
               stan::model::assign(p, mean_p, "assigning variable p",
@@ -11562,58 +10408,58 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 27;
-        if (lcm_sym36__) {
+        if (lcm_sym35__) {
           current_statement__ = 20;
           stan::model::assign(inline_prob_uncaptured_chi_sym2__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym2__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym43__ = (n_occasions - 1);
-          lcm_sym37__ = stan::math::logical_gte(lcm_sym43__, 1);
-          if (lcm_sym37__) {
+          lcm_sym42__ = (n_occasions - 1);
+          lcm_sym36__ = stan::math::logical_gte(lcm_sym42__, 1);
+          if (lcm_sym36__) {
             int inline_prob_uncaptured_t_curr_sym3__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym4__ =
               std::numeric_limits<int>::min();
-            lcm_sym49__ = (lcm_sym43__ + 1);
+            lcm_sym48__ = (lcm_sym42__ + 1);
             current_statement__ = 23;
             stan::model::assign(inline_prob_uncaptured_chi_sym2__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym43__)) * (1 -
+                   stan::model::index_uni(lcm_sym42__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym49__ - 1))))),
+                  stan::model::index_uni((lcm_sym48__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                   "inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym49__)), (1 -
+                  stan::model::index_uni(lcm_sym48__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym43__)))),
+                  stan::model::index_uni(lcm_sym42__)))),
               "assigning variable inline_prob_uncaptured_chi_sym2__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym43__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym42__));
             for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                 <= lcm_sym43__; ++inline_prob_uncaptured_t_sym5__) {
+                 <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym42__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
-              lcm_sym48__ = (lcm_sym42__ + 1);
+              lcm_sym41__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
+              lcm_sym47__ = (lcm_sym41__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym42__)) * (1 -
+                     stan::model::index_uni(lcm_sym41__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym48__ - 1))))),
+                    stan::model::index_uni((lcm_sym47__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym48__)), (1 -
+                    stan::model::index_uni(lcm_sym47__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym42__)))),
+                    stan::model::index_uni(lcm_sym41__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym42__));
+                stan::model::index_uni(lcm_sym41__));
             }
           }
           for (int inline_prob_uncaptured_i_sym6__ = 2; inline_prob_uncaptured_i_sym6__
@@ -11624,59 +10470,59 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
               stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 25;
-            if (lcm_sym37__) {
+            if (lcm_sym36__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym49__ = (lcm_sym43__ + 1);
+              lcm_sym48__ = (lcm_sym42__ + 1);
               current_statement__ = 23;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                     stan::model::index_uni(lcm_sym43__)) * (1 -
+                     stan::model::index_uni(lcm_sym42__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni((lcm_sym49__ - 1))))),
+                    stan::model::index_uni((lcm_sym48__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym49__)), (1 -
+                    stan::model::index_uni(lcm_sym48__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym43__)))),
+                    stan::model::index_uni(lcm_sym42__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                stan::model::index_uni(lcm_sym43__));
+                stan::model::index_uni(lcm_sym42__));
               for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                   <= lcm_sym43__; ++inline_prob_uncaptured_t_sym5__) {
+                   <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
                 int inline_prob_uncaptured_t_curr_sym3__ =
                   std::numeric_limits<int>::min();
                 int inline_prob_uncaptured_t_next_sym4__ =
                   std::numeric_limits<int>::min();
-                lcm_sym42__ = (n_occasions -
+                lcm_sym41__ = (n_occasions -
                   inline_prob_uncaptured_t_sym5__);
-                lcm_sym48__ = (lcm_sym42__ + 1);
+                lcm_sym47__ = (lcm_sym41__ + 1);
                 current_statement__ = 23;
                 stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                       stan::model::index_uni(lcm_sym42__)) * (1 -
+                       stan::model::index_uni(lcm_sym41__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni((lcm_sym48__ - 1))))),
+                      stan::model::index_uni((lcm_sym47__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                       "inline_prob_uncaptured_chi_sym2__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym48__)), (1 -
+                      stan::model::index_uni(lcm_sym47__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym42__)))),
+                      stan::model::index_uni(lcm_sym41__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                  stan::model::index_uni(lcm_sym42__));
+                  stan::model::index_uni(lcm_sym41__));
               }
             }
           }
@@ -11706,17 +10552,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         out__.write(phi);
         out__.write(p);
         out__.write(inline_prob_uncaptured_return_sym1__);
-        out__.write(lcm_sym58__);
+        out__.write(lcm_sym57__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
         return ;
       }
       double sigma2 = std::numeric_limits<double>::quiet_NaN();
-      lcm_sym59__ = stan::math::square(sigma);
-      sigma2 = lcm_sym59__;
+      lcm_sym58__ = stan::math::square(sigma);
+      sigma2 = lcm_sym58__;
       current_statement__ = 29;
-      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym59__, 0);
-      out__.write(lcm_sym59__);
+      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym58__, 0);
+      out__.write(lcm_sym58__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11735,7 +10581,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym35__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mean_phi;
@@ -11744,16 +10589,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(nind, DUMMY_VAR__);
-      if (stan::math::logical_gte(nind, 1)) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= nind; ++sym1__) {
-          stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-            "assigning variable epsilon", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(nind),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
@@ -11810,28 +10649,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+    for (int sym115__ = 1; sym115__ <= nind; ++sym115__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym116__));
+        std::to_string(sym115__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym116__ = 1; sym116__ <= n_occ_minus_1; ++sym116__) {
-        for (int sym117__ = 1; sym117__ <= nind; ++sym117__) {
+      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
+        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym117__) + '.' + std::to_string(sym116__));
+            std::to_string(sym116__) + '.' + std::to_string(sym115__));
         }
       }
-      for (int sym116__ = 1; sym116__ <= n_occ_minus_1; ++sym116__) {
-        for (int sym117__ = 1; sym117__ <= nind; ++sym117__) {
+      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
+        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym117__) + '.' + std::to_string(sym116__));
+            std::to_string(sym116__) + '.' + std::to_string(sym115__));
         }
       }
-      for (int sym116__ = 1; sym116__ <= n_occasions; ++sym116__) {
-        for (int sym117__ = 1; sym117__ <= nind; ++sym117__) {
+      for (int sym115__ = 1; sym115__ <= n_occasions; ++sym115__) {
+        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym117__) + '.' + std::to_string(sym116__));
+            std::to_string(sym116__) + '.' + std::to_string(sym115__));
         }
       }
       param_names__.emplace_back(std::string() + "mu");
@@ -11846,28 +10685,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
+    for (int sym115__ = 1; sym115__ <= nind; ++sym115__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym116__));
+        std::to_string(sym115__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym116__ = 1; sym116__ <= n_occ_minus_1; ++sym116__) {
-        for (int sym117__ = 1; sym117__ <= nind; ++sym117__) {
+      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
+        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym117__) + '.' + std::to_string(sym116__));
+            std::to_string(sym116__) + '.' + std::to_string(sym115__));
         }
       }
-      for (int sym116__ = 1; sym116__ <= n_occ_minus_1; ++sym116__) {
-        for (int sym117__ = 1; sym117__ <= nind; ++sym117__) {
+      for (int sym115__ = 1; sym115__ <= n_occ_minus_1; ++sym115__) {
+        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym117__) + '.' + std::to_string(sym116__));
+            std::to_string(sym116__) + '.' + std::to_string(sym115__));
         }
       }
-      for (int sym116__ = 1; sym116__ <= n_occasions; ++sym116__) {
-        for (int sym117__ = 1; sym117__ <= nind; ++sym117__) {
+      for (int sym115__ = 1; sym115__ <= n_occasions; ++sym115__) {
+        for (int sym116__ = 1; sym116__ <= nind; ++sym116__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym117__) + '.' + std::to_string(sym116__));
+            std::to_string(sym116__) + '.' + std::to_string(sym115__));
         }
       }
       param_names__.emplace_back(std::string() + "mu");
@@ -12922,8 +11761,6 @@ js_super_lp(const std::vector<std::vector<int>>& y, const std::vector<int>&
 }
 class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model> {
  private:
-  int lcm_sym248__;
-  int lcm_sym247__;
   int lcm_sym246__;
   int lcm_sym245__;
   int lcm_sym244__;
@@ -12932,6 +11769,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   int lcm_sym241__;
   int lcm_sym240__;
   int lcm_sym239__;
+  int lcm_sym238__;
+  int lcm_sym237__;
   int M;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -12994,8 +11833,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         pos__ = 1;
         current_statement__ = 115;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym239__ = stan::math::logical_gte(M, 1);
-          if (lcm_sym239__) {
+          lcm_sym237__ = stan::math::logical_gte(M, 1);
+          if (lcm_sym237__) {
             current_statement__ = 115;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -13014,7 +11853,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 115;
-            if (lcm_sym239__) {
+            if (lcm_sym237__) {
               current_statement__ = 115;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -13032,7 +11871,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             }
           }
         } else {
-          lcm_sym239__ = stan::math::logical_gte(M, 1);
+          lcm_sym237__ = stan::math::logical_gte(M, 1);
         }
       }
       current_statement__ = 115;
@@ -13048,7 +11887,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       current_statement__ = 119;
       last = std::vector<int>(M, std::numeric_limits<int>::min());
       current_statement__ = 121;
-      if (lcm_sym239__) {
+      if (lcm_sym237__) {
         current_statement__ = 120;
         stan::model::assign(first,
           first_capture(
@@ -13064,7 +11903,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         }
       }
       current_statement__ = 123;
-      if (lcm_sym239__) {
+      if (lcm_sym237__) {
         current_statement__ = 122;
         stan::model::assign(last,
           last_capture(
@@ -13096,11 +11935,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::validate_non_negative_index("phi", "M", M);
       current_statement__ = 127;
       phi_2dim__ = std::numeric_limits<int>::min();
-      lcm_sym241__ = (n_occasions - 1);
-      phi_2dim__ = lcm_sym241__;
+      lcm_sym239__ = (n_occasions - 1);
+      phi_2dim__ = lcm_sym239__;
       current_statement__ = 127;
       stan::math::validate_non_negative_index("phi", "n_occasions - 1",
-        lcm_sym241__);
+        lcm_sym239__);
       current_statement__ = 128;
       stan::math::validate_non_negative_index("p", "M", M);
       current_statement__ = 129;
@@ -13155,26 +11994,24 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym238__;
-      int lcm_sym237__;
-      local_scalar_t__ lcm_sym236__;
+      int lcm_sym236__;
       int lcm_sym235__;
-      int lcm_sym234__;
+      local_scalar_t__ lcm_sym234__;
       int lcm_sym233__;
       int lcm_sym232__;
       int lcm_sym231__;
-      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym230__;
-      double lcm_sym229__;
-      double lcm_sym228__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym227__;
+      int lcm_sym230__;
+      int lcm_sym229__;
+      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym228__;
+      double lcm_sym227__;
       double lcm_sym226__;
-      double lcm_sym225__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym225__;
       double lcm_sym224__;
       double lcm_sym223__;
       double lcm_sym222__;
-      int lcm_sym221__;
+      double lcm_sym221__;
       double lcm_sym220__;
-      double lcm_sym219__;
+      int lcm_sym219__;
       double lcm_sym218__;
       double lcm_sym217__;
       double lcm_sym216__;
@@ -13187,12 +12024,12 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       double lcm_sym209__;
       double lcm_sym208__;
       double lcm_sym207__;
-      int lcm_sym206__;
+      double lcm_sym206__;
       double lcm_sym205__;
       int lcm_sym204__;
-      int lcm_sym203__;
-      double lcm_sym202__;
-      double lcm_sym201__;
+      double lcm_sym203__;
+      int lcm_sym202__;
+      int lcm_sym201__;
       double lcm_sym200__;
       double lcm_sym199__;
       double lcm_sym198__;
@@ -13205,18 +12042,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       double lcm_sym191__;
       double lcm_sym190__;
       double lcm_sym189__;
-      int lcm_sym188__;
-      int lcm_sym187__;
-      double lcm_sym186__;
+      double lcm_sym188__;
+      double lcm_sym187__;
+      int lcm_sym186__;
       int lcm_sym185__;
-      int lcm_sym184__;
+      double lcm_sym184__;
       int lcm_sym183__;
       int lcm_sym182__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym181__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym180__;
+      int lcm_sym181__;
+      int lcm_sym180__;
       Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym179__;
-      int lcm_sym178__;
-      int lcm_sym177__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym178__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym177__;
       int lcm_sym176__;
       int lcm_sym175__;
       int lcm_sym174__;
@@ -13228,9 +12065,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       int lcm_sym168__;
       int lcm_sym167__;
       int lcm_sym166__;
-      double lcm_sym165__;
-      double lcm_sym164__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym163__;
+      int lcm_sym165__;
+      int lcm_sym164__;
+      double lcm_sym163__;
+      double lcm_sym162__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym161__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -13270,56 +12109,56 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       Eigen::Matrix<local_scalar_t__,-1,-1> chi =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, n_occasions,
           DUMMY_VAR__);
-      lcm_sym178__ = (n_occasions - 1);
-      stan::model::assign(lcm_sym230__,
-        stan::math::rep_matrix(mean_phi, M, lcm_sym178__),
-        "assigning variable lcm_sym230__");
-      stan::model::assign(phi, lcm_sym230__, "assigning variable phi");
+      lcm_sym176__ = (n_occasions - 1);
+      stan::model::assign(lcm_sym228__,
+        stan::math::rep_matrix(mean_phi, M, lcm_sym176__),
+        "assigning variable lcm_sym228__");
+      stan::model::assign(phi, lcm_sym228__, "assigning variable phi");
       current_statement__ = 76;
       if (stan::math::logical_gte(n_occasions, 1)) {
-        stan::model::assign(lcm_sym227__,
+        stan::model::assign(lcm_sym225__,
           stan::math::inv_logit(
             stan::math::add(stan::math::logit(mean_p), epsilon)),
-          "assigning variable lcm_sym227__");
-        stan::model::assign(p, lcm_sym227__, "assigning variable p",
+          "assigning variable lcm_sym225__");
+        stan::model::assign(p, lcm_sym225__, "assigning variable p",
           stan::model::index_omni(), stan::model::index_uni(1));
         for (int t = 2; t <= n_occasions; ++t) {
           current_statement__ = 12;
-          stan::model::assign(p, lcm_sym227__, "assigning variable p",
+          stan::model::assign(p, lcm_sym225__, "assigning variable p",
             stan::model::index_omni(), stan::model::index_uni(t));
         }
       }
-      stan::model::assign(lcm_sym163__,
+      stan::model::assign(lcm_sym161__,
         stan::math::divide(beta, stan::math::sum(beta)),
-        "assigning variable lcm_sym163__");
-      stan::model::assign(b, lcm_sym163__, "assigning variable b");
+        "assigning variable lcm_sym161__");
+      stan::model::assign(b, lcm_sym161__, "assigning variable b");
       {
         local_scalar_t__ cum_b = DUMMY_VAR__;
-        lcm_sym236__ = stan::model::rvalue(lcm_sym163__, "lcm_sym163__",
+        lcm_sym234__ = stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
                          stan::model::index_uni(1));
         current_statement__ = 14;
-        stan::model::assign(nu, lcm_sym236__, "assigning variable nu",
+        stan::model::assign(nu, lcm_sym234__, "assigning variable nu",
           stan::model::index_uni(1));
         current_statement__ = 18;
-        if (stan::math::logical_gte(lcm_sym178__, 2)) {
+        if (stan::math::logical_gte(lcm_sym176__, 2)) {
           current_statement__ = 15;
           stan::model::assign(nu,
-            (stan::model::rvalue(lcm_sym163__, "lcm_sym163__",
-               stan::model::index_uni(2)) / (1.0 - lcm_sym236__)),
+            (stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
+               stan::model::index_uni(2)) / (1.0 - lcm_sym234__)),
             "assigning variable nu", stan::model::index_uni(2));
           current_statement__ = 16;
-          cum_b = (lcm_sym236__ +
-            stan::model::rvalue(lcm_sym163__, "lcm_sym163__",
+          cum_b = (lcm_sym234__ +
+            stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
               stan::model::index_uni(2)));
-          for (int t = 3; t <= lcm_sym178__; ++t) {
+          for (int t = 3; t <= lcm_sym176__; ++t) {
             current_statement__ = 15;
             stan::model::assign(nu,
-              (stan::model::rvalue(lcm_sym163__, "lcm_sym163__",
+              (stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
                  stan::model::index_uni(t)) / (1.0 - cum_b)),
               "assigning variable nu", stan::model::index_uni(t));
             current_statement__ = 16;
             cum_b = (cum_b +
-              stan::model::rvalue(lcm_sym163__, "lcm_sym163__",
+              stan::model::rvalue(lcm_sym161__, "lcm_sym161__",
                 stan::model::index_uni(t)));
           }
         }
@@ -13332,141 +12171,141 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       {
         int inline_prob_uncaptured_n_ind_sym15__ =
           std::numeric_limits<int>::min();
-        lcm_sym231__ = stan::math::rows(p);
+        lcm_sym229__ = stan::math::rows(p);
         int inline_prob_uncaptured_n_occasions_sym16__ =
           std::numeric_limits<int>::min();
-        lcm_sym221__ = stan::math::cols(p);
+        lcm_sym219__ = stan::math::cols(p);
         current_statement__ = 23;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym231__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym229__);
         current_statement__ = 24;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym221__);
+          lcm_sym219__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym17__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym231__,
-            lcm_sym221__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym229__,
+            lcm_sym219__, DUMMY_VAR__);
         current_statement__ = 33;
-        if (stan::math::logical_gte(lcm_sym231__, 1)) {
+        if (stan::math::logical_gte(lcm_sym229__, 1)) {
           current_statement__ = 26;
           stan::model::assign(inline_prob_uncaptured_chi_sym17__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym17__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym221__));
-          lcm_sym183__ = (lcm_sym221__ - 1);
-          lcm_sym170__ = stan::math::logical_gte(lcm_sym183__, 1);
-          if (lcm_sym170__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym219__));
+          lcm_sym181__ = (lcm_sym219__ - 1);
+          lcm_sym168__ = stan::math::logical_gte(lcm_sym181__, 1);
+          if (lcm_sym168__) {
             int inline_prob_uncaptured_t_curr_sym18__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym19__ =
               std::numeric_limits<int>::min();
-            lcm_sym188__ = (lcm_sym183__ + 1);
+            lcm_sym186__ = (lcm_sym181__ + 1);
             current_statement__ = 29;
             stan::model::assign(inline_prob_uncaptured_chi_sym17__,
               stan::math::fma(
-                (stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                    stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym183__)) * (1 -
+                   stan::model::index_uni(lcm_sym181__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym188__)))),
+                  stan::model::index_uni(lcm_sym186__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                   "inline_prob_uncaptured_chi_sym17__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym188__)), (1 -
-                stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                  stan::model::index_uni(lcm_sym186__)), (1 -
+                stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym183__)))),
+                  stan::model::index_uni(lcm_sym181__)))),
               "assigning variable inline_prob_uncaptured_chi_sym17__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym183__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym181__));
             for (int inline_prob_uncaptured_t_sym20__ = 2; inline_prob_uncaptured_t_sym20__
-                 <= lcm_sym183__; ++inline_prob_uncaptured_t_sym20__) {
+                 <= lcm_sym181__; ++inline_prob_uncaptured_t_sym20__) {
               int inline_prob_uncaptured_t_curr_sym18__ =
                 std::numeric_limits<int>::min();
-              lcm_sym182__ = (lcm_sym221__ -
+              lcm_sym180__ = (lcm_sym219__ -
                 inline_prob_uncaptured_t_sym20__);
               int inline_prob_uncaptured_t_next_sym19__ =
                 std::numeric_limits<int>::min();
-              lcm_sym187__ = (lcm_sym182__ + 1);
+              lcm_sym185__ = (lcm_sym180__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym17__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                  (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                      stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym182__)) * (1 -
+                     stan::model::index_uni(lcm_sym180__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym187__)))),
+                    stan::model::index_uni(lcm_sym185__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                     "inline_prob_uncaptured_chi_sym17__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym187__)), (1 -
-                  stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                    stan::model::index_uni(lcm_sym185__)), (1 -
+                  stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym182__)))),
+                    stan::model::index_uni(lcm_sym180__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym17__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym182__));
+                stan::model::index_uni(lcm_sym180__));
             }
           }
           for (int inline_prob_uncaptured_i_sym21__ = 2; inline_prob_uncaptured_i_sym21__
-               <= lcm_sym231__; ++inline_prob_uncaptured_i_sym21__) {
+               <= lcm_sym229__; ++inline_prob_uncaptured_i_sym21__) {
             current_statement__ = 26;
             stan::model::assign(inline_prob_uncaptured_chi_sym17__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym17__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-              stan::model::index_uni(lcm_sym221__));
+              stan::model::index_uni(lcm_sym219__));
             current_statement__ = 31;
-            if (lcm_sym170__) {
+            if (lcm_sym168__) {
               int inline_prob_uncaptured_t_curr_sym18__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym19__ =
                 std::numeric_limits<int>::min();
-              lcm_sym188__ = (lcm_sym183__ + 1);
+              lcm_sym186__ = (lcm_sym181__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym17__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                  (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                     stan::model::index_uni(lcm_sym183__)) * (1 -
+                     stan::model::index_uni(lcm_sym181__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                    stan::model::index_uni(lcm_sym188__)))),
+                    stan::model::index_uni(lcm_sym186__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                     "inline_prob_uncaptured_chi_sym17__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                    stan::model::index_uni(lcm_sym188__)), (1 -
-                  stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                    stan::model::index_uni(lcm_sym186__)), (1 -
+                  stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                    stan::model::index_uni(lcm_sym183__)))),
+                    stan::model::index_uni(lcm_sym181__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym17__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                stan::model::index_uni(lcm_sym183__));
+                stan::model::index_uni(lcm_sym181__));
               for (int inline_prob_uncaptured_t_sym20__ = 2; inline_prob_uncaptured_t_sym20__
-                   <= lcm_sym183__; ++inline_prob_uncaptured_t_sym20__) {
+                   <= lcm_sym181__; ++inline_prob_uncaptured_t_sym20__) {
                 int inline_prob_uncaptured_t_curr_sym18__ =
                   std::numeric_limits<int>::min();
-                lcm_sym182__ = (lcm_sym221__ -
+                lcm_sym180__ = (lcm_sym219__ -
                   inline_prob_uncaptured_t_sym20__);
                 int inline_prob_uncaptured_t_next_sym19__ =
                   std::numeric_limits<int>::min();
-                lcm_sym187__ = (lcm_sym182__ + 1);
+                lcm_sym185__ = (lcm_sym180__ + 1);
                 current_statement__ = 29;
                 stan::model::assign(inline_prob_uncaptured_chi_sym17__,
                   stan::math::fma(
-                    (stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                    (stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym21__),
-                       stan::model::index_uni(lcm_sym182__)) * (1 -
+                       stan::model::index_uni(lcm_sym180__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                      stan::model::index_uni(lcm_sym187__)))),
+                      stan::model::index_uni(lcm_sym185__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym17__,
                       "inline_prob_uncaptured_chi_sym17__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                      stan::model::index_uni(lcm_sym187__)), (1 -
-                    stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                      stan::model::index_uni(lcm_sym185__)), (1 -
+                    stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                      stan::model::index_uni(lcm_sym182__)))),
+                      stan::model::index_uni(lcm_sym180__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym17__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym21__),
-                  stan::model::index_uni(lcm_sym182__));
+                  stan::model::index_uni(lcm_sym180__));
               }
             }
           }
@@ -13479,15 +12318,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::model::assign(chi, inline_prob_uncaptured_return_sym14__,
         "assigning variable chi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "phi", lcm_sym230__, 0);
+      stan::math::check_greater_or_equal(function__, "phi", lcm_sym228__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "phi", lcm_sym230__, 1);
+      stan::math::check_less_or_equal(function__, "phi", lcm_sym228__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "p", p, 0);
       current_statement__ = 8;
       stan::math::check_less_or_equal(function__, "p", p, 1);
       current_statement__ = 9;
-      stan::math::check_simplex(function__, "b", lcm_sym163__);
+      stan::math::check_simplex(function__, "b", lcm_sym161__);
       current_statement__ = 10;
       stan::math::check_greater_or_equal(function__, "nu", nu, 0);
       current_statement__ = 10;
@@ -13506,40 +12345,40 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         {
           int inline_js_super_lp_n_ind_sym23__ =
             std::numeric_limits<int>::min();
-          lcm_sym237__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym235__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(1));
           int inline_js_super_lp_n_occasions_sym24__ =
             std::numeric_limits<int>::min();
-          lcm_sym238__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym236__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(2));
           current_statement__ = 81;
           stan::math::validate_non_negative_index("qnu", "n_occasions",
-            lcm_sym238__);
+            lcm_sym236__);
           Eigen::Matrix<double,-1,1> inline_js_super_lp_qnu_sym25__ =
-            Eigen::Matrix<double,-1,1>::Constant(lcm_sym238__,
+            Eigen::Matrix<double,-1,1>::Constant(lcm_sym236__,
               std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym179__, stan::math::subtract(1.0, nu),
-            "assigning variable lcm_sym179__");
+          stan::model::assign(lcm_sym177__, stan::math::subtract(1.0, nu),
+            "assigning variable lcm_sym177__");
           current_statement__ = 109;
-          if (stan::math::logical_gte(lcm_sym237__, 1)) {
+          if (stan::math::logical_gte(lcm_sym235__, 1)) {
             current_statement__ = 83;
             stan::math::validate_non_negative_index("qp", "n_occasions",
-              lcm_sym238__);
+              lcm_sym236__);
             Eigen::Matrix<double,-1,1> inline_js_super_lp_qp_sym26__ =
-              Eigen::Matrix<double,-1,1>::Constant(lcm_sym238__,
+              Eigen::Matrix<double,-1,1>::Constant(lcm_sym236__,
                 std::numeric_limits<double>::quiet_NaN());
-            stan::model::assign(lcm_sym181__,
+            stan::model::assign(lcm_sym179__,
               stan::math::subtract(1.0,
                 stan::math::transpose(
                   stan::model::rvalue(p, "p", stan::model::index_uni(1)))),
-              "assigning variable lcm_sym181__");
-            lcm_sym233__ = stan::model::rvalue(first, "first",
+              "assigning variable lcm_sym179__");
+            lcm_sym231__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(1));
-            if (lcm_sym233__) {
+            if (lcm_sym231__) {
               current_statement__ = 92;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1, psi));
               current_statement__ = 102;
-              if (stan::math::logical_eq(lcm_sym233__, 1)) {
+              if (stan::math::logical_eq(lcm_sym231__, 1)) {
                 current_statement__ = 100;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  (stan::model::rvalue(nu, "nu",
@@ -13550,84 +12389,84 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               } else {
                 current_statement__ = 93;
                 stan::math::validate_non_negative_index("lp", "first[i]",
-                  lcm_sym233__);
+                  lcm_sym231__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_js_super_lp_lp_sym27__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym233__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym231__,
                     DUMMY_VAR__);
-                lcm_sym185__ = (lcm_sym233__ - 1);
+                lcm_sym183__ = (lcm_sym231__ - 1);
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::model::rvalue(nu, "nu",
                          stan::model::index_uni(1))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym181__, "lcm_sym181__",
-                        stan::model::index_min_max(1, lcm_sym185__))))) +
+                      stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                        stan::model::index_min_max(1, lcm_sym183__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                      stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                         stan::model::index_uni(1),
-                        stan::model::index_min_max(1, lcm_sym185__))))) +
+                        stan::model::index_min_max(1, lcm_sym183__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym233__)))),
+                      stan::model::index_uni(lcm_sym231__)))),
                   "assigning variable inline_js_super_lp_lp_sym27__",
                   stan::model::index_uni(1));
                 current_statement__ = 96;
-                if (stan::math::logical_gte(lcm_sym185__, 2)) {
+                if (stan::math::logical_gte(lcm_sym183__, 2)) {
                   current_statement__ = 95;
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((((stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                            stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
                               stan::model::index_min_max(1, 1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(nu, "nu", stan::model::index_uni(2))))
                     +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym181__, "lcm_sym181__",
-                          stan::model::index_min_max(2, lcm_sym185__))))) +
+                        stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                          stan::model::index_min_max(2, lcm_sym183__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                        stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                           stan::model::index_uni(1),
-                          stan::model::index_min_max(2, lcm_sym185__))))) +
+                          stan::model::index_min_max(2, lcm_sym183__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                        stan::model::index_uni(lcm_sym233__)))),
+                        stan::model::index_uni(lcm_sym231__)))),
                     "assigning variable inline_js_super_lp_lp_sym27__",
                     stan::model::index_uni(2));
                   for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                       <= lcm_sym185__; ++inline_js_super_lp_t_sym28__) {
+                       <= lcm_sym183__; ++inline_js_super_lp_t_sym28__) {
                     current_statement__ = 95;
                     stan::model::assign(inline_js_super_lp_lp_sym27__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym179__,
-                                "lcm_sym179__",
+                              stan::model::rvalue(lcm_sym177__,
+                                "lcm_sym177__",
                                 stan::model::index_min_max(1,
                                   (inline_js_super_lp_t_sym28__ - 1))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         nu[(inline_js_super_lp_t_sym28__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym181__, "lcm_sym181__",
+                          stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
                             stan::model::index_min_max(
-                              inline_js_super_lp_t_sym28__, lcm_sym185__)))))
+                              inline_js_super_lp_t_sym28__, lcm_sym183__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                          stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                             stan::model::index_uni(1),
                             stan::model::index_min_max(
-                              inline_js_super_lp_t_sym28__, lcm_sym185__)))))
+                              inline_js_super_lp_t_sym28__, lcm_sym183__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(p, "p",
                           stan::model::index_uni(1),
-                          stan::model::index_uni(lcm_sym233__)))),
+                          stan::model::index_uni(lcm_sym231__)))),
                       "assigning variable inline_js_super_lp_lp_sym27__",
                       stan::model::index_uni(inline_js_super_lp_t_sym28__));
                   }
@@ -13636,42 +12475,42 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   ((stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
-                          stan::model::index_min_max(1, lcm_sym185__)))) +
-                  stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym233__ - 1)]))
+                        stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                          stan::model::index_min_max(1, lcm_sym183__)))) +
+                  stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym231__ - 1)]))
                   +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym233__)))),
+                      stan::model::index_uni(lcm_sym231__)))),
                   "assigning variable inline_js_super_lp_lp_sym27__",
-                  stan::model::index_uni(lcm_sym233__));
+                  stan::model::index_uni(lcm_sym231__));
                 current_statement__ = 98;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_js_super_lp_lp_sym27__));
               }
-              lcm_sym235__ = stan::model::rvalue(last, "last",
+              lcm_sym233__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(1));
-              if (stan::math::logical_gte(lcm_sym235__, (lcm_sym233__ + 1))) {
+              if (stan::math::logical_gte(lcm_sym233__, (lcm_sym231__ + 1))) {
                 current_statement__ = 103;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                 stan::model::rvalue(lcm_sym230__,
-                                   "lcm_sym230__", stan::model::index_uni(1),
-                                   stan::model::index_uni(((lcm_sym233__ + 1)
+                                 stan::model::rvalue(lcm_sym228__,
+                                   "lcm_sym228__", stan::model::index_uni(1),
+                                   stan::model::index_uni(((lcm_sym231__ + 1)
                                      - 1)))));
-                lcm_sym204__ = ((lcm_sym233__ + 1) + 1);
+                lcm_sym202__ = ((lcm_sym231__ + 1) + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym233__ + 1))),
+                                   stan::model::index_uni((lcm_sym231__ + 1))),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym233__ + 1)))));
-                for (int inline_js_super_lp_t_sym28__ = lcm_sym204__; inline_js_super_lp_t_sym28__
-                     <= lcm_sym235__; ++inline_js_super_lp_t_sym28__) {
+                                   stan::model::index_uni((lcm_sym231__ + 1)))));
+                for (int inline_js_super_lp_t_sym28__ = lcm_sym202__; inline_js_super_lp_t_sym28__
+                     <= lcm_sym233__; ++inline_js_super_lp_t_sym28__) {
                   current_statement__ = 103;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                   stan::model::rvalue(lcm_sym230__,
-                                     "lcm_sym230__",
+                                   stan::model::rvalue(lcm_sym228__,
+                                     "lcm_sym228__",
                                      stan::model::index_uni(1),
                                      stan::model::index_uni(
                                        (inline_js_super_lp_t_sym28__ - 1)))));
@@ -13693,14 +12532,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                                  inline_prob_uncaptured_return_sym14__,
                                  "inline_prob_uncaptured_return_sym14__",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym235__))));
+                                 stan::model::index_uni(lcm_sym233__))));
             } else {
-              lcm_sym206__ = (lcm_sym238__ + 1);
+              lcm_sym204__ = (lcm_sym236__ + 1);
               stan::math::validate_non_negative_index("lp",
-                "n_occasions + 1", lcm_sym206__);
+                "n_occasions + 1", lcm_sym204__);
               Eigen::Matrix<local_scalar_t__,-1,1>
                 inline_js_super_lp_lp_sym27__ =
-                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym206__,
+                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym204__,
                   DUMMY_VAR__);
               current_statement__ = 86;
               stan::model::assign(inline_js_super_lp_lp_sym27__,
@@ -13718,13 +12557,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 "assigning variable inline_js_super_lp_lp_sym27__",
                 stan::model::index_uni(1));
               current_statement__ = 88;
-              if (stan::math::logical_gte(lcm_sym238__, 2)) {
+              if (stan::math::logical_gte(lcm_sym236__, 2)) {
                 current_statement__ = 87;
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                      stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
                         stan::model::index_min_max(1, 1))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(nu, "nu", stan::model::index_uni(2))))
@@ -13740,13 +12579,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   "assigning variable inline_js_super_lp_lp_sym27__",
                   stan::model::index_uni(2));
                 for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                     <= lcm_sym238__; ++inline_js_super_lp_t_sym28__) {
+                     <= lcm_sym236__; ++inline_js_super_lp_t_sym28__) {
                   current_statement__ = 87;
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                        stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
                           stan::model::index_min_max(1,
                             (inline_js_super_lp_t_sym28__ - 1)))))) +
                     stan::math::bernoulli_lpmf<false>(1,
@@ -13769,31 +12608,31 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::model::assign(inline_js_super_lp_lp_sym27__,
                 stan::math::bernoulli_lpmf<false>(0, psi),
                 "assigning variable inline_js_super_lp_lp_sym27__",
-                stan::model::index_uni(lcm_sym206__));
+                stan::model::index_uni(lcm_sym204__));
               current_statement__ = 90;
               lp_accum__.add(stan::math::log_sum_exp(
                                inline_js_super_lp_lp_sym27__));
             }
             for (int inline_js_super_lp_i_sym29__ = 2; inline_js_super_lp_i_sym29__
-                 <= lcm_sym237__; ++inline_js_super_lp_i_sym29__) {
+                 <= lcm_sym235__; ++inline_js_super_lp_i_sym29__) {
               current_statement__ = 83;
               stan::math::validate_non_negative_index("qp", "n_occasions",
-                lcm_sym238__);
+                lcm_sym236__);
               Eigen::Matrix<double,-1,1> inline_js_super_lp_qp_sym26__ =
-                Eigen::Matrix<double,-1,1>::Constant(lcm_sym238__,
+                Eigen::Matrix<double,-1,1>::Constant(lcm_sym236__,
                   std::numeric_limits<double>::quiet_NaN());
-              stan::model::assign(lcm_sym180__,
+              stan::model::assign(lcm_sym178__,
                 stan::math::subtract(1.0,
                   stan::math::transpose(
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_js_super_lp_i_sym29__)))),
-                "assigning variable lcm_sym180__");
-              lcm_sym232__ = first[(inline_js_super_lp_i_sym29__ - 1)];
-              if (lcm_sym232__) {
+                "assigning variable lcm_sym178__");
+              lcm_sym230__ = first[(inline_js_super_lp_i_sym29__ - 1)];
+              if (lcm_sym230__) {
                 current_statement__ = 92;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1, psi));
                 current_statement__ = 102;
-                if (stan::math::logical_eq(lcm_sym232__, 1)) {
+                if (stan::math::logical_eq(lcm_sym230__, 1)) {
                   current_statement__ = 100;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    (stan::model::rvalue(nu, "nu",
@@ -13805,90 +12644,90 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 } else {
                   current_statement__ = 93;
                   stan::math::validate_non_negative_index("lp", "first[i]",
-                    lcm_sym232__);
+                    lcm_sym230__);
                   Eigen::Matrix<local_scalar_t__,-1,1>
                     inline_js_super_lp_lp_sym27__ =
-                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym232__,
+                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym230__,
                       DUMMY_VAR__);
-                  lcm_sym184__ = (lcm_sym232__ - 1);
+                  lcm_sym182__ = (lcm_sym230__ - 1);
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::model::rvalue(nu, "nu",
                            stan::model::index_uni(1))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym180__, "lcm_sym180__",
-                          stan::model::index_min_max(1, lcm_sym184__))))) +
+                        stan::model::rvalue(lcm_sym178__, "lcm_sym178__",
+                          stan::model::index_min_max(1, lcm_sym182__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                        stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                           stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                          stan::model::index_min_max(1, lcm_sym184__))))) +
+                          stan::model::index_min_max(1, lcm_sym182__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                        stan::model::index_uni(lcm_sym232__)))),
+                        stan::model::index_uni(lcm_sym230__)))),
                     "assigning variable inline_js_super_lp_lp_sym27__",
                     stan::model::index_uni(1));
                   current_statement__ = 96;
-                  if (stan::math::logical_gte(lcm_sym184__, 2)) {
+                  if (stan::math::logical_gte(lcm_sym182__, 2)) {
                     current_statement__ = 95;
                     stan::model::assign(inline_js_super_lp_lp_sym27__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym179__,
-                                "lcm_sym179__",
+                              stan::model::rvalue(lcm_sym177__,
+                                "lcm_sym177__",
                                 stan::model::index_min_max(1, 1)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(nu, "nu",
                           stan::model::index_uni(2)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym180__, "lcm_sym180__",
-                            stan::model::index_min_max(2, lcm_sym184__))))) +
+                          stan::model::rvalue(lcm_sym178__, "lcm_sym178__",
+                            stan::model::index_min_max(2, lcm_sym182__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                          stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                             stan::model::index_uni(
                               inline_js_super_lp_i_sym29__),
-                            stan::model::index_min_max(2, lcm_sym184__))))) +
+                            stan::model::index_min_max(2, lcm_sym182__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(p, "p",
                           stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                          stan::model::index_uni(lcm_sym232__)))),
+                          stan::model::index_uni(lcm_sym230__)))),
                       "assigning variable inline_js_super_lp_lp_sym27__",
                       stan::model::index_uni(2));
                     for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                         <= lcm_sym184__; ++inline_js_super_lp_t_sym28__) {
+                         <= lcm_sym182__; ++inline_js_super_lp_t_sym28__) {
                       current_statement__ = 95;
                       stan::model::assign(inline_js_super_lp_lp_sym27__,
                         ((((stan::math::bernoulli_lpmf<false>(1,
                               stan::math::prod(
-                                stan::model::rvalue(lcm_sym179__,
-                                  "lcm_sym179__",
+                                stan::model::rvalue(lcm_sym177__,
+                                  "lcm_sym177__",
                                   stan::model::index_min_max(1,
                                     (inline_js_super_lp_t_sym28__ - 1))))) +
                         stan::math::bernoulli_lpmf<false>(1,
                           nu[(inline_js_super_lp_t_sym28__ - 1)])) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym180__, "lcm_sym180__",
+                            stan::model::rvalue(lcm_sym178__, "lcm_sym178__",
                               stan::model::index_min_max(
-                                inline_js_super_lp_t_sym28__, lcm_sym184__)))))
+                                inline_js_super_lp_t_sym28__, lcm_sym182__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym230__, "lcm_sym230__",
+                            stan::model::rvalue(lcm_sym228__, "lcm_sym228__",
                               stan::model::index_uni(
                                 inline_js_super_lp_i_sym29__),
                               stan::model::index_min_max(
-                                inline_js_super_lp_t_sym28__, lcm_sym184__)))))
+                                inline_js_super_lp_t_sym28__, lcm_sym182__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::model::rvalue(p, "p",
                             stan::model::index_uni(
                               inline_js_super_lp_i_sym29__),
-                            stan::model::index_uni(lcm_sym232__)))),
+                            stan::model::index_uni(lcm_sym230__)))),
                         "assigning variable inline_js_super_lp_lp_sym27__",
                         stan::model::index_uni(inline_js_super_lp_t_sym28__));
                     }
@@ -13897,48 +12736,48 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
-                            stan::model::index_min_max(1, lcm_sym184__)))) +
-                    stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym232__ -
+                          stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
+                            stan::model::index_min_max(1, lcm_sym182__)))) +
+                    stan::math::bernoulli_lpmf<false>(1, nu[(lcm_sym230__ -
                       1)])) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(p, "p",
                         stan::model::index_uni(inline_js_super_lp_i_sym29__),
-                        stan::model::index_uni(lcm_sym232__)))),
+                        stan::model::index_uni(lcm_sym230__)))),
                     "assigning variable inline_js_super_lp_lp_sym27__",
-                    stan::model::index_uni(lcm_sym232__));
+                    stan::model::index_uni(lcm_sym230__));
                   current_statement__ = 98;
                   lp_accum__.add(stan::math::log_sum_exp(
                                    inline_js_super_lp_lp_sym27__));
                 }
-                lcm_sym234__ = last[(inline_js_super_lp_i_sym29__ - 1)];
-                if (stan::math::logical_gte(lcm_sym234__, (lcm_sym232__ + 1))) {
+                lcm_sym232__ = last[(inline_js_super_lp_i_sym29__ - 1)];
+                if (stan::math::logical_gte(lcm_sym232__, (lcm_sym230__ + 1))) {
                   current_statement__ = 103;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                   stan::model::rvalue(lcm_sym230__,
-                                     "lcm_sym230__",
+                                   stan::model::rvalue(lcm_sym228__,
+                                     "lcm_sym228__",
                                      stan::model::index_uni(
                                        inline_js_super_lp_i_sym29__),
-                                     stan::model::index_uni(((lcm_sym232__ +
+                                     stan::model::index_uni(((lcm_sym230__ +
                                        1) - 1)))));
-                  lcm_sym203__ = ((lcm_sym232__ + 1) + 1);
+                  lcm_sym201__ = ((lcm_sym230__ + 1) + 1);
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                    stan::model::rvalue(y, "y",
                                      stan::model::index_uni(
                                        inline_js_super_lp_i_sym29__),
-                                     stan::model::index_uni((lcm_sym232__ +
+                                     stan::model::index_uni((lcm_sym230__ +
                                        1))),
                                    stan::model::rvalue(p, "p",
                                      stan::model::index_uni(
                                        inline_js_super_lp_i_sym29__),
-                                     stan::model::index_uni((lcm_sym232__ +
+                                     stan::model::index_uni((lcm_sym230__ +
                                        1)))));
-                  for (int inline_js_super_lp_t_sym28__ = lcm_sym203__; inline_js_super_lp_t_sym28__
-                       <= lcm_sym234__; ++inline_js_super_lp_t_sym28__) {
+                  for (int inline_js_super_lp_t_sym28__ = lcm_sym201__; inline_js_super_lp_t_sym28__
+                       <= lcm_sym232__; ++inline_js_super_lp_t_sym28__) {
                     current_statement__ = 103;
                     lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
-                                     stan::model::rvalue(lcm_sym230__,
-                                       "lcm_sym230__",
+                                     stan::model::rvalue(lcm_sym228__,
+                                       "lcm_sym228__",
                                        stan::model::index_uni(
                                          inline_js_super_lp_i_sym29__),
                                        stan::model::index_uni(
@@ -13961,14 +12800,14 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                                    "inline_prob_uncaptured_return_sym14__",
                                    stan::model::index_uni(
                                      inline_js_super_lp_i_sym29__),
-                                   stan::model::index_uni(lcm_sym234__))));
+                                   stan::model::index_uni(lcm_sym232__))));
               } else {
-                lcm_sym206__ = (lcm_sym238__ + 1);
+                lcm_sym204__ = (lcm_sym236__ + 1);
                 stan::math::validate_non_negative_index("lp",
-                  "n_occasions + 1", lcm_sym206__);
+                  "n_occasions + 1", lcm_sym204__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_js_super_lp_lp_sym27__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym206__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym204__,
                     DUMMY_VAR__);
                 current_statement__ = 86;
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
@@ -13989,13 +12828,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   "assigning variable inline_js_super_lp_lp_sym27__",
                   stan::model::index_uni(1));
                 current_statement__ = 88;
-                if (stan::math::logical_gte(lcm_sym238__, 2)) {
+                if (stan::math::logical_gte(lcm_sym236__, 2)) {
                   current_statement__ = 87;
                   stan::model::assign(inline_js_super_lp_lp_sym27__,
                     ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                        stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
                           stan::model::index_min_max(1, 1))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(nu, "nu", stan::model::index_uni(2))))
@@ -14013,13 +12852,13 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     "assigning variable inline_js_super_lp_lp_sym27__",
                     stan::model::index_uni(2));
                   for (int inline_js_super_lp_t_sym28__ = 3; inline_js_super_lp_t_sym28__
-                       <= lcm_sym238__; ++inline_js_super_lp_t_sym28__) {
+                       <= lcm_sym236__; ++inline_js_super_lp_t_sym28__) {
                     current_statement__ = 87;
                     stan::model::assign(inline_js_super_lp_lp_sym27__,
                       ((((stan::math::bernoulli_lpmf<false>(1, psi) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym179__, "lcm_sym179__",
+                          stan::model::rvalue(lcm_sym177__, "lcm_sym177__",
                             stan::model::index_min_max(1,
                               (inline_js_super_lp_t_sym28__ - 1)))))) +
                       stan::math::bernoulli_lpmf<false>(1,
@@ -14043,7 +12882,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 stan::model::assign(inline_js_super_lp_lp_sym27__,
                   stan::math::bernoulli_lpmf<false>(0, psi),
                   "assigning variable inline_js_super_lp_lp_sym27__",
-                  stan::model::index_uni(lcm_sym206__));
+                  stan::model::index_uni(lcm_sym204__));
                 current_statement__ = 90;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_js_super_lp_lp_sym27__));
@@ -14089,48 +12928,46 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym162__;
-      int lcm_sym161__;
-      local_scalar_t__ lcm_sym160__;
+      int lcm_sym160__;
       int lcm_sym159__;
-      int lcm_sym158__;
+      local_scalar_t__ lcm_sym158__;
       int lcm_sym157__;
       int lcm_sym156__;
-      double lcm_sym135__;
       int lcm_sym155__;
       int lcm_sym154__;
+      double lcm_sym133__;
       int lcm_sym153__;
       int lcm_sym152__;
       int lcm_sym151__;
       int lcm_sym150__;
       int lcm_sym149__;
-      double lcm_sym148__;
+      int lcm_sym148__;
       int lcm_sym147__;
-      int lcm_sym146__;
+      double lcm_sym146__;
       int lcm_sym145__;
-      Eigen::Matrix<double,-1,-1> lcm_sym144__;
-      std::vector<int> lcm_sym143__;
-      std::vector<std::vector<int>> lcm_sym142__;
-      Eigen::Matrix<double,-1,1> lcm_sym141__;
-      double lcm_sym134__;
-      double lcm_sym133__;
+      int lcm_sym144__;
+      int lcm_sym143__;
+      Eigen::Matrix<double,-1,-1> lcm_sym142__;
+      std::vector<int> lcm_sym141__;
+      std::vector<std::vector<int>> lcm_sym140__;
+      Eigen::Matrix<double,-1,1> lcm_sym139__;
       double lcm_sym132__;
       double lcm_sym131__;
-      double lcm_sym140__;
-      double lcm_sym139__;
+      double lcm_sym130__;
+      double lcm_sym129__;
       double lcm_sym138__;
       double lcm_sym137__;
-      int lcm_sym136__;
-      int lcm_sym130__;
-      int lcm_sym129__;
+      double lcm_sym136__;
+      double lcm_sym135__;
+      int lcm_sym134__;
       int lcm_sym128__;
       int lcm_sym127__;
-      double lcm_sym126__;
+      int lcm_sym126__;
       int lcm_sym125__;
-      int lcm_sym124__;
-      double lcm_sym123__;
+      double lcm_sym124__;
+      int lcm_sym123__;
       int lcm_sym122__;
-      int lcm_sym121__;
+      double lcm_sym121__;
       int lcm_sym120__;
       int lcm_sym119__;
       int lcm_sym118__;
@@ -14143,9 +12980,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       int lcm_sym111__;
       int lcm_sym110__;
       int lcm_sym109__;
-      double lcm_sym108__;
-      double lcm_sym107__;
-      Eigen::Matrix<double,-1,1> lcm_sym106__;
+      int lcm_sym108__;
+      int lcm_sym107__;
+      double lcm_sym106__;
+      double lcm_sym105__;
+      Eigen::Matrix<double,-1,1> lcm_sym104__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -14196,56 +13035,56 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym118__ = (n_occasions - 1);
-      stan::model::assign(lcm_sym144__,
-        stan::math::rep_matrix(mean_phi, M, lcm_sym118__),
-        "assigning variable lcm_sym144__");
-      stan::model::assign(phi, lcm_sym144__, "assigning variable phi");
-      lcm_sym110__ = stan::math::logical_gte(n_occasions, 1);
-      if (lcm_sym110__) {
-        stan::model::assign(lcm_sym141__,
+      lcm_sym116__ = (n_occasions - 1);
+      stan::model::assign(lcm_sym142__,
+        stan::math::rep_matrix(mean_phi, M, lcm_sym116__),
+        "assigning variable lcm_sym142__");
+      stan::model::assign(phi, lcm_sym142__, "assigning variable phi");
+      lcm_sym108__ = stan::math::logical_gte(n_occasions, 1);
+      if (lcm_sym108__) {
+        stan::model::assign(lcm_sym139__,
           stan::math::inv_logit(
             stan::math::add(stan::math::logit(mean_p), epsilon)),
-          "assigning variable lcm_sym141__");
-        stan::model::assign(p, lcm_sym141__, "assigning variable p",
+          "assigning variable lcm_sym139__");
+        stan::model::assign(p, lcm_sym139__, "assigning variable p",
           stan::model::index_omni(), stan::model::index_uni(1));
         for (int t = 2; t <= n_occasions; ++t) {
           current_statement__ = 12;
-          stan::model::assign(p, lcm_sym141__, "assigning variable p",
+          stan::model::assign(p, lcm_sym139__, "assigning variable p",
             stan::model::index_omni(), stan::model::index_uni(t));
         }
       }
-      stan::model::assign(lcm_sym106__,
+      stan::model::assign(lcm_sym104__,
         stan::math::divide(beta, stan::math::sum(beta)),
-        "assigning variable lcm_sym106__");
-      stan::model::assign(b, lcm_sym106__, "assigning variable b");
+        "assigning variable lcm_sym104__");
+      stan::model::assign(b, lcm_sym104__, "assigning variable b");
       {
         double cum_b = std::numeric_limits<double>::quiet_NaN();
-        lcm_sym160__ = stan::model::rvalue(lcm_sym106__, "lcm_sym106__",
+        lcm_sym158__ = stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
                          stan::model::index_uni(1));
         current_statement__ = 14;
-        stan::model::assign(nu, lcm_sym160__, "assigning variable nu",
+        stan::model::assign(nu, lcm_sym158__, "assigning variable nu",
           stan::model::index_uni(1));
         current_statement__ = 18;
-        if (stan::math::logical_gte(lcm_sym118__, 2)) {
+        if (stan::math::logical_gte(lcm_sym116__, 2)) {
           current_statement__ = 15;
           stan::model::assign(nu,
-            (stan::model::rvalue(lcm_sym106__, "lcm_sym106__",
-               stan::model::index_uni(2)) / (1.0 - lcm_sym160__)),
+            (stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
+               stan::model::index_uni(2)) / (1.0 - lcm_sym158__)),
             "assigning variable nu", stan::model::index_uni(2));
           current_statement__ = 16;
-          cum_b = (lcm_sym160__ +
-            stan::model::rvalue(lcm_sym106__, "lcm_sym106__",
+          cum_b = (lcm_sym158__ +
+            stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
               stan::model::index_uni(2)));
-          for (int t = 3; t <= lcm_sym118__; ++t) {
+          for (int t = 3; t <= lcm_sym116__; ++t) {
             current_statement__ = 15;
             stan::model::assign(nu,
-              (stan::model::rvalue(lcm_sym106__, "lcm_sym106__",
+              (stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
                  stan::model::index_uni(t)) / (1.0 - cum_b)),
               "assigning variable nu", stan::model::index_uni(t));
             current_statement__ = 16;
             cum_b = (cum_b +
-              stan::model::rvalue(lcm_sym106__, "lcm_sym106__",
+              stan::model::rvalue(lcm_sym104__, "lcm_sym104__",
                 stan::model::index_uni(t)));
           }
         }
@@ -14257,140 +13096,140 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       {
         int inline_prob_uncaptured_n_ind_sym2__ =
           std::numeric_limits<int>::min();
-        lcm_sym145__ = stan::math::rows(p);
+        lcm_sym143__ = stan::math::rows(p);
         int inline_prob_uncaptured_n_occasions_sym3__ =
           std::numeric_limits<int>::min();
-        lcm_sym136__ = stan::math::cols(p);
+        lcm_sym134__ = stan::math::cols(p);
         current_statement__ = 23;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym145__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym143__);
         current_statement__ = 24;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym136__);
+          lcm_sym134__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym4__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym145__,
-            lcm_sym136__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym143__,
+            lcm_sym134__, DUMMY_VAR__);
         current_statement__ = 33;
-        if (stan::math::logical_gte(lcm_sym145__, 1)) {
+        if (stan::math::logical_gte(lcm_sym143__, 1)) {
           current_statement__ = 26;
           stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym4__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym136__));
-          lcm_sym120__ = (lcm_sym136__ - 1);
-          lcm_sym113__ = stan::math::logical_gte(lcm_sym120__, 1);
-          if (lcm_sym113__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym134__));
+          lcm_sym118__ = (lcm_sym134__ - 1);
+          lcm_sym111__ = stan::math::logical_gte(lcm_sym118__, 1);
+          if (lcm_sym111__) {
             int inline_prob_uncaptured_t_curr_sym5__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym6__ =
               std::numeric_limits<int>::min();
-            lcm_sym125__ = (lcm_sym120__ + 1);
+            lcm_sym123__ = (lcm_sym118__ + 1);
             current_statement__ = 29;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__,
               stan::math::fma(
-                (stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                    stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym120__)) * (1 -
+                   stan::model::index_uni(lcm_sym118__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym125__)))),
+                  stan::model::index_uni(lcm_sym123__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                   "inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym125__)), (1 -
-                stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                  stan::model::index_uni(lcm_sym123__)), (1 -
+                stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym120__)))),
+                  stan::model::index_uni(lcm_sym118__)))),
               "assigning variable inline_prob_uncaptured_chi_sym4__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym120__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym118__));
             for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                 <= lcm_sym120__; ++inline_prob_uncaptured_t_sym7__) {
+                 <= lcm_sym118__; ++inline_prob_uncaptured_t_sym7__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
-              lcm_sym119__ = (lcm_sym136__ -
+              lcm_sym117__ = (lcm_sym134__ -
                 inline_prob_uncaptured_t_sym7__);
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym124__ = (lcm_sym119__ + 1);
+              lcm_sym122__ = (lcm_sym117__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                  (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                      stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym119__)) * (1 -
+                     stan::model::index_uni(lcm_sym117__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym124__)))),
+                    stan::model::index_uni(lcm_sym122__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym124__)), (1 -
-                  stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                    stan::model::index_uni(lcm_sym122__)), (1 -
+                  stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym119__)))),
+                    stan::model::index_uni(lcm_sym117__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym119__));
+                stan::model::index_uni(lcm_sym117__));
             }
           }
           for (int inline_prob_uncaptured_i_sym8__ = 2; inline_prob_uncaptured_i_sym8__
-               <= lcm_sym145__; ++inline_prob_uncaptured_i_sym8__) {
+               <= lcm_sym143__; ++inline_prob_uncaptured_i_sym8__) {
             current_statement__ = 26;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym4__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-              stan::model::index_uni(lcm_sym136__));
+              stan::model::index_uni(lcm_sym134__));
             current_statement__ = 31;
-            if (lcm_sym113__) {
+            if (lcm_sym111__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym125__ = (lcm_sym120__ + 1);
+              lcm_sym123__ = (lcm_sym118__ + 1);
               current_statement__ = 29;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
-                  (stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                  (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                     stan::model::index_uni(lcm_sym120__)) * (1 -
+                     stan::model::index_uni(lcm_sym118__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym125__)))),
+                    stan::model::index_uni(lcm_sym123__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym125__)), (1 -
-                  stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                    stan::model::index_uni(lcm_sym123__)), (1 -
+                  stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym120__)))),
+                    stan::model::index_uni(lcm_sym118__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                stan::model::index_uni(lcm_sym120__));
+                stan::model::index_uni(lcm_sym118__));
               for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                   <= lcm_sym120__; ++inline_prob_uncaptured_t_sym7__) {
+                   <= lcm_sym118__; ++inline_prob_uncaptured_t_sym7__) {
                 int inline_prob_uncaptured_t_curr_sym5__ =
                   std::numeric_limits<int>::min();
-                lcm_sym119__ = (lcm_sym136__ -
+                lcm_sym117__ = (lcm_sym134__ -
                   inline_prob_uncaptured_t_sym7__);
                 int inline_prob_uncaptured_t_next_sym6__ =
                   std::numeric_limits<int>::min();
-                lcm_sym124__ = (lcm_sym119__ + 1);
+                lcm_sym122__ = (lcm_sym117__ + 1);
                 current_statement__ = 29;
                 stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                   stan::math::fma(
-                    (stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                    (stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                       stan::model::index_uni(lcm_sym119__)) * (1 -
+                       stan::model::index_uni(lcm_sym117__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym124__)))),
+                      stan::model::index_uni(lcm_sym122__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                       "inline_prob_uncaptured_chi_sym4__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym124__)), (1 -
-                    stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                      stan::model::index_uni(lcm_sym122__)), (1 -
+                    stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym119__)))),
+                      stan::model::index_uni(lcm_sym117__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                  stan::model::index_uni(lcm_sym119__));
+                  stan::model::index_uni(lcm_sym117__));
               }
             }
           }
@@ -14403,15 +13242,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::model::assign(chi, inline_prob_uncaptured_return_sym1__,
         "assigning variable chi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "phi", lcm_sym144__, 0);
+      stan::math::check_greater_or_equal(function__, "phi", lcm_sym142__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "phi", lcm_sym144__, 1);
+      stan::math::check_less_or_equal(function__, "phi", lcm_sym142__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "p", p, 0);
       current_statement__ = 8;
       stan::math::check_less_or_equal(function__, "p", p, 1);
       current_statement__ = 9;
-      stan::math::check_simplex(function__, "b", lcm_sym106__);
+      stan::math::check_simplex(function__, "b", lcm_sym104__);
       current_statement__ = 10;
       stan::math::check_greater_or_equal(function__, "nu", nu, 0);
       current_statement__ = 10;
@@ -14423,9 +13262,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_less_or_equal(function__, "chi",
         inline_prob_uncaptured_return_sym1__, 1);
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym144__);
+        out__.write(lcm_sym142__);
         out__.write(p);
-        out__.write(lcm_sym106__);
+        out__.write(lcm_sym104__);
         out__.write(nu);
         out__.write(inline_prob_uncaptured_return_sym1__);
       }
@@ -14441,10 +13280,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       std::vector<std::vector<int>> z =
         std::vector<std::vector<int>>(M,
           std::vector<int>(n_occasions, std::numeric_limits<int>::min()));
-      lcm_sym148__ = stan::math::square(sigma);
-      sigma2 = lcm_sym148__;
-      lcm_sym109__ = stan::math::logical_gte(M, 1);
-      if (lcm_sym109__) {
+      lcm_sym146__ = stan::math::square(sigma);
+      sigma2 = lcm_sym146__;
+      lcm_sym107__ = stan::math::logical_gte(M, 1);
+      if (lcm_sym107__) {
         int q = std::numeric_limits<int>::min();
         current_statement__ = 49;
         if (stan::math::bernoulli_rng(psi, base_rng__)) {
@@ -14456,18 +13295,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::model::index_uni(1));
           current_statement__ = 47;
           if (stan::math::logical_gte(n_occasions, 2)) {
-            lcm_sym159__ = stan::model::rvalue(z, "z",
+            lcm_sym157__ = stan::model::rvalue(z, "z",
                              stan::model::index_uni(1),
                              stan::model::index_uni(1));
-            lcm_sym130__ = (1 * (1 - lcm_sym159__));
-            q = lcm_sym130__;
+            lcm_sym128__ = (1 * (1 - lcm_sym157__));
+            q = lcm_sym128__;
             current_statement__ = 44;
             stan::model::assign(z,
               stan::math::bernoulli_rng(
-                stan::math::fma(lcm_sym159__,
-                  stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                stan::math::fma(lcm_sym157__,
+                  stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                     stan::model::index_uni(1), stan::model::index_uni(1)),
-                  (lcm_sym130__ *
+                  (lcm_sym128__ *
                   stan::model::rvalue(nu, "nu", stan::model::index_uni(2)))),
                 base_rng__), "assigning variable z",
               stan::model::index_uni(1), stan::model::index_uni(2));
@@ -14482,7 +13321,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                   stan::math::fma(
                     stan::model::rvalue(z, "z", stan::model::index_uni(1),
                       stan::model::index_uni((t - 1))),
-                    stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                    stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                       stan::model::index_uni(1),
                       stan::model::index_uni((t - 1))), (q *
                     stan::model::rvalue(nu, "nu", stan::model::index_uni(t)))),
@@ -14508,19 +13347,19 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 47;
             if (stan::math::logical_gte(n_occasions, 2)) {
-              lcm_sym129__ = (1 * (1 -
+              lcm_sym127__ = (1 * (1 -
                 stan::model::rvalue(z, "z", stan::model::index_uni(i),
                   stan::model::index_uni(1))));
-              q = lcm_sym129__;
+              q = lcm_sym127__;
               current_statement__ = 44;
               stan::model::assign(z,
                 stan::math::bernoulli_rng(
                   stan::math::fma(
                     stan::model::rvalue(z, "z", stan::model::index_uni(i),
                       stan::model::index_uni(1)),
-                    stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                    stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                       stan::model::index_uni(i), stan::model::index_uni(1)),
-                    (lcm_sym129__ *
+                    (lcm_sym127__ *
                     stan::model::rvalue(nu, "nu", stan::model::index_uni(2)))),
                   base_rng__), "assigning variable z",
                 stan::model::index_uni(i), stan::model::index_uni(2));
@@ -14535,7 +13374,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     stan::math::fma(
                       stan::model::rvalue(z, "z", stan::model::index_uni(i),
                         stan::model::index_uni((t - 1))),
-                      stan::model::rvalue(lcm_sym144__, "lcm_sym144__",
+                      stan::model::rvalue(lcm_sym142__, "lcm_sym142__",
                         stan::model::index_uni(i),
                         stan::model::index_uni((t - 1))), (q *
                       stan::model::rvalue(nu, "nu", stan::model::index_uni(t)))),
@@ -14573,18 +13412,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         std::vector<int> Nalive =
           std::vector<int>(M, std::numeric_limits<int>::min());
         current_statement__ = 65;
-        if (lcm_sym109__) {
+        if (lcm_sym107__) {
           int f = std::numeric_limits<int>::min();
           int inline_first_capture_return_sym10__;
           int inline_first_capture_early_ret_check_sym12__;
           inline_first_capture_early_ret_check_sym12__ = 0;
           for (int inline_first_capture_iterator_sym13__ = 1; inline_first_capture_iterator_sym13__
                <= 1; ++inline_first_capture_iterator_sym13__) {
-            lcm_sym147__ = stan::math::size(
+            lcm_sym145__ = stan::math::size(
                              stan::model::rvalue(z, "z",
                                stan::model::index_uni(1)));
             for (int inline_first_capture_k_sym11__ = 1; inline_first_capture_k_sym11__
-                 <= lcm_sym147__; ++inline_first_capture_k_sym11__) {
+                 <= lcm_sym145__; ++inline_first_capture_k_sym11__) {
               current_statement__ = 60;
               if (stan::model::rvalue(z, "z", stan::model::index_uni(1),
                     stan::model::index_uni(inline_first_capture_k_sym11__))) {
@@ -14614,11 +13453,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             inline_first_capture_early_ret_check_sym12__ = 0;
             for (int inline_first_capture_iterator_sym13__ = 1; inline_first_capture_iterator_sym13__
                  <= 1; ++inline_first_capture_iterator_sym13__) {
-              lcm_sym146__ = stan::math::size(
+              lcm_sym144__ = stan::math::size(
                                stan::model::rvalue(z, "z",
                                  stan::model::index_uni(i)));
               for (int inline_first_capture_k_sym11__ = 1; inline_first_capture_k_sym11__
-                   <= lcm_sym146__; ++inline_first_capture_k_sym11__) {
+                   <= lcm_sym144__; ++inline_first_capture_k_sym11__) {
                 current_statement__ = 60;
                 if (stan::model::rvalue(z, "z", stan::model::index_uni(i),
                       stan::model::index_uni(inline_first_capture_k_sym11__))) {
@@ -14644,7 +13483,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
         }
         current_statement__ = 69;
-        if (lcm_sym110__) {
+        if (lcm_sym108__) {
           current_statement__ = 66;
           stan::model::assign(N,
             stan::math::sum(
@@ -14673,7 +13512,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
         }
         current_statement__ = 73;
-        if (lcm_sym109__) {
+        if (lcm_sym107__) {
           current_statement__ = 70;
           stan::model::assign(Nind,
             stan::math::sum(
@@ -14701,7 +13540,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         Nsuper = stan::math::sum(Nalive);
       }
       current_statement__ = 35;
-      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym148__,
+      stan::math::check_greater_or_equal(function__, "sigma2", lcm_sym146__,
         0);
       current_statement__ = 36;
       stan::math::check_greater_or_equal(function__, "Nsuper", Nsuper, 0);
@@ -14713,12 +13552,12 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_greater_or_equal(function__, "z", z, 0);
       current_statement__ = 39;
       stan::math::check_less_or_equal(function__, "z", z, 1);
-      out__.write(lcm_sym148__);
+      out__.write(lcm_sym146__);
       out__.write(Nsuper);
       out__.write(N);
       out__.write(B);
-      if (lcm_sym110__) {
-        if (lcm_sym109__) {
+      if (lcm_sym108__) {
+        if (lcm_sym107__) {
           out__.write(stan::model::rvalue(z, "z", stan::model::index_uni(1),
                         stan::model::index_uni(1)));
           for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
@@ -14728,7 +13567,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
           }
         }
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          if (lcm_sym109__) {
+          if (lcm_sym107__) {
             out__.write(stan::model::rvalue(z, "z",
                           stan::model::index_uni(1),
                           stan::model::index_uni(sym1__)));
@@ -14756,8 +13595,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym105__;
-      int lcm_sym104__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mean_phi;
@@ -14769,28 +13606,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       local_scalar_t__ psi;
       psi = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, psi);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
-          DUMMY_VAR__);
-      if (stan::math::logical_gte(n_occasions, 1)) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_occasions),
+        "assigning variable beta");
       out__.write_free_lb(0, beta);
-      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      if (stan::math::logical_gte(M, 1)) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= M; ++sym1__) {
-          stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-            "assigning variable epsilon", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
@@ -14856,58 +13680,58 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
     param_names__.emplace_back(std::string() + "psi");
-    for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+    for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym249__));
+        std::to_string(sym247__));
     }
-    for (int sym249__ = 1; sym249__ <= M; ++sym249__) {
+    for (int sym247__ = 1; sym247__ <= M; ++sym247__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym249__));
+        std::to_string(sym247__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym249__ = 1; sym249__ <= phi_2dim__; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= phi_2dim__; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "nu" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
     }
@@ -14919,58 +13743,58 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
     param_names__.emplace_back(std::string() + "psi");
-    for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+    for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym249__));
+        std::to_string(sym247__));
     }
-    for (int sym249__ = 1; sym249__ <= M; ++sym249__) {
+    for (int sym247__ = 1; sym247__ <= M; ++sym247__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym249__));
+        std::to_string(sym247__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym249__ = 1; sym249__ <= phi_2dim__; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= phi_2dim__; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
-      for (int sym249__ = 1; sym249__ <= (n_occasions - 1); ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= (n_occasions - 1); ++sym247__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "nu" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym249__));
+          std::to_string(sym247__));
       }
-      for (int sym249__ = 1; sym249__ <= n_occasions; ++sym249__) {
-        for (int sym250__ = 1; sym250__ <= M; ++sym250__) {
+      for (int sym247__ = 1; sym247__ <= n_occasions; ++sym247__) {
+        for (int sym248__ = 1; sym248__ <= M; ++sym248__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym250__) + '.' + std::to_string(sym249__));
+            std::to_string(sym248__) + '.' + std::to_string(sym247__));
         }
       }
     }
@@ -15824,75 +14648,40 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       int lcm_sym1__;
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> pi =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
-      lcm_sym2__ = stan::math::logical_gte(K, 1);
-      if (lcm_sym2__) {
-        stan::model::assign(pi, in__.read<local_scalar_t__>(),
-          "assigning variable pi", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
-          stan::model::assign(pi, in__.read<local_scalar_t__>(),
-            "assigning variable pi", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> pi;
+      stan::model::assign(pi,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+        "assigning variable pi");
       out__.write_free_simplex(pi);
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> theta =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
-      if (lcm_sym2__) {
-        if (lcm_sym2__) {
-          lcm_sym1__ = stan::math::logical_gte(J, 1);
-          if (lcm_sym1__) {
-            stan::model::assign(theta, in__.read<local_scalar_t__>(),
-              "assigning variable theta", stan::model::index_uni(1),
-              stan::model::index_uni(1), stan::model::index_uni(1));
-            for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
-              stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                "assigning variable theta", stan::model::index_uni(sym3__),
-                stan::model::index_uni(1), stan::model::index_uni(1));
-            }
-          }
-          for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
-            if (lcm_sym1__) {
-              stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                "assigning variable theta", stan::model::index_uni(1),
-                stan::model::index_uni(sym2__), stan::model::index_uni(1));
-              for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
-                stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                  "assigning variable theta", stan::model::index_uni(sym3__),
-                  stan::model::index_uni(sym2__), stan::model::index_uni(1));
-              }
-            }
+      if (stan::math::logical_gte(K, 1)) {
+        lcm_sym1__ = stan::math::logical_gte(J, 1);
+        if (lcm_sym1__) {
+          stan::model::assign(theta,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+            "assigning variable theta", stan::model::index_uni(1),
+            stan::model::index_uni(1));
+          for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
+            stan::model::assign(theta,
+              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+              "assigning variable theta", stan::model::index_uni(sym2__),
+              stan::model::index_uni(1));
           }
         }
         for (int sym1__ = 2; sym1__ <= K; ++sym1__) {
-          if (lcm_sym2__) {
-            lcm_sym1__ = stan::math::logical_gte(J, 1);
-            if (lcm_sym1__) {
-              stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                "assigning variable theta", stan::model::index_uni(1),
-                stan::model::index_uni(1), stan::model::index_uni(sym1__));
-              for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
-                stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                  "assigning variable theta", stan::model::index_uni(sym3__),
-                  stan::model::index_uni(1), stan::model::index_uni(sym1__));
-              }
-            }
-            for (int sym2__ = 2; sym2__ <= K; ++sym2__) {
-              if (lcm_sym1__) {
-                stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                  "assigning variable theta", stan::model::index_uni(1),
-                  stan::model::index_uni(sym2__),
-                  stan::model::index_uni(sym1__));
-                for (int sym3__ = 2; sym3__ <= J; ++sym3__) {
-                  stan::model::assign(theta, in__.read<local_scalar_t__>(),
-                    "assigning variable theta",
-                    stan::model::index_uni(sym3__),
-                    stan::model::index_uni(sym2__),
-                    stan::model::index_uni(sym1__));
-                }
-              }
+          if (lcm_sym1__) {
+            stan::model::assign(theta,
+              in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+              "assigning variable theta", stan::model::index_uni(1),
+              stan::model::index_uni(sym1__));
+            for (int sym2__ = 2; sym2__ <= J; ++sym2__) {
+              stan::model::assign(theta,
+                in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+                "assigning variable theta", stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
             }
           }
         }
@@ -16118,10 +14907,10 @@ static constexpr std::array<const char*, 25> locations_array__ =
   " (in 'expr-prop-fail8.stan', line 22, column 9 to column 10)"};
 class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model> {
  private:
-  double lcm_sym12__;
   double lcm_sym11__;
-  int lcm_sym10__;
+  double lcm_sym10__;
   int lcm_sym9__;
+  int lcm_sym8__;
   int N;
   int N_edges;
   std::vector<int> node1;
@@ -16270,9 +15059,9 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) function__;
     try {
-      local_scalar_t__ lcm_sym8__;
-      double lcm_sym7__;
-      Eigen::Matrix<double,-1,1> lcm_sym6__;
+      local_scalar_t__ lcm_sym7__;
+      double lcm_sym6__;
+      Eigen::Matrix<double,-1,1> lcm_sym5__;
       local_scalar_t__ beta0;
       current_statement__ = 1;
       beta0 = in__.template read<local_scalar_t__>();
@@ -16300,8 +15089,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                       stan::conditional_var_value_t<local_scalar_t__,
                         Eigen::Matrix<local_scalar_t__,-1,1>>>(N);
       local_scalar_t__ sigma_phi = DUMMY_VAR__;
-      lcm_sym8__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym8__;
+      lcm_sym7__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym7__;
       stan::conditional_var_value_t<local_scalar_t__,
         Eigen::Matrix<local_scalar_t__,-1,1>> phi =
         stan::conditional_var_value_t<local_scalar_t__,
@@ -16313,10 +15102,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         stan::model::index_min_max(1, N));
       current_statement__ = 10;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym8__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym7__),
         "assigning variable phi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym8__,
+      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym7__,
         0);
       {
         current_statement__ = 11;
@@ -16361,10 +15150,10 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym5__;
-      Eigen::Matrix<double,-1,1> lcm_sym4__;
-      int lcm_sym3__;
+      double lcm_sym4__;
+      Eigen::Matrix<double,-1,1> lcm_sym3__;
       int lcm_sym2__;
+      int lcm_sym1__;
       double beta0;
       current_statement__ = 1;
       beta0 = in__.template read<local_scalar_t__>();
@@ -16401,20 +15190,20 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym5__ = stan::math::inv_sqrt(tau_phi);
-      sigma_phi = lcm_sym5__;
+      lcm_sym4__ = stan::math::inv_sqrt(tau_phi);
+      sigma_phi = lcm_sym4__;
       current_statement__ = 9;
       stan::model::assign(phi, phi_std_raw, "assigning variable phi",
         stan::model::index_min_max(1, N));
       current_statement__ = 10;
       stan::model::assign(phi,
-        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym5__),
+        stan::math::multiply(stan::model::deep_copy(phi), lcm_sym4__),
         "assigning variable phi");
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym5__,
+      stan::math::check_greater_or_equal(function__, "sigma_phi", lcm_sym4__,
         0);
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym5__);
+        out__.write(lcm_sym4__);
         out__.write(phi);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -16438,7 +15227,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ beta0;
@@ -16453,28 +15241,15 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       local_scalar_t__ tau_phi;
       tau_phi = in__.read<local_scalar_t__>();
       out__.write_free_lb(0, tau_phi);
-      Eigen::Matrix<local_scalar_t__,-1,1> theta_std =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      lcm_sym1__ = stan::math::logical_gte(N, 1);
-      if (lcm_sym1__) {
-        stan::model::assign(theta_std, in__.read<local_scalar_t__>(),
-          "assigning variable theta_std", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
-          stan::model::assign(theta_std, in__.read<local_scalar_t__>(),
-            "assigning variable theta_std", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_std;
+      stan::model::assign(theta_std,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable theta_std");
       out__.write(theta_std);
-      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      if (lcm_sym1__) {
-        stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-          "assigning variable phi_std_raw", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= N; ++sym1__) {
-          stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-            "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw;
+      stan::model::assign(phi_std_raw,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable phi_std_raw");
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16519,19 +15294,19 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     param_names__.emplace_back(std::string() + "beta1");
     param_names__.emplace_back(std::string() + "tau_theta");
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
       param_names__.emplace_back(std::string() + "theta_std" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym12__));
     }
-    for (int sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym12__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym13__));
+          std::to_string(sym12__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -16544,19 +15319,19 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     param_names__.emplace_back(std::string() + "beta1");
     param_names__.emplace_back(std::string() + "tau_theta");
     param_names__.emplace_back(std::string() + "tau_phi");
-    for (int sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
       param_names__.emplace_back(std::string() + "theta_std" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym12__));
     }
-    for (int sym13__ = 1; sym13__ <= N; ++sym13__) {
+    for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
       param_names__.emplace_back(std::string() + "phi_std_raw" + '.' +
-        std::to_string(sym13__));
+        std::to_string(sym12__));
     }
     if (emit_transformed_parameters__) {
       param_names__.emplace_back(std::string() + "sigma_phi");
-      for (int sym13__ = 1; sym13__ <= N; ++sym13__) {
+      for (int sym12__ = 1; sym12__ <= N; ++sym12__) {
         param_names__.emplace_back(std::string() + "phi" + '.' +
-          std::to_string(sym13__));
+          std::to_string(sym12__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -16966,7 +15741,6 @@ prob_uncaptured(const int& nind, const int& n_occasions, const T2__& p_arg__,
 }
 class fails_test_model final : public model_base_crtp<fails_test_model> {
  private:
-  int lcm_sym118__;
   int lcm_sym117__;
   int lcm_sym116__;
   int lcm_sym115__;
@@ -16979,6 +15753,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   int lcm_sym108__;
   int lcm_sym107__;
   int lcm_sym106__;
+  int lcm_sym105__;
   int nind;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -17043,8 +15818,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         pos__ = 1;
         current_statement__ = 37;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym107__ = stan::math::logical_gte(nind, 1);
-          if (lcm_sym107__) {
+          lcm_sym106__ = stan::math::logical_gte(nind, 1);
+          if (lcm_sym106__) {
             current_statement__ = 37;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -17063,7 +15838,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 37;
-            if (lcm_sym107__) {
+            if (lcm_sym106__) {
               current_statement__ = 37;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -17081,7 +15856,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             }
           }
         } else {
-          lcm_sym107__ = stan::math::logical_gte(nind, 1);
+          lcm_sym106__ = stan::math::logical_gte(nind, 1);
         }
       }
       current_statement__ = 37;
@@ -17098,15 +15873,15 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::math::check_greater_or_equal(function__, "max_age", max_age, 1);
       current_statement__ = 39;
       stan::math::validate_non_negative_index("x", "nind", nind);
-      lcm_sym109__ = (n_occasions - 1);
+      lcm_sym108__ = (n_occasions - 1);
       stan::math::validate_non_negative_index("x", "n_occasions - 1",
-        lcm_sym109__);
+        lcm_sym108__);
       current_statement__ = 40;
       context__.validate_dims("data initialization", "x", "int",
         std::vector<size_t>{static_cast<size_t>(nind),
-          static_cast<size_t>(lcm_sym109__)});
+          static_cast<size_t>(lcm_sym108__)});
       x = std::vector<std::vector<int>>(nind,
-            std::vector<int>(lcm_sym109__, std::numeric_limits<int>::min()));
+            std::vector<int>(lcm_sym108__, std::numeric_limits<int>::min()));
       {
         std::vector<int> x_flat__;
         current_statement__ = 40;
@@ -17114,9 +15889,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         current_statement__ = 40;
         pos__ = 1;
         current_statement__ = 40;
-        if (stan::math::logical_gte(lcm_sym109__, 1)) {
+        if (stan::math::logical_gte(lcm_sym108__, 1)) {
           current_statement__ = 40;
-          if (lcm_sym107__) {
+          if (lcm_sym106__) {
             current_statement__ = 40;
             stan::model::assign(x,
               stan::model::rvalue(x_flat__, "x_flat__",
@@ -17133,9 +15908,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               pos__ = (pos__ + 1);
             }
           }
-          for (int sym1__ = 2; sym1__ <= lcm_sym109__; ++sym1__) {
+          for (int sym1__ = 2; sym1__ <= lcm_sym108__; ++sym1__) {
             current_statement__ = 40;
-            if (lcm_sym107__) {
+            if (lcm_sym106__) {
               current_statement__ = 40;
               stan::model::assign(x, x_flat__[(pos__ - 1)],
                 "assigning variable x", stan::model::index_uni(1),
@@ -17161,7 +15936,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 41;
       n_occ_minus_1 = std::numeric_limits<int>::min();
       current_statement__ = 41;
-      n_occ_minus_1 = lcm_sym109__;
+      n_occ_minus_1 = lcm_sym108__;
       current_statement__ = 42;
       stan::math::validate_non_negative_index("first", "nind", nind);
       current_statement__ = 43;
@@ -17171,7 +15946,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 45;
       last = std::vector<int>(nind, std::numeric_limits<int>::min());
       current_statement__ = 47;
-      if (lcm_sym107__) {
+      if (lcm_sym106__) {
         current_statement__ = 46;
         stan::model::assign(first,
           first_capture(
@@ -17187,7 +15962,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         }
       }
       current_statement__ = 49;
-      if (lcm_sym107__) {
+      if (lcm_sym106__) {
         current_statement__ = 48;
         stan::model::assign(last,
           last_capture(
@@ -17216,12 +15991,12 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::math::validate_non_negative_index("phi", "nind", nind);
       current_statement__ = 52;
       stan::math::validate_non_negative_index("phi", "n_occ_minus_1",
-        lcm_sym109__);
+        lcm_sym108__);
       current_statement__ = 53;
       stan::math::validate_non_negative_index("p", "nind", nind);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("p", "n_occ_minus_1",
-        lcm_sym109__);
+        lcm_sym108__);
       current_statement__ = 55;
       stan::math::validate_non_negative_index("chi", "nind", nind);
       current_statement__ = 56;
@@ -17259,12 +16034,11 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym105__;
-      int lcm_sym104__;
+      double lcm_sym104__;
       int lcm_sym103__;
       int lcm_sym102__;
       int lcm_sym101__;
-      double lcm_sym100__;
+      int lcm_sym100__;
       double lcm_sym99__;
       double lcm_sym98__;
       double lcm_sym97__;
@@ -17282,7 +16056,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       double lcm_sym85__;
       double lcm_sym84__;
       double lcm_sym83__;
-      int lcm_sym82__;
+      double lcm_sym82__;
       int lcm_sym81__;
       int lcm_sym80__;
       int lcm_sym79__;
@@ -17302,6 +16076,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       int lcm_sym65__;
       int lcm_sym64__;
       int lcm_sym63__;
+      int lcm_sym62__;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -17320,18 +16095,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       Eigen::Matrix<local_scalar_t__,-1,-1> chi =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
           DUMMY_VAR__);
-      lcm_sym63__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym63__) {
-        lcm_sym102__ = stan::model::rvalue(first, "first",
+      lcm_sym62__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym62__) {
+        lcm_sym101__ = stan::model::rvalue(first, "first",
                          stan::model::index_uni(1));
-        lcm_sym76__ = (lcm_sym102__ - 1);
-        if (stan::math::logical_gte(lcm_sym76__, 1)) {
+        lcm_sym75__ = (lcm_sym101__ - 1);
+        if (stan::math::logical_gte(lcm_sym75__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym76__; ++t) {
+          for (int t = 2; t <= lcm_sym75__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -17340,20 +16115,20 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym74__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym74__, lcm_sym102__)) {
+        lcm_sym73__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym73__, lcm_sym101__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym102__)))),
+                  stan::model::index_uni(lcm_sym101__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym102__));
-          lcm_sym82__ = (lcm_sym102__ + 1);
+            stan::model::index_uni(lcm_sym101__));
+          lcm_sym81__ = (lcm_sym101__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym102__));
-          for (int t = lcm_sym82__; t <= lcm_sym74__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym101__));
+          for (int t = lcm_sym81__; t <= lcm_sym73__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -17367,16 +16142,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym101__ = stan::model::rvalue(first, "first",
+          lcm_sym100__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(i));
-          lcm_sym75__ = (lcm_sym101__ - 1);
-          if (stan::math::logical_gte(lcm_sym75__, 1)) {
+          lcm_sym74__ = (lcm_sym100__ - 1);
+          if (stan::math::logical_gte(lcm_sym74__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym75__; ++t) {
+            for (int t = 2; t <= lcm_sym74__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -17386,19 +16161,19 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym74__, lcm_sym101__)) {
+          if (stan::math::logical_gte(lcm_sym73__, lcm_sym100__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym101__)))),
+                    stan::model::index_uni(lcm_sym100__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym101__));
-            lcm_sym81__ = (lcm_sym101__ + 1);
+              stan::model::index_uni(lcm_sym100__));
+            lcm_sym80__ = (lcm_sym100__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym101__));
-            for (int t = lcm_sym81__; t <= lcm_sym74__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym100__));
+            for (int t = lcm_sym80__; t <= lcm_sym73__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -17426,58 +16201,58 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym63__) {
+        if (lcm_sym62__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym9__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym9__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym74__ = (n_occasions - 1);
-          lcm_sym64__ = stan::math::logical_gte(lcm_sym74__, 1);
-          if (lcm_sym64__) {
+          lcm_sym73__ = (n_occasions - 1);
+          lcm_sym63__ = stan::math::logical_gte(lcm_sym73__, 1);
+          if (lcm_sym63__) {
             int inline_prob_uncaptured_t_curr_sym10__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym11__ =
               std::numeric_limits<int>::min();
-            lcm_sym78__ = (lcm_sym74__ + 1);
+            lcm_sym77__ = (lcm_sym73__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym9__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym74__)) * (1 -
+                   stan::model::index_uni(lcm_sym73__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym78__ - 1))))),
+                  stan::model::index_uni((lcm_sym77__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                   "inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym78__)), (1 -
+                  stan::model::index_uni(lcm_sym77__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym74__)))),
+                  stan::model::index_uni(lcm_sym73__)))),
               "assigning variable inline_prob_uncaptured_chi_sym9__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym74__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym73__));
             for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                 <= lcm_sym74__; ++inline_prob_uncaptured_t_sym12__) {
+                 <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
-              lcm_sym73__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
+              lcm_sym72__ = (n_occasions - inline_prob_uncaptured_t_sym12__);
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym77__ = (lcm_sym73__ + 1);
+              lcm_sym76__ = (lcm_sym72__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym73__)) * (1 -
+                     stan::model::index_uni(lcm_sym72__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym77__ - 1))))),
+                    stan::model::index_uni((lcm_sym76__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym77__)), (1 -
+                    stan::model::index_uni(lcm_sym76__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym73__)))),
+                    stan::model::index_uni(lcm_sym72__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym73__));
+                stan::model::index_uni(lcm_sym72__));
             }
           }
           for (int inline_prob_uncaptured_i_sym13__ = 2; inline_prob_uncaptured_i_sym13__
@@ -17488,60 +16263,60 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym64__) {
+            if (lcm_sym63__) {
               int inline_prob_uncaptured_t_curr_sym10__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym11__ =
                 std::numeric_limits<int>::min();
-              lcm_sym78__ = (lcm_sym74__ + 1);
+              lcm_sym77__ = (lcm_sym73__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                     stan::model::index_uni(lcm_sym74__)) * (1 -
+                     stan::model::index_uni(lcm_sym73__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni((lcm_sym78__ - 1))))),
+                    stan::model::index_uni((lcm_sym77__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                     "inline_prob_uncaptured_chi_sym9__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym78__)), (1 -
+                    stan::model::index_uni(lcm_sym77__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                    stan::model::index_uni(lcm_sym74__)))),
+                    stan::model::index_uni(lcm_sym73__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym9__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                stan::model::index_uni(lcm_sym74__));
+                stan::model::index_uni(lcm_sym73__));
               for (int inline_prob_uncaptured_t_sym12__ = 2; inline_prob_uncaptured_t_sym12__
-                   <= lcm_sym74__; ++inline_prob_uncaptured_t_sym12__) {
+                   <= lcm_sym73__; ++inline_prob_uncaptured_t_sym12__) {
                 int inline_prob_uncaptured_t_curr_sym10__ =
                   std::numeric_limits<int>::min();
-                lcm_sym73__ = (n_occasions -
+                lcm_sym72__ = (n_occasions -
                   inline_prob_uncaptured_t_sym12__);
                 int inline_prob_uncaptured_t_next_sym11__ =
                   std::numeric_limits<int>::min();
-                lcm_sym77__ = (lcm_sym73__ + 1);
+                lcm_sym76__ = (lcm_sym72__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym9__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym13__),
-                       stan::model::index_uni(lcm_sym73__)) * (1 -
+                       stan::model::index_uni(lcm_sym72__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni((lcm_sym77__ - 1))))),
+                      stan::model::index_uni((lcm_sym76__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym9__,
                       "inline_prob_uncaptured_chi_sym9__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym77__)), (1 -
+                      stan::model::index_uni(lcm_sym76__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                      stan::model::index_uni(lcm_sym73__)))),
+                      stan::model::index_uni(lcm_sym72__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym9__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym13__),
-                  stan::model::index_uni(lcm_sym73__));
+                  stan::model::index_uni(lcm_sym72__));
               }
             }
           }
@@ -17569,28 +16344,28 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         inline_prob_uncaptured_return_sym8__, 1);
       {
         current_statement__ = 32;
-        if (lcm_sym63__) {
-          lcm_sym102__ = stan::model::rvalue(first, "first",
+        if (lcm_sym62__) {
+          lcm_sym101__ = stan::model::rvalue(first, "first",
                            stan::model::index_uni(1));
-          if (stan::math::logical_gt(lcm_sym102__, 0)) {
-            lcm_sym104__ = stan::model::rvalue(last, "last",
+          if (stan::math::logical_gt(lcm_sym101__, 0)) {
+            lcm_sym103__ = stan::model::rvalue(last, "last",
                              stan::model::index_uni(1));
-            lcm_sym82__ = (lcm_sym102__ + 1);
-            if (stan::math::logical_gte(lcm_sym104__, lcm_sym82__)) {
+            lcm_sym81__ = (lcm_sym101__ + 1);
+            if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
               current_statement__ = 26;
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym82__ - 1)))));
-              lcm_sym80__ = (lcm_sym82__ + 1);
+                                 stan::model::index_uni((lcm_sym81__ - 1)))));
+              lcm_sym79__ = (lcm_sym81__ + 1);
               lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                stan::model::rvalue(y, "y",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym82__)),
+                                 stan::model::index_uni(lcm_sym81__)),
                                stan::model::rvalue(p, "p",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni((lcm_sym82__ - 1)))));
-              for (int t = lcm_sym80__; t <= lcm_sym104__; ++t) {
+                                 stan::model::index_uni((lcm_sym81__ - 1)))));
+              for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
@@ -17612,30 +16387,30 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                                inline_prob_uncaptured_return_sym8__,
                                "inline_prob_uncaptured_return_sym8__",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(lcm_sym104__))));
+                               stan::model::index_uni(lcm_sym103__))));
           }
           for (int i = 2; i <= nind; ++i) {
-            lcm_sym101__ = stan::model::rvalue(first, "first",
+            lcm_sym100__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(i));
-            if (stan::math::logical_gt(lcm_sym101__, 0)) {
-              lcm_sym103__ = stan::model::rvalue(last, "last",
+            if (stan::math::logical_gt(lcm_sym100__, 0)) {
+              lcm_sym102__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(i));
-              lcm_sym81__ = (lcm_sym101__ + 1);
-              if (stan::math::logical_gte(lcm_sym103__, lcm_sym81__)) {
+              lcm_sym80__ = (lcm_sym100__ + 1);
+              if (stan::math::logical_gte(lcm_sym102__, lcm_sym80__)) {
                 current_statement__ = 26;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym81__ - 1)))));
-                lcm_sym79__ = (lcm_sym81__ + 1);
+                                   stan::model::index_uni((lcm_sym80__ - 1)))));
+                lcm_sym78__ = (lcm_sym80__ + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni(lcm_sym81__)),
+                                   stan::model::index_uni(lcm_sym80__)),
                                  stan::model::rvalue(p, "p",
                                    stan::model::index_uni(i),
-                                   stan::model::index_uni((lcm_sym81__ - 1)))));
-                for (int t = lcm_sym79__; t <= lcm_sym103__; ++t) {
+                                   stan::model::index_uni((lcm_sym80__ - 1)))));
+                for (int t = lcm_sym78__; t <= lcm_sym102__; ++t) {
                   current_statement__ = 26;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -17657,7 +16432,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                                  inline_prob_uncaptured_return_sym8__,
                                  "inline_prob_uncaptured_return_sym8__",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(lcm_sym103__))));
+                                 stan::model::index_uni(lcm_sym102__))));
             }
           }
         }
@@ -17699,10 +16474,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym62__;
-      int lcm_sym61__;
+      double lcm_sym61__;
       int lcm_sym60__;
-      double lcm_sym59__;
+      int lcm_sym59__;
       double lcm_sym58__;
       double lcm_sym57__;
       double lcm_sym56__;
@@ -17710,7 +16484,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       double lcm_sym54__;
       double lcm_sym53__;
       double lcm_sym52__;
-      int lcm_sym51__;
+      double lcm_sym51__;
       int lcm_sym50__;
       int lcm_sym49__;
       int lcm_sym48__;
@@ -17726,6 +16500,7 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       int lcm_sym38__;
       int lcm_sym37__;
       int lcm_sym36__;
+      int lcm_sym35__;
       double mean_p;
       current_statement__ = 1;
       mean_p = in__.template read_constrain_lub<local_scalar_t__,
@@ -17751,18 +16526,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      lcm_sym36__ = stan::math::logical_gte(nind, 1);
-      if (lcm_sym36__) {
-        lcm_sym61__ = stan::model::rvalue(first, "first",
+      lcm_sym35__ = stan::math::logical_gte(nind, 1);
+      if (lcm_sym35__) {
+        lcm_sym60__ = stan::model::rvalue(first, "first",
                         stan::model::index_uni(1));
-        lcm_sym45__ = (lcm_sym61__ - 1);
-        if (stan::math::logical_gte(lcm_sym45__, 1)) {
+        lcm_sym44__ = (lcm_sym60__ - 1);
+        if (stan::math::logical_gte(lcm_sym44__, 1)) {
           stan::model::assign(phi, 0, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           current_statement__ = 6;
           stan::model::assign(p, 0, "assigning variable p",
             stan::model::index_uni(1), stan::model::index_uni(1));
-          for (int t = 2; t <= lcm_sym45__; ++t) {
+          for (int t = 2; t <= lcm_sym44__; ++t) {
             current_statement__ = 7;
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
@@ -17771,20 +16546,20 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(1), stan::model::index_uni(t));
           }
         }
-        lcm_sym43__ = (n_occasions - 1);
-        if (stan::math::logical_gte(lcm_sym43__, lcm_sym61__)) {
+        lcm_sym42__ = (n_occasions - 1);
+        if (stan::math::logical_gte(lcm_sym42__, lcm_sym60__)) {
           current_statement__ = 9;
           stan::model::assign(phi,
             stan::model::rvalue(beta, "beta",
               stan::model::index_uni(
                 stan::model::rvalue(x, "x", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym61__)))),
+                  stan::model::index_uni(lcm_sym60__)))),
             "assigning variable phi", stan::model::index_uni(1),
-            stan::model::index_uni(lcm_sym61__));
-          lcm_sym51__ = (lcm_sym61__ + 1);
+            stan::model::index_uni(lcm_sym60__));
+          lcm_sym50__ = (lcm_sym60__ + 1);
           stan::model::assign(p, mean_p, "assigning variable p",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym61__));
-          for (int t = lcm_sym51__; t <= lcm_sym43__; ++t) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym60__));
+          for (int t = lcm_sym50__; t <= lcm_sym42__; ++t) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
@@ -17798,16 +16573,16 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           }
         }
         for (int i = 2; i <= nind; ++i) {
-          lcm_sym60__ = stan::model::rvalue(first, "first",
+          lcm_sym59__ = stan::model::rvalue(first, "first",
                           stan::model::index_uni(i));
-          lcm_sym44__ = (lcm_sym60__ - 1);
-          if (stan::math::logical_gte(lcm_sym44__, 1)) {
+          lcm_sym43__ = (lcm_sym59__ - 1);
+          if (stan::math::logical_gte(lcm_sym43__, 1)) {
             stan::model::assign(phi, 0, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
             current_statement__ = 6;
             stan::model::assign(p, 0, "assigning variable p",
               stan::model::index_uni(i), stan::model::index_uni(1));
-            for (int t = 2; t <= lcm_sym44__; ++t) {
+            for (int t = 2; t <= lcm_sym43__; ++t) {
               current_statement__ = 7;
               stan::model::assign(phi, 0, "assigning variable phi",
                 stan::model::index_uni(i), stan::model::index_uni(t));
@@ -17817,19 +16592,19 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             }
           }
           current_statement__ = 12;
-          if (stan::math::logical_gte(lcm_sym43__, lcm_sym60__)) {
+          if (stan::math::logical_gte(lcm_sym42__, lcm_sym59__)) {
             current_statement__ = 9;
             stan::model::assign(phi,
               stan::model::rvalue(beta, "beta",
                 stan::model::index_uni(
                   stan::model::rvalue(x, "x", stan::model::index_uni(i),
-                    stan::model::index_uni(lcm_sym60__)))),
+                    stan::model::index_uni(lcm_sym59__)))),
               "assigning variable phi", stan::model::index_uni(i),
-              stan::model::index_uni(lcm_sym60__));
-            lcm_sym50__ = (lcm_sym60__ + 1);
+              stan::model::index_uni(lcm_sym59__));
+            lcm_sym49__ = (lcm_sym59__ + 1);
             stan::model::assign(p, mean_p, "assigning variable p",
-              stan::model::index_uni(i), stan::model::index_uni(lcm_sym60__));
-            for (int t = lcm_sym50__; t <= lcm_sym43__; ++t) {
+              stan::model::index_uni(i), stan::model::index_uni(lcm_sym59__));
+            for (int t = lcm_sym49__; t <= lcm_sym42__; ++t) {
               current_statement__ = 9;
               stan::model::assign(phi,
                 stan::model::rvalue(beta, "beta",
@@ -17856,58 +16631,58 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(nind, n_occasions,
             DUMMY_VAR__);
         current_statement__ = 24;
-        if (lcm_sym36__) {
+        if (lcm_sym35__) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym2__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym2__",
             stan::model::index_uni(1), stan::model::index_uni(n_occasions));
-          lcm_sym43__ = (n_occasions - 1);
-          lcm_sym37__ = stan::math::logical_gte(lcm_sym43__, 1);
-          if (lcm_sym37__) {
+          lcm_sym42__ = (n_occasions - 1);
+          lcm_sym36__ = stan::math::logical_gte(lcm_sym42__, 1);
+          if (lcm_sym36__) {
             int inline_prob_uncaptured_t_curr_sym3__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym4__ =
               std::numeric_limits<int>::min();
-            lcm_sym49__ = (lcm_sym43__ + 1);
+            lcm_sym48__ = (lcm_sym42__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym2__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym43__)) * (1 -
+                   stan::model::index_uni(lcm_sym42__)) * (1 -
                 stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                  stan::model::index_uni((lcm_sym49__ - 1))))),
+                  stan::model::index_uni((lcm_sym48__ - 1))))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                   "inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym49__)), (1 -
+                  stan::model::index_uni(lcm_sym48__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym43__)))),
+                  stan::model::index_uni(lcm_sym42__)))),
               "assigning variable inline_prob_uncaptured_chi_sym2__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym43__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym42__));
             for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                 <= lcm_sym43__; ++inline_prob_uncaptured_t_sym5__) {
+                 <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
-              lcm_sym42__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
+              lcm_sym41__ = (n_occasions - inline_prob_uncaptured_t_sym5__);
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym48__ = (lcm_sym42__ + 1);
+              lcm_sym47__ = (lcm_sym41__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym42__)) * (1 -
+                     stan::model::index_uni(lcm_sym41__)) * (1 -
                   stan::model::rvalue(p, "p", stan::model::index_uni(1),
-                    stan::model::index_uni((lcm_sym48__ - 1))))),
+                    stan::model::index_uni((lcm_sym47__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym48__)), (1 -
+                    stan::model::index_uni(lcm_sym47__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym42__)))),
+                    stan::model::index_uni(lcm_sym41__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym42__));
+                stan::model::index_uni(lcm_sym41__));
             }
           }
           for (int inline_prob_uncaptured_i_sym6__ = 2; inline_prob_uncaptured_i_sym6__
@@ -17918,59 +16693,59 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
               stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
               stan::model::index_uni(n_occasions));
             current_statement__ = 22;
-            if (lcm_sym37__) {
+            if (lcm_sym36__) {
               int inline_prob_uncaptured_t_curr_sym3__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym4__ =
                 std::numeric_limits<int>::min();
-              lcm_sym49__ = (lcm_sym43__ + 1);
+              lcm_sym48__ = (lcm_sym42__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                     stan::model::index_uni(lcm_sym43__)) * (1 -
+                     stan::model::index_uni(lcm_sym42__)) * (1 -
                   stan::model::rvalue(p, "p",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni((lcm_sym49__ - 1))))),
+                    stan::model::index_uni((lcm_sym48__ - 1))))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                     "inline_prob_uncaptured_chi_sym2__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym49__)), (1 -
+                    stan::model::index_uni(lcm_sym48__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                    stan::model::index_uni(lcm_sym43__)))),
+                    stan::model::index_uni(lcm_sym42__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym2__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                stan::model::index_uni(lcm_sym43__));
+                stan::model::index_uni(lcm_sym42__));
               for (int inline_prob_uncaptured_t_sym5__ = 2; inline_prob_uncaptured_t_sym5__
-                   <= lcm_sym43__; ++inline_prob_uncaptured_t_sym5__) {
+                   <= lcm_sym42__; ++inline_prob_uncaptured_t_sym5__) {
                 int inline_prob_uncaptured_t_curr_sym3__ =
                   std::numeric_limits<int>::min();
-                lcm_sym42__ = (n_occasions -
+                lcm_sym41__ = (n_occasions -
                   inline_prob_uncaptured_t_sym5__);
                 int inline_prob_uncaptured_t_next_sym4__ =
                   std::numeric_limits<int>::min();
-                lcm_sym48__ = (lcm_sym42__ + 1);
+                lcm_sym47__ = (lcm_sym41__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym2__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                       stan::model::index_uni(lcm_sym42__)) * (1 -
+                       stan::model::index_uni(lcm_sym41__)) * (1 -
                     stan::model::rvalue(p, "p",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni((lcm_sym48__ - 1))))),
+                      stan::model::index_uni((lcm_sym47__ - 1))))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym2__,
                       "inline_prob_uncaptured_chi_sym2__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym48__)), (1 -
+                      stan::model::index_uni(lcm_sym47__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                      stan::model::index_uni(lcm_sym42__)))),
+                      stan::model::index_uni(lcm_sym41__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym2__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym6__),
-                  stan::model::index_uni(lcm_sym42__));
+                  stan::model::index_uni(lcm_sym41__));
               }
             }
           }
@@ -18022,22 +16797,15 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym35__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
-      if (stan::math::logical_gte(max_age, 1)) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= max_age; ++sym1__) {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
+        "assigning variable beta");
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18079,27 +16847,27 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym119__ = 1; sym119__ <= max_age; ++sym119__) {
+    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym119__));
+        std::to_string(sym118__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occasions; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
     }
@@ -18110,27 +16878,27 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym119__ = 1; sym119__ <= max_age; ++sym119__) {
+    for (int sym118__ = 1; sym118__ <= max_age; ++sym118__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym119__));
+        std::to_string(sym118__));
     }
     if (emit_transformed_parameters__) {
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occ_minus_1; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occ_minus_1; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
-      for (int sym119__ = 1; sym119__ <= n_occasions; ++sym119__) {
-        for (int sym120__ = 1; sym120__ <= nind; ++sym120__) {
+      for (int sym118__ = 1; sym118__ <= n_occasions; ++sym118__) {
+        for (int sym119__ = 1; sym119__ <= nind; ++sym119__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym120__) + '.' + std::to_string(sym119__));
+            std::to_string(sym119__) + '.' + std::to_string(sym118__));
         }
       }
     }
@@ -19408,55 +18176,15 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      {
-        stan::model::assign(p_single_ret_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_single_ret_vec", stan::model::index_uni(1));
-        {
-          stan::model::assign(p_single_ret_vec,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_single_ret_vec", stan::model::index_uni(2));
-        }
-        {
-          stan::model::assign(p_single_ret_vec,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_single_ret_vec", stan::model::index_uni(3));
-        }
-        {
-          stan::model::assign(p_single_ret_vec,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_single_ret_vec", stan::model::index_uni(4));
-        }
-        {
-          stan::model::assign(p_single_ret_vec,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_single_ret_vec", stan::model::index_uni(5));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec;
+      stan::model::assign(p_single_ret_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable p_single_ret_vec");
       out__.write(p_single_ret_vec);
-      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      {
-        stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_multi_ret_vec", stan::model::index_uni(1));
-        {
-          stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-            "assigning variable p_multi_ret_vec", stan::model::index_uni(2));
-        }
-        {
-          stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-            "assigning variable p_multi_ret_vec", stan::model::index_uni(3));
-        }
-        {
-          stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-            "assigning variable p_multi_ret_vec", stan::model::index_uni(4));
-        }
-        {
-          stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-            "assigning variable p_multi_ret_vec", stan::model::index_uni(5));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec;
+      stan::model::assign(p_multi_ret_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable p_multi_ret_vec");
       out__.write(p_multi_ret_vec);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21369,9 +20097,6 @@ seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
 }
 class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> {
  private:
-  int lcm_sym266__;
-  int lcm_sym265__;
-  int lcm_sym264__;
   int lcm_sym263__;
   int lcm_sym262__;
   int lcm_sym261__;
@@ -21379,6 +20104,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   int lcm_sym259__;
   int lcm_sym258__;
   int lcm_sym257__;
+  int lcm_sym256__;
+  int lcm_sym255__;
+  int lcm_sym254__;
   int M;
   int n_occasions;
   std::vector<std::vector<int>> y;
@@ -21442,8 +20170,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         pos__ = 1;
         current_statement__ = 114;
         if (stan::math::logical_gte(n_occasions, 1)) {
-          lcm_sym257__ = stan::math::logical_gte(M, 1);
-          if (lcm_sym257__) {
+          lcm_sym254__ = stan::math::logical_gte(M, 1);
+          if (lcm_sym254__) {
             current_statement__ = 114;
             stan::model::assign(y,
               stan::model::rvalue(y_flat__, "y_flat__",
@@ -21462,7 +20190,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
           for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
             current_statement__ = 114;
-            if (lcm_sym257__) {
+            if (lcm_sym254__) {
               current_statement__ = 114;
               stan::model::assign(y, y_flat__[(pos__ - 1)],
                 "assigning variable y", stan::model::index_uni(1),
@@ -21480,7 +20208,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             }
           }
         } else {
-          lcm_sym257__ = stan::math::logical_gte(M, 1);
+          lcm_sym254__ = stan::math::logical_gte(M, 1);
         }
       }
       current_statement__ = 114;
@@ -21496,7 +20224,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 118;
       last = std::vector<int>(M, std::numeric_limits<int>::min());
       current_statement__ = 120;
-      if (lcm_sym257__) {
+      if (lcm_sym254__) {
         current_statement__ = 119;
         stan::model::assign(first,
           first_capture(
@@ -21512,7 +20240,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         }
       }
       current_statement__ = 122;
-      if (lcm_sym257__) {
+      if (lcm_sym254__) {
         current_statement__ = 121;
         stan::model::assign(last,
           last_capture(
@@ -21540,20 +20268,20 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         n_occasions);
       current_statement__ = 124;
       epsilon_1dim__ = std::numeric_limits<int>::min();
-      lcm_sym259__ = (n_occasions - 1);
-      epsilon_1dim__ = lcm_sym259__;
+      lcm_sym256__ = (n_occasions - 1);
+      epsilon_1dim__ = lcm_sym256__;
       current_statement__ = 124;
       stan::math::validate_non_negative_index("epsilon", "n_occasions - 1",
-        lcm_sym259__);
+        lcm_sym256__);
       current_statement__ = 125;
       stan::math::validate_non_negative_index("phi", "M", M);
       current_statement__ = 126;
       phi_2dim__ = std::numeric_limits<int>::min();
       current_statement__ = 126;
-      phi_2dim__ = lcm_sym259__;
+      phi_2dim__ = lcm_sym256__;
       current_statement__ = 126;
       stan::math::validate_non_negative_index("phi", "n_occasions - 1",
-        lcm_sym259__);
+        lcm_sym256__);
       current_statement__ = 127;
       stan::math::validate_non_negative_index("p", "M", M);
       current_statement__ = 128;
@@ -21605,26 +20333,23 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) function__;
     try {
-      int lcm_sym256__;
-      int lcm_sym255__;
-      int lcm_sym254__;
       int lcm_sym253__;
       int lcm_sym252__;
       int lcm_sym251__;
+      int lcm_sym250__;
       int lcm_sym249__;
-      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym248__;
-      double lcm_sym247__;
-      double lcm_sym246__;
-      local_scalar_t__ lcm_sym245__;
-      local_scalar_t__ lcm_sym244__;
+      int lcm_sym248__;
+      int lcm_sym246__;
+      Eigen::Matrix<local_scalar_t__,-1,-1> lcm_sym245__;
+      double lcm_sym244__;
       double lcm_sym243__;
-      double lcm_sym242__;
-      double lcm_sym241__;
+      local_scalar_t__ lcm_sym242__;
+      local_scalar_t__ lcm_sym241__;
       double lcm_sym240__;
-      int lcm_sym239__;
+      double lcm_sym239__;
       double lcm_sym238__;
       double lcm_sym237__;
-      double lcm_sym236__;
+      int lcm_sym236__;
       double lcm_sym235__;
       double lcm_sym234__;
       double lcm_sym233__;
@@ -21635,12 +20360,12 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       double lcm_sym228__;
       double lcm_sym227__;
       double lcm_sym226__;
-      int lcm_sym225__;
-      int lcm_sym224__;
-      int lcm_sym223__;
-      double lcm_sym222__;
-      double lcm_sym221__;
-      double lcm_sym220__;
+      double lcm_sym225__;
+      double lcm_sym224__;
+      double lcm_sym223__;
+      int lcm_sym222__;
+      int lcm_sym221__;
+      int lcm_sym220__;
       double lcm_sym219__;
       double lcm_sym218__;
       double lcm_sym217__;
@@ -21652,19 +20377,19 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       double lcm_sym211__;
       double lcm_sym210__;
       double lcm_sym209__;
-      int lcm_sym208__;
-      int lcm_sym207__;
-      int lcm_sym206__;
+      double lcm_sym208__;
+      double lcm_sym207__;
+      double lcm_sym206__;
       int lcm_sym205__;
       int lcm_sym204__;
       int lcm_sym203__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym202__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym201__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym200__;
-      int lcm_sym250__;
-      int lcm_sym198__;
-      int lcm_sym197__;
-      int lcm_sym196__;
+      int lcm_sym202__;
+      int lcm_sym201__;
+      int lcm_sym200__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym199__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym198__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym197__;
+      int lcm_sym247__;
       int lcm_sym195__;
       int lcm_sym194__;
       int lcm_sym193__;
@@ -21674,6 +20399,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       int lcm_sym189__;
       int lcm_sym188__;
       int lcm_sym187__;
+      int lcm_sym186__;
+      int lcm_sym185__;
+      int lcm_sym184__;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -21690,15 +20418,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant((n_occasions - 1),
           DUMMY_VAR__);
-      lcm_sym250__ = (n_occasions - 1);
+      lcm_sym247__ = (n_occasions - 1);
       epsilon = in__.template read<
-                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym250__);
+                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym247__);
       local_scalar_t__ sigma;
       current_statement__ = 5;
       sigma = in__.template read_constrain_lub<local_scalar_t__,
                 jacobian__>(0, 5, lp__);
       Eigen::Matrix<local_scalar_t__,-1,-1> phi =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, lcm_sym250__,
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, lcm_sym247__,
           DUMMY_VAR__);
       Eigen::Matrix<local_scalar_t__,-1,-1> p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, n_occasions,
@@ -21707,180 +20435,180 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(M, n_occasions,
           DUMMY_VAR__);
       current_statement__ = 11;
-      if (stan::math::logical_gte(lcm_sym250__, 1)) {
-        lcm_sym189__ = stan::math::logical_gte(M, 1);
-        if (lcm_sym189__) {
-          lcm_sym245__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
+      if (stan::math::logical_gte(lcm_sym247__, 1)) {
+        lcm_sym186__ = stan::math::logical_gte(M, 1);
+        if (lcm_sym186__) {
+          lcm_sym242__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
                            stan::model::rvalue(epsilon, "epsilon",
                              stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym245__, "assigning variable phi",
+          stan::model::assign(phi, lcm_sym242__, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 9;
-            stan::model::assign(phi, lcm_sym245__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym242__, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
           }
         }
-        for (int t = 2; t <= lcm_sym250__; ++t) {
+        for (int t = 2; t <= lcm_sym247__; ++t) {
           current_statement__ = 10;
-          if (lcm_sym189__) {
-            lcm_sym244__ = stan::math::inv_logit((stan::math::logit(mean_phi)
+          if (lcm_sym186__) {
+            lcm_sym241__ = stan::math::inv_logit((stan::math::logit(mean_phi)
                              +
                              stan::model::rvalue(epsilon, "epsilon",
                                stan::model::index_uni(t))));
-            stan::model::assign(phi, lcm_sym244__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym241__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             for (int i = 2; i <= M; ++i) {
               current_statement__ = 9;
-              stan::model::assign(phi, lcm_sym244__,
+              stan::model::assign(phi, lcm_sym241__,
                 "assigning variable phi", stan::model::index_uni(i),
                 stan::model::index_uni(t));
             }
           }
         }
       }
-      stan::model::assign(lcm_sym248__,
+      stan::model::assign(lcm_sym245__,
         stan::math::rep_matrix(mean_p, M, n_occasions),
-        "assigning variable lcm_sym248__");
-      stan::model::assign(p, lcm_sym248__, "assigning variable p");
+        "assigning variable lcm_sym245__");
+      stan::model::assign(p, lcm_sym245__, "assigning variable p");
       Eigen::Matrix<local_scalar_t__,-1,-1>
         inline_prob_uncaptured_return_sym20__;
       {
         int inline_prob_uncaptured_n_ind_sym21__ =
           std::numeric_limits<int>::min();
-        lcm_sym249__ = stan::math::rows(lcm_sym248__);
+        lcm_sym246__ = stan::math::rows(lcm_sym245__);
         int inline_prob_uncaptured_n_occasions_sym22__ =
           std::numeric_limits<int>::min();
-        lcm_sym239__ = stan::math::cols(lcm_sym248__);
+        lcm_sym236__ = stan::math::cols(lcm_sym245__);
         current_statement__ = 14;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym249__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym246__);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym239__);
+          lcm_sym236__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym23__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym249__,
-            lcm_sym239__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym246__,
+            lcm_sym236__, DUMMY_VAR__);
         current_statement__ = 24;
-        if (stan::math::logical_gte(lcm_sym249__, 1)) {
+        if (stan::math::logical_gte(lcm_sym246__, 1)) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym23__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym23__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym239__));
-          lcm_sym204__ = (lcm_sym239__ - 1);
-          lcm_sym191__ = stan::math::logical_gte(lcm_sym204__, 1);
-          if (lcm_sym191__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym236__));
+          lcm_sym201__ = (lcm_sym236__ - 1);
+          lcm_sym188__ = stan::math::logical_gte(lcm_sym201__, 1);
+          if (lcm_sym188__) {
             int inline_prob_uncaptured_t_curr_sym24__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym25__ =
               std::numeric_limits<int>::min();
-            lcm_sym208__ = (lcm_sym204__ + 1);
+            lcm_sym205__ = (lcm_sym201__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym23__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym204__)) * (1 -
-                stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                   stan::model::index_uni(lcm_sym201__)) * (1 -
+                stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym208__)))),
+                  stan::model::index_uni(lcm_sym205__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                   "inline_prob_uncaptured_chi_sym23__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym208__)), (1 -
+                  stan::model::index_uni(lcm_sym205__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym204__)))),
+                  stan::model::index_uni(lcm_sym201__)))),
               "assigning variable inline_prob_uncaptured_chi_sym23__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym204__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym201__));
             for (int inline_prob_uncaptured_t_sym26__ = 2; inline_prob_uncaptured_t_sym26__
-                 <= lcm_sym204__; ++inline_prob_uncaptured_t_sym26__) {
+                 <= lcm_sym201__; ++inline_prob_uncaptured_t_sym26__) {
               int inline_prob_uncaptured_t_curr_sym24__ =
                 std::numeric_limits<int>::min();
-              lcm_sym203__ = (lcm_sym239__ -
+              lcm_sym200__ = (lcm_sym236__ -
                 inline_prob_uncaptured_t_sym26__);
               int inline_prob_uncaptured_t_next_sym25__ =
                 std::numeric_limits<int>::min();
-              lcm_sym207__ = (lcm_sym203__ + 1);
+              lcm_sym204__ = (lcm_sym200__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym23__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym203__)) * (1 -
-                  stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                     stan::model::index_uni(lcm_sym200__)) * (1 -
+                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym207__)))),
+                    stan::model::index_uni(lcm_sym204__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                     "inline_prob_uncaptured_chi_sym23__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym207__)), (1 -
+                    stan::model::index_uni(lcm_sym204__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym203__)))),
+                    stan::model::index_uni(lcm_sym200__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym23__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym203__));
+                stan::model::index_uni(lcm_sym200__));
             }
           }
           for (int inline_prob_uncaptured_i_sym27__ = 2; inline_prob_uncaptured_i_sym27__
-               <= lcm_sym249__; ++inline_prob_uncaptured_i_sym27__) {
+               <= lcm_sym246__; ++inline_prob_uncaptured_i_sym27__) {
             current_statement__ = 17;
             stan::model::assign(inline_prob_uncaptured_chi_sym23__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym23__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-              stan::model::index_uni(lcm_sym239__));
+              stan::model::index_uni(lcm_sym236__));
             current_statement__ = 22;
-            if (lcm_sym191__) {
+            if (lcm_sym188__) {
               int inline_prob_uncaptured_t_curr_sym24__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym25__ =
                 std::numeric_limits<int>::min();
-              lcm_sym208__ = (lcm_sym204__ + 1);
+              lcm_sym205__ = (lcm_sym201__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym23__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                     stan::model::index_uni(lcm_sym204__)) * (1 -
-                  stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                     stan::model::index_uni(lcm_sym201__)) * (1 -
+                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                    stan::model::index_uni(lcm_sym208__)))),
+                    stan::model::index_uni(lcm_sym205__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                     "inline_prob_uncaptured_chi_sym23__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                    stan::model::index_uni(lcm_sym208__)), (1 -
+                    stan::model::index_uni(lcm_sym205__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                    stan::model::index_uni(lcm_sym204__)))),
+                    stan::model::index_uni(lcm_sym201__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym23__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                stan::model::index_uni(lcm_sym204__));
+                stan::model::index_uni(lcm_sym201__));
               for (int inline_prob_uncaptured_t_sym26__ = 2; inline_prob_uncaptured_t_sym26__
-                   <= lcm_sym204__; ++inline_prob_uncaptured_t_sym26__) {
+                   <= lcm_sym201__; ++inline_prob_uncaptured_t_sym26__) {
                 int inline_prob_uncaptured_t_curr_sym24__ =
                   std::numeric_limits<int>::min();
-                lcm_sym203__ = (lcm_sym239__ -
+                lcm_sym200__ = (lcm_sym236__ -
                   inline_prob_uncaptured_t_sym26__);
                 int inline_prob_uncaptured_t_next_sym25__ =
                   std::numeric_limits<int>::min();
-                lcm_sym207__ = (lcm_sym203__ + 1);
+                lcm_sym204__ = (lcm_sym200__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym23__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(
                          inline_prob_uncaptured_i_sym27__),
-                       stan::model::index_uni(lcm_sym203__)) * (1 -
-                    stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                       stan::model::index_uni(lcm_sym200__)) * (1 -
+                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                      stan::model::index_uni(lcm_sym207__)))),
+                      stan::model::index_uni(lcm_sym204__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym23__,
                       "inline_prob_uncaptured_chi_sym23__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                      stan::model::index_uni(lcm_sym207__)), (1 -
+                      stan::model::index_uni(lcm_sym204__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                      stan::model::index_uni(lcm_sym203__)))),
+                      stan::model::index_uni(lcm_sym200__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym23__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym27__),
-                  stan::model::index_uni(lcm_sym203__));
+                  stan::model::index_uni(lcm_sym200__));
               }
             }
           }
@@ -21897,9 +20625,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 6;
       stan::math::check_less_or_equal(function__, "phi", phi, 1);
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "p", lcm_sym248__, 0);
+      stan::math::check_greater_or_equal(function__, "p", lcm_sym245__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "p", lcm_sym248__, 1);
+      stan::math::check_less_or_equal(function__, "p", lcm_sym245__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "chi",
         inline_prob_uncaptured_return_sym20__, 0);
@@ -21912,129 +20640,129 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         {
           int inline_jolly_seber_lp_n_ind_sym29__ =
             std::numeric_limits<int>::min();
-          lcm_sym255__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym252__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(1));
           int inline_jolly_seber_lp_n_occasions_sym30__ =
             std::numeric_limits<int>::min();
-          lcm_sym256__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
+          lcm_sym253__ = stan::model::rvalue(stan::math::dims(y), "dims(y)",
                            stan::model::index_uni(2));
           current_statement__ = 81;
           stan::math::validate_non_negative_index("qgamma", "n_occasions",
-            lcm_sym256__);
+            lcm_sym253__);
           Eigen::Matrix<double,-1,1> inline_jolly_seber_lp_qgamma_sym31__ =
-            Eigen::Matrix<double,-1,1>::Constant(lcm_sym256__,
+            Eigen::Matrix<double,-1,1>::Constant(lcm_sym253__,
               std::numeric_limits<double>::quiet_NaN());
-          stan::model::assign(lcm_sym200__, stan::math::subtract(1.0, gamma),
-            "assigning variable lcm_sym200__");
+          stan::model::assign(lcm_sym197__, stan::math::subtract(1.0, gamma),
+            "assigning variable lcm_sym197__");
           current_statement__ = 108;
-          if (stan::math::logical_gte(lcm_sym255__, 1)) {
+          if (stan::math::logical_gte(lcm_sym252__, 1)) {
             current_statement__ = 83;
             stan::math::validate_non_negative_index("qp", "n_occasions",
-              lcm_sym256__);
+              lcm_sym253__);
             Eigen::Matrix<double,-1,1> inline_jolly_seber_lp_qp_sym32__ =
-              Eigen::Matrix<double,-1,1>::Constant(lcm_sym256__,
+              Eigen::Matrix<double,-1,1>::Constant(lcm_sym253__,
                 std::numeric_limits<double>::quiet_NaN());
-            stan::model::assign(lcm_sym202__,
+            stan::model::assign(lcm_sym199__,
               stan::math::subtract(1.0,
                 stan::math::transpose(
-                  stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                     stan::model::index_uni(1)))),
-              "assigning variable lcm_sym202__");
-            lcm_sym252__ = stan::model::rvalue(first, "first",
+              "assigning variable lcm_sym199__");
+            lcm_sym249__ = stan::model::rvalue(first, "first",
                              stan::model::index_uni(1));
-            if (lcm_sym252__) {
+            if (lcm_sym249__) {
               current_statement__ = 101;
-              if (stan::math::logical_eq(lcm_sym252__, 1)) {
+              if (stan::math::logical_eq(lcm_sym249__, 1)) {
                 current_statement__ = 99;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  (stan::model::rvalue(gamma, "gamma",
                                     stan::model::index_uni(1)) *
-                                 stan::model::rvalue(lcm_sym248__,
-                                   "lcm_sym248__", stan::model::index_uni(1),
+                                 stan::model::rvalue(lcm_sym245__,
+                                   "lcm_sym245__", stan::model::index_uni(1),
                                    stan::model::index_uni(1)))));
               } else {
                 current_statement__ = 92;
                 stan::math::validate_non_negative_index("lp", "first[i]",
-                  lcm_sym252__);
+                  lcm_sym249__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_jolly_seber_lp_lp_sym33__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym252__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym249__,
                     DUMMY_VAR__);
-                lcm_sym206__ = (lcm_sym252__ - 1);
+                lcm_sym203__ = (lcm_sym249__ - 1);
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
-                      stan::model::rvalue(lcm_sym202__, "lcm_sym202__",
-                        stan::model::index_min_max(1, lcm_sym206__))))) +
+                      stan::model::rvalue(lcm_sym199__, "lcm_sym199__",
+                        stan::model::index_min_max(1, lcm_sym203__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::math::prod(
                       stan::model::rvalue(phi, "phi",
                         stan::model::index_uni(1),
-                        stan::model::index_min_max(1, lcm_sym206__))))) +
+                        stan::model::index_min_max(1, lcm_sym203__))))) +
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                       stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym252__)))),
+                      stan::model::index_uni(lcm_sym249__)))),
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
                   stan::model::index_uni(1));
                 current_statement__ = 95;
-                if (stan::math::logical_gte(lcm_sym206__, 2)) {
+                if (stan::math::logical_gte(lcm_sym203__, 2)) {
                   current_statement__ = 94;
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     ((((stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym200__, "lcm_sym200__",
+                            stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
                               stan::model::index_min_max(1, 1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(2)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym202__, "lcm_sym202__",
-                          stan::model::index_min_max(2, lcm_sym206__))))) +
+                        stan::model::rvalue(lcm_sym199__, "lcm_sym199__",
+                          stan::model::index_min_max(2, lcm_sym203__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
                         stan::model::rvalue(phi, "phi",
                           stan::model::index_uni(1),
-                          stan::model::index_min_max(2, lcm_sym206__))))) +
+                          stan::model::index_min_max(2, lcm_sym203__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                         stan::model::index_uni(1),
-                        stan::model::index_uni(lcm_sym252__)))),
+                        stan::model::index_uni(lcm_sym249__)))),
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
                     stan::model::index_uni(2));
                   for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                       <= lcm_sym206__; ++inline_jolly_seber_lp_t_sym34__) {
+                       <= lcm_sym203__; ++inline_jolly_seber_lp_t_sym34__) {
                     current_statement__ = 94;
                     stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym200__,
-                                "lcm_sym200__",
+                              stan::model::rvalue(lcm_sym197__,
+                                "lcm_sym197__",
                                 stan::model::index_min_max(1,
                                   (inline_jolly_seber_lp_t_sym34__ - 1))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym202__, "lcm_sym202__",
+                          stan::model::rvalue(lcm_sym199__, "lcm_sym199__",
                             stan::model::index_min_max(
-                              inline_jolly_seber_lp_t_sym34__, lcm_sym206__)))))
+                              inline_jolly_seber_lp_t_sym34__, lcm_sym203__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
                           stan::model::rvalue(phi, "phi",
                             stan::model::index_uni(1),
                             stan::model::index_min_max(
-                              inline_jolly_seber_lp_t_sym34__, lcm_sym206__)))))
+                              inline_jolly_seber_lp_t_sym34__, lcm_sym203__)))))
                       +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                        stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                           stan::model::index_uni(1),
-                          stan::model::index_uni(lcm_sym252__)))),
+                          stan::model::index_uni(lcm_sym249__)))),
                       "assigning variable inline_jolly_seber_lp_lp_sym33__",
                       stan::model::index_uni(inline_jolly_seber_lp_t_sym34__));
                   }
@@ -22043,39 +20771,39 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   ((stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym200__, "lcm_sym200__",
-                          stan::model::index_min_max(1, lcm_sym206__)))) +
-                  stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym252__ -
+                        stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
+                          stan::model::index_min_max(1, lcm_sym203__)))) +
+                  stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym249__ -
                     1)])) +
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                       stan::model::index_uni(1),
-                      stan::model::index_uni(lcm_sym252__)))),
+                      stan::model::index_uni(lcm_sym249__)))),
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                  stan::model::index_uni(lcm_sym252__));
+                  stan::model::index_uni(lcm_sym249__));
                 current_statement__ = 97;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_jolly_seber_lp_lp_sym33__));
               }
-              lcm_sym254__ = stan::model::rvalue(last, "last",
+              lcm_sym251__ = stan::model::rvalue(last, "last",
                                stan::model::index_uni(1));
-              if (stan::math::logical_gte(lcm_sym254__, (lcm_sym252__ + 1))) {
+              if (stan::math::logical_gte(lcm_sym251__, (lcm_sym249__ + 1))) {
                 current_statement__ = 102;
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                  stan::model::rvalue(phi, "phi",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni(((lcm_sym252__ + 1)
+                                   stan::model::index_uni(((lcm_sym249__ + 1)
                                      - 1)))));
-                lcm_sym224__ = ((lcm_sym252__ + 1) + 1);
+                lcm_sym221__ = ((lcm_sym249__ + 1) + 1);
                 lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                  stan::model::rvalue(y, "y",
                                    stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym252__ + 1))),
-                                 stan::model::rvalue(lcm_sym248__,
-                                   "lcm_sym248__", stan::model::index_uni(1),
-                                   stan::model::index_uni((lcm_sym252__ + 1)))));
-                for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym224__; inline_jolly_seber_lp_t_sym34__
-                     <= lcm_sym254__; ++inline_jolly_seber_lp_t_sym34__) {
+                                   stan::model::index_uni((lcm_sym249__ + 1))),
+                                 stan::model::rvalue(lcm_sym245__,
+                                   "lcm_sym245__", stan::model::index_uni(1),
+                                   stan::model::index_uni((lcm_sym249__ + 1)))));
+                for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym221__; inline_jolly_seber_lp_t_sym34__
+                     <= lcm_sym251__; ++inline_jolly_seber_lp_t_sym34__) {
                   current_statement__ = 102;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
@@ -22088,8 +20816,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                      stan::model::index_uni(1),
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_t_sym34__)),
-                                   stan::model::rvalue(lcm_sym248__,
-                                     "lcm_sym248__",
+                                   stan::model::rvalue(lcm_sym245__,
+                                     "lcm_sym245__",
                                      stan::model::index_uni(1),
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_t_sym34__))));
@@ -22101,14 +20829,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                  inline_prob_uncaptured_return_sym20__,
                                  "inline_prob_uncaptured_return_sym20__",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(lcm_sym254__))));
+                                 stan::model::index_uni(lcm_sym251__))));
             } else {
-              lcm_sym225__ = (lcm_sym256__ + 1);
+              lcm_sym222__ = (lcm_sym253__ + 1);
               stan::math::validate_non_negative_index("lp",
-                "n_occasions + 1", lcm_sym225__);
+                "n_occasions + 1", lcm_sym222__);
               Eigen::Matrix<local_scalar_t__,-1,1>
                 inline_jolly_seber_lp_lp_sym33__ =
-                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym225__,
+                Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym222__,
                   DUMMY_VAR__);
               current_statement__ = 86;
               stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
@@ -22116,7 +20844,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     stan::model::rvalue(gamma, "gamma",
                       stan::model::index_uni(1))) +
                 stan::math::bernoulli_lpmf<false>(0,
-                  stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                  stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                     stan::model::index_uni(1), stan::model::index_uni(1)))) +
                 stan::math::bernoulli_lpmf<false>(1,
                   stan::model::rvalue(inline_prob_uncaptured_return_sym20__,
@@ -22125,18 +20853,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 "assigning variable inline_jolly_seber_lp_lp_sym33__",
                 stan::model::index_uni(1));
               current_statement__ = 88;
-              if (stan::math::logical_gte(lcm_sym256__, 2)) {
+              if (stan::math::logical_gte(lcm_sym253__, 2)) {
                 current_statement__ = 87;
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   (((stan::math::bernoulli_lpmf<false>(1,
                        stan::math::prod(
-                         stan::model::rvalue(lcm_sym200__, "lcm_sym200__",
+                         stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
                            stan::model::index_min_max(1, 1)))) +
                   stan::math::bernoulli_lpmf<false>(1,
                     stan::model::rvalue(gamma, "gamma",
                       stan::model::index_uni(2)))) +
                   stan::math::bernoulli_lpmf<false>(0,
-                    stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                       stan::model::index_uni(1), stan::model::index_uni(2))))
                   +
                   stan::math::bernoulli_lpmf<false>(1,
@@ -22147,18 +20875,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
                   stan::model::index_uni(2));
                 for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                     <= lcm_sym256__; ++inline_jolly_seber_lp_t_sym34__) {
+                     <= lcm_sym253__; ++inline_jolly_seber_lp_t_sym34__) {
                   current_statement__ = 87;
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
-                           stan::model::rvalue(lcm_sym200__, "lcm_sym200__",
+                           stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
                              stan::model::index_min_max(1,
                                (inline_jolly_seber_lp_t_sym34__ - 1))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                     stan::math::bernoulli_lpmf<false>(0,
-                      stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                         stan::model::index_uni(1),
                         stan::model::index_uni(
                           inline_jolly_seber_lp_t_sym34__)))) +
@@ -22176,107 +20904,107 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               current_statement__ = 89;
               stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                 stan::math::bernoulli_lpmf<false>(1,
-                  stan::math::prod(lcm_sym200__)),
+                  stan::math::prod(lcm_sym197__)),
                 "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                stan::model::index_uni(lcm_sym225__));
+                stan::model::index_uni(lcm_sym222__));
               current_statement__ = 90;
               lp_accum__.add(stan::math::log_sum_exp(
                                inline_jolly_seber_lp_lp_sym33__));
             }
             for (int inline_jolly_seber_lp_i_sym35__ = 2; inline_jolly_seber_lp_i_sym35__
-                 <= lcm_sym255__; ++inline_jolly_seber_lp_i_sym35__) {
+                 <= lcm_sym252__; ++inline_jolly_seber_lp_i_sym35__) {
               current_statement__ = 83;
               stan::math::validate_non_negative_index("qp", "n_occasions",
-                lcm_sym256__);
+                lcm_sym253__);
               Eigen::Matrix<double,-1,1> inline_jolly_seber_lp_qp_sym32__ =
-                Eigen::Matrix<double,-1,1>::Constant(lcm_sym256__,
+                Eigen::Matrix<double,-1,1>::Constant(lcm_sym253__,
                   std::numeric_limits<double>::quiet_NaN());
-              stan::model::assign(lcm_sym201__,
+              stan::model::assign(lcm_sym198__,
                 stan::math::subtract(1.0,
                   stan::math::transpose(
-                    stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                       stan::model::index_uni(inline_jolly_seber_lp_i_sym35__)))),
-                "assigning variable lcm_sym201__");
-              lcm_sym251__ = first[(inline_jolly_seber_lp_i_sym35__ - 1)];
-              if (lcm_sym251__) {
+                "assigning variable lcm_sym198__");
+              lcm_sym248__ = first[(inline_jolly_seber_lp_i_sym35__ - 1)];
+              if (lcm_sym248__) {
                 current_statement__ = 101;
-                if (stan::math::logical_eq(lcm_sym251__, 1)) {
+                if (stan::math::logical_eq(lcm_sym248__, 1)) {
                   current_statement__ = 99;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    (stan::model::rvalue(gamma, "gamma",
                                       stan::model::index_uni(1)) *
-                                   stan::model::rvalue(lcm_sym248__,
-                                     "lcm_sym248__",
+                                   stan::model::rvalue(lcm_sym245__,
+                                     "lcm_sym245__",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
                                      stan::model::index_uni(1)))));
                 } else {
                   current_statement__ = 92;
                   stan::math::validate_non_negative_index("lp", "first[i]",
-                    lcm_sym251__);
+                    lcm_sym248__);
                   Eigen::Matrix<local_scalar_t__,-1,1>
                     inline_jolly_seber_lp_lp_sym33__ =
-                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym251__,
+                    Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym248__,
                       DUMMY_VAR__);
-                  lcm_sym205__ = (lcm_sym251__ - 1);
+                  lcm_sym202__ = (lcm_sym248__ - 1);
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::model::rvalue(gamma, "gamma",
                            stan::model::index_uni(1))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
-                        stan::model::rvalue(lcm_sym201__, "lcm_sym201__",
-                          stan::model::index_min_max(1, lcm_sym205__))))) +
+                        stan::model::rvalue(lcm_sym198__, "lcm_sym198__",
+                          stan::model::index_min_max(1, lcm_sym202__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::math::prod(
                         stan::model::rvalue(phi, "phi",
                           stan::model::index_uni(
                             inline_jolly_seber_lp_i_sym35__),
-                          stan::model::index_min_max(1, lcm_sym205__))))) +
+                          stan::model::index_min_max(1, lcm_sym202__))))) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_i_sym35__),
-                        stan::model::index_uni(lcm_sym251__)))),
+                        stan::model::index_uni(lcm_sym248__)))),
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
                     stan::model::index_uni(1));
                   current_statement__ = 95;
-                  if (stan::math::logical_gte(lcm_sym205__, 2)) {
+                  if (stan::math::logical_gte(lcm_sym202__, 2)) {
                     current_statement__ = 94;
                     stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                       ((((stan::math::bernoulli_lpmf<false>(1,
                             stan::math::prod(
-                              stan::model::rvalue(lcm_sym200__,
-                                "lcm_sym200__",
+                              stan::model::rvalue(lcm_sym197__,
+                                "lcm_sym197__",
                                 stan::model::index_min_max(1, 1)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::model::rvalue(gamma, "gamma",
                           stan::model::index_uni(2)))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym201__, "lcm_sym201__",
-                            stan::model::index_min_max(2, lcm_sym205__))))) +
+                          stan::model::rvalue(lcm_sym198__, "lcm_sym198__",
+                            stan::model::index_min_max(2, lcm_sym202__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
                           stan::model::rvalue(phi, "phi",
                             stan::model::index_uni(
                               inline_jolly_seber_lp_i_sym35__),
-                            stan::model::index_min_max(2, lcm_sym205__))))) +
+                            stan::model::index_min_max(2, lcm_sym202__))))) +
                       stan::math::bernoulli_lpmf<false>(1,
-                        stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                        stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                           stan::model::index_uni(
                             inline_jolly_seber_lp_i_sym35__),
-                          stan::model::index_uni(lcm_sym251__)))),
+                          stan::model::index_uni(lcm_sym248__)))),
                       "assigning variable inline_jolly_seber_lp_lp_sym33__",
                       stan::model::index_uni(2));
                     for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                         <= lcm_sym205__; ++inline_jolly_seber_lp_t_sym34__) {
+                         <= lcm_sym202__; ++inline_jolly_seber_lp_t_sym34__) {
                       current_statement__ = 94;
                       stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                         ((((stan::math::bernoulli_lpmf<false>(1,
                               stan::math::prod(
-                                stan::model::rvalue(lcm_sym200__,
-                                  "lcm_sym200__",
+                                stan::model::rvalue(lcm_sym197__,
+                                  "lcm_sym197__",
                                   stan::model::index_min_max(1,
                                     (inline_jolly_seber_lp_t_sym34__ - 1)))))
                         +
@@ -22284,9 +21012,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                           gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
-                            stan::model::rvalue(lcm_sym201__, "lcm_sym201__",
+                            stan::model::rvalue(lcm_sym198__, "lcm_sym198__",
                               stan::model::index_min_max(
-                                inline_jolly_seber_lp_t_sym34__, lcm_sym205__)))))
+                                inline_jolly_seber_lp_t_sym34__, lcm_sym202__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
                           stan::math::prod(
@@ -22294,13 +21022,13 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                               stan::model::index_uni(
                                 inline_jolly_seber_lp_i_sym35__),
                               stan::model::index_min_max(
-                                inline_jolly_seber_lp_t_sym34__, lcm_sym205__)))))
+                                inline_jolly_seber_lp_t_sym34__, lcm_sym202__)))))
                         +
                         stan::math::bernoulli_lpmf<false>(1,
-                          stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                          stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                             stan::model::index_uni(
                               inline_jolly_seber_lp_i_sym35__),
-                            stan::model::index_uni(lcm_sym251__)))),
+                            stan::model::index_uni(lcm_sym248__)))),
                         "assigning variable inline_jolly_seber_lp_lp_sym33__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_t_sym34__));
@@ -22310,45 +21038,45 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     ((stan::math::bernoulli_lpmf<false>(1,
                         stan::math::prod(
-                          stan::model::rvalue(lcm_sym200__, "lcm_sym200__",
-                            stan::model::index_min_max(1, lcm_sym205__)))) +
-                    stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym251__
+                          stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
+                            stan::model::index_min_max(1, lcm_sym202__)))) +
+                    stan::math::bernoulli_lpmf<false>(1, gamma[(lcm_sym248__
                       - 1)])) +
                     stan::math::bernoulli_lpmf<false>(1,
-                      stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_i_sym35__),
-                        stan::model::index_uni(lcm_sym251__)))),
+                        stan::model::index_uni(lcm_sym248__)))),
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                    stan::model::index_uni(lcm_sym251__));
+                    stan::model::index_uni(lcm_sym248__));
                   current_statement__ = 97;
                   lp_accum__.add(stan::math::log_sum_exp(
                                    inline_jolly_seber_lp_lp_sym33__));
                 }
-                lcm_sym253__ = last[(inline_jolly_seber_lp_i_sym35__ - 1)];
-                if (stan::math::logical_gte(lcm_sym253__, (lcm_sym251__ + 1))) {
+                lcm_sym250__ = last[(inline_jolly_seber_lp_i_sym35__ - 1)];
+                if (stan::math::logical_gte(lcm_sym250__, (lcm_sym248__ + 1))) {
                   current_statement__ = 102;
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                    stan::model::rvalue(phi, "phi",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
-                                     stan::model::index_uni(((lcm_sym251__ +
+                                     stan::model::index_uni(((lcm_sym248__ +
                                        1) - 1)))));
-                  lcm_sym223__ = ((lcm_sym251__ + 1) + 1);
+                  lcm_sym220__ = ((lcm_sym248__ + 1) + 1);
                   lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(
                                    stan::model::rvalue(y, "y",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
-                                     stan::model::index_uni((lcm_sym251__ +
+                                     stan::model::index_uni((lcm_sym248__ +
                                        1))),
-                                   stan::model::rvalue(lcm_sym248__,
-                                     "lcm_sym248__",
+                                   stan::model::rvalue(lcm_sym245__,
+                                     "lcm_sym245__",
                                      stan::model::index_uni(
                                        inline_jolly_seber_lp_i_sym35__),
-                                     stan::model::index_uni((lcm_sym251__ +
+                                     stan::model::index_uni((lcm_sym248__ +
                                        1)))));
-                  for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym223__; inline_jolly_seber_lp_t_sym34__
-                       <= lcm_sym253__; ++inline_jolly_seber_lp_t_sym34__) {
+                  for (int inline_jolly_seber_lp_t_sym34__ = lcm_sym220__; inline_jolly_seber_lp_t_sym34__
+                       <= lcm_sym250__; ++inline_jolly_seber_lp_t_sym34__) {
                     current_statement__ = 102;
                     lp_accum__.add(stan::math::bernoulli_lpmf<propto__>(1,
                                      stan::model::rvalue(phi, "phi",
@@ -22362,8 +21090,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                      y[(inline_jolly_seber_lp_i_sym35__ -
                                      1)][(inline_jolly_seber_lp_t_sym34__ -
                                      1)],
-                                     stan::model::rvalue(lcm_sym248__,
-                                       "lcm_sym248__",
+                                     stan::model::rvalue(lcm_sym245__,
+                                       "lcm_sym245__",
                                        stan::model::index_uni(
                                          inline_jolly_seber_lp_i_sym35__),
                                        stan::model::index_uni(
@@ -22377,14 +21105,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                    "inline_prob_uncaptured_return_sym20__",
                                    stan::model::index_uni(
                                      inline_jolly_seber_lp_i_sym35__),
-                                   stan::model::index_uni(lcm_sym253__))));
+                                   stan::model::index_uni(lcm_sym250__))));
               } else {
-                lcm_sym225__ = (lcm_sym256__ + 1);
+                lcm_sym222__ = (lcm_sym253__ + 1);
                 stan::math::validate_non_negative_index("lp",
-                  "n_occasions + 1", lcm_sym225__);
+                  "n_occasions + 1", lcm_sym222__);
                 Eigen::Matrix<local_scalar_t__,-1,1>
                   inline_jolly_seber_lp_lp_sym33__ =
-                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym225__,
+                  Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym222__,
                     DUMMY_VAR__);
                 current_statement__ = 86;
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
@@ -22392,7 +21120,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(1))) +
                   stan::math::bernoulli_lpmf<false>(0,
-                    stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                    stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                       stan::model::index_uni(inline_jolly_seber_lp_i_sym35__),
                       stan::model::index_uni(1)))) +
                   stan::math::bernoulli_lpmf<false>(1,
@@ -22404,18 +21132,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
                   stan::model::index_uni(1));
                 current_statement__ = 88;
-                if (stan::math::logical_gte(lcm_sym256__, 2)) {
+                if (stan::math::logical_gte(lcm_sym253__, 2)) {
                   current_statement__ = 87;
                   stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                     (((stan::math::bernoulli_lpmf<false>(1,
                          stan::math::prod(
-                           stan::model::rvalue(lcm_sym200__, "lcm_sym200__",
+                           stan::model::rvalue(lcm_sym197__, "lcm_sym197__",
                              stan::model::index_min_max(1, 1)))) +
                     stan::math::bernoulli_lpmf<false>(1,
                       stan::model::rvalue(gamma, "gamma",
                         stan::model::index_uni(2)))) +
                     stan::math::bernoulli_lpmf<false>(0,
-                      stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                      stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                         stan::model::index_uni(
                           inline_jolly_seber_lp_i_sym35__),
                         stan::model::index_uni(2)))) +
@@ -22429,19 +21157,19 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     "assigning variable inline_jolly_seber_lp_lp_sym33__",
                     stan::model::index_uni(2));
                   for (int inline_jolly_seber_lp_t_sym34__ = 3; inline_jolly_seber_lp_t_sym34__
-                       <= lcm_sym256__; ++inline_jolly_seber_lp_t_sym34__) {
+                       <= lcm_sym253__; ++inline_jolly_seber_lp_t_sym34__) {
                     current_statement__ = 87;
                     stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                       (((stan::math::bernoulli_lpmf<false>(1,
                            stan::math::prod(
-                             stan::model::rvalue(lcm_sym200__,
-                               "lcm_sym200__",
+                             stan::model::rvalue(lcm_sym197__,
+                               "lcm_sym197__",
                                stan::model::index_min_max(1,
                                  (inline_jolly_seber_lp_t_sym34__ - 1))))) +
                       stan::math::bernoulli_lpmf<false>(1,
                         gamma[(inline_jolly_seber_lp_t_sym34__ - 1)])) +
                       stan::math::bernoulli_lpmf<false>(0,
-                        stan::model::rvalue(lcm_sym248__, "lcm_sym248__",
+                        stan::model::rvalue(lcm_sym245__, "lcm_sym245__",
                           stan::model::index_uni(
                             inline_jolly_seber_lp_i_sym35__),
                           stan::model::index_uni(
@@ -22461,9 +21189,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                 current_statement__ = 89;
                 stan::model::assign(inline_jolly_seber_lp_lp_sym33__,
                   stan::math::bernoulli_lpmf<false>(1,
-                    stan::math::prod(lcm_sym200__)),
+                    stan::math::prod(lcm_sym197__)),
                   "assigning variable inline_jolly_seber_lp_lp_sym33__",
-                  stan::model::index_uni(lcm_sym225__));
+                  stan::model::index_uni(lcm_sym222__));
                 current_statement__ = 90;
                 lp_accum__.add(stan::math::log_sum_exp(
                                  inline_jolly_seber_lp_lp_sym33__));
@@ -22509,67 +21237,67 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym186__;
-      int lcm_sym185__;
-      int lcm_sym184__;
-      int lcm_sym183__;
+      double lcm_sym183__;
       int lcm_sym182__;
       int lcm_sym181__;
       int lcm_sym180__;
-      double lcm_sym151__;
+      int lcm_sym179__;
       int lcm_sym178__;
       int lcm_sym177__;
-      int lcm_sym176__;
+      double lcm_sym148__;
       int lcm_sym175__;
       int lcm_sym174__;
       int lcm_sym173__;
-      double lcm_sym172__;
+      int lcm_sym172__;
       int lcm_sym171__;
-      double lcm_sym170__;
-      int lcm_sym169__;
+      int lcm_sym170__;
+      double lcm_sym169__;
       int lcm_sym168__;
-      int lcm_sym167__;
+      double lcm_sym167__;
       int lcm_sym166__;
-      Eigen::Matrix<double,-1,-1> lcm_sym165__;
-      std::vector<std::vector<int>> lcm_sym164__;
-      local_scalar_t__ lcm_sym163__;
-      local_scalar_t__ lcm_sym162__;
-      double lcm_sym161__;
-      double lcm_sym160__;
-      double lcm_sym159__;
+      int lcm_sym165__;
+      int lcm_sym164__;
+      int lcm_sym163__;
+      Eigen::Matrix<double,-1,-1> lcm_sym162__;
+      std::vector<std::vector<int>> lcm_sym161__;
+      local_scalar_t__ lcm_sym160__;
+      local_scalar_t__ lcm_sym159__;
       double lcm_sym158__;
       double lcm_sym157__;
       double lcm_sym156__;
       double lcm_sym155__;
       double lcm_sym154__;
-      Eigen::Matrix<double,-1,1> lcm_sym153__;
-      int lcm_sym152__;
-      int lcm_sym146__;
-      int lcm_sym145__;
-      int lcm_sym144__;
+      double lcm_sym153__;
+      double lcm_sym152__;
+      double lcm_sym151__;
+      Eigen::Matrix<double,-1,1> lcm_sym150__;
+      int lcm_sym149__;
       int lcm_sym143__;
-      double lcm_sym142__;
-      double lcm_sym141__;
-      double lcm_sym140__;
-      int lcm_sym139__;
-      int lcm_sym138__;
+      int lcm_sym142__;
+      int lcm_sym141__;
+      int lcm_sym140__;
+      double lcm_sym139__;
+      double lcm_sym138__;
       double lcm_sym137__;
       int lcm_sym136__;
       int lcm_sym135__;
-      int lcm_sym134__;
+      double lcm_sym134__;
       int lcm_sym133__;
       int lcm_sym132__;
       int lcm_sym131__;
-      int lcm_sym179__;
+      int lcm_sym130__;
       int lcm_sym129__;
       int lcm_sym128__;
-      int lcm_sym127__;
+      int lcm_sym176__;
       int lcm_sym126__;
       int lcm_sym125__;
       int lcm_sym124__;
       int lcm_sym123__;
       int lcm_sym122__;
-      Eigen::Matrix<double,-1,1> lcm_sym121__;
+      int lcm_sym121__;
+      int lcm_sym120__;
+      int lcm_sym119__;
+      Eigen::Matrix<double,-1,1> lcm_sym118__;
       double mean_phi;
       current_statement__ = 1;
       mean_phi = in__.template read_constrain_lub<local_scalar_t__,
@@ -22586,15 +21314,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<double,-1,1> epsilon =
         Eigen::Matrix<double,-1,1>::Constant((n_occasions - 1),
           std::numeric_limits<double>::quiet_NaN());
-      lcm_sym179__ = (n_occasions - 1);
+      lcm_sym176__ = (n_occasions - 1);
       epsilon = in__.template read<
-                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym179__);
+                  Eigen::Matrix<local_scalar_t__,-1,1>>(lcm_sym176__);
       double sigma;
       current_statement__ = 5;
       sigma = in__.template read_constrain_lub<local_scalar_t__,
                 jacobian__>(0, 5, lp__);
       Eigen::Matrix<double,-1,-1> phi =
-        Eigen::Matrix<double,-1,-1>::Constant(M, lcm_sym179__,
+        Eigen::Matrix<double,-1,-1>::Constant(M, lcm_sym176__,
           std::numeric_limits<double>::quiet_NaN());
       Eigen::Matrix<double,-1,-1> p =
         Eigen::Matrix<double,-1,-1>::Constant(M, n_occasions,
@@ -22613,180 +21341,180 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         return ;
       }
       current_statement__ = 11;
-      if (stan::math::logical_gte(lcm_sym179__, 1)) {
-        lcm_sym122__ = stan::math::logical_gte(M, 1);
-        if (lcm_sym122__) {
-          lcm_sym163__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
+      if (stan::math::logical_gte(lcm_sym176__, 1)) {
+        lcm_sym119__ = stan::math::logical_gte(M, 1);
+        if (lcm_sym119__) {
+          lcm_sym160__ = stan::math::inv_logit((stan::math::logit(mean_phi) +
                            stan::model::rvalue(epsilon, "epsilon",
                              stan::model::index_uni(1))));
-          stan::model::assign(phi, lcm_sym163__, "assigning variable phi",
+          stan::model::assign(phi, lcm_sym160__, "assigning variable phi",
             stan::model::index_uni(1), stan::model::index_uni(1));
           for (int i = 2; i <= M; ++i) {
             current_statement__ = 9;
-            stan::model::assign(phi, lcm_sym163__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym160__, "assigning variable phi",
               stan::model::index_uni(i), stan::model::index_uni(1));
           }
         }
-        for (int t = 2; t <= lcm_sym179__; ++t) {
+        for (int t = 2; t <= lcm_sym176__; ++t) {
           current_statement__ = 10;
-          if (lcm_sym122__) {
-            lcm_sym162__ = stan::math::inv_logit((stan::math::logit(mean_phi)
+          if (lcm_sym119__) {
+            lcm_sym159__ = stan::math::inv_logit((stan::math::logit(mean_phi)
                              +
                              stan::model::rvalue(epsilon, "epsilon",
                                stan::model::index_uni(t))));
-            stan::model::assign(phi, lcm_sym162__, "assigning variable phi",
+            stan::model::assign(phi, lcm_sym159__, "assigning variable phi",
               stan::model::index_uni(1), stan::model::index_uni(t));
             for (int i = 2; i <= M; ++i) {
               current_statement__ = 9;
-              stan::model::assign(phi, lcm_sym162__,
+              stan::model::assign(phi, lcm_sym159__,
                 "assigning variable phi", stan::model::index_uni(i),
                 stan::model::index_uni(t));
             }
           }
         }
       } else {
-        lcm_sym122__ = stan::math::logical_gte(M, 1);
+        lcm_sym119__ = stan::math::logical_gte(M, 1);
       }
-      stan::model::assign(lcm_sym165__,
+      stan::model::assign(lcm_sym162__,
         stan::math::rep_matrix(mean_p, M, n_occasions),
-        "assigning variable lcm_sym165__");
-      stan::model::assign(p, lcm_sym165__, "assigning variable p");
+        "assigning variable lcm_sym162__");
+      stan::model::assign(p, lcm_sym162__, "assigning variable p");
       Eigen::Matrix<double,-1,-1> inline_prob_uncaptured_return_sym1__;
       {
         int inline_prob_uncaptured_n_ind_sym2__ =
           std::numeric_limits<int>::min();
-        lcm_sym167__ = stan::math::rows(lcm_sym165__);
+        lcm_sym164__ = stan::math::rows(lcm_sym162__);
         int inline_prob_uncaptured_n_occasions_sym3__ =
           std::numeric_limits<int>::min();
-        lcm_sym152__ = stan::math::cols(lcm_sym165__);
+        lcm_sym149__ = stan::math::cols(lcm_sym162__);
         current_statement__ = 14;
-        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym167__);
+        stan::math::validate_non_negative_index("chi", "n_ind", lcm_sym164__);
         current_statement__ = 15;
         stan::math::validate_non_negative_index("chi", "n_occasions",
-          lcm_sym152__);
+          lcm_sym149__);
         Eigen::Matrix<local_scalar_t__,-1,-1>
           inline_prob_uncaptured_chi_sym4__ =
-          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym167__,
-            lcm_sym152__, DUMMY_VAR__);
+          Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(lcm_sym164__,
+            lcm_sym149__, DUMMY_VAR__);
         current_statement__ = 24;
-        if (stan::math::logical_gte(lcm_sym167__, 1)) {
+        if (stan::math::logical_gte(lcm_sym164__, 1)) {
           current_statement__ = 17;
           stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
             "assigning variable inline_prob_uncaptured_chi_sym4__",
-            stan::model::index_uni(1), stan::model::index_uni(lcm_sym152__));
-          lcm_sym134__ = (lcm_sym152__ - 1);
-          lcm_sym126__ = stan::math::logical_gte(lcm_sym134__, 1);
-          if (lcm_sym126__) {
+            stan::model::index_uni(1), stan::model::index_uni(lcm_sym149__));
+          lcm_sym131__ = (lcm_sym149__ - 1);
+          lcm_sym123__ = stan::math::logical_gte(lcm_sym131__, 1);
+          if (lcm_sym123__) {
             int inline_prob_uncaptured_t_curr_sym5__ =
               std::numeric_limits<int>::min();
             int inline_prob_uncaptured_t_next_sym6__ =
               std::numeric_limits<int>::min();
-            lcm_sym139__ = (lcm_sym134__ + 1);
+            lcm_sym136__ = (lcm_sym131__ + 1);
             current_statement__ = 20;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__,
               stan::math::fma(
                 (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                   stan::model::index_uni(lcm_sym134__)) * (1 -
-                stan::model::rvalue(lcm_sym165__, "lcm_sym165__",
+                   stan::model::index_uni(lcm_sym131__)) * (1 -
+                stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym139__)))),
+                  stan::model::index_uni(lcm_sym136__)))),
                 stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                   "inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym139__)), (1 -
+                  stan::model::index_uni(lcm_sym136__)), (1 -
                 stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                  stan::model::index_uni(lcm_sym134__)))),
+                  stan::model::index_uni(lcm_sym131__)))),
               "assigning variable inline_prob_uncaptured_chi_sym4__",
-              stan::model::index_uni(1), stan::model::index_uni(lcm_sym134__));
+              stan::model::index_uni(1), stan::model::index_uni(lcm_sym131__));
             for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                 <= lcm_sym134__; ++inline_prob_uncaptured_t_sym7__) {
+                 <= lcm_sym131__; ++inline_prob_uncaptured_t_sym7__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
-              lcm_sym133__ = (lcm_sym152__ -
+              lcm_sym130__ = (lcm_sym149__ -
                 inline_prob_uncaptured_t_sym7__);
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym138__ = (lcm_sym133__ + 1);
+              lcm_sym135__ = (lcm_sym130__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                     stan::model::index_uni(lcm_sym133__)) * (1 -
-                  stan::model::rvalue(lcm_sym165__, "lcm_sym165__",
+                     stan::model::index_uni(lcm_sym130__)) * (1 -
+                  stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym138__)))),
+                    stan::model::index_uni(lcm_sym135__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym138__)), (1 -
+                    stan::model::index_uni(lcm_sym135__)), (1 -
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(1),
-                    stan::model::index_uni(lcm_sym133__)))),
+                    stan::model::index_uni(lcm_sym130__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(1),
-                stan::model::index_uni(lcm_sym133__));
+                stan::model::index_uni(lcm_sym130__));
             }
           }
           for (int inline_prob_uncaptured_i_sym8__ = 2; inline_prob_uncaptured_i_sym8__
-               <= lcm_sym167__; ++inline_prob_uncaptured_i_sym8__) {
+               <= lcm_sym164__; ++inline_prob_uncaptured_i_sym8__) {
             current_statement__ = 17;
             stan::model::assign(inline_prob_uncaptured_chi_sym4__, 1.0,
               "assigning variable inline_prob_uncaptured_chi_sym4__",
               stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-              stan::model::index_uni(lcm_sym152__));
+              stan::model::index_uni(lcm_sym149__));
             current_statement__ = 22;
-            if (lcm_sym126__) {
+            if (lcm_sym123__) {
               int inline_prob_uncaptured_t_curr_sym5__ =
                 std::numeric_limits<int>::min();
               int inline_prob_uncaptured_t_next_sym6__ =
                 std::numeric_limits<int>::min();
-              lcm_sym139__ = (lcm_sym134__ + 1);
+              lcm_sym136__ = (lcm_sym131__ + 1);
               current_statement__ = 20;
               stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                 stan::math::fma(
                   (stan::model::rvalue(phi, "phi",
                      stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                     stan::model::index_uni(lcm_sym134__)) * (1 -
-                  stan::model::rvalue(lcm_sym165__, "lcm_sym165__",
+                     stan::model::index_uni(lcm_sym131__)) * (1 -
+                  stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym139__)))),
+                    stan::model::index_uni(lcm_sym136__)))),
                   stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                     "inline_prob_uncaptured_chi_sym4__",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym139__)), (1 -
+                    stan::model::index_uni(lcm_sym136__)), (1 -
                   stan::model::rvalue(phi, "phi",
                     stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                    stan::model::index_uni(lcm_sym134__)))),
+                    stan::model::index_uni(lcm_sym131__)))),
                 "assigning variable inline_prob_uncaptured_chi_sym4__",
                 stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                stan::model::index_uni(lcm_sym134__));
+                stan::model::index_uni(lcm_sym131__));
               for (int inline_prob_uncaptured_t_sym7__ = 2; inline_prob_uncaptured_t_sym7__
-                   <= lcm_sym134__; ++inline_prob_uncaptured_t_sym7__) {
+                   <= lcm_sym131__; ++inline_prob_uncaptured_t_sym7__) {
                 int inline_prob_uncaptured_t_curr_sym5__ =
                   std::numeric_limits<int>::min();
-                lcm_sym133__ = (lcm_sym152__ -
+                lcm_sym130__ = (lcm_sym149__ -
                   inline_prob_uncaptured_t_sym7__);
                 int inline_prob_uncaptured_t_next_sym6__ =
                   std::numeric_limits<int>::min();
-                lcm_sym138__ = (lcm_sym133__ + 1);
+                lcm_sym135__ = (lcm_sym130__ + 1);
                 current_statement__ = 20;
                 stan::model::assign(inline_prob_uncaptured_chi_sym4__,
                   stan::math::fma(
                     (stan::model::rvalue(phi, "phi",
                        stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                       stan::model::index_uni(lcm_sym133__)) * (1 -
-                    stan::model::rvalue(lcm_sym165__, "lcm_sym165__",
+                       stan::model::index_uni(lcm_sym130__)) * (1 -
+                    stan::model::rvalue(lcm_sym162__, "lcm_sym162__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym138__)))),
+                      stan::model::index_uni(lcm_sym135__)))),
                     stan::model::rvalue(inline_prob_uncaptured_chi_sym4__,
                       "inline_prob_uncaptured_chi_sym4__",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym138__)), (1 -
+                      stan::model::index_uni(lcm_sym135__)), (1 -
                     stan::model::rvalue(phi, "phi",
                       stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                      stan::model::index_uni(lcm_sym133__)))),
+                      stan::model::index_uni(lcm_sym130__)))),
                   "assigning variable inline_prob_uncaptured_chi_sym4__",
                   stan::model::index_uni(inline_prob_uncaptured_i_sym8__),
-                  stan::model::index_uni(lcm_sym133__));
+                  stan::model::index_uni(lcm_sym130__));
               }
             }
           }
@@ -22803,9 +21531,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 6;
       stan::math::check_less_or_equal(function__, "phi", phi, 1);
       current_statement__ = 7;
-      stan::math::check_greater_or_equal(function__, "p", lcm_sym165__, 0);
+      stan::math::check_greater_or_equal(function__, "p", lcm_sym162__, 0);
       current_statement__ = 7;
-      stan::math::check_less_or_equal(function__, "p", lcm_sym165__, 1);
+      stan::math::check_less_or_equal(function__, "p", lcm_sym162__, 1);
       current_statement__ = 8;
       stan::math::check_greater_or_equal(function__, "chi",
         inline_prob_uncaptured_return_sym1__, 0);
@@ -22814,7 +21542,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         inline_prob_uncaptured_return_sym1__, 1);
       if (emit_transformed_parameters__) {
         out__.write(phi);
-        out__.write(lcm_sym165__);
+        out__.write(lcm_sym162__);
         out__.write(inline_prob_uncaptured_return_sym1__);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -22834,31 +21562,31 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         std::vector<std::vector<int>>(M,
           std::vector<int>(n_occasions, std::numeric_limits<int>::min()));
       current_statement__ = 41;
-      if (lcm_sym122__) {
+      if (lcm_sym119__) {
         int q = std::numeric_limits<int>::min();
         double mu2 = std::numeric_limits<double>::quiet_NaN();
-        lcm_sym151__ = stan::model::rvalue(gamma, "gamma",
+        lcm_sym148__ = stan::model::rvalue(gamma, "gamma",
                          stan::model::index_uni(1));
         stan::model::assign(z,
-          stan::math::bernoulli_rng(lcm_sym151__, base_rng__),
+          stan::math::bernoulli_rng(lcm_sym148__, base_rng__),
           "assigning variable z", stan::model::index_uni(1),
           stan::model::index_uni(1));
-        lcm_sym124__ = stan::math::logical_gte(n_occasions, 2);
-        if (lcm_sym124__) {
-          lcm_sym183__ = stan::model::rvalue(z, "z",
+        lcm_sym121__ = stan::math::logical_gte(n_occasions, 2);
+        if (lcm_sym121__) {
+          lcm_sym180__ = stan::model::rvalue(z, "z",
                            stan::model::index_uni(1),
                            stan::model::index_uni(1));
-          lcm_sym146__ = (1 * (1 - lcm_sym183__));
-          q = lcm_sym146__;
-          lcm_sym160__ = stan::math::fma(
+          lcm_sym143__ = (1 * (1 - lcm_sym180__));
+          q = lcm_sym143__;
+          lcm_sym157__ = stan::math::fma(
                            stan::model::rvalue(phi, "phi",
                              stan::model::index_uni(1),
-                             stan::model::index_uni(1)), lcm_sym183__,
+                             stan::model::index_uni(1)), lcm_sym180__,
                            (stan::model::rvalue(gamma, "gamma",
-                              stan::model::index_uni(2)) * lcm_sym146__));
+                              stan::model::index_uni(2)) * lcm_sym143__));
           current_statement__ = 35;
           stan::model::assign(z,
-            stan::math::bernoulli_rng(lcm_sym160__, base_rng__),
+            stan::math::bernoulli_rng(lcm_sym157__, base_rng__),
             "assigning variable z", stan::model::index_uni(1),
             stan::model::index_uni(2));
           for (int t = 3; t <= n_occasions; ++t) {
@@ -22866,7 +21594,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             q = (q * (1 -
               stan::model::rvalue(z, "z", stan::model::index_uni(1),
                 stan::model::index_uni((t - 1)))));
-            lcm_sym161__ = stan::math::fma(
+            lcm_sym158__ = stan::math::fma(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(1),
                                stan::model::index_uni((t - 1))),
@@ -22877,7 +21605,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                 stan::model::index_uni(t)) * q));
             current_statement__ = 35;
             stan::model::assign(z,
-              stan::math::bernoulli_rng(lcm_sym161__, base_rng__),
+              stan::math::bernoulli_rng(lcm_sym158__, base_rng__),
               "assigning variable z", stan::model::index_uni(1),
               stan::model::index_uni(t));
           }
@@ -22887,16 +21615,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           double mu2 = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 38;
           stan::model::assign(z,
-            stan::math::bernoulli_rng(lcm_sym151__, base_rng__),
+            stan::math::bernoulli_rng(lcm_sym148__, base_rng__),
             "assigning variable z", stan::model::index_uni(i),
             stan::model::index_uni(1));
           current_statement__ = 39;
-          if (lcm_sym124__) {
-            lcm_sym145__ = (1 * (1 -
+          if (lcm_sym121__) {
+            lcm_sym142__ = (1 * (1 -
               stan::model::rvalue(z, "z", stan::model::index_uni(i),
                 stan::model::index_uni(1))));
-            q = lcm_sym145__;
-            lcm_sym158__ = stan::math::fma(
+            q = lcm_sym142__;
+            lcm_sym155__ = stan::math::fma(
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(i),
                                stan::model::index_uni(1)),
@@ -22904,10 +21632,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                stan::model::index_uni(i),
                                stan::model::index_uni(1)),
                              (stan::model::rvalue(gamma, "gamma",
-                                stan::model::index_uni(2)) * lcm_sym145__));
+                                stan::model::index_uni(2)) * lcm_sym142__));
             current_statement__ = 35;
             stan::model::assign(z,
-              stan::math::bernoulli_rng(lcm_sym158__, base_rng__),
+              stan::math::bernoulli_rng(lcm_sym155__, base_rng__),
               "assigning variable z", stan::model::index_uni(i),
               stan::model::index_uni(2));
             for (int t = 3; t <= n_occasions; ++t) {
@@ -22915,7 +21643,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               q = (q * (1 -
                 stan::model::rvalue(z, "z", stan::model::index_uni(i),
                   stan::model::index_uni((t - 1)))));
-              lcm_sym159__ = stan::math::fma(
+              lcm_sym156__ = stan::math::fma(
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(i),
                                  stan::model::index_uni((t - 1))),
@@ -22926,7 +21654,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                   stan::model::index_uni(t)) * q));
               current_statement__ = 35;
               stan::model::assign(z,
-                stan::math::bernoulli_rng(lcm_sym159__, base_rng__),
+                stan::math::bernoulli_rng(lcm_sym156__, base_rng__),
                 "assigning variable z", stan::model::index_uni(i),
                 stan::model::index_uni(t));
             }
@@ -22943,29 +21671,29 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         Eigen::Matrix<double,-1,1> inline_seq_cprob_return_sym10__;
         {
           int inline_seq_cprob_N_sym11__ = std::numeric_limits<int>::min();
-          lcm_sym166__ = stan::math::rows(gamma);
+          lcm_sym163__ = stan::math::rows(gamma);
           current_statement__ = 45;
           stan::math::validate_non_negative_index("log_cprob", "N",
-            lcm_sym166__);
+            lcm_sym163__);
           Eigen::Matrix<local_scalar_t__,-1,1>
             inline_seq_cprob_log_cprob_sym12__ =
-            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym166__,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(lcm_sym163__,
               DUMMY_VAR__);
           local_scalar_t__ inline_seq_cprob_log_residual_prob_sym13__ =
             DUMMY_VAR__;
           current_statement__ = 51;
-          if (stan::math::logical_gte(lcm_sym166__, 1)) {
-            lcm_sym151__ = stan::model::rvalue(gamma, "gamma",
+          if (stan::math::logical_gte(lcm_sym163__, 1)) {
+            lcm_sym148__ = stan::model::rvalue(gamma, "gamma",
                              stan::model::index_uni(1));
             stan::model::assign(inline_seq_cprob_log_cprob_sym12__,
-              (stan::math::log(lcm_sym151__) + 0),
+              (stan::math::log(lcm_sym148__) + 0),
               "assigning variable inline_seq_cprob_log_cprob_sym12__",
               stan::model::index_uni(1));
             current_statement__ = 48;
             inline_seq_cprob_log_residual_prob_sym13__ = (0 +
-              stan::math::log1m(lcm_sym151__));
+              stan::math::log1m(lcm_sym148__));
             for (int inline_seq_cprob_n_sym14__ = 2; inline_seq_cprob_n_sym14__
-                 <= lcm_sym166__; ++inline_seq_cprob_n_sym14__) {
+                 <= lcm_sym163__; ++inline_seq_cprob_n_sym14__) {
               current_statement__ = 49;
               stan::model::assign(inline_seq_cprob_log_cprob_sym12__,
                 (stan::math::log(gamma[(inline_seq_cprob_n_sym14__ - 1)]) +
@@ -23003,27 +21731,27 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         stan::math::validate_non_negative_index("Nalive", "M", M);
         std::vector<int> Nalive =
           std::vector<int>(M, std::numeric_limits<int>::min());
-        lcm_sym170__ = stan::math::square(sigma);
-        sigma2 = lcm_sym170__;
-        lcm_sym172__ = stan::math::sum(inline_seq_cprob_return_sym10__);
-        psi = lcm_sym172__;
+        lcm_sym167__ = stan::math::square(sigma);
+        sigma2 = lcm_sym167__;
+        lcm_sym169__ = stan::math::sum(inline_seq_cprob_return_sym10__);
+        psi = lcm_sym169__;
         current_statement__ = 60;
         stan::model::assign(b,
-          stan::math::divide(inline_seq_cprob_return_sym10__, lcm_sym172__),
+          stan::math::divide(inline_seq_cprob_return_sym10__, lcm_sym169__),
           "assigning variable b");
         current_statement__ = 68;
-        if (lcm_sym122__) {
+        if (lcm_sym119__) {
           int f = std::numeric_limits<int>::min();
           int inline_first_capture_return_sym16__;
           int inline_first_capture_early_ret_check_sym18__;
           inline_first_capture_early_ret_check_sym18__ = 0;
           for (int inline_first_capture_iterator_sym19__ = 1; inline_first_capture_iterator_sym19__
                <= 1; ++inline_first_capture_iterator_sym19__) {
-            lcm_sym169__ = stan::math::size(
+            lcm_sym166__ = stan::math::size(
                              stan::model::rvalue(z, "z",
                                stan::model::index_uni(1)));
             for (int inline_first_capture_k_sym17__ = 1; inline_first_capture_k_sym17__
-                 <= lcm_sym169__; ++inline_first_capture_k_sym17__) {
+                 <= lcm_sym166__; ++inline_first_capture_k_sym17__) {
               current_statement__ = 63;
               if (stan::model::rvalue(z, "z", stan::model::index_uni(1),
                     stan::model::index_uni(inline_first_capture_k_sym17__))) {
@@ -23053,11 +21781,11 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             inline_first_capture_early_ret_check_sym18__ = 0;
             for (int inline_first_capture_iterator_sym19__ = 1; inline_first_capture_iterator_sym19__
                  <= 1; ++inline_first_capture_iterator_sym19__) {
-              lcm_sym168__ = stan::math::size(
+              lcm_sym165__ = stan::math::size(
                                stan::model::rvalue(z, "z",
                                  stan::model::index_uni(i)));
               for (int inline_first_capture_k_sym17__ = 1; inline_first_capture_k_sym17__
-                   <= lcm_sym168__; ++inline_first_capture_k_sym17__) {
+                   <= lcm_sym165__; ++inline_first_capture_k_sym17__) {
                 current_statement__ = 63;
                 if (stan::model::rvalue(z, "z", stan::model::index_uni(i),
                       stan::model::index_uni(inline_first_capture_k_sym17__))) {
@@ -23082,8 +21810,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             }
           }
         }
-        lcm_sym123__ = stan::math::logical_gte(n_occasions, 1);
-        if (lcm_sym123__) {
+        lcm_sym120__ = stan::math::logical_gte(n_occasions, 1);
+        if (lcm_sym120__) {
           current_statement__ = 69;
           stan::model::assign(N,
             stan::math::sum(
@@ -23112,7 +21840,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         }
         current_statement__ = 75;
-        if (lcm_sym122__) {
+        if (lcm_sym119__) {
           current_statement__ = 72;
           stan::model::assign(Nind,
             stan::math::sum(
@@ -23139,14 +21867,14 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         current_statement__ = 76;
         Nsuper = stan::math::sum(Nalive);
       }
-      out__.write(lcm_sym170__);
+      out__.write(lcm_sym167__);
       out__.write(psi);
       out__.write(b);
       out__.write(Nsuper);
       out__.write(N);
       out__.write(B);
-      if (lcm_sym123__) {
-        if (lcm_sym122__) {
+      if (lcm_sym120__) {
+        if (lcm_sym119__) {
           out__.write(stan::model::rvalue(z, "z", stan::model::index_uni(1),
                         stan::model::index_uni(1)));
           for (int sym2__ = 2; sym2__ <= M; ++sym2__) {
@@ -23156,7 +21884,7 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           }
         }
         for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          if (lcm_sym122__) {
+          if (lcm_sym119__) {
             out__.write(stan::model::rvalue(z, "z",
                           stan::model::index_uni(1),
                           stan::model::index_uni(sym1__)));
@@ -23184,8 +21912,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym120__;
-      int lcm_sym118__;
       int lcm_sym117__;
       int pos__;
       pos__ = 1;
@@ -23195,30 +21921,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> gamma =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
-          DUMMY_VAR__);
-      if (stan::math::logical_gte(n_occasions, 1)) {
-        stan::model::assign(gamma, in__.read<local_scalar_t__>(),
-          "assigning variable gamma", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_occasions; ++sym1__) {
-          stan::model::assign(gamma, in__.read<local_scalar_t__>(),
-            "assigning variable gamma", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> gamma;
+      stan::model::assign(gamma,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_occasions),
+        "assigning variable gamma");
       out__.write_free_lub(0, 1, gamma);
-      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant((n_occasions - 1),
-          DUMMY_VAR__);
-      lcm_sym120__ = (n_occasions - 1);
-      if (stan::math::logical_gte(lcm_sym120__, 1)) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= lcm_sym120__; ++sym1__) {
-          stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-            "assigning variable epsilon", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>((n_occasions - 1)),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
@@ -23284,55 +21995,55 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+    for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
       param_names__.emplace_back(std::string() + "gamma" + '.' +
-        std::to_string(sym267__));
+        std::to_string(sym264__));
     }
-    for (int sym267__ = 1; sym267__ <= epsilon_1dim__; ++sym267__) {
+    for (int sym264__ = 1; sym264__ <= epsilon_1dim__; ++sym264__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym267__));
+        std::to_string(sym264__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym267__ = 1; sym267__ <= phi_2dim__; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= phi_2dim__; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "psi");
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym267__));
+          std::to_string(sym264__));
       }
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym267__));
+          std::to_string(sym264__));
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym267__));
+          std::to_string(sym264__));
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
     }
@@ -23343,55 +22054,55 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "mean_phi");
     param_names__.emplace_back(std::string() + "mean_p");
-    for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+    for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
       param_names__.emplace_back(std::string() + "gamma" + '.' +
-        std::to_string(sym267__));
+        std::to_string(sym264__));
     }
-    for (int sym267__ = 1; sym267__ <= epsilon_1dim__; ++sym267__) {
+    for (int sym264__ = 1; sym264__ <= epsilon_1dim__; ++sym264__) {
       param_names__.emplace_back(std::string() + "epsilon" + '.' +
-        std::to_string(sym267__));
+        std::to_string(sym264__));
     }
     param_names__.emplace_back(std::string() + "sigma");
     if (emit_transformed_parameters__) {
-      for (int sym267__ = 1; sym267__ <= phi_2dim__; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= phi_2dim__; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "phi" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "p" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "chi" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
     }
     if (emit_generated_quantities__) {
       param_names__.emplace_back(std::string() + "sigma2");
       param_names__.emplace_back(std::string() + "psi");
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
         param_names__.emplace_back(std::string() + "b" + '.' +
-          std::to_string(sym267__));
+          std::to_string(sym264__));
       }
       param_names__.emplace_back(std::string() + "Nsuper");
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
         param_names__.emplace_back(std::string() + "N" + '.' +
-          std::to_string(sym267__));
+          std::to_string(sym264__));
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
         param_names__.emplace_back(std::string() + "B" + '.' +
-          std::to_string(sym267__));
+          std::to_string(sym264__));
       }
-      for (int sym267__ = 1; sym267__ <= n_occasions; ++sym267__) {
-        for (int sym268__ = 1; sym268__ <= M; ++sym268__) {
+      for (int sym264__ = 1; sym264__ <= n_occasions; ++sym264__) {
+        for (int sym265__ = 1; sym265__ <= M; ++sym265__) {
           param_names__.emplace_back(std::string() + "z" + '.' +
-            std::to_string(sym268__) + '.' + std::to_string(sym267__));
+            std::to_string(sym265__) + '.' + std::to_string(sym264__));
         }
       }
     }
@@ -27170,14 +25881,14 @@ static constexpr std::array<const char*, 35> locations_array__ =
   " (in 'off-small.stan', line 22, column 9 to column 10)"};
 class off_small_model final : public model_base_crtp<off_small_model> {
  private:
-  double lcm_sym27__;
   double lcm_sym26__;
   double lcm_sym25__;
   double lcm_sym24__;
   double lcm_sym23__;
   double lcm_sym22__;
-  int lcm_sym21__;
+  double lcm_sym21__;
   int lcm_sym20__;
+  int lcm_sym19__;
   int J;
   int N;
   std::vector<int> person;
@@ -27251,8 +25962,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         time_flat__ = context__.vals_r("time");
         current_statement__ = 25;
         pos__ = 1;
-        lcm_sym20__ = stan::math::logical_gte(N, 1);
-        if (lcm_sym20__) {
+        lcm_sym19__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym19__) {
           current_statement__ = 25;
           stan::model::assign(time,
             stan::model::rvalue(time_flat__, "time_flat__",
@@ -27285,7 +25996,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         current_statement__ = 27;
         pos__ = 1;
         current_statement__ = 27;
-        if (lcm_sym20__) {
+        if (lcm_sym19__) {
           current_statement__ = 27;
           stan::model::assign(treatment,
             stan::model::rvalue(treatment_flat__, "treatment_flat__",
@@ -27317,7 +26028,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         current_statement__ = 29;
         pos__ = 1;
         current_statement__ = 29;
-        if (lcm_sym20__) {
+        if (lcm_sym19__) {
           current_statement__ = 29;
           stan::model::assign(y,
             stan::model::rvalue(y_flat__, "y_flat__",
@@ -27376,17 +26087,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym19__;
       double lcm_sym18__;
       double lcm_sym17__;
       double lcm_sym16__;
       double lcm_sym15__;
       double lcm_sym14__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym13__;
-      double lcm_sym12__;
+      double lcm_sym13__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym12__;
       double lcm_sym11__;
-      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym10__;
-      int lcm_sym9__;
+      double lcm_sym10__;
+      Eigen::Matrix<local_scalar_t__,-1,1> lcm_sym9__;
+      int lcm_sym8__;
       local_scalar_t__ beta;
       current_statement__ = 1;
       beta = in__.template read<local_scalar_t__>();
@@ -27420,20 +26131,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
       Eigen::Matrix<local_scalar_t__,-1,1> y_hat =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      stan::model::assign(lcm_sym13__,
+      stan::model::assign(lcm_sym12__,
         stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable lcm_sym13__");
-      stan::model::assign(a1, lcm_sym13__, "assigning variable a1");
-      stan::model::assign(lcm_sym10__,
+        "assigning variable lcm_sym12__");
+      stan::model::assign(a1, lcm_sym12__, "assigning variable a1");
+      stan::model::assign(lcm_sym9__,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
-        "assigning variable lcm_sym10__");
-      stan::model::assign(a2, lcm_sym10__, "assigning variable a2");
+        "assigning variable lcm_sym9__");
+      stan::model::assign(a2, lcm_sym9__, "assigning variable a2");
       current_statement__ = 13;
       if (stan::math::logical_gte(N, 1)) {
         current_statement__ = 12;
         stan::model::assign(y_hat,
           stan::math::fma(
-            stan::model::rvalue(lcm_sym10__, "lcm_sym10__",
+            stan::model::rvalue(lcm_sym9__, "lcm_sym9__",
               stan::model::index_uni(
                 stan::model::rvalue(person, "person",
                   stan::model::index_uni(1)))),
@@ -27442,7 +26153,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
               stan::model::rvalue(time, "time", stan::model::index_uni(1))),
               stan::model::rvalue(treatment, "treatment",
                 stan::model::index_uni(1)),
-              stan::model::rvalue(lcm_sym13__, "lcm_sym13__",
+              stan::model::rvalue(lcm_sym12__, "lcm_sym12__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(1)))))),
@@ -27451,7 +26162,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
           current_statement__ = 12;
           stan::model::assign(y_hat,
             stan::math::fma(
-              stan::model::rvalue(lcm_sym10__, "lcm_sym10__",
+              stan::model::rvalue(lcm_sym9__, "lcm_sym9__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(i)))),
@@ -27460,7 +26171,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                 stan::model::rvalue(time, "time", stan::model::index_uni(i))),
                 stan::model::rvalue(treatment, "treatment",
                   stan::model::index_uni(i)),
-                stan::model::rvalue(lcm_sym13__, "lcm_sym13__",
+                stan::model::rvalue(lcm_sym12__, "lcm_sym12__",
                   stan::model::index_uni(
                     stan::model::rvalue(person, "person",
                       stan::model::index_uni(i)))))),
@@ -27518,13 +26229,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      Eigen::Matrix<double,-1,1> lcm_sym8__;
-      double lcm_sym7__;
+      Eigen::Matrix<double,-1,1> lcm_sym7__;
       double lcm_sym6__;
-      Eigen::Matrix<double,-1,1> lcm_sym5__;
-      int lcm_sym4__;
+      double lcm_sym5__;
+      Eigen::Matrix<double,-1,1> lcm_sym4__;
       int lcm_sym3__;
       int lcm_sym2__;
+      int lcm_sym1__;
       double beta;
       current_statement__ = 1;
       beta = in__.template read<local_scalar_t__>();
@@ -27574,20 +26285,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
             stan::math::primitive_value(emit_generated_quantities__)))) {
         return ;
       }
-      stan::model::assign(lcm_sym8__,
+      stan::model::assign(lcm_sym7__,
         stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable lcm_sym8__");
-      stan::model::assign(a1, lcm_sym8__, "assigning variable a1");
-      stan::model::assign(lcm_sym5__,
+        "assigning variable lcm_sym7__");
+      stan::model::assign(a1, lcm_sym7__, "assigning variable a1");
+      stan::model::assign(lcm_sym4__,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
-        "assigning variable lcm_sym5__");
-      stan::model::assign(a2, lcm_sym5__, "assigning variable a2");
+        "assigning variable lcm_sym4__");
+      stan::model::assign(a2, lcm_sym4__, "assigning variable a2");
       current_statement__ = 13;
       if (stan::math::logical_gte(N, 1)) {
         current_statement__ = 12;
         stan::model::assign(y_hat,
           stan::math::fma(
-            stan::model::rvalue(lcm_sym5__, "lcm_sym5__",
+            stan::model::rvalue(lcm_sym4__, "lcm_sym4__",
               stan::model::index_uni(
                 stan::model::rvalue(person, "person",
                   stan::model::index_uni(1)))),
@@ -27596,7 +26307,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
               stan::model::rvalue(time, "time", stan::model::index_uni(1))),
               stan::model::rvalue(treatment, "treatment",
                 stan::model::index_uni(1)),
-              stan::model::rvalue(lcm_sym8__, "lcm_sym8__",
+              stan::model::rvalue(lcm_sym7__, "lcm_sym7__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(1)))))),
@@ -27605,7 +26316,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
           current_statement__ = 12;
           stan::model::assign(y_hat,
             stan::math::fma(
-              stan::model::rvalue(lcm_sym5__, "lcm_sym5__",
+              stan::model::rvalue(lcm_sym4__, "lcm_sym4__",
                 stan::model::index_uni(
                   stan::model::rvalue(person, "person",
                     stan::model::index_uni(i)))),
@@ -27614,7 +26325,7 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                 stan::model::rvalue(time, "time", stan::model::index_uni(i))),
                 stan::model::rvalue(treatment, "treatment",
                   stan::model::index_uni(i)),
-                stan::model::rvalue(lcm_sym8__, "lcm_sym8__",
+                stan::model::rvalue(lcm_sym7__, "lcm_sym7__",
                   stan::model::index_uni(
                     stan::model::rvalue(person, "person",
                       stan::model::index_uni(i)))))),
@@ -27622,8 +26333,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         }
       }
       if (emit_transformed_parameters__) {
-        out__.write(lcm_sym8__);
-        out__.write(lcm_sym5__);
+        out__.write(lcm_sym7__);
+        out__.write(lcm_sym4__);
         out__.write(y_hat);
       }
       if (stan::math::logical_negation(emit_generated_quantities__)) {
@@ -27647,34 +26358,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
       local_scalar_t__ beta;
       beta = in__.read<local_scalar_t__>();
       out__.write(beta);
-      Eigen::Matrix<local_scalar_t__,-1,1> eta1 =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      lcm_sym1__ = stan::math::logical_gte(J, 1);
-      if (lcm_sym1__) {
-        stan::model::assign(eta1, in__.read<local_scalar_t__>(),
-          "assigning variable eta1", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
-          stan::model::assign(eta1, in__.read<local_scalar_t__>(),
-            "assigning variable eta1", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> eta1;
+      stan::model::assign(eta1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable eta1");
       out__.write(eta1);
-      Eigen::Matrix<local_scalar_t__,-1,1> eta2 =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      if (lcm_sym1__) {
-        stan::model::assign(eta2, in__.read<local_scalar_t__>(),
-          "assigning variable eta2", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= J; ++sym1__) {
-          stan::model::assign(eta2, in__.read<local_scalar_t__>(),
-            "assigning variable eta2", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> eta2;
+      stan::model::assign(eta2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable eta2");
       out__.write(eta2);
       local_scalar_t__ mu_a1;
       mu_a1 = in__.read<local_scalar_t__>();
@@ -27733,13 +26430,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "beta");
-    for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
       param_names__.emplace_back(std::string() + "eta1" + '.' +
-        std::to_string(sym28__));
+        std::to_string(sym27__));
     }
-    for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
       param_names__.emplace_back(std::string() + "eta2" + '.' +
-        std::to_string(sym28__));
+        std::to_string(sym27__));
     }
     param_names__.emplace_back(std::string() + "mu_a1");
     param_names__.emplace_back(std::string() + "mu_a2");
@@ -27747,17 +26444,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     param_names__.emplace_back(std::string() + "sigma_a2");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
         param_names__.emplace_back(std::string() + "a1" + '.' +
-          std::to_string(sym28__));
+          std::to_string(sym27__));
       }
-      for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
         param_names__.emplace_back(std::string() + "a2" + '.' +
-          std::to_string(sym28__));
+          std::to_string(sym27__));
       }
-      for (int sym28__ = 1; sym28__ <= N; ++sym28__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym28__));
+          std::to_string(sym27__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -27767,13 +26464,13 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
     param_names__.emplace_back(std::string() + "beta");
-    for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
       param_names__.emplace_back(std::string() + "eta1" + '.' +
-        std::to_string(sym28__));
+        std::to_string(sym27__));
     }
-    for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+    for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
       param_names__.emplace_back(std::string() + "eta2" + '.' +
-        std::to_string(sym28__));
+        std::to_string(sym27__));
     }
     param_names__.emplace_back(std::string() + "mu_a1");
     param_names__.emplace_back(std::string() + "mu_a2");
@@ -27781,17 +26478,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     param_names__.emplace_back(std::string() + "sigma_a2");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
         param_names__.emplace_back(std::string() + "a1" + '.' +
-          std::to_string(sym28__));
+          std::to_string(sym27__));
       }
-      for (int sym28__ = 1; sym28__ <= J; ++sym28__) {
+      for (int sym27__ = 1; sym27__ <= J; ++sym27__) {
         param_names__.emplace_back(std::string() + "a2" + '.' +
-          std::to_string(sym28__));
+          std::to_string(sym27__));
       }
-      for (int sym28__ = 1; sym28__ <= N; ++sym28__) {
+      for (int sym27__ = 1; sym27__ <= N; ++sym27__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym28__));
+          std::to_string(sym27__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -28743,76 +27440,20 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       local_scalar_t__ phi;
       phi = in__.read<local_scalar_t__>();
       out__.write(phi);
-      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 2, DUMMY_VAR__);
-      {
-        {
-          stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-            "assigning variable x_matrix", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          {
-            stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-              "assigning variable x_matrix", stan::model::index_uni(2),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-              "assigning variable x_matrix", stan::model::index_uni(3),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-            "assigning variable x_matrix", stan::model::index_uni(1),
-            stan::model::index_uni(2));
-          {
-            stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-              "assigning variable x_matrix", stan::model::index_uni(2),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-              "assigning variable x_matrix", stan::model::index_uni(3),
-              stan::model::index_uni(2));
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix;
+      stan::model::assign(x_matrix,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(3, 2),
+        "assigning variable x_matrix");
       out__.write(x_matrix);
-      Eigen::Matrix<local_scalar_t__,-1,1> x_vector =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      {
-        stan::model::assign(x_vector, in__.read<local_scalar_t__>(),
-          "assigning variable x_vector", stan::model::index_uni(1));
-        {
-          stan::model::assign(x_vector, in__.read<local_scalar_t__>(),
-            "assigning variable x_vector", stan::model::index_uni(2));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> x_vector;
+      stan::model::assign(x_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable x_vector");
       out__.write(x_vector);
-      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
-      {
-        {
-          stan::model::assign(x_cov, in__.read<local_scalar_t__>(),
-            "assigning variable x_cov", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          {
-            stan::model::assign(x_cov, in__.read<local_scalar_t__>(),
-              "assigning variable x_cov", stan::model::index_uni(2),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          stan::model::assign(x_cov, in__.read<local_scalar_t__>(),
-            "assigning variable x_cov", stan::model::index_uni(1),
-            stan::model::index_uni(2));
-          {
-            stan::model::assign(x_cov, in__.read<local_scalar_t__>(),
-              "assigning variable x_cov", stan::model::index_uni(2),
-              stan::model::index_uni(2));
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov;
+      stan::model::assign(x_cov,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
+        "assigning variable x_cov");
       out__.write_free_cov_matrix(x_cov);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -29695,14 +28336,14 @@ static constexpr std::array<const char*, 28> locations_array__ =
   " (in 'partial-eval.stan', line 17, column 9 to column 10)"};
 class partial_eval_model final : public model_base_crtp<partial_eval_model> {
  private:
-  double lcm_sym24__;
   double lcm_sym23__;
   double lcm_sym22__;
   double lcm_sym21__;
   double lcm_sym20__;
   double lcm_sym19__;
-  int lcm_sym18__;
+  double lcm_sym18__;
   int lcm_sym17__;
+  int lcm_sym16__;
   int N;
   int n_pair;
   std::vector<int> pair;
@@ -29776,8 +28417,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         pre_test_flat__ = context__.vals_r("pre_test");
         current_statement__ = 21;
         pos__ = 1;
-        lcm_sym17__ = stan::math::logical_gte(N, 1);
-        if (lcm_sym17__) {
+        lcm_sym16__ = stan::math::logical_gte(N, 1);
+        if (lcm_sym16__) {
           current_statement__ = 21;
           stan::model::assign(pre_test,
             stan::model::rvalue(pre_test_flat__, "pre_test_flat__",
@@ -29810,7 +28451,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 23;
         pos__ = 1;
         current_statement__ = 23;
-        if (lcm_sym17__) {
+        if (lcm_sym16__) {
           current_statement__ = 23;
           stan::model::assign(treatment,
             stan::model::rvalue(treatment_flat__, "treatment_flat__",
@@ -29847,7 +28488,7 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         current_statement__ = 25;
         pos__ = 1;
         current_statement__ = 25;
-        if (lcm_sym17__) {
+        if (lcm_sym16__) {
           current_statement__ = 25;
           stan::model::assign(y,
             stan::model::rvalue(y_flat__, "y_flat__",
@@ -29900,16 +28541,16 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      std::complex<double> lcm_sym16__;
       std::complex<double> lcm_sym15__;
-      double lcm_sym14__;
+      std::complex<double> lcm_sym14__;
       double lcm_sym13__;
       double lcm_sym12__;
       double lcm_sym11__;
       double lcm_sym10__;
       double lcm_sym9__;
       double lcm_sym8__;
-      int lcm_sym7__;
+      double lcm_sym7__;
+      int lcm_sym6__;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair);
@@ -29976,15 +28617,15 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
         std::complex<double> z =
           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
             std::numeric_limits<double>::quiet_NaN());
-        lcm_sym16__ = stan::math::to_complex(7, 5);
+        lcm_sym15__ = stan::math::to_complex(7, 5);
         current_statement__ = 14;
         if (pstream__) {
-          stan::math::stan_print(pstream__, lcm_sym16__);
+          stan::math::stan_print(pstream__, lcm_sym15__);
           *(pstream__) << std::endl;
         }
-        lcm_sym15__ = stan::math::to_complex(5, 4);
+        lcm_sym14__ = stan::math::to_complex(5, 4);
         current_statement__ = 15;
-        lp_accum__.add(stan::math::get_real(lcm_sym15__));
+        lp_accum__.add(stan::math::get_real(lcm_sym14__));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -30023,11 +28664,11 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) function__;
     try {
-      double lcm_sym6__;
       double lcm_sym5__;
-      int lcm_sym4__;
+      double lcm_sym4__;
       int lcm_sym3__;
       int lcm_sym2__;
+      int lcm_sym1__;
       Eigen::Matrix<double,-1,1> a;
       current_statement__ = 1;
       a = in__.template read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair);
@@ -30116,30 +28757,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int lcm_sym1__;
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> a =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
-      if (stan::math::logical_gte(n_pair, 1)) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(1));
-        for (int sym1__ = 2; sym1__ <= n_pair; ++sym1__) {
-          stan::model::assign(a, in__.read<local_scalar_t__>(),
-            "assigning variable a", stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> a;
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair),
+        "assigning variable a");
       out__.write(a);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(1));
-        {
-          stan::model::assign(beta, in__.read<local_scalar_t__>(),
-            "assigning variable beta", stan::model::index_uni(2));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable beta");
       out__.write(beta);
       local_scalar_t__ mu_a;
       mu_a = in__.read<local_scalar_t__>();
@@ -30189,21 +28817,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   constrained_param_names(std::vector<std::string>& param_names__, bool
                           emit_transformed_parameters__ = true, bool
                           emit_generated_quantities__ = true) const final {
-    for (int sym25__ = 1; sym25__ <= n_pair; ++sym25__) {
+    for (int sym24__ = 1; sym24__ <= n_pair; ++sym24__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym25__));
+        std::to_string(sym24__));
     }
-    for (int sym25__ = 1; sym25__ <= 2; ++sym25__) {
+    for (int sym24__ = 1; sym24__ <= 2; ++sym24__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym25__));
+        std::to_string(sym24__));
     }
     param_names__.emplace_back(std::string() + "mu_a");
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym25__ = 1; sym25__ <= N; ++sym25__) {
+      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym25__));
+          std::to_string(sym24__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -30212,21 +28840,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   unconstrained_param_names(std::vector<std::string>& param_names__, bool
                             emit_transformed_parameters__ = true, bool
                             emit_generated_quantities__ = true) const final {
-    for (int sym25__ = 1; sym25__ <= n_pair; ++sym25__) {
+    for (int sym24__ = 1; sym24__ <= n_pair; ++sym24__) {
       param_names__.emplace_back(std::string() + "a" + '.' +
-        std::to_string(sym25__));
+        std::to_string(sym24__));
     }
-    for (int sym25__ = 1; sym25__ <= 2; ++sym25__) {
+    for (int sym24__ = 1; sym24__ <= 2; ++sym24__) {
       param_names__.emplace_back(std::string() + "beta" + '.' +
-        std::to_string(sym25__));
+        std::to_string(sym24__));
     }
     param_names__.emplace_back(std::string() + "mu_a");
     param_names__.emplace_back(std::string() + "sigma_a");
     param_names__.emplace_back(std::string() + "sigma_y");
     if (emit_transformed_parameters__) {
-      for (int sym25__ = 1; sym25__ <= N; ++sym25__) {
+      for (int sym24__ = 1; sym24__ <= N; ++sym24__) {
         param_names__.emplace_back(std::string() + "y_hat" + '.' +
-          std::to_string(sym25__));
+          std::to_string(sym24__));
       }
     }
     if (emit_generated_quantities__) {}
@@ -32175,1015 +30803,15 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      {
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(2));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(2));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(3));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(3));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(4));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(4));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(5));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(5));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(6));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(6));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(7));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(7));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(8));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(8));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(9));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(9));
-          }
-        }
-        {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(1),
-            stan::model::index_uni(10));
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(2),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(3),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(4),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(5),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(6),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(7),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(8),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(9),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m2, in__.read<local_scalar_t__>(),
-              "assigning variable m2", stan::model::index_uni(10),
-              stan::model::index_uni(10));
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> m2;
+      stan::model::assign(m2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable m2");
       out__.write(m2);
-      Eigen::Matrix<local_scalar_t__,-1,-1> m3 =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      {
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(1));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(2));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(2));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(2));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(3));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(3));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(3));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(4));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(4));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(4));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(5));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(5));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(5));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(6));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(6));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(6));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(7));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(7));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(7));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(8));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(8));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(8));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(9));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(9));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(9));
-          }
-        }
-        {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(1),
-            stan::model::index_uni(10));
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(2),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(3),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(4),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(5),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(6),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(7),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(8),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(9),
-              stan::model::index_uni(10));
-          }
-          {
-            stan::model::assign(m3, in__.read<local_scalar_t__>(),
-              "assigning variable m3", stan::model::index_uni(10),
-              stan::model::index_uni(10));
-          }
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> m3;
+      stan::model::assign(m3,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable m3");
       out__.write(m3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -33901,101 +31529,14 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(8, DUMMY_VAR__));
-      {
-        lcm_sym1__ = stan::math::logical_gte(I, 1);
-        if (lcm_sym1__) {
-          stan::model::assign(b, in__.read<local_scalar_t__>(),
-            "assigning variable b", stan::model::index_uni(1),
-            stan::model::index_uni(1));
-          for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(sym2__),
-              stan::model::index_uni(1));
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(2));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(2));
-            }
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(3));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(3));
-            }
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(4));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(4));
-            }
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(5));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(5));
-            }
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(6));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(6));
-            }
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(7));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(7));
-            }
-          }
-        }
-        {
-          if (lcm_sym1__) {
-            stan::model::assign(b, in__.read<local_scalar_t__>(),
-              "assigning variable b", stan::model::index_uni(1),
-              stan::model::index_uni(8));
-            for (int sym2__ = 2; sym2__ <= I; ++sym2__) {
-              stan::model::assign(b, in__.read<local_scalar_t__>(),
-                "assigning variable b", stan::model::index_uni(sym2__),
-                stan::model::index_uni(8));
-            }
-          }
+      if (stan::math::logical_gte(I, 1)) {
+        stan::model::assign(b,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(8),
+          "assigning variable b", stan::model::index_uni(1));
+        for (int sym1__ = 2; sym1__ <= I; ++sym1__) {
+          stan::model::assign(b,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(8),
+            "assigning variable b", stan::model::index_uni(sym1__));
         }
       }
       out__.write(b);

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -4819,9 +4819,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       out__.write_free_ordered(mu);
       std::vector<local_scalar_t__> sigma =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        sigma[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(sigma, in__.read<std::vector<local_scalar_t__>>(2),
+        "assigning variable sigma");
       out__.write_free_lb(0, sigma);
       local_scalar_t__ theta = DUMMY_VAR__;
       theta = in__.read<local_scalar_t__>();
@@ -5228,9 +5227,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       out__.write(mu);
       std::vector<local_scalar_t__> theta =
         std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
+        "assigning variable theta");
       out__.write(theta);
       local_scalar_t__ tau = DUMMY_VAR__;
       tau = in__.read<local_scalar_t__>();
@@ -9982,11 +9980,12 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= J; ++sym2__) {
-          stan::model::assign(theta,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-            "assigning variable theta", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
+            stan::model::assign(theta, in__.read<local_scalar_t__>(),
+              "assigning variable theta", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write_free_simplex(theta);
@@ -16008,9 +16007,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       pos__ = 1;
       std::vector<local_scalar_t__> theta =
         std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
+        "assigning variable theta");
       out__.write(theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21967,10 +21965,12 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
-        stan::model::assign(b,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-          "assigning variable b", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
+          stan::model::assign(b, in__.read<local_scalar_t__>(),
+            "assigning variable b", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(b);
     } catch (const std::exception& e) {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -537,7 +537,18 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1158,7 +1169,18 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1583,7 +1605,18 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1970,7 +2003,18 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2854,7 +2898,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -3855,7 +3910,18 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4165,7 +4231,18 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4471,7 +4548,18 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4902,7 +4990,18 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -5283,7 +5382,18 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -6285,7 +6395,18 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -6958,7 +7079,18 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -7868,7 +8000,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -9379,7 +9522,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -10046,7 +10200,18 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -10635,7 +10800,18 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -11519,7 +11695,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -11873,7 +12060,18 @@ class function_in_function_inline_model final : public model_base_crtp<function_
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12247,7 +12445,18 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12734,7 +12943,18 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -13076,7 +13296,18 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -13450,7 +13681,18 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -14925,7 +15167,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -15232,7 +15485,18 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -15544,7 +15808,18 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -15873,7 +16148,18 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -16673,7 +16959,18 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -17089,7 +17386,18 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -17779,7 +18087,18 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -18505,7 +18824,18 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19423,7 +19753,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19739,7 +20080,18 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -20085,7 +20437,18 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -20709,7 +21072,18 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21183,7 +21557,18 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21782,7 +22167,18 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22155,7 +22551,18 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22536,7 +22943,18 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22864,7 +23282,18 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -266,13 +266,9 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1342,13 +1338,9 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1748,13 +1740,9 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(X, in__.read<local_scalar_t__>(),
-            "assigning variable X", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(X,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable X");
       out__.write(X);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2559,10 +2547,9 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       out__.write_free_lub(0, 1, mean_p);
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
+        "assigning variable beta");
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3405,42 +3392,34 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       out__.write(b_v_prev);
       Eigen::Matrix<local_scalar_t__,-1,1> b_age =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
-        stan::model::assign(b_age, in__.read<local_scalar_t__>(),
-          "assigning variable b_age", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b_age,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age),
+        "assigning variable b_age");
       out__.write(b_age);
       Eigen::Matrix<local_scalar_t__,-1,1> b_edu =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
-        stan::model::assign(b_edu, in__.read<local_scalar_t__>(),
-          "assigning variable b_edu", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b_edu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_edu),
+        "assigning variable b_edu");
       out__.write(b_edu);
       Eigen::Matrix<local_scalar_t__,-1,1> b_region =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_region; ++sym1__) {
-        stan::model::assign(b_region, in__.read<local_scalar_t__>(),
-          "assigning variable b_region", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b_region,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_region),
+        "assigning variable b_region");
       out__.write(b_region);
       Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_age, n_edu,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n_age; ++sym2__) {
-          stan::model::assign(b_age_edu, in__.read<local_scalar_t__>(),
-            "assigning variable b_age_edu", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(b_age_edu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n_age, n_edu),
+        "assigning variable b_age_edu");
       out__.write(b_age_edu);
       Eigen::Matrix<local_scalar_t__,-1,1> b_hat =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
-        stan::model::assign(b_hat, in__.read<local_scalar_t__>(),
-          "assigning variable b_hat", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b_hat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
+        "assigning variable b_hat");
       out__.write(b_hat);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4495,10 +4474,9 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> mu =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(mu, in__.read<local_scalar_t__>(),
-          "assigning variable mu", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(mu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable mu");
       out__.write_free_ordered(mu);
       std::vector<local_scalar_t__> sigma =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
@@ -5647,47 +5625,41 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age),
+        "assigning variable a");
       out__.write(a);
       Eigen::Matrix<local_scalar_t__,-1,1> b =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
-        stan::model::assign(b, in__.read<local_scalar_t__>(),
-          "assigning variable b", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_edu),
+        "assigning variable b");
       out__.write(b);
       Eigen::Matrix<local_scalar_t__,-1,1> c =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age_edu,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_age_edu; ++sym1__) {
-        stan::model::assign(c, in__.read<local_scalar_t__>(),
-          "assigning variable c", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(c,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age_edu),
+        "assigning variable c");
       out__.write(c);
       Eigen::Matrix<local_scalar_t__,-1,1> d =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
-        stan::model::assign(d, in__.read<local_scalar_t__>(),
-          "assigning variable d", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(d,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
+        "assigning variable d");
       out__.write(d);
       Eigen::Matrix<local_scalar_t__,-1,1> e =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region_full,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_region_full; ++sym1__) {
-        stan::model::assign(e, in__.read<local_scalar_t__>(),
-          "assigning variable e", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(e,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_region_full),
+        "assigning variable e");
       out__.write(e);
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable beta");
       out__.write(beta);
       local_scalar_t__ sigma_a = DUMMY_VAR__;
       sigma_a = in__.read<local_scalar_t__>();
@@ -6347,10 +6319,9 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(phi_std_raw_1dim__,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= phi_std_raw_1dim__; ++sym1__) {
-        stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-          "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(phi_std_raw,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(phi_std_raw_1dim__),
+        "assigning variable phi_std_raw");
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7231,10 +7202,9 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       out__.write_free_lub(0, 1, mean_p);
       Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(nind, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= nind; ++sym1__) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(nind),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
@@ -8623,17 +8593,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_occasions),
+        "assigning variable beta");
       out__.write_free_lb(0, beta);
       Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
@@ -9345,22 +9313,20 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> pi =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        stan::model::assign(pi, in__.read<local_scalar_t__>(),
-          "assigning variable pi", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(pi,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+        "assigning variable pi");
       out__.write_free_simplex(pi);
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> theta =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
-            stan::model::assign(theta, in__.read<local_scalar_t__>(),
-              "assigning variable theta", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+        for (int sym2__ = 1; sym2__ <= J; ++sym2__) {
+          stan::model::assign(theta,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+            "assigning variable theta", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write_free_simplex(theta);
@@ -9897,17 +9863,15 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       out__.write_free_lb(0, tau_phi);
       Eigen::Matrix<local_scalar_t__,-1,1> theta_std =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(theta_std, in__.read<local_scalar_t__>(),
-          "assigning variable theta_std", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(theta_std,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable theta_std");
       out__.write(theta_std);
       Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-          "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(phi_std_raw,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable phi_std_raw");
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10752,10 +10716,9 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       out__.write_free_lub(0, 1, mean_p);
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
+        "assigning variable beta");
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11922,19 +11885,15 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(p_single_ret_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_single_ret_vec",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_single_ret_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable p_single_ret_vec");
       out__.write(p_single_ret_vec);
       Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_multi_ret_vec",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_multi_ret_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable p_multi_ret_vec");
       out__.write(p_multi_ret_vec);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13943,18 +13902,16 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       Eigen::Matrix<local_scalar_t__,-1,1> gamma =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
-        stan::model::assign(gamma, in__.read<local_scalar_t__>(),
-          "assigning variable gamma", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(gamma,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_occasions),
+        "assigning variable gamma");
       out__.write_free_lub(0, 1, gamma);
       Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(epsilon_1dim__,
           DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= epsilon_1dim__; ++sym1__) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(epsilon_1dim__),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
@@ -17449,17 +17406,15 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       out__.write(beta);
       Eigen::Matrix<local_scalar_t__,-1,1> eta1 =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        stan::model::assign(eta1, in__.read<local_scalar_t__>(),
-          "assigning variable eta1", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(eta1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable eta1");
       out__.write(eta1);
       Eigen::Matrix<local_scalar_t__,-1,1> eta2 =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        stan::model::assign(eta2, in__.read<local_scalar_t__>(),
-          "assigning variable eta2", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(eta2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable eta2");
       out__.write(eta2);
       local_scalar_t__ mu_a1 = DUMMY_VAR__;
       mu_a1 = in__.read<local_scalar_t__>();
@@ -18352,30 +18307,21 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       out__.write(phi);
       Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-          stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-            "assigning variable x_matrix", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(x_matrix,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(3, 2),
+        "assigning variable x_matrix");
       out__.write(x_matrix);
       Eigen::Matrix<local_scalar_t__,-1,1> x_vector =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(x_vector, in__.read<local_scalar_t__>(),
-          "assigning variable x_vector", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(x_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable x_vector");
       out__.write(x_vector);
       Eigen::Matrix<local_scalar_t__,-1,-1> x_cov =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-          stan::model::assign(x_cov, in__.read<local_scalar_t__>(),
-            "assigning variable x_cov", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(x_cov,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
+        "assigning variable x_cov");
       out__.write_free_cov_matrix(x_cov);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19575,17 +19521,15 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_pair; ++sym1__) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair),
+        "assigning variable a");
       out__.write(a);
       Eigen::Matrix<local_scalar_t__,-1,1> beta =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable beta");
       out__.write(beta);
       local_scalar_t__ mu_a = DUMMY_VAR__;
       mu_a = in__.read<local_scalar_t__>();
@@ -20038,23 +19982,15 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(m2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable m2");
       out__.write(m2);
       Eigen::Matrix<local_scalar_t__,-1,-1> m3 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(m3,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable m3");
       out__.write(m3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20598,12 +20534,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
-          stan::model::assign(b, in__.read<local_scalar_t__>(),
-            "assigning variable b", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+      for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
+        stan::model::assign(b,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+          "assigning variable b", stan::model::index_uni(sym1__));
       }
       out__.write(b);
     } catch (const std::exception& e) {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -252,8 +252,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -269,6 +269,39 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -496,24 +529,17 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -939,8 +965,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -962,6 +988,35 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       out__.write_free_lb(0, xi);
       local_scalar_t__ delta = DUMMY_VAR__;
       delta = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, delta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ beta = DUMMY_VAR__;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write_free_lb(0, beta);
+      local_scalar_t__ gamma = DUMMY_VAR__;
+      gamma = context__.vals_r("gamma")[(1 - 1)];
+      out__.write_free_lb(0, gamma);
+      local_scalar_t__ xi = DUMMY_VAR__;
+      xi = context__.vals_r("xi")[(1 - 1)];
+      out__.write_free_lb(0, xi);
+      local_scalar_t__ delta = DUMMY_VAR__;
+      delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1095,25 +1150,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"beta", "gamma", "xi", "delta"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1324,8 +1371,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1341,6 +1388,39 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1495,24 +1575,17 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1726,8 +1799,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1743,6 +1816,39 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       stan::model::assign(X,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
         "assigning variable X");
+      out__.write(X);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_flat__;
+        X_flat__ = context__.vals_r("X");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(X, X_flat__[(pos__ - 1)],
+              "assigning variable X", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1856,24 +1962,17 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(N * N)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2530,8 +2629,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -2550,6 +2649,39 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::model::assign(beta,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
         "assigning variable beta");
+      out__.write_free_lub(0, 1, beta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mean_p = DUMMY_VAR__;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2714,24 +2846,17 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3345,8 +3470,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -3420,6 +3545,125 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       stan::model::assign(b_hat,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
         "assigning variable b_hat");
+      out__.write(b_hat);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ sigma_age = DUMMY_VAR__;
+      sigma_age = context__.vals_r("sigma_age")[(1 - 1)];
+      out__.write_free_lb(0, sigma_age);
+      local_scalar_t__ sigma_edu = DUMMY_VAR__;
+      sigma_edu = context__.vals_r("sigma_edu")[(1 - 1)];
+      out__.write_free_lb(0, sigma_edu);
+      local_scalar_t__ sigma_state = DUMMY_VAR__;
+      sigma_state = context__.vals_r("sigma_state")[(1 - 1)];
+      out__.write_free_lb(0, sigma_state);
+      local_scalar_t__ sigma_region = DUMMY_VAR__;
+      sigma_region = context__.vals_r("sigma_region")[(1 - 1)];
+      out__.write_free_lb(0, sigma_region);
+      local_scalar_t__ sigma_age_edu = DUMMY_VAR__;
+      sigma_age_edu = context__.vals_r("sigma_age_edu")[(1 - 1)];
+      out__.write_free_lb(0, sigma_age_edu);
+      local_scalar_t__ b_0 = DUMMY_VAR__;
+      b_0 = context__.vals_r("b_0")[(1 - 1)];
+      out__.write(b_0);
+      local_scalar_t__ b_female = DUMMY_VAR__;
+      b_female = context__.vals_r("b_female")[(1 - 1)];
+      out__.write(b_female);
+      local_scalar_t__ b_black = DUMMY_VAR__;
+      b_black = context__.vals_r("b_black")[(1 - 1)];
+      out__.write(b_black);
+      local_scalar_t__ b_female_black = DUMMY_VAR__;
+      b_female_black = context__.vals_r("b_female_black")[(1 - 1)];
+      out__.write(b_female_black);
+      local_scalar_t__ b_v_prev = DUMMY_VAR__;
+      b_v_prev = context__.vals_r("b_v_prev")[(1 - 1)];
+      out__.write(b_v_prev);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_age =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_age_flat__;
+        b_age_flat__ = context__.vals_r("b_age");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
+          stan::model::assign(b_age, b_age_flat__[(pos__ - 1)],
+            "assigning variable b_age", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b_age);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_edu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_edu_flat__;
+        b_edu_flat__ = context__.vals_r("b_edu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
+          stan::model::assign(b_edu, b_edu_flat__[(pos__ - 1)],
+            "assigning variable b_edu", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b_edu);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_region =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_region_flat__;
+        b_region_flat__ = context__.vals_r("b_region");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_region; ++sym1__) {
+          stan::model::assign(b_region, b_region_flat__[(pos__ - 1)],
+            "assigning variable b_region", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b_region);
+      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_age, n_edu,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_age_edu_flat__;
+        b_age_edu_flat__ = context__.vals_r("b_age_edu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= n_age; ++sym2__) {
+            stan::model::assign(b_age_edu, b_age_edu_flat__[(pos__ - 1)],
+              "assigning variable b_age_edu", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b_age_edu);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_hat =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_hat_flat__;
+        b_hat_flat__ = context__.vals_r("b_hat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
+          stan::model::assign(b_hat, b_hat_flat__[(pos__ - 1)],
+            "assigning variable b_hat", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(b_hat);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3603,30 +3847,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16>
-      names__{"sigma", "sigma_age", "sigma_edu", "sigma_state",
-              "sigma_region", "sigma_age_edu", "b_0", "b_female", "b_black",
-              "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
-              "b_age_edu", "b_hat"};
-    const std::array<Eigen::Index, 16>
-      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu,
-                              n_region, (n_age * n_edu), n_state};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3799,10 +4030,27 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3909,24 +4157,17 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4095,10 +4336,27 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4205,24 +4463,17 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4460,8 +4711,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4486,6 +4737,43 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       out__.write_free_lb(0, sigma);
       local_scalar_t__ theta = DUMMY_VAR__;
       theta = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 1, theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> mu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> mu_flat__;
+        mu_flat__ = context__.vals_r("mu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(mu, mu_flat__[(pos__ - 1)],
+            "assigning variable mu", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_ordered(mu);
+      std::vector<local_scalar_t__> sigma =
+        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
+      sigma = context__.vals_r("sigma");
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ theta = DUMMY_VAR__;
+      theta = context__.vals_r("theta")[(1 - 1)];
       out__.write_free_lub(0, 1, theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4606,24 +4894,17 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "sigma", "theta"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{2, 2, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4831,8 +5112,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4854,6 +5135,33 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       out__.write(theta);
       local_scalar_t__ tau = DUMMY_VAR__;
       tau = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, tau);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mu = DUMMY_VAR__;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      std::vector<local_scalar_t__> theta =
+        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
+      theta = context__.vals_r("theta");
+      out__.write(theta);
+      local_scalar_t__ tau = DUMMY_VAR__;
+      tau = context__.vals_r("tau")[(1 - 1)];
       out__.write_free_lb(0, tau);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4967,24 +5275,17 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "theta", "tau"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, J, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -5611,8 +5912,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -5675,6 +5976,118 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       out__.write_free_lub(0, 100, sigma_d);
       local_scalar_t__ sigma_e = DUMMY_VAR__;
       sigma_e = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_e);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
+          stan::model::assign(a, a_flat__[(pos__ - 1)],
+            "assigning variable a", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> b =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
+          stan::model::assign(b, b_flat__[(pos__ - 1)],
+            "assigning variable b", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b);
+      Eigen::Matrix<local_scalar_t__,-1,1> c =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age_edu,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> c_flat__;
+        c_flat__ = context__.vals_r("c");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_age_edu; ++sym1__) {
+          stan::model::assign(c, c_flat__[(pos__ - 1)],
+            "assigning variable c", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(c);
+      Eigen::Matrix<local_scalar_t__,-1,1> d =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> d_flat__;
+        d_flat__ = context__.vals_r("d");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
+          stan::model::assign(d, d_flat__[(pos__ - 1)],
+            "assigning variable d", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(d);
+      Eigen::Matrix<local_scalar_t__,-1,1> e =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region_full,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> e_flat__;
+        e_flat__ = context__.vals_r("e");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_region_full; ++sym1__) {
+          stan::model::assign(e, e_flat__[(pos__ - 1)],
+            "assigning variable e", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(e);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(beta);
+      local_scalar_t__ sigma_a = DUMMY_VAR__;
+      sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a);
+      local_scalar_t__ sigma_b = DUMMY_VAR__;
+      sigma_b = context__.vals_r("sigma_b")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_b);
+      local_scalar_t__ sigma_c = DUMMY_VAR__;
+      sigma_c = context__.vals_r("sigma_c")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_c);
+      local_scalar_t__ sigma_d = DUMMY_VAR__;
+      sigma_d = context__.vals_r("sigma_d")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_d);
+      local_scalar_t__ sigma_e = DUMMY_VAR__;
+      sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_e);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5864,28 +6277,17 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 11>
-      names__{"a", "b", "c", "d", "e", "beta", "sigma_a", "sigma_b",
-              "sigma_c", "sigma_d", "sigma_e"};
-    const std::array<Eigen::Index, 11>
-      constrain_param_sizes__{n_age, n_edu, n_age_edu, n_state,
-                              n_region_full, 5, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -6301,8 +6703,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -6322,6 +6724,40 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       stan::model::assign(phi_std_raw,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(phi_std_raw_1dim__),
         "assigning variable phi_std_raw");
+      out__.write(phi_std_raw);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ tau_phi = DUMMY_VAR__;
+      tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      out__.write_free_lb(0, tau_phi);
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(phi_std_raw_1dim__,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> phi_std_raw_flat__;
+        phi_std_raw_flat__ = context__.vals_r("phi_std_raw");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= phi_std_raw_1dim__; ++sym1__) {
+          stan::model::assign(phi_std_raw, phi_std_raw_flat__[(pos__ - 1)],
+            "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6514,25 +6950,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{1, phi_std_raw_1dim__};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -7182,8 +7610,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7208,6 +7636,45 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       out__.write(epsilon);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mean_phi = DUMMY_VAR__;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p = DUMMY_VAR__;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(nind, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= nind; ++sym1__) {
+          stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+            "assigning variable epsilon", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7393,25 +7860,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"mean_phi", "mean_p", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, nind, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -8569,8 +9028,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -8605,6 +9064,62 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       out__.write(epsilon);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mean_phi = DUMMY_VAR__;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p = DUMMY_VAR__;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      local_scalar_t__ psi = DUMMY_VAR__;
+      psi = context__.vals_r("psi")[(1 - 1)];
+      out__.write_free_lub(0, 1, psi);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lb(0, beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+            "assigning variable epsilon", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8856,26 +9371,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"mean_phi", "mean_p", "psi", "beta", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, n_occasions, M, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -9299,8 +9805,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -9327,6 +9833,57 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
             "assigning variable theta", stan::model::index_uni(sym2__),
             stan::model::index_uni(sym1__));
+        }
+      }
+      out__.write_free_simplex(theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> pi =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> pi_flat__;
+        pi_flat__ = context__.vals_r("pi");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          stan::model::assign(pi, pi_flat__[(pos__ - 1)],
+            "assigning variable pi", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_simplex(pi);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> theta =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> theta_flat__;
+        theta_flat__ = context__.vals_r("theta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
+              stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                "assigning variable theta", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
         }
       }
       out__.write_free_simplex(theta);
@@ -9481,24 +10038,17 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"pi", "theta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{K, (J * K * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -9837,8 +10387,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -9872,6 +10422,61 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       stan::model::assign(phi_std_raw,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
         "assigning variable phi_std_raw");
+      out__.write(phi_std_raw);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ beta0 = DUMMY_VAR__;
+      beta0 = context__.vals_r("beta0")[(1 - 1)];
+      out__.write(beta0);
+      local_scalar_t__ beta1 = DUMMY_VAR__;
+      beta1 = context__.vals_r("beta1")[(1 - 1)];
+      out__.write(beta1);
+      local_scalar_t__ tau_theta = DUMMY_VAR__;
+      tau_theta = context__.vals_r("tau_theta")[(1 - 1)];
+      out__.write_free_lb(0, tau_theta);
+      local_scalar_t__ tau_phi = DUMMY_VAR__;
+      tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      out__.write_free_lb(0, tau_phi);
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_std =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> theta_std_flat__;
+        theta_std_flat__ = context__.vals_r("theta_std");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(theta_std, theta_std_flat__[(pos__ - 1)],
+            "assigning variable theta_std", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(theta_std);
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> phi_std_raw_flat__;
+        phi_std_raw_flat__ = context__.vals_r("phi_std_raw");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(phi_std_raw, phi_std_raw_flat__[(pos__ - 1)],
+            "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10022,27 +10627,17 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"beta0", "beta1", "tau_theta", "tau_phi", "theta_std",
-              "phi_std_raw"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, N, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -10699,8 +11294,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -10719,6 +11314,39 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::model::assign(beta,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
         "assigning variable beta");
+      out__.write_free_lub(0, 1, beta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mean_p = DUMMY_VAR__;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10883,24 +11511,17 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -11117,10 +11738,27 @@ class function_in_function_inline_model final : public model_base_crtp<function_
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -11227,24 +11865,17 @@ class function_in_function_inline_model final : public model_base_crtp<function_
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -11481,10 +12112,27 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -11591,24 +12239,17 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -11871,8 +12512,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -11894,6 +12535,52 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       stan::model::assign(p_multi_ret_vec,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
         "assigning variable p_multi_ret_vec");
+      out__.write(p_multi_ret_vec);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_single_ret_vec_flat__;
+        p_single_ret_vec_flat__ = context__.vals_r("p_single_ret_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(p_single_ret_vec,
+            p_single_ret_vec_flat__[(pos__ - 1)],
+            "assigning variable p_single_ret_vec",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_single_ret_vec);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_multi_ret_vec_flat__;
+        p_multi_ret_vec_flat__ = context__.vals_r("p_multi_ret_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(p_multi_ret_vec, p_multi_ret_vec_flat__[(pos__
+            - 1)], "assigning variable p_multi_ret_vec",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(p_multi_ret_vec);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12039,25 +12726,17 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2>
-      names__{"p_single_ret_vec", "p_multi_ret_vec"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{5, 5};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -12254,8 +12933,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -12268,6 +12947,26 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       pos__ = 1;
       local_scalar_t__ alpha = DUMMY_VAR__;
       alpha = in__.read<local_scalar_t__>();
+      out__.write(alpha);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
       out__.write(alpha);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12369,24 +13068,17 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"alpha"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -12595,10 +13287,27 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -12733,24 +13442,17 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -13881,8 +14583,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -13915,6 +14617,60 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       out__.write(epsilon);
       local_scalar_t__ sigma = DUMMY_VAR__;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mean_phi = DUMMY_VAR__;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p = DUMMY_VAR__;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> gamma =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> gamma_flat__;
+        gamma_flat__ = context__.vals_r("gamma");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
+          stan::model::assign(gamma, gamma_flat__[(pos__ - 1)],
+            "assigning variable gamma", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(0, 1, gamma);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(epsilon_1dim__,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= epsilon_1dim__; ++sym1__) {
+          stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+            "assigning variable epsilon", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma = DUMMY_VAR__;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -14161,26 +14917,17 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"mean_phi", "mean_p", "gamma", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{1, 1, n_occasions, epsilon_1dim__, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -14350,10 +15097,27 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -14460,24 +15224,17 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -14644,8 +15401,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -14658,6 +15415,26 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       x = in__.read<local_scalar_t__>();
+      out__.write(x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ x = DUMMY_VAR__;
+      x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -14759,24 +15536,17 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"x"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -14949,8 +15719,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -14966,6 +15736,27 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
         theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      std::vector<local_scalar_t__> theta =
+        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
+      theta = context__.vals_r("theta");
       out__.write(theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15074,24 +15865,17 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"theta"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{J};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -15683,8 +16467,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -15700,6 +16484,29 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       out__.write_free_lub(0, 1, mean_phi);
       local_scalar_t__ mean_p = DUMMY_VAR__;
       mean_p = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 1, mean_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mean_phi = DUMMY_VAR__;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p = DUMMY_VAR__;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
       out__.write_free_lub(0, 1, mean_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15858,24 +16665,17 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_phi", "mean_p"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -16119,8 +16919,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -16133,6 +16933,26 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       mu = in__.read<local_scalar_t__>();
+      out__.write(mu);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ mu = DUMMY_VAR__;
+      mu = context__.vals_r("mu")[(1 - 1)];
       out__.write(mu);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16261,24 +17081,17 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"mu"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -16728,8 +17541,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -16751,6 +17564,35 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       out__.write(alpha_p);
       local_scalar_t__ beta_p = DUMMY_VAR__;
       beta_p = in__.read<local_scalar_t__>();
+      out__.write(beta_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ alpha_occ = DUMMY_VAR__;
+      alpha_occ = context__.vals_r("alpha_occ")[(1 - 1)];
+      out__.write(alpha_occ);
+      local_scalar_t__ beta_occ = DUMMY_VAR__;
+      beta_occ = context__.vals_r("beta_occ")[(1 - 1)];
+      out__.write(beta_occ);
+      local_scalar_t__ alpha_p = DUMMY_VAR__;
+      alpha_p = context__.vals_r("alpha_p")[(1 - 1)];
+      out__.write(alpha_p);
+      local_scalar_t__ beta_p = DUMMY_VAR__;
+      beta_p = context__.vals_r("beta_p")[(1 - 1)];
       out__.write(beta_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16929,25 +17771,17 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"alpha_occ", "beta_occ", "alpha_p", "beta_p"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -17389,8 +18223,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -17430,6 +18264,67 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       out__.write_free_lub(0, 100, sigma_a2);
       local_scalar_t__ sigma_y = DUMMY_VAR__;
       sigma_y = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ beta = DUMMY_VAR__;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write(beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> eta1 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> eta1_flat__;
+        eta1_flat__ = context__.vals_r("eta1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+          stan::model::assign(eta1, eta1_flat__[(pos__ - 1)],
+            "assigning variable eta1", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(eta1);
+      Eigen::Matrix<local_scalar_t__,-1,1> eta2 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> eta2_flat__;
+        eta2_flat__ = context__.vals_r("eta2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+          stan::model::assign(eta2, eta2_flat__[(pos__ - 1)],
+            "assigning variable eta2", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(eta2);
+      local_scalar_t__ mu_a1 = DUMMY_VAR__;
+      mu_a1 = context__.vals_r("mu_a1")[(1 - 1)];
+      out__.write(mu_a1);
+      local_scalar_t__ mu_a2 = DUMMY_VAR__;
+      mu_a2 = context__.vals_r("mu_a2")[(1 - 1)];
+      out__.write(mu_a2);
+      local_scalar_t__ sigma_a1 = DUMMY_VAR__;
+      sigma_a1 = context__.vals_r("sigma_a1")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a1);
+      local_scalar_t__ sigma_a2 = DUMMY_VAR__;
+      sigma_a2 = context__.vals_r("sigma_a2")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a2);
+      local_scalar_t__ sigma_y = DUMMY_VAR__;
+      sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -17602,27 +18497,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8>
-      names__{"beta", "eta1", "eta2", "mu_a1", "mu_a2", "sigma_a1",
-              "sigma_a2", "sigma_y"};
-    const std::array<Eigen::Index, 8>
-      constrain_param_sizes__{1, J, J, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18287,8 +19172,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -18322,6 +19207,74 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       stan::model::assign(x_cov,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
         "assigning variable x_cov");
+      out__.write_free_cov_matrix(x_cov);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ theta = DUMMY_VAR__;
+      theta = context__.vals_r("theta")[(1 - 1)];
+      out__.write(theta);
+      local_scalar_t__ phi = DUMMY_VAR__;
+      phi = context__.vals_r("phi")[(1 - 1)];
+      out__.write(phi);
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_matrix_flat__;
+        x_matrix_flat__ = context__.vals_r("x_matrix");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+            stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+              "assigning variable x_matrix", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(x_matrix);
+      Eigen::Matrix<local_scalar_t__,-1,1> x_vector =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_vector_flat__;
+        x_vector_flat__ = context__.vals_r("x_vector");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(x_vector, x_vector_flat__[(pos__ - 1)],
+            "assigning variable x_vector", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(x_vector);
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_cov_flat__;
+        x_cov_flat__ = context__.vals_r("x_cov");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+            stan::model::assign(x_cov, x_cov_flat__[(pos__ - 1)],
+              "assigning variable x_cov", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write_free_cov_matrix(x_cov);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18462,26 +19415,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"theta", "phi", "x_matrix", "x_vector", "x_cov"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{1, 1, (3 * 2), 2, (2 * 2)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18660,10 +19604,27 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -18770,24 +19731,17 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18996,10 +19950,27 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -19106,24 +20077,17 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -19507,8 +20471,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -19539,6 +20503,58 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       out__.write_free_lub(0, 100, sigma_a);
       local_scalar_t__ sigma_y = DUMMY_VAR__;
       sigma_y = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_pair; ++sym1__) {
+          stan::model::assign(a, a_flat__[(pos__ - 1)],
+            "assigning variable a", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(beta);
+      local_scalar_t__ mu_a = DUMMY_VAR__;
+      mu_a = context__.vals_r("mu_a")[(1 - 1)];
+      out__.write(mu_a);
+      local_scalar_t__ sigma_a = DUMMY_VAR__;
+      sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a);
+      local_scalar_t__ sigma_y = DUMMY_VAR__;
+      sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19685,26 +20701,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"a", "beta", "mu_a", "sigma_a", "sigma_y"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{n_pair, 2, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -19968,8 +20975,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -19991,6 +20998,55 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       stan::model::assign(m3,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable m3");
+      out__.write(m3);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> m2_flat__;
+        m2_flat__ = context__.vals_r("m2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(m2);
+      Eigen::Matrix<local_scalar_t__,-1,-1> m3 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> m3_flat__;
+        m3_flat__ = context__.vals_r("m3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(m3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20119,25 +21175,17 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"m2", "m3"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(10 * 10), (10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20504,8 +21552,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -20538,6 +21586,55 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         stan::model::assign(b,
           in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
           "assigning variable b", stan::model::index_uni(sym1__));
+      }
+      out__.write(b);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ alpha0 = DUMMY_VAR__;
+      alpha0 = context__.vals_r("alpha0")[(1 - 1)];
+      out__.write(alpha0);
+      local_scalar_t__ alpha1 = DUMMY_VAR__;
+      alpha1 = context__.vals_r("alpha1")[(1 - 1)];
+      out__.write(alpha1);
+      local_scalar_t__ alpha2 = DUMMY_VAR__;
+      alpha2 = context__.vals_r("alpha2")[(1 - 1)];
+      out__.write(alpha2);
+      local_scalar_t__ alpha12 = DUMMY_VAR__;
+      alpha12 = context__.vals_r("alpha12")[(1 - 1)];
+      out__.write(alpha12);
+      local_scalar_t__ tau = DUMMY_VAR__;
+      tau = context__.vals_r("tau")[(1 - 1)];
+      out__.write_free_lb(0, tau);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
+            stan::model::assign(b, b_flat__[(pos__ - 1)],
+              "assigning variable b", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
       }
       out__.write(b);
     } catch (const std::exception& e) {
@@ -20677,26 +21774,17 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"alpha0", "alpha1", "alpha2", "alpha12", "tau", "b"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, 1, (I * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20900,8 +21988,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -20914,6 +22002,26 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       pos__ = 1;
       local_scalar_t__ param = DUMMY_VAR__;
       param = in__.read<local_scalar_t__>();
+      out__.write(param);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ param = DUMMY_VAR__;
+      param = context__.vals_r("param")[(1 - 1)];
       out__.write(param);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21039,24 +22147,17 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"param"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -21263,8 +22364,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -21277,6 +22378,26 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       pos__ = 1;
       local_scalar_t__ y = DUMMY_VAR__;
       y = in__.read<local_scalar_t__>();
+      out__.write(y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ y = DUMMY_VAR__;
+      y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21407,24 +22528,17 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"y"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -21603,10 +22717,27 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -21725,24 +22856,17 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -4895,11 +4895,9 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
         "assigning variable mu");
       out__.write_free_ordered(mu);
-      std::vector<local_scalar_t__> sigma =
-        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        sigma[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      std::vector<local_scalar_t__> sigma;
+      stan::model::assign(sigma, in__.read<std::vector<local_scalar_t__>>(2),
+        "assigning variable sigma");
       out__.write_free_lb(0, sigma);
       local_scalar_t__ theta;
       theta = in__.read<local_scalar_t__>();
@@ -5302,11 +5300,9 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       local_scalar_t__ mu;
       mu = in__.read<local_scalar_t__>();
       out__.write(mu);
-      std::vector<local_scalar_t__> theta =
-        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      std::vector<local_scalar_t__> theta;
+      stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
+        "assigning variable theta");
       out__.write(theta);
       local_scalar_t__ tau;
       tau = in__.read<local_scalar_t__>();
@@ -10537,11 +10533,12 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= J; ++sym2__) {
-          stan::model::assign(theta,
-            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-            "assigning variable theta", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
+        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+          for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
+            stan::model::assign(theta, in__.read<local_scalar_t__>(),
+              "assigning variable theta", stan::model::index_uni(sym3__),
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+          }
         }
       }
       out__.write_free_simplex(theta);
@@ -17203,11 +17200,9 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     try {
       int pos__;
       pos__ = 1;
-      std::vector<local_scalar_t__> theta =
-        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
-      }
+      std::vector<local_scalar_t__> theta;
+      stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
+        "assigning variable theta");
       out__.write(theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -23269,10 +23264,12 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
-        stan::model::assign(b,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
-          "assigning variable b", stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
+          stan::model::assign(b, in__.read<local_scalar_t__>(),
+            "assigning variable b", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
+        }
       }
       out__.write(b);
     } catch (const std::exception& e) {

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -252,8 +252,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -268,6 +268,39 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -495,24 +528,17 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -936,8 +962,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -959,6 +985,35 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       out__.write_free_lb(0, xi);
       local_scalar_t__ delta;
       delta = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, delta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ beta;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write_free_lb(0, beta);
+      local_scalar_t__ gamma;
+      gamma = context__.vals_r("gamma")[(1 - 1)];
+      out__.write_free_lb(0, gamma);
+      local_scalar_t__ xi;
+      xi = context__.vals_r("xi")[(1 - 1)];
+      out__.write_free_lb(0, xi);
+      local_scalar_t__ delta;
+      delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1092,25 +1147,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"beta", "gamma", "xi", "delta"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1321,8 +1368,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1337,6 +1384,39 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1491,24 +1571,17 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1717,8 +1790,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1733,6 +1806,39 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       stan::model::assign(X,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
         "assigning variable X");
+      out__.write(X);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_flat__;
+        X_flat__ = context__.vals_r("X");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(X, X_flat__[(pos__ - 1)],
+              "assigning variable X", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1846,24 +1952,17 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(N * N)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2633,8 +2732,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -2652,6 +2751,39 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       stan::model::assign(beta,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
         "assigning variable beta");
+      out__.write_free_lub(0, 1, beta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2816,24 +2948,17 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3435,8 +3560,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -3504,6 +3629,125 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       stan::model::assign(b_hat,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
         "assigning variable b_hat");
+      out__.write(b_hat);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ sigma_age;
+      sigma_age = context__.vals_r("sigma_age")[(1 - 1)];
+      out__.write_free_lb(0, sigma_age);
+      local_scalar_t__ sigma_edu;
+      sigma_edu = context__.vals_r("sigma_edu")[(1 - 1)];
+      out__.write_free_lb(0, sigma_edu);
+      local_scalar_t__ sigma_state;
+      sigma_state = context__.vals_r("sigma_state")[(1 - 1)];
+      out__.write_free_lb(0, sigma_state);
+      local_scalar_t__ sigma_region;
+      sigma_region = context__.vals_r("sigma_region")[(1 - 1)];
+      out__.write_free_lb(0, sigma_region);
+      local_scalar_t__ sigma_age_edu;
+      sigma_age_edu = context__.vals_r("sigma_age_edu")[(1 - 1)];
+      out__.write_free_lb(0, sigma_age_edu);
+      local_scalar_t__ b_0;
+      b_0 = context__.vals_r("b_0")[(1 - 1)];
+      out__.write(b_0);
+      local_scalar_t__ b_female;
+      b_female = context__.vals_r("b_female")[(1 - 1)];
+      out__.write(b_female);
+      local_scalar_t__ b_black;
+      b_black = context__.vals_r("b_black")[(1 - 1)];
+      out__.write(b_black);
+      local_scalar_t__ b_female_black;
+      b_female_black = context__.vals_r("b_female_black")[(1 - 1)];
+      out__.write(b_female_black);
+      local_scalar_t__ b_v_prev;
+      b_v_prev = context__.vals_r("b_v_prev")[(1 - 1)];
+      out__.write(b_v_prev);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_age =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_age_flat__;
+        b_age_flat__ = context__.vals_r("b_age");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
+          stan::model::assign(b_age, b_age_flat__[(pos__ - 1)],
+            "assigning variable b_age", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b_age);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_edu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_edu_flat__;
+        b_edu_flat__ = context__.vals_r("b_edu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
+          stan::model::assign(b_edu, b_edu_flat__[(pos__ - 1)],
+            "assigning variable b_edu", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b_edu);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_region =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_region_flat__;
+        b_region_flat__ = context__.vals_r("b_region");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_region; ++sym1__) {
+          stan::model::assign(b_region, b_region_flat__[(pos__ - 1)],
+            "assigning variable b_region", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b_region);
+      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_age, n_edu,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_age_edu_flat__;
+        b_age_edu_flat__ = context__.vals_r("b_age_edu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= n_age; ++sym2__) {
+            stan::model::assign(b_age_edu, b_age_edu_flat__[(pos__ - 1)],
+              "assigning variable b_age_edu", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(b_age_edu);
+      Eigen::Matrix<local_scalar_t__,-1,1> b_hat =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_hat_flat__;
+        b_hat_flat__ = context__.vals_r("b_hat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
+          stan::model::assign(b_hat, b_hat_flat__[(pos__ - 1)],
+            "assigning variable b_hat", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(b_hat);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3687,30 +3931,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 16>
-      names__{"sigma", "sigma_age", "sigma_edu", "sigma_state",
-              "sigma_region", "sigma_age_edu", "b_0", "b_female", "b_black",
-              "b_female_black", "b_v_prev", "b_age", "b_edu", "b_region",
-              "b_age_edu", "b_hat"};
-    const std::array<Eigen::Index, 16>
-      constrain_param_sizes__{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, n_age, n_edu,
-                              n_region, (n_age * n_edu), n_state};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3883,10 +4114,27 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -3993,24 +4241,17 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4179,10 +4420,27 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -4289,24 +4547,17 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4539,8 +4790,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4564,6 +4815,43 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       out__.write_free_lb(0, sigma);
       local_scalar_t__ theta;
       theta = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 1, theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> mu =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> mu_flat__;
+        mu_flat__ = context__.vals_r("mu");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(mu, mu_flat__[(pos__ - 1)],
+            "assigning variable mu", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_ordered(mu);
+      std::vector<local_scalar_t__> sigma =
+        std::vector<local_scalar_t__>(2, DUMMY_VAR__);
+      sigma = context__.vals_r("sigma");
+      out__.write_free_lb(0, sigma);
+      local_scalar_t__ theta;
+      theta = context__.vals_r("theta")[(1 - 1)];
       out__.write_free_lub(0, 1, theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4684,24 +4972,17 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "sigma", "theta"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{2, 2, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4907,8 +5188,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4930,6 +5211,33 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       out__.write(theta);
       local_scalar_t__ tau;
       tau = in__.read<local_scalar_t__>();
+      out__.write_free_lb(0, tau);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mu;
+      mu = context__.vals_r("mu")[(1 - 1)];
+      out__.write(mu);
+      std::vector<local_scalar_t__> theta =
+        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
+      theta = context__.vals_r("theta");
+      out__.write(theta);
+      local_scalar_t__ tau;
+      tau = context__.vals_r("tau")[(1 - 1)];
       out__.write_free_lb(0, tau);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5043,24 +5351,17 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"mu", "theta", "tau"};
-    const std::array<Eigen::Index, 3> constrain_param_sizes__{1, J, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -5689,8 +5990,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -5745,6 +6046,118 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       out__.write_free_lub(0, 100, sigma_d);
       local_scalar_t__ sigma_e;
       sigma_e = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_e);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
+          stan::model::assign(a, a_flat__[(pos__ - 1)],
+            "assigning variable a", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> b =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
+          stan::model::assign(b, b_flat__[(pos__ - 1)],
+            "assigning variable b", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b);
+      Eigen::Matrix<local_scalar_t__,-1,1> c =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age_edu,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> c_flat__;
+        c_flat__ = context__.vals_r("c");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_age_edu; ++sym1__) {
+          stan::model::assign(c, c_flat__[(pos__ - 1)],
+            "assigning variable c", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(c);
+      Eigen::Matrix<local_scalar_t__,-1,1> d =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> d_flat__;
+        d_flat__ = context__.vals_r("d");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
+          stan::model::assign(d, d_flat__[(pos__ - 1)],
+            "assigning variable d", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(d);
+      Eigen::Matrix<local_scalar_t__,-1,1> e =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region_full,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> e_flat__;
+        e_flat__ = context__.vals_r("e");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_region_full; ++sym1__) {
+          stan::model::assign(e, e_flat__[(pos__ - 1)],
+            "assigning variable e", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(e);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(beta);
+      local_scalar_t__ sigma_a;
+      sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a);
+      local_scalar_t__ sigma_b;
+      sigma_b = context__.vals_r("sigma_b")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_b);
+      local_scalar_t__ sigma_c;
+      sigma_c = context__.vals_r("sigma_c")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_c);
+      local_scalar_t__ sigma_d;
+      sigma_d = context__.vals_r("sigma_d")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_d);
+      local_scalar_t__ sigma_e;
+      sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_e);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5934,28 +6347,17 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 11>
-      names__{"a", "b", "c", "d", "e", "beta", "sigma_a", "sigma_b",
-              "sigma_c", "sigma_d", "sigma_e"};
-    const std::array<Eigen::Index, 11>
-      constrain_param_sizes__{n_age, n_edu, n_age_edu, n_state,
-                              n_region_full, 5, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -6374,8 +6776,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -6393,6 +6795,40 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       stan::model::assign(phi_std_raw,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(phi_std_raw_1dim__),
         "assigning variable phi_std_raw");
+      out__.write(phi_std_raw);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ tau_phi;
+      tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      out__.write_free_lb(0, tau_phi);
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(phi_std_raw_1dim__,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> phi_std_raw_flat__;
+        phi_std_raw_flat__ = context__.vals_r("phi_std_raw");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= phi_std_raw_1dim__; ++sym1__) {
+          stan::model::assign(phi_std_raw, phi_std_raw_flat__[(pos__ - 1)],
+            "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6585,25 +7021,17 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"tau_phi", "phi_std_raw"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{1, phi_std_raw_1dim__};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -7366,8 +7794,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -7391,6 +7819,45 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(nind, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= nind; ++sym1__) {
+          stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+            "assigning variable epsilon", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7576,25 +8043,17 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"mean_phi", "mean_p", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, nind, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -9138,8 +9597,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -9171,6 +9630,62 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      local_scalar_t__ psi;
+      psi = context__.vals_r("psi")[(1 - 1)];
+      out__.write_free_lub(0, 1, psi);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lb(0, beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+            "assigning variable epsilon", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9422,26 +9937,17 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"mean_phi", "mean_p", "psi", "beta", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, n_occasions, M, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -9855,8 +10361,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -9882,6 +10388,57 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
             in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
             "assigning variable theta", stan::model::index_uni(sym2__),
             stan::model::index_uni(sym1__));
+        }
+      }
+      out__.write_free_simplex(theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> pi =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> pi_flat__;
+        pi_flat__ = context__.vals_r("pi");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          stan::model::assign(pi, pi_flat__[(pos__ - 1)],
+            "assigning variable pi", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_simplex(pi);
+      std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> theta =
+        std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
+          std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
+            Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
+      {
+        std::vector<local_scalar_t__> theta_flat__;
+        theta_flat__ = context__.vals_r("theta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
+              stan::model::assign(theta, theta_flat__[(pos__ - 1)],
+                "assigning variable theta", stan::model::index_uni(sym3__),
+                stan::model::index_uni(sym2__),
+                stan::model::index_uni(sym1__));
+              pos__ = (pos__ + 1);
+            }
+          }
         }
       }
       out__.write_free_simplex(theta);
@@ -10036,24 +10593,17 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"pi", "theta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{K, (J * K * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -10395,8 +10945,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -10428,6 +10978,61 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       stan::model::assign(phi_std_raw,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
         "assigning variable phi_std_raw");
+      out__.write(phi_std_raw);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ beta0;
+      beta0 = context__.vals_r("beta0")[(1 - 1)];
+      out__.write(beta0);
+      local_scalar_t__ beta1;
+      beta1 = context__.vals_r("beta1")[(1 - 1)];
+      out__.write(beta1);
+      local_scalar_t__ tau_theta;
+      tau_theta = context__.vals_r("tau_theta")[(1 - 1)];
+      out__.write_free_lb(0, tau_theta);
+      local_scalar_t__ tau_phi;
+      tau_phi = context__.vals_r("tau_phi")[(1 - 1)];
+      out__.write_free_lb(0, tau_phi);
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_std =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> theta_std_flat__;
+        theta_std_flat__ = context__.vals_r("theta_std");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(theta_std, theta_std_flat__[(pos__ - 1)],
+            "assigning variable theta_std", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(theta_std);
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> phi_std_raw_flat__;
+        phi_std_raw_flat__ = context__.vals_r("phi_std_raw");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(phi_std_raw, phi_std_raw_flat__[(pos__ - 1)],
+            "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10578,27 +11183,17 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"beta0", "beta1", "tau_theta", "tau_phi", "theta_std",
-              "phi_std_raw"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, N, N};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -11368,8 +11963,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -11387,6 +11982,39 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       stan::model::assign(beta,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
         "assigning variable beta");
+      out__.write_free_lub(0, 1, beta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11551,24 +12179,17 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_p", "beta"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, max_age};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -11794,10 +12415,27 @@ class function_in_function_inline_model final : public model_base_crtp<function_
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -11904,24 +12542,17 @@ class function_in_function_inline_model final : public model_base_crtp<function_
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -12179,10 +12810,27 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -12289,24 +12937,17 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -12624,8 +13265,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -12645,6 +13286,52 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
       stan::model::assign(p_multi_ret_vec,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
         "assigning variable p_multi_ret_vec");
+      out__.write(p_multi_ret_vec);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_single_ret_vec_flat__;
+        p_single_ret_vec_flat__ = context__.vals_r("p_single_ret_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(p_single_ret_vec,
+            p_single_ret_vec_flat__[(pos__ - 1)],
+            "assigning variable p_single_ret_vec",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_single_ret_vec);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_multi_ret_vec_flat__;
+        p_multi_ret_vec_flat__ = context__.vals_r("p_multi_ret_vec");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
+          stan::model::assign(p_multi_ret_vec, p_multi_ret_vec_flat__[(pos__
+            - 1)], "assigning variable p_multi_ret_vec",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(p_multi_ret_vec);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12790,25 +13477,17 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2>
-      names__{"p_single_ret_vec", "p_multi_ret_vec"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{5, 5};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -13006,8 +13685,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -13020,6 +13699,26 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       pos__ = 1;
       local_scalar_t__ alpha;
       alpha = in__.read<local_scalar_t__>();
+      out__.write(alpha);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ alpha;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
       out__.write(alpha);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13121,24 +13820,17 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"alpha"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -13379,10 +14071,27 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -13517,24 +14226,17 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -15085,8 +15787,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -15115,6 +15817,60 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 5, sigma);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_p);
+      Eigen::Matrix<local_scalar_t__,-1,1> gamma =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> gamma_flat__;
+        gamma_flat__ = context__.vals_r("gamma");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
+          stan::model::assign(gamma, gamma_flat__[(pos__ - 1)],
+            "assigning variable gamma", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(0, 1, gamma);
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(epsilon_1dim__,
+          DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> epsilon_flat__;
+        epsilon_flat__ = context__.vals_r("epsilon");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= epsilon_1dim__; ++sym1__) {
+          stan::model::assign(epsilon, epsilon_flat__[(pos__ - 1)],
+            "assigning variable epsilon", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(epsilon);
+      local_scalar_t__ sigma;
+      sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15361,26 +16117,17 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"mean_phi", "mean_p", "gamma", "epsilon", "sigma"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{1, 1, n_occasions, epsilon_1dim__, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -15550,10 +16297,27 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -15660,24 +16424,17 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -15843,8 +16600,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -15857,6 +16614,26 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       pos__ = 1;
       local_scalar_t__ x;
       x = in__.read<local_scalar_t__>();
+      out__.write(x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ x;
+      x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15958,24 +16735,17 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"x"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -16146,8 +16916,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -16163,6 +16933,27 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
         theta[(sym1__ - 1)] = in__.read<local_scalar_t__>();
       }
+      out__.write(theta);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      std::vector<local_scalar_t__> theta =
+        std::vector<local_scalar_t__>(J, DUMMY_VAR__);
+      theta = context__.vals_r("theta");
       out__.write(theta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -16271,24 +17062,17 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"theta"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{J};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -16996,8 +17780,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -17013,6 +17797,29 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       out__.write_free_lub(0, 1, mean_phi);
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 1, mean_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mean_phi;
+      mean_phi = context__.vals_r("mean_phi")[(1 - 1)];
+      out__.write_free_lub(0, 1, mean_phi);
+      local_scalar_t__ mean_p;
+      mean_p = context__.vals_r("mean_p")[(1 - 1)];
       out__.write_free_lub(0, 1, mean_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -17171,24 +17978,17 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"mean_phi", "mean_p"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -17474,8 +18274,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -17488,6 +18288,26 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       pos__ = 1;
       local_scalar_t__ mu;
       mu = in__.read<local_scalar_t__>();
+      out__.write(mu);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ mu;
+      mu = context__.vals_r("mu")[(1 - 1)];
       out__.write(mu);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -17616,24 +18436,17 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"mu"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18077,8 +18890,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -18100,6 +18913,35 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       out__.write(alpha_p);
       local_scalar_t__ beta_p;
       beta_p = in__.read<local_scalar_t__>();
+      out__.write(beta_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ alpha_occ;
+      alpha_occ = context__.vals_r("alpha_occ")[(1 - 1)];
+      out__.write(alpha_occ);
+      local_scalar_t__ beta_occ;
+      beta_occ = context__.vals_r("beta_occ")[(1 - 1)];
+      out__.write(beta_occ);
+      local_scalar_t__ alpha_p;
+      alpha_p = context__.vals_r("alpha_p")[(1 - 1)];
+      out__.write(alpha_p);
+      local_scalar_t__ beta_p;
+      beta_p = context__.vals_r("beta_p")[(1 - 1)];
       out__.write(beta_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18278,25 +19120,17 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 4>
-      names__{"alpha_occ", "beta_occ", "alpha_p", "beta_p"};
-    const std::array<Eigen::Index, 4> constrain_param_sizes__{1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -18736,8 +19570,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -18775,6 +19609,67 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       out__.write_free_lub(0, 100, sigma_a2);
       local_scalar_t__ sigma_y;
       sigma_y = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ beta;
+      beta = context__.vals_r("beta")[(1 - 1)];
+      out__.write(beta);
+      Eigen::Matrix<local_scalar_t__,-1,1> eta1 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> eta1_flat__;
+        eta1_flat__ = context__.vals_r("eta1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+          stan::model::assign(eta1, eta1_flat__[(pos__ - 1)],
+            "assigning variable eta1", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(eta1);
+      Eigen::Matrix<local_scalar_t__,-1,1> eta2 =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> eta2_flat__;
+        eta2_flat__ = context__.vals_r("eta2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
+          stan::model::assign(eta2, eta2_flat__[(pos__ - 1)],
+            "assigning variable eta2", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(eta2);
+      local_scalar_t__ mu_a1;
+      mu_a1 = context__.vals_r("mu_a1")[(1 - 1)];
+      out__.write(mu_a1);
+      local_scalar_t__ mu_a2;
+      mu_a2 = context__.vals_r("mu_a2")[(1 - 1)];
+      out__.write(mu_a2);
+      local_scalar_t__ sigma_a1;
+      sigma_a1 = context__.vals_r("sigma_a1")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a1);
+      local_scalar_t__ sigma_a2;
+      sigma_a2 = context__.vals_r("sigma_a2")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a2);
+      local_scalar_t__ sigma_y;
+      sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -18947,27 +19842,17 @@ class off_small_model final : public model_base_crtp<off_small_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 8>
-      names__{"beta", "eta1", "eta2", "mu_a1", "mu_a2", "sigma_a1",
-              "sigma_a2", "sigma_y"};
-    const std::array<Eigen::Index, 8>
-      constrain_param_sizes__{1, J, J, 1, 1, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -19599,8 +20484,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -19631,6 +20516,74 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       stan::model::assign(x_cov,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
         "assigning variable x_cov");
+      out__.write_free_cov_matrix(x_cov);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ theta;
+      theta = context__.vals_r("theta")[(1 - 1)];
+      out__.write(theta);
+      local_scalar_t__ phi;
+      phi = context__.vals_r("phi")[(1 - 1)];
+      out__.write(phi);
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_matrix_flat__;
+        x_matrix_flat__ = context__.vals_r("x_matrix");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
+            stan::model::assign(x_matrix, x_matrix_flat__[(pos__ - 1)],
+              "assigning variable x_matrix", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(x_matrix);
+      Eigen::Matrix<local_scalar_t__,-1,1> x_vector =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_vector_flat__;
+        x_vector_flat__ = context__.vals_r("x_vector");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(x_vector, x_vector_flat__[(pos__ - 1)],
+            "assigning variable x_vector", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(x_vector);
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> x_cov_flat__;
+        x_cov_flat__ = context__.vals_r("x_cov");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
+            stan::model::assign(x_cov, x_cov_flat__[(pos__ - 1)],
+              "assigning variable x_cov", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write_free_cov_matrix(x_cov);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19771,26 +20724,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"theta", "phi", "x_matrix", "x_vector", "x_cov"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{1, 1, (3 * 2), 2, (2 * 2)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -19969,10 +20913,27 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -20079,24 +21040,17 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20306,10 +21260,27 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -20416,24 +21387,17 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -20816,8 +21780,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -20846,6 +21810,58 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       out__.write_free_lub(0, 100, sigma_a);
       local_scalar_t__ sigma_y;
       sigma_y = in__.read<local_scalar_t__>();
+      out__.write_free_lub(0, 100, sigma_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> a =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> a_flat__;
+        a_flat__ = context__.vals_r("a");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= n_pair; ++sym1__) {
+          stan::model::assign(a, a_flat__[(pos__ - 1)],
+            "assigning variable a", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(a);
+      Eigen::Matrix<local_scalar_t__,-1,1> beta =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> beta_flat__;
+        beta_flat__ = context__.vals_r("beta");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(beta, beta_flat__[(pos__ - 1)],
+            "assigning variable beta", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(beta);
+      local_scalar_t__ mu_a;
+      mu_a = context__.vals_r("mu_a")[(1 - 1)];
+      out__.write(mu_a);
+      local_scalar_t__ sigma_a;
+      sigma_a = context__.vals_r("sigma_a")[(1 - 1)];
+      out__.write_free_lub(0, 100, sigma_a);
+      local_scalar_t__ sigma_y;
+      sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20992,26 +22008,17 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 5>
-      names__{"a", "beta", "mu_a", "sigma_a", "sigma_y"};
-    const std::array<Eigen::Index, 5>
-      constrain_param_sizes__{n_pair, 2, 1, 1, 1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -21270,8 +22277,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -21291,6 +22298,55 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       stan::model::assign(m3,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable m3");
+      out__.write(m3);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> m2_flat__;
+        m2_flat__ = context__.vals_r("m2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(m2, m2_flat__[(pos__ - 1)],
+              "assigning variable m2", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(m2);
+      Eigen::Matrix<local_scalar_t__,-1,-1> m3 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> m3_flat__;
+        m3_flat__ = context__.vals_r("m3");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(m3, m3_flat__[(pos__ - 1)],
+              "assigning variable m3", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(m3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21419,25 +22475,17 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"m2", "m3"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(10 * 10), (10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -21806,8 +22854,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -21835,11 +22883,60 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       out__.write_free_lb(0, tau);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
-          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(8, DUMMY_VAR__));
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__));
       for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
         stan::model::assign(b,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(8),
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
           "assigning variable b", stan::model::index_uni(sym1__));
+      }
+      out__.write(b);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ alpha0;
+      alpha0 = context__.vals_r("alpha0")[(1 - 1)];
+      out__.write(alpha0);
+      local_scalar_t__ alpha1;
+      alpha1 = context__.vals_r("alpha1")[(1 - 1)];
+      out__.write(alpha1);
+      local_scalar_t__ alpha2;
+      alpha2 = context__.vals_r("alpha2")[(1 - 1)];
+      out__.write(alpha2);
+      local_scalar_t__ alpha12;
+      alpha12 = context__.vals_r("alpha12")[(1 - 1)];
+      out__.write(alpha12);
+      local_scalar_t__ tau;
+      tau = context__.vals_r("tau")[(1 - 1)];
+      out__.write_free_lb(0, tau);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(8, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 8; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
+            stan::model::assign(b, b_flat__[(pos__ - 1)],
+              "assigning variable b", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
       }
       out__.write(b);
     } catch (const std::exception& e) {
@@ -21979,26 +23076,17 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 6>
-      names__{"alpha0", "alpha1", "alpha2", "alpha12", "tau", "b"};
-    const std::array<Eigen::Index, 6>
-      constrain_param_sizes__{1, 1, 1, 1, 1, (I * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22202,8 +23290,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -22216,6 +23304,26 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       pos__ = 1;
       local_scalar_t__ param;
       param = in__.read<local_scalar_t__>();
+      out__.write(param);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ param;
+      param = context__.vals_r("param")[(1 - 1)];
       out__.write(param);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22341,24 +23449,17 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"param"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22562,8 +23663,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -22576,6 +23677,26 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       pos__ = 1;
       local_scalar_t__ y;
       y = in__.read<local_scalar_t__>();
+      out__.write(y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+      local_scalar_t__ y;
+      y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22706,24 +23827,17 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"y"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{1};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -22902,10 +24016,27 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__;
+      pos__ = 1;
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
     stan::io::serializer<local_scalar_t__> out__(vars__);
     int current_statement__ = 0;
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
@@ -23024,24 +24155,17 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 0> names__{};
-    const std::array<Eigen::Index, 0> constrain_param_sizes__{};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -264,15 +264,10 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1338,15 +1333,10 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1739,15 +1729,10 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> X =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(X, in__.read<local_scalar_t__>(),
-            "assigning variable X", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> X;
+      stan::model::assign(X,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable X");
       out__.write(X);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2663,12 +2648,10 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
+        "assigning variable beta");
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3497,44 +3480,30 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       local_scalar_t__ b_v_prev;
       b_v_prev = in__.read<local_scalar_t__>();
       out__.write(b_v_prev);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_age =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
-        stan::model::assign(b_age, in__.read<local_scalar_t__>(),
-          "assigning variable b_age", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_age;
+      stan::model::assign(b_age,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age),
+        "assigning variable b_age");
       out__.write(b_age);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_edu =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
-        stan::model::assign(b_edu, in__.read<local_scalar_t__>(),
-          "assigning variable b_edu", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_edu;
+      stan::model::assign(b_edu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_edu),
+        "assigning variable b_edu");
       out__.write(b_edu);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_region =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_region; ++sym1__) {
-        stan::model::assign(b_region, in__.read<local_scalar_t__>(),
-          "assigning variable b_region", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_region;
+      stan::model::assign(b_region,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_region),
+        "assigning variable b_region");
       out__.write(b_region);
-      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_age, n_edu,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= n_age; ++sym2__) {
-          stan::model::assign(b_age_edu, in__.read<local_scalar_t__>(),
-            "assigning variable b_age_edu", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> b_age_edu;
+      stan::model::assign(b_age_edu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(n_age, n_edu),
+        "assigning variable b_age_edu");
       out__.write(b_age_edu);
-      Eigen::Matrix<local_scalar_t__,-1,1> b_hat =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
-        stan::model::assign(b_hat, in__.read<local_scalar_t__>(),
-          "assigning variable b_hat", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b_hat;
+      stan::model::assign(b_hat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
+        "assigning variable b_hat");
       out__.write(b_hat);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4582,12 +4551,10 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> mu =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(mu, in__.read<local_scalar_t__>(),
-          "assigning variable mu", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> mu;
+      stan::model::assign(mu,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable mu");
       out__.write_free_ordered(mu);
       std::vector<local_scalar_t__> sigma =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
@@ -5734,49 +5701,35 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> a =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_age; ++sym1__) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> a;
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age),
+        "assigning variable a");
       out__.write(a);
-      Eigen::Matrix<local_scalar_t__,-1,1> b =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_edu, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_edu; ++sym1__) {
-        stan::model::assign(b, in__.read<local_scalar_t__>(),
-          "assigning variable b", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> b;
+      stan::model::assign(b,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_edu),
+        "assigning variable b");
       out__.write(b);
-      Eigen::Matrix<local_scalar_t__,-1,1> c =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age_edu,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_age_edu; ++sym1__) {
-        stan::model::assign(c, in__.read<local_scalar_t__>(),
-          "assigning variable c", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> c;
+      stan::model::assign(c,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_age_edu),
+        "assigning variable c");
       out__.write(c);
-      Eigen::Matrix<local_scalar_t__,-1,1> d =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_state; ++sym1__) {
-        stan::model::assign(d, in__.read<local_scalar_t__>(),
-          "assigning variable d", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> d;
+      stan::model::assign(d,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_state),
+        "assigning variable d");
       out__.write(d);
-      Eigen::Matrix<local_scalar_t__,-1,1> e =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_region_full,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_region_full; ++sym1__) {
-        stan::model::assign(e, in__.read<local_scalar_t__>(),
-          "assigning variable e", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> e;
+      stan::model::assign(e,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_region_full),
+        "assigning variable e");
       out__.write(e);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable beta");
       out__.write(beta);
       local_scalar_t__ sigma_a;
       sigma_a = in__.read<local_scalar_t__>();
@@ -6436,13 +6389,10 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       local_scalar_t__ tau_phi;
       tau_phi = in__.read<local_scalar_t__>();
       out__.write_free_lb(0, tau_phi);
-      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(phi_std_raw_1dim__,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= phi_std_raw_1dim__; ++sym1__) {
-        stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-          "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw;
+      stan::model::assign(phi_std_raw,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(phi_std_raw_1dim__),
+        "assigning variable phi_std_raw");
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7434,12 +7384,10 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(nind, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= nind; ++sym1__) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(nind),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
@@ -9211,20 +9159,15 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       local_scalar_t__ psi;
       psi = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, psi);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_occasions),
+        "assigning variable beta");
       out__.write_free_lb(0, beta);
-      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
@@ -9924,24 +9867,21 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> pi =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        stan::model::assign(pi, in__.read<local_scalar_t__>(),
-          "assigning variable pi", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> pi;
+      stan::model::assign(pi,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+        "assigning variable pi");
       out__.write_free_simplex(pi);
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>> theta =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>>(J,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(K,
             Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__)));
       for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          for (int sym3__ = 1; sym3__ <= J; ++sym3__) {
-            stan::model::assign(theta, in__.read<local_scalar_t__>(),
-              "assigning variable theta", stan::model::index_uni(sym3__),
-              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-          }
+        for (int sym2__ = 1; sym2__ <= J; ++sym2__) {
+          stan::model::assign(theta,
+            in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+            "assigning variable theta", stan::model::index_uni(sym2__),
+            stan::model::index_uni(sym1__));
         }
       }
       out__.write_free_simplex(theta);
@@ -10479,19 +10419,15 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       local_scalar_t__ tau_phi;
       tau_phi = in__.read<local_scalar_t__>();
       out__.write_free_lb(0, tau_phi);
-      Eigen::Matrix<local_scalar_t__,-1,1> theta_std =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(theta_std, in__.read<local_scalar_t__>(),
-          "assigning variable theta_std", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> theta_std;
+      stan::model::assign(theta_std,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable theta_std");
       out__.write(theta_std);
-      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(phi_std_raw, in__.read<local_scalar_t__>(),
-          "assigning variable phi_std_raw", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> phi_std_raw;
+      stan::model::assign(phi_std_raw,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable phi_std_raw");
       out__.write(phi_std_raw);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11447,12 +11383,10 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(max_age, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= max_age; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(max_age),
+        "assigning variable beta");
       out__.write_free_lub(0, 1, beta);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12702,21 +12636,15 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(p_single_ret_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_single_ret_vec",
-          stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec;
+      stan::model::assign(p_single_ret_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable p_single_ret_vec");
       out__.write(p_single_ret_vec);
-      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 5; ++sym1__) {
-        stan::model::assign(p_multi_ret_vec, in__.read<local_scalar_t__>(),
-          "assigning variable p_multi_ret_vec",
-          stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> p_multi_ret_vec;
+      stan::model::assign(p_multi_ret_vec,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(5),
+        "assigning variable p_multi_ret_vec");
       out__.write(p_multi_ret_vec);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15175,21 +15103,15 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       local_scalar_t__ mean_p;
       mean_p = in__.read<local_scalar_t__>();
       out__.write_free_lub(0, 1, mean_p);
-      Eigen::Matrix<local_scalar_t__,-1,1> gamma =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_occasions,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_occasions; ++sym1__) {
-        stan::model::assign(gamma, in__.read<local_scalar_t__>(),
-          "assigning variable gamma", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> gamma;
+      stan::model::assign(gamma,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_occasions),
+        "assigning variable gamma");
       out__.write_free_lub(0, 1, gamma);
-      Eigen::Matrix<local_scalar_t__,-1,1> epsilon =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(epsilon_1dim__,
-          DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= epsilon_1dim__; ++sym1__) {
-        stan::model::assign(epsilon, in__.read<local_scalar_t__>(),
-          "assigning variable epsilon", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> epsilon;
+      stan::model::assign(epsilon,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(epsilon_1dim__),
+        "assigning variable epsilon");
       out__.write(epsilon);
       local_scalar_t__ sigma;
       sigma = in__.read<local_scalar_t__>();
@@ -18829,19 +18751,15 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       local_scalar_t__ beta;
       beta = in__.read<local_scalar_t__>();
       out__.write(beta);
-      Eigen::Matrix<local_scalar_t__,-1,1> eta1 =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        stan::model::assign(eta1, in__.read<local_scalar_t__>(),
-          "assigning variable eta1", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> eta1;
+      stan::model::assign(eta1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable eta1");
       out__.write(eta1);
-      Eigen::Matrix<local_scalar_t__,-1,1> eta2 =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(J, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= J; ++sym1__) {
-        stan::model::assign(eta2, in__.read<local_scalar_t__>(),
-          "assigning variable eta2", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> eta2;
+      stan::model::assign(eta2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(J),
+        "assigning variable eta2");
       out__.write(eta2);
       local_scalar_t__ mu_a1;
       mu_a1 = in__.read<local_scalar_t__>();
@@ -19699,32 +19617,20 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
       local_scalar_t__ phi;
       phi = in__.read<local_scalar_t__>();
       out__.write(phi);
-      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(3, 2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 3; ++sym2__) {
-          stan::model::assign(x_matrix, in__.read<local_scalar_t__>(),
-            "assigning variable x_matrix", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_matrix;
+      stan::model::assign(x_matrix,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(3, 2),
+        "assigning variable x_matrix");
       out__.write(x_matrix);
-      Eigen::Matrix<local_scalar_t__,-1,1> x_vector =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(x_vector, in__.read<local_scalar_t__>(),
-          "assigning variable x_vector", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> x_vector;
+      stan::model::assign(x_vector,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable x_vector");
       out__.write(x_vector);
-      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 2; ++sym2__) {
-          stan::model::assign(x_cov, in__.read<local_scalar_t__>(),
-            "assigning variable x_cov", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> x_cov;
+      stan::model::assign(x_cov,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(2, 2),
+        "assigning variable x_cov");
       out__.write_free_cov_matrix(x_cov);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20922,19 +20828,15 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,1> a =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= n_pair; ++sym1__) {
-        stan::model::assign(a, in__.read<local_scalar_t__>(),
-          "assigning variable a", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> a;
+      stan::model::assign(a,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(n_pair),
+        "assigning variable a");
       out__.write(a);
-      Eigen::Matrix<local_scalar_t__,-1,1> beta =
-        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(beta, in__.read<local_scalar_t__>(),
-          "assigning variable beta", stan::model::index_uni(sym1__));
-      }
+      Eigen::Matrix<local_scalar_t__,-1,1> beta;
+      stan::model::assign(beta,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable beta");
       out__.write(beta);
       local_scalar_t__ mu_a;
       mu_a = in__.read<local_scalar_t__>();
@@ -21380,25 +21282,15 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     try {
       int pos__;
       pos__ = 1;
-      Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(m2, in__.read<local_scalar_t__>(),
-            "assigning variable m2", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> m2;
+      stan::model::assign(m2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable m2");
       out__.write(m2);
-      Eigen::Matrix<local_scalar_t__,-1,-1> m3 =
-        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(m3, in__.read<local_scalar_t__>(),
-            "assigning variable m3", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      Eigen::Matrix<local_scalar_t__,-1,-1> m3;
+      stan::model::assign(m3,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable m3");
       out__.write(m3);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21944,12 +21836,10 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> b =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(I,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(8, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= 8; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= I; ++sym2__) {
-          stan::model::assign(b, in__.read<local_scalar_t__>(),
-            "assigning variable b", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
+      for (int sym1__ = 1; sym1__ <= I; ++sym1__) {
+        stan::model::assign(b,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(8),
+          "assigning variable b", stan::model::index_uni(sym1__));
       }
       out__.write(b);
     } catch (const std::exception& e) {

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -536,7 +536,18 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1155,7 +1166,18 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1579,7 +1601,18 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -1960,7 +1993,18 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2956,7 +3000,18 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -3939,7 +3994,18 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4249,7 +4315,18 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4555,7 +4632,18 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4980,7 +5068,18 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -5359,7 +5458,18 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -6355,7 +6465,18 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -7029,7 +7150,18 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -8051,7 +8183,18 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -9945,7 +10088,18 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -10601,7 +10755,18 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -11191,7 +11356,18 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12187,7 +12363,18 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12550,7 +12737,18 @@ class function_in_function_inline_model final : public model_base_crtp<function_
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -12945,7 +13143,18 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -13485,7 +13694,18 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -13828,7 +14048,18 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -14234,7 +14465,18 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -16125,7 +16367,18 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -16432,7 +16685,18 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -16743,7 +17007,18 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -17070,7 +17345,18 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -17986,7 +18272,18 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -18444,7 +18741,18 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19128,7 +19436,18 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -19850,7 +20169,18 @@ class off_small_model final : public model_base_crtp<off_small_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -20732,7 +21062,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21048,7 +21389,18 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -21395,7 +21747,18 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22016,7 +22379,18 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -22483,7 +22857,18 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -23084,7 +23469,18 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -23457,7 +23853,18 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -23835,7 +24242,18 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -24163,7 +24581,18 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -144,8 +144,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -161,6 +161,39 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
       stan::model::assign(A_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable A_p");
+      out__.write(A_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> A_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> A_p_flat__;
+        A_p_flat__ = context__.vals_r("A_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(A_p, A_p_flat__[(pos__ - 1)],
+              "assigning variable A_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(A_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -309,24 +342,17 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"A_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -1499,8 +1525,8 @@ class constraints_model final : public model_base_crtp<constraints_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -1629,6 +1655,286 @@ class constraints_model final : public model_base_crtp<constraints_model> {
       stan::model::assign(chol_fac_corr_test,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(K, K),
         "assigning variable chol_fac_corr_test");
+      out__.write_free_cholesky_factor_corr(chol_fac_corr_test);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,1> high_low_est =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> high_low_est_flat__;
+        high_low_est_flat__ = context__.vals_r("high_low_est");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(high_low_est, high_low_est_flat__[(pos__ - 1)],
+            "assigning variable high_low_est", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(diff_low_mid, diff_high_mid, high_low_est);
+      Eigen::Matrix<local_scalar_t__,-1,1> b =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> b_flat__;
+        b_flat__ = context__.vals_r("b");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          stan::model::assign(b, b_flat__[(pos__ - 1)],
+            "assigning variable b", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(b);
+      Eigen::Matrix<local_scalar_t__,-1,1> h =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(Nr, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> h_flat__;
+        h_flat__ = context__.vals_r("h");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= Nr; ++sym1__) {
+          stan::model::assign(h, h_flat__[(pos__ - 1)],
+            "assigning variable h", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(h);
+      Eigen::Matrix<local_scalar_t__,-1,1> ar =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> ar_flat__;
+        ar_flat__ = context__.vals_r("ar");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
+          stan::model::assign(ar, ar_flat__[(pos__ - 1)],
+            "assigning variable ar", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(ar);
+      local_scalar_t__ ma = DUMMY_VAR__;
+      ma = context__.vals_r("ma")[(1 - 1)];
+      out__.write(ma);
+      local_scalar_t__ phi_beta = DUMMY_VAR__;
+      phi_beta = context__.vals_r("phi_beta")[(1 - 1)];
+      out__.write_free_lub(0, 1, phi_beta);
+      local_scalar_t__ sigma2 = DUMMY_VAR__;
+      sigma2 = context__.vals_r("sigma2")[(1 - 1)];
+      out__.write_free_lb(0, sigma2);
+      local_scalar_t__ Intercept = DUMMY_VAR__;
+      Intercept = context__.vals_r("Intercept")[(1 - 1)];
+      out__.write(Intercept);
+      Eigen::Matrix<local_scalar_t__,-1,1> mean_price =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> mean_price_flat__;
+        mean_price_flat__ = context__.vals_r("mean_price");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(mean_price, mean_price_flat__[(pos__ - 1)],
+            "assigning variable mean_price", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(mean_price);
+      Eigen::Matrix<local_scalar_t__,-1,1> sigma_price =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> sigma_price_flat__;
+        sigma_price_flat__ = context__.vals_r("sigma_price");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(sigma_price, sigma_price_flat__[(pos__ - 1)],
+            "assigning variable sigma_price", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lb(0.0, sigma_price);
+      local_scalar_t__ theta = DUMMY_VAR__;
+      theta = context__.vals_r("theta")[(1 - 1)];
+      out__.write(theta);
+      Eigen::Matrix<local_scalar_t__,-1,1> upper_test =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> upper_test_flat__;
+        upper_test_flat__ = context__.vals_r("upper_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(upper_test, upper_test_flat__[(pos__ - 1)],
+            "assigning variable upper_test", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_ub(ma, upper_test);
+      Eigen::Matrix<local_scalar_t__,-1,1> lower_upper_test =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> lower_upper_test_flat__;
+        lower_upper_test_flat__ = context__.vals_r("lower_upper_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(lower_upper_test,
+            lower_upper_test_flat__[(pos__ - 1)],
+            "assigning variable lower_upper_test",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(sigma_price, upper_test, lower_upper_test);
+      Eigen::Matrix<local_scalar_t__,1,-1> row_vec_lower_upper_test =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> row_vec_lower_upper_test_flat__;
+        row_vec_lower_upper_test_flat__ = context__.vals_r("row_vec_lower_upper_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(row_vec_lower_upper_test,
+            row_vec_lower_upper_test_flat__[(pos__ - 1)],
+            "assigning variable row_vec_lower_upper_test",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_lub(stan::math::transpose(sigma_price),
+        stan::math::transpose(upper_test), row_vec_lower_upper_test);
+      Eigen::Matrix<local_scalar_t__,-1,1> offset_mult_test =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> offset_mult_test_flat__;
+        offset_mult_test_flat__ = context__.vals_r("offset_mult_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(offset_mult_test,
+            offset_mult_test_flat__[(pos__ - 1)],
+            "assigning variable offset_mult_test",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_offset_multiplier(mean_price, sigma_price,
+        offset_mult_test);
+      Eigen::Matrix<local_scalar_t__,-1,1> ordered_test =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> ordered_test_flat__;
+        ordered_test_flat__ = context__.vals_r("ordered_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(ordered_test, ordered_test_flat__[(pos__ - 1)],
+            "assigning variable ordered_test", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_ordered(ordered_test);
+      Eigen::Matrix<local_scalar_t__,-1,1> unit_vec_test =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> unit_vec_test_flat__;
+        unit_vec_test_flat__ = context__.vals_r("unit_vec_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(unit_vec_test, unit_vec_test_flat__[(pos__ -
+            1)], "assigning variable unit_vec_test",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_unit_vector(unit_vec_test);
+      Eigen::Matrix<local_scalar_t__,-1,1> pos_ordered_test =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> pos_ordered_test_flat__;
+        pos_ordered_test_flat__ = context__.vals_r("pos_ordered_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(pos_ordered_test,
+            pos_ordered_test_flat__[(pos__ - 1)],
+            "assigning variable pos_ordered_test",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write_free_positive_ordered(pos_ordered_test);
+      Eigen::Matrix<local_scalar_t__,-1,-1> corr_matrix_test =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> corr_matrix_test_flat__;
+        corr_matrix_test_flat__ = context__.vals_r("corr_matrix_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(corr_matrix_test,
+              corr_matrix_test_flat__[(pos__ - 1)],
+              "assigning variable corr_matrix_test",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_corr_matrix(corr_matrix_test);
+      Eigen::Matrix<local_scalar_t__,-1,-1> cov_matrix_test =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> cov_matrix_test_flat__;
+        cov_matrix_test_flat__ = context__.vals_r("cov_matrix_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(cov_matrix_test,
+              cov_matrix_test_flat__[(pos__ - 1)],
+              "assigning variable cov_matrix_test",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_cov_matrix(cov_matrix_test);
+      Eigen::Matrix<local_scalar_t__,-1,-1> chol_fac_cov_test =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(K, K, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> chol_fac_cov_test_flat__;
+        chol_fac_cov_test_flat__ = context__.vals_r("chol_fac_cov_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            stan::model::assign(chol_fac_cov_test,
+              chol_fac_cov_test_flat__[(pos__ - 1)],
+              "assigning variable chol_fac_cov_test",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write_free_cholesky_factor_cov(chol_fac_cov_test);
+      Eigen::Matrix<local_scalar_t__,-1,-1> chol_fac_corr_test =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(K, K, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> chol_fac_corr_test_flat__;
+        chol_fac_corr_test_flat__ = context__.vals_r("chol_fac_corr_test");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
+            stan::model::assign(chol_fac_corr_test,
+              chol_fac_corr_test_flat__[(pos__ - 1)],
+              "assigning variable chol_fac_corr_test",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write_free_cholesky_factor_corr(chol_fac_corr_test);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1999,32 +2305,17 @@ class constraints_model final : public model_base_crtp<constraints_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 22>
-      names__{"high_low_est", "b", "h", "ar", "ma", "phi_beta", "sigma2",
-              "Intercept", "mean_price", "sigma_price", "theta",
-              "upper_test", "lower_upper_test", "row_vec_lower_upper_test",
-              "offset_mult_test", "ordered_test", "unit_vec_test",
-              "pos_ordered_test", "corr_matrix_test", "cov_matrix_test",
-              "chol_fac_cov_test", "chol_fac_corr_test"};
-    const std::array<Eigen::Index, 22>
-      constrain_param_sizes__{N, K, Nr, 2, 1, 1, 1, 1, N, N, 1, N, N, N, N,
-                              N, N, N, (N * N), (N * N), (K * K), (K * K)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -2292,8 +2583,8 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -2309,6 +2600,39 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
       stan::model::assign(X_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable X_p");
+      out__.write(X_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> X_p_flat__;
+        X_p_flat__ = context__.vals_r("X_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(X_p, X_p_flat__[(pos__ - 1)],
+              "assigning variable X_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2536,24 +2860,17 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 1> names__{"X_p"};
-    const std::array<Eigen::Index, 1> constrain_param_sizes__{(10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -3688,8 +4005,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -3830,6 +4147,352 @@ class indexing_model final : public model_base_crtp<indexing_model> {
       stan::model::assign(p_aos_mat_fail_uni_uni_idx2,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
         "assigning variable p_aos_mat_fail_uni_uni_idx2");
+      out__.write(p_aos_mat_fail_uni_uni_idx2);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
+      out__.write(alpha);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_soa_vec_v =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_vec_v_flat__;
+        p_soa_vec_v_flat__ = context__.vals_r("p_soa_vec_v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(p_soa_vec_v, p_soa_vec_v_flat__[(pos__ - 1)],
+            "assigning variable p_soa_vec_v", stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_soa_vec_v);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_mat =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_mat_flat__;
+        p_soa_mat_flat__ = context__.vals_r("p_soa_mat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_soa_mat, p_soa_mat_flat__[(pos__ - 1)],
+              "assigning variable p_soa_mat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_soa_mat);
+      std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_soa_arr_vec_v =
+        std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(10,
+          Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
+      {
+        std::vector<local_scalar_t__> p_soa_arr_vec_v_flat__;
+        p_soa_arr_vec_v_flat__ = context__.vals_r("p_soa_arr_vec_v");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(p_soa_arr_vec_v,
+              p_soa_arr_vec_v_flat__[(pos__ - 1)],
+              "assigning variable p_soa_arr_vec_v",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_soa_arr_vec_v);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_mat_uni_col_idx =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_mat_uni_col_idx_flat__;
+        p_soa_mat_uni_col_idx_flat__ = context__.vals_r("p_soa_mat_uni_col_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_soa_mat_uni_col_idx,
+              p_soa_mat_uni_col_idx_flat__[(pos__ - 1)],
+              "assigning variable p_soa_mat_uni_col_idx",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_soa_mat_uni_col_idx);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_soa_vec_uni_idx =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_vec_uni_idx_flat__;
+        p_soa_vec_uni_idx_flat__ = context__.vals_r("p_soa_vec_uni_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_soa_vec_uni_idx,
+            p_soa_vec_uni_idx_flat__[(pos__ - 1)],
+            "assigning variable p_soa_vec_uni_idx",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_soa_vec_uni_idx);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_loop_mat_uni_col_idx =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_loop_mat_uni_col_idx_flat__;
+        p_soa_loop_mat_uni_col_idx_flat__ = context__.vals_r("p_soa_loop_mat_uni_col_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_soa_loop_mat_uni_col_idx,
+              p_soa_loop_mat_uni_col_idx_flat__[(pos__ - 1)],
+              "assigning variable p_soa_loop_mat_uni_col_idx",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_soa_loop_mat_uni_col_idx);
+      Eigen::Matrix<local_scalar_t__,1,-1> p_soa_lhs_loop_mul =
+        Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_lhs_loop_mul_flat__;
+        p_soa_lhs_loop_mul_flat__ = context__.vals_r("p_soa_lhs_loop_mul");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_soa_lhs_loop_mul,
+            p_soa_lhs_loop_mul_flat__[(pos__ - 1)],
+            "assigning variable p_soa_lhs_loop_mul",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_soa_lhs_loop_mul);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_soa_rhs_loop_mul =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_rhs_loop_mul_flat__;
+        p_soa_rhs_loop_mul_flat__ = context__.vals_r("p_soa_rhs_loop_mul");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_soa_rhs_loop_mul,
+            p_soa_rhs_loop_mul_flat__[(pos__ - 1)],
+            "assigning variable p_soa_rhs_loop_mul",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_soa_rhs_loop_mul);
+      Eigen::Matrix<local_scalar_t__,-1,1>
+        p_soa_used_with_aos_in_excluded_fun =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__>
+          p_soa_used_with_aos_in_excluded_fun_flat__;
+        p_soa_used_with_aos_in_excluded_fun_flat__ = context__.vals_r("p_soa_used_with_aos_in_excluded_fun");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+          stan::model::assign(p_soa_used_with_aos_in_excluded_fun,
+            p_soa_used_with_aos_in_excluded_fun_flat__[(pos__ - 1)],
+            "assigning variable p_soa_used_with_aos_in_excluded_fun",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_soa_used_with_aos_in_excluded_fun);
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_soa_loop_mat_multi_uni_uni_idx =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_soa_loop_mat_multi_uni_uni_idx_flat__;
+        p_soa_loop_mat_multi_uni_uni_idx_flat__ = context__.vals_r("p_soa_loop_mat_multi_uni_uni_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_soa_loop_mat_multi_uni_uni_idx,
+              p_soa_loop_mat_multi_uni_uni_idx_flat__[(pos__ - 1)],
+              "assigning variable p_soa_loop_mat_multi_uni_uni_idx",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_soa_loop_mat_multi_uni_uni_idx);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_aos_vec_v_assign_to_aos =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_vec_v_assign_to_aos_flat__;
+        p_aos_vec_v_assign_to_aos_flat__ = context__.vals_r("p_aos_vec_v_assign_to_aos");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(p_aos_vec_v_assign_to_aos,
+            p_aos_vec_v_assign_to_aos_flat__[(pos__ - 1)],
+            "assigning variable p_aos_vec_v_assign_to_aos",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_aos_vec_v_assign_to_aos);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_aos_vec_v_tp_fails_func =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_vec_v_tp_fails_func_flat__;
+        p_aos_vec_v_tp_fails_func_flat__ = context__.vals_r("p_aos_vec_v_tp_fails_func");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(p_aos_vec_v_tp_fails_func,
+            p_aos_vec_v_tp_fails_func_flat__[(pos__ - 1)],
+            "assigning variable p_aos_vec_v_tp_fails_func",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_aos_vec_v_tp_fails_func);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_aos_loop_vec_v_uni_idx =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_loop_vec_v_uni_idx_flat__;
+        p_aos_loop_vec_v_uni_idx_flat__ = context__.vals_r("p_aos_loop_vec_v_uni_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(p_aos_loop_vec_v_uni_idx,
+            p_aos_loop_vec_v_uni_idx_flat__[(pos__ - 1)],
+            "assigning variable p_aos_loop_vec_v_uni_idx",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_aos_loop_vec_v_uni_idx);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_aos_fail_assign_from_top_idx =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_fail_assign_from_top_idx_flat__;
+        p_aos_fail_assign_from_top_idx_flat__ = context__.vals_r("p_aos_fail_assign_from_top_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          stan::model::assign(p_aos_fail_assign_from_top_idx,
+            p_aos_fail_assign_from_top_idx_flat__[(pos__ - 1)],
+            "assigning variable p_aos_fail_assign_from_top_idx",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
+      out__.write(p_aos_fail_assign_from_top_idx);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_loop_mat_uni_uni_idx =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_loop_mat_uni_uni_idx_flat__;
+        p_aos_loop_mat_uni_uni_idx_flat__ = context__.vals_r("p_aos_loop_mat_uni_uni_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_aos_loop_mat_uni_uni_idx,
+              p_aos_loop_mat_uni_uni_idx_flat__[(pos__ - 1)],
+              "assigning variable p_aos_loop_mat_uni_uni_idx",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_aos_loop_mat_uni_uni_idx);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_mat_flat__;
+        p_aos_mat_flat__ = context__.vals_r("p_aos_mat");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_aos_mat, p_aos_mat_flat__[(pos__ - 1)],
+              "assigning variable p_aos_mat", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_aos_mat);
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_aos_mat_pass_func_outer_single_indexed1 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__>
+          p_aos_mat_pass_func_outer_single_indexed1_flat__;
+        p_aos_mat_pass_func_outer_single_indexed1_flat__ = context__.vals_r("p_aos_mat_pass_func_outer_single_indexed1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_aos_mat_pass_func_outer_single_indexed1,
+              p_aos_mat_pass_func_outer_single_indexed1_flat__[(pos__ - 1)],
+              "assigning variable p_aos_mat_pass_func_outer_single_indexed1",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_aos_mat_pass_func_outer_single_indexed1);
+      Eigen::Matrix<local_scalar_t__,-1,-1>
+        p_aos_mat_pass_func_outer_single_indexed2 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__>
+          p_aos_mat_pass_func_outer_single_indexed2_flat__;
+        p_aos_mat_pass_func_outer_single_indexed2_flat__ = context__.vals_r("p_aos_mat_pass_func_outer_single_indexed2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_aos_mat_pass_func_outer_single_indexed2,
+              p_aos_mat_pass_func_outer_single_indexed2_flat__[(pos__ - 1)],
+              "assigning variable p_aos_mat_pass_func_outer_single_indexed2",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_aos_mat_pass_func_outer_single_indexed2);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_fail_uni_uni_idx1 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_mat_fail_uni_uni_idx1_flat__;
+        p_aos_mat_fail_uni_uni_idx1_flat__ = context__.vals_r("p_aos_mat_fail_uni_uni_idx1");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_aos_mat_fail_uni_uni_idx1,
+              p_aos_mat_fail_uni_uni_idx1_flat__[(pos__ - 1)],
+              "assigning variable p_aos_mat_fail_uni_uni_idx1",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(p_aos_mat_fail_uni_uni_idx1);
+      Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_fail_uni_uni_idx2 =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_mat_fail_uni_uni_idx2_flat__;
+        p_aos_mat_fail_uni_uni_idx2_flat__ = context__.vals_r("p_aos_mat_fail_uni_uni_idx2");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
+            stan::model::assign(p_aos_mat_fail_uni_uni_idx2,
+              p_aos_mat_fail_uni_uni_idx2_flat__[(pos__ - 1)],
+              "assigning variable p_aos_mat_fail_uni_uni_idx2",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(p_aos_mat_fail_uni_uni_idx2);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4248,38 +4911,17 @@ class indexing_model final : public model_base_crtp<indexing_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 21>
-      names__{"alpha", "p_soa_vec_v", "p_soa_mat", "p_soa_arr_vec_v",
-              "p_soa_mat_uni_col_idx", "p_soa_vec_uni_idx",
-              "p_soa_loop_mat_uni_col_idx", "p_soa_lhs_loop_mul",
-              "p_soa_rhs_loop_mul", "p_soa_used_with_aos_in_excluded_fun",
-              "p_soa_loop_mat_multi_uni_uni_idx",
-              "p_aos_vec_v_assign_to_aos", "p_aos_vec_v_tp_fails_func",
-              "p_aos_loop_vec_v_uni_idx", "p_aos_fail_assign_from_top_idx",
-              "p_aos_loop_mat_uni_uni_idx", "p_aos_mat",
-              "p_aos_mat_pass_func_outer_single_indexed1",
-              "p_aos_mat_pass_func_outer_single_indexed2",
-              "p_aos_mat_fail_uni_uni_idx1", "p_aos_mat_fail_uni_uni_idx2"};
-    const std::array<Eigen::Index, 21>
-      constrain_param_sizes__{1, M, (N * M), (10 * N), (N * M), N, (N * M),
-                              N, N, N, (N * M), M, M, M, M, (N * M), (N * M),
-                              (N * M), (N * M), (N * M), (N * M)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4519,8 +5161,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4539,6 +5181,41 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
       stan::model::assign(p_aos_loop_single_idx,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(10),
         "assigning variable p_aos_loop_single_idx");
+      out__.write(p_aos_loop_single_idx);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      local_scalar_t__ alpha = DUMMY_VAR__;
+      alpha = context__.vals_r("alpha")[(1 - 1)];
+      out__.write(alpha);
+      Eigen::Matrix<local_scalar_t__,-1,1> p_aos_loop_single_idx =
+        Eigen::Matrix<local_scalar_t__,-1,1>::Constant(10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> p_aos_loop_single_idx_flat__;
+        p_aos_loop_single_idx_flat__ = context__.vals_r("p_aos_loop_single_idx");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          stan::model::assign(p_aos_loop_single_idx,
+            p_aos_loop_single_idx_flat__[(pos__ - 1)],
+            "assigning variable p_aos_loop_single_idx",
+            stan::model::index_uni(sym1__));
+          pos__ = (pos__ + 1);
+        }
+      }
       out__.write(p_aos_loop_single_idx);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4649,25 +5326,17 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2>
-      names__{"alpha", "p_aos_loop_single_idx"};
-    const std::array<Eigen::Index, 2> constrain_param_sizes__{1, 10};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -4967,8 +5636,8 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -4996,6 +5665,71 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
       stan::model::assign(aos_y,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
         "assigning variable aos_y");
+      out__.write(aos_y);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> soa_x =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> soa_x_flat__;
+        soa_x_flat__ = context__.vals_r("soa_x");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(soa_x, soa_x_flat__[(pos__ - 1)],
+              "assigning variable soa_x", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(soa_x);
+      Eigen::Matrix<local_scalar_t__,-1,-1> aos_x =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> aos_x_flat__;
+        aos_x_flat__ = context__.vals_r("aos_x");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(aos_x, aos_x_flat__[(pos__ - 1)],
+              "assigning variable aos_x", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(aos_x);
+      Eigen::Matrix<local_scalar_t__,-1,-1> aos_y =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> aos_y_flat__;
+        aos_y_flat__ = context__.vals_r("aos_y");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(aos_y, aos_y_flat__[(pos__ - 1)],
+              "assigning variable aos_y", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(aos_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5184,25 +5918,17 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 3> names__{"soa_x", "aos_x", "aos_y"};
-    const std::array<Eigen::Index, 3>
-      constrain_param_sizes__{(5 * 10), (5 * 10), (5 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -5499,8 +6225,8 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -5522,6 +6248,55 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
       stan::model::assign(udf_input_aos,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable udf_input_aos");
+      out__.write(udf_input_aos);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> row_soa =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> row_soa_flat__;
+        row_soa_flat__ = context__.vals_r("row_soa");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(row_soa, row_soa_flat__[(pos__ - 1)],
+              "assigning variable row_soa", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(row_soa);
+      Eigen::Matrix<local_scalar_t__,-1,-1> udf_input_aos =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> udf_input_aos_flat__;
+        udf_input_aos_flat__ = context__.vals_r("udf_input_aos");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(udf_input_aos, udf_input_aos_flat__[(pos__ -
+              1)], "assigning variable udf_input_aos",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(udf_input_aos);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5736,25 +6511,17 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"row_soa", "udf_input_aos"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(10 * 10), (10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -5986,8 +6753,8 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -6009,6 +6776,55 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
       stan::model::assign(soa_p,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
         "assigning variable soa_p");
+      out__.write(soa_p);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> aos_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> aos_p_flat__;
+        aos_p_flat__ = context__.vals_r("aos_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(aos_p, aos_p_flat__[(pos__ - 1)],
+              "assigning variable aos_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(aos_p);
+      Eigen::Matrix<local_scalar_t__,-1,-1> soa_p =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> soa_p_flat__;
+        soa_p_flat__ = context__.vals_r("soa_p");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+            stan::model::assign(soa_p, soa_p_flat__[(pos__ - 1)],
+              "assigning variable soa_p", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(soa_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6149,25 +6965,17 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"aos_p", "soa_p"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(10 * 10), (10 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }
@@ -6418,8 +7226,8 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
             stan::require_vector_t<VecVar>* = nullptr,
             stan::require_vector_like_vt<std::is_integral, VecI>* = nullptr>
   inline void
-  transform_inits_impl(VecVar& params_r__, VecI& params_i__, VecVar& vars__,
-                       std::ostream* pstream__ = nullptr) const {
+  unconstrain_array_impl(const VecVar& params_r__, const VecI& params_i__,
+                         VecVar& vars__, std::ostream* pstream__ = nullptr) const {
     using local_scalar_t__ = double;
     stan::io::deserializer<local_scalar_t__> in__(params_r__, params_i__);
     stan::io::serializer<local_scalar_t__> out__(vars__);
@@ -6441,6 +7249,56 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
       stan::model::assign(aos_x,
         in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
         "assigning variable aos_x");
+      out__.write(aos_x);
+    } catch (const std::exception& e) {
+      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
+    }
+  }
+  template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
+  inline void
+  transform_inits_impl(const stan::io::var_context& context__, VecVar&
+                       vars__, std::ostream* pstream__ = nullptr) const {
+    using local_scalar_t__ = double;
+    stan::io::serializer<local_scalar_t__> out__(vars__);
+    int current_statement__ = 0;
+    local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+    // suppress unused var warning
+    (void) DUMMY_VAR__;
+    try {
+      int pos__ = std::numeric_limits<int>::min();
+      pos__ = 1;
+      Eigen::Matrix<local_scalar_t__,-1,-1> first_pass_soa_x =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> first_pass_soa_x_flat__;
+        first_pass_soa_x_flat__ = context__.vals_r("first_pass_soa_x");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(first_pass_soa_x,
+              first_pass_soa_x_flat__[(pos__ - 1)],
+              "assigning variable first_pass_soa_x",
+              stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
+      out__.write(first_pass_soa_x);
+      Eigen::Matrix<local_scalar_t__,-1,-1> aos_x =
+        Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
+      {
+        std::vector<local_scalar_t__> aos_x_flat__;
+        aos_x_flat__ = context__.vals_r("aos_x");
+        pos__ = 1;
+        for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+          for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
+            stan::model::assign(aos_x, aos_x_flat__[(pos__ - 1)],
+              "assigning variable aos_x", stan::model::index_uni(sym2__),
+              stan::model::index_uni(sym1__));
+            pos__ = (pos__ + 1);
+          }
+        }
+      }
       out__.write(aos_x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6592,25 +7450,17 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
   transform_inits(const stan::io::var_context& context, std::vector<int>&
                   params_i, std::vector<double>& vars, std::ostream*
                   pstream__ = nullptr) const {
-    constexpr std::array<const char*, 2> names__{"first_pass_soa_x", "aos_x"};
-    const std::array<Eigen::Index, 2>
-      constrain_param_sizes__{(5 * 10), (5 * 10)};
-    const auto num_constrained_params__ =
-      std::accumulate(constrain_param_sizes__.begin(),
-        constrain_param_sizes__.end(), 0);
-    std::vector<double> params_r_flat__(num_constrained_params__);
-    Eigen::Index size_iter__ = 0;
-    Eigen::Index flat_iter__ = 0;
-    for (auto&& param_name__: names__) {
-      const auto param_vec__ = context.vals_r(param_name__);
-      for (Eigen::Index i = 0; i < constrain_param_sizes__[size_iter__]; ++i) {
-        params_r_flat__[flat_iter__] = param_vec__[i];
-        ++flat_iter__;
-      }
-      ++size_iter__;
-    }
     vars.resize(num_params_r__);
-    transform_inits_impl(params_r_flat__, params_i, vars, pstream__);
+    transform_inits_impl(context, vars, pstream__);
+  }
+  inline void
+  unconstrain_array(const std::vector<double>& params_constrained,
+                    std::vector<double>& params_unconstrained, std::ostream*
+                    pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained.resize(num_params_r__);
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
   }
 };
 }

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -350,7 +350,18 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2313,7 +2324,18 @@ class constraints_model final : public model_base_crtp<constraints_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -2868,7 +2890,18 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -4919,7 +4952,18 @@ class indexing_model final : public model_base_crtp<indexing_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -5334,7 +5378,18 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -5926,7 +5981,18 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -6519,7 +6585,18 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -6973,7 +7050,18 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }
@@ -7458,7 +7546,18 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
                     std::vector<double>& params_unconstrained, std::ostream*
                     pstream = nullptr) const {
     const std::vector<int> params_i;
-    params_unconstrained.resize(num_params_r__);
+    params_unconstrained = std::vector<double>(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
+    unconstrain_array_impl(params_constrained, params_i,
+      params_unconstrained, pstream);
+  }
+  inline void
+  unconstrain_array(const Eigen::Matrix<double,-1,1>& params_constrained,
+                    Eigen::Matrix<double,-1,1>& params_unconstrained,
+                    std::ostream* pstream = nullptr) const {
+    const std::vector<int> params_i;
+    params_unconstrained = Eigen::Matrix<double,-1,1>::Constant(num_params_r__,
+                             std::numeric_limits<double>::quiet_NaN());
     unconstrain_array_impl(params_constrained, params_i,
       params_unconstrained, pstream);
   }

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -4068,11 +4068,12 @@ class indexing_model final : public model_base_crtp<indexing_model> {
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_soa_arr_vec_v =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(10,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        stan::model::assign(p_soa_arr_vec_v,
-          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
-          "assigning variable p_soa_arr_vec_v",
-          stan::model::index_uni(sym1__));
+      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
+        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
+          stan::model::assign(p_soa_arr_vec_v, in__.read<local_scalar_t__>(),
+            "assigning variable p_soa_arr_vec_v",
+            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
+        }
       }
       out__.write(p_soa_arr_vec_v);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_mat_uni_col_idx =

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -158,13 +158,9 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> A_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(A_p, in__.read<local_scalar_t__>(),
-            "assigning variable A_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(A_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable A_p");
       out__.write(A_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1517,31 +1513,27 @@ class constraints_model final : public model_base_crtp<constraints_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> high_low_est =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(high_low_est, in__.read<local_scalar_t__>(),
-          "assigning variable high_low_est", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(high_low_est,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable high_low_est");
       out__.write_free_lub(diff_low_mid, diff_high_mid, high_low_est);
       Eigen::Matrix<local_scalar_t__,-1,1> b =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        stan::model::assign(b, in__.read<local_scalar_t__>(),
-          "assigning variable b", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(b,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(K),
+        "assigning variable b");
       out__.write(b);
       Eigen::Matrix<local_scalar_t__,-1,1> h =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(Nr, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= Nr; ++sym1__) {
-        stan::model::assign(h, in__.read<local_scalar_t__>(),
-          "assigning variable h", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(h,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(Nr),
+        "assigning variable h");
       out__.write(h);
       Eigen::Matrix<local_scalar_t__,-1,1> ar =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 2; ++sym1__) {
-        stan::model::assign(ar, in__.read<local_scalar_t__>(),
-          "assigning variable ar", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(ar,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(2),
+        "assigning variable ar");
       out__.write(ar);
       local_scalar_t__ ma = DUMMY_VAR__;
       ma = in__.read<local_scalar_t__>();
@@ -1557,119 +1549,86 @@ class constraints_model final : public model_base_crtp<constraints_model> {
       out__.write(Intercept);
       Eigen::Matrix<local_scalar_t__,-1,1> mean_price =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(mean_price, in__.read<local_scalar_t__>(),
-          "assigning variable mean_price", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(mean_price,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable mean_price");
       out__.write(mean_price);
       Eigen::Matrix<local_scalar_t__,-1,1> sigma_price =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(sigma_price, in__.read<local_scalar_t__>(),
-          "assigning variable sigma_price", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(sigma_price,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable sigma_price");
       out__.write_free_lb(0.0, sigma_price);
       local_scalar_t__ theta = DUMMY_VAR__;
       theta = in__.read<local_scalar_t__>();
       out__.write(theta);
       Eigen::Matrix<local_scalar_t__,-1,1> upper_test =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(upper_test, in__.read<local_scalar_t__>(),
-          "assigning variable upper_test", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(upper_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable upper_test");
       out__.write_free_ub(ma, upper_test);
       Eigen::Matrix<local_scalar_t__,-1,1> lower_upper_test =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(lower_upper_test, in__.read<local_scalar_t__>(),
-          "assigning variable lower_upper_test",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(lower_upper_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable lower_upper_test");
       out__.write_free_lub(sigma_price, upper_test, lower_upper_test);
       Eigen::Matrix<local_scalar_t__,1,-1> row_vec_lower_upper_test =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(row_vec_lower_upper_test,
-          in__.read<local_scalar_t__>(),
-          "assigning variable row_vec_lower_upper_test",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(row_vec_lower_upper_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable row_vec_lower_upper_test");
       out__.write_free_lub(stan::math::transpose(sigma_price),
         stan::math::transpose(upper_test), row_vec_lower_upper_test);
       Eigen::Matrix<local_scalar_t__,-1,1> offset_mult_test =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(offset_mult_test, in__.read<local_scalar_t__>(),
-          "assigning variable offset_mult_test",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(offset_mult_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable offset_mult_test");
       out__.write_free_offset_multiplier(mean_price, sigma_price,
         offset_mult_test);
       Eigen::Matrix<local_scalar_t__,-1,1> ordered_test =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(ordered_test, in__.read<local_scalar_t__>(),
-          "assigning variable ordered_test", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(ordered_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable ordered_test");
       out__.write_free_ordered(ordered_test);
       Eigen::Matrix<local_scalar_t__,-1,1> unit_vec_test =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(unit_vec_test, in__.read<local_scalar_t__>(),
-          "assigning variable unit_vec_test", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(unit_vec_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable unit_vec_test");
       out__.write_free_unit_vector(unit_vec_test);
       Eigen::Matrix<local_scalar_t__,-1,1> pos_ordered_test =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(pos_ordered_test, in__.read<local_scalar_t__>(),
-          "assigning variable pos_ordered_test",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(pos_ordered_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable pos_ordered_test");
       out__.write_free_positive_ordered(pos_ordered_test);
       Eigen::Matrix<local_scalar_t__,-1,-1> corr_matrix_test =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(corr_matrix_test,
-            in__.read<local_scalar_t__>(),
-            "assigning variable corr_matrix_test",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(corr_matrix_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable corr_matrix_test");
       out__.write_free_corr_matrix(corr_matrix_test);
       Eigen::Matrix<local_scalar_t__,-1,-1> cov_matrix_test =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(cov_matrix_test, in__.read<local_scalar_t__>(),
-            "assigning variable cov_matrix_test",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(cov_matrix_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, N),
+        "assigning variable cov_matrix_test");
       out__.write_free_cov_matrix(cov_matrix_test);
       Eigen::Matrix<local_scalar_t__,-1,-1> chol_fac_cov_test =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(K, K, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          stan::model::assign(chol_fac_cov_test,
-            in__.read<local_scalar_t__>(),
-            "assigning variable chol_fac_cov_test",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(chol_fac_cov_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(K, K),
+        "assigning variable chol_fac_cov_test");
       out__.write_free_cholesky_factor_cov(chol_fac_cov_test);
       Eigen::Matrix<local_scalar_t__,-1,-1> chol_fac_corr_test =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(K, K, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= K; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= K; ++sym2__) {
-          stan::model::assign(chol_fac_corr_test,
-            in__.read<local_scalar_t__>(),
-            "assigning variable chol_fac_corr_test",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(chol_fac_corr_test,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(K, K),
+        "assigning variable chol_fac_corr_test");
       out__.write_free_cholesky_factor_corr(chol_fac_corr_test);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2347,13 +2306,9 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(X_p, in__.read<local_scalar_t__>(),
-            "assigning variable X_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(X_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable X_p");
       out__.write(X_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -3750,204 +3705,131 @@ class indexing_model final : public model_base_crtp<indexing_model> {
       out__.write(alpha);
       Eigen::Matrix<local_scalar_t__,-1,1> p_soa_vec_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(p_soa_vec_v, in__.read<local_scalar_t__>(),
-          "assigning variable p_soa_vec_v", stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_soa_vec_v,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable p_soa_vec_v");
       out__.write(p_soa_vec_v);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_mat =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_soa_mat, in__.read<local_scalar_t__>(),
-            "assigning variable p_soa_mat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_soa_mat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_soa_mat");
       out__.write(p_soa_mat);
       std::vector<Eigen::Matrix<local_scalar_t__,-1,1>> p_soa_arr_vec_v =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,1>>(10,
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__));
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(p_soa_arr_vec_v, in__.read<local_scalar_t__>(),
-            "assigning variable p_soa_arr_vec_v",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
+      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
+        stan::model::assign(p_soa_arr_vec_v,
+          in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+          "assigning variable p_soa_arr_vec_v",
+          stan::model::index_uni(sym1__));
       }
       out__.write(p_soa_arr_vec_v);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_mat_uni_col_idx =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_soa_mat_uni_col_idx,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_soa_mat_uni_col_idx",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_soa_mat_uni_col_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_soa_mat_uni_col_idx");
       out__.write(p_soa_mat_uni_col_idx);
       Eigen::Matrix<local_scalar_t__,-1,1> p_soa_vec_uni_idx =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_soa_vec_uni_idx, in__.read<local_scalar_t__>(),
-          "assigning variable p_soa_vec_uni_idx",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_soa_vec_uni_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable p_soa_vec_uni_idx");
       out__.write(p_soa_vec_uni_idx);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_soa_loop_mat_uni_col_idx =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_soa_loop_mat_uni_col_idx,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_soa_loop_mat_uni_col_idx",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_soa_loop_mat_uni_col_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_soa_loop_mat_uni_col_idx");
       out__.write(p_soa_loop_mat_uni_col_idx);
       Eigen::Matrix<local_scalar_t__,1,-1> p_soa_lhs_loop_mul =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_soa_lhs_loop_mul,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_soa_lhs_loop_mul",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_soa_lhs_loop_mul,
+        in__.read<Eigen::Matrix<local_scalar_t__,1,-1>>(N),
+        "assigning variable p_soa_lhs_loop_mul");
       out__.write(p_soa_lhs_loop_mul);
       Eigen::Matrix<local_scalar_t__,-1,1> p_soa_rhs_loop_mul =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_soa_rhs_loop_mul,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_soa_rhs_loop_mul",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_soa_rhs_loop_mul,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable p_soa_rhs_loop_mul");
       out__.write(p_soa_rhs_loop_mul);
       Eigen::Matrix<local_scalar_t__,-1,1>
         p_soa_used_with_aos_in_excluded_fun =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
-        stan::model::assign(p_soa_used_with_aos_in_excluded_fun,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_soa_used_with_aos_in_excluded_fun",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_soa_used_with_aos_in_excluded_fun,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(N),
+        "assigning variable p_soa_used_with_aos_in_excluded_fun");
       out__.write(p_soa_used_with_aos_in_excluded_fun);
       Eigen::Matrix<local_scalar_t__,-1,-1>
         p_soa_loop_mat_multi_uni_uni_idx =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_soa_loop_mat_multi_uni_uni_idx,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_soa_loop_mat_multi_uni_uni_idx",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_soa_loop_mat_multi_uni_uni_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_soa_loop_mat_multi_uni_uni_idx");
       out__.write(p_soa_loop_mat_multi_uni_uni_idx);
       Eigen::Matrix<local_scalar_t__,-1,1> p_aos_vec_v_assign_to_aos =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(p_aos_vec_v_assign_to_aos,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_aos_vec_v_assign_to_aos",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_aos_vec_v_assign_to_aos,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable p_aos_vec_v_assign_to_aos");
       out__.write(p_aos_vec_v_assign_to_aos);
       Eigen::Matrix<local_scalar_t__,-1,1> p_aos_vec_v_tp_fails_func =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(p_aos_vec_v_tp_fails_func,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_aos_vec_v_tp_fails_func",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_aos_vec_v_tp_fails_func,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable p_aos_vec_v_tp_fails_func");
       out__.write(p_aos_vec_v_tp_fails_func);
       Eigen::Matrix<local_scalar_t__,-1,1> p_aos_loop_vec_v_uni_idx =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(p_aos_loop_vec_v_uni_idx,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_aos_loop_vec_v_uni_idx",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_aos_loop_vec_v_uni_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable p_aos_loop_vec_v_uni_idx");
       out__.write(p_aos_loop_vec_v_uni_idx);
       Eigen::Matrix<local_scalar_t__,-1,1> p_aos_fail_assign_from_top_idx =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        stan::model::assign(p_aos_fail_assign_from_top_idx,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_aos_fail_assign_from_top_idx",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_aos_fail_assign_from_top_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(M),
+        "assigning variable p_aos_fail_assign_from_top_idx");
       out__.write(p_aos_fail_assign_from_top_idx);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_loop_mat_uni_uni_idx =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_aos_loop_mat_uni_uni_idx,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_aos_loop_mat_uni_uni_idx",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_aos_loop_mat_uni_uni_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_aos_loop_mat_uni_uni_idx");
       out__.write(p_aos_loop_mat_uni_uni_idx);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_aos_mat, in__.read<local_scalar_t__>(),
-            "assigning variable p_aos_mat", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_aos_mat,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_aos_mat");
       out__.write(p_aos_mat);
       Eigen::Matrix<local_scalar_t__,-1,-1>
         p_aos_mat_pass_func_outer_single_indexed1 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_aos_mat_pass_func_outer_single_indexed1,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_aos_mat_pass_func_outer_single_indexed1",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_aos_mat_pass_func_outer_single_indexed1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_aos_mat_pass_func_outer_single_indexed1");
       out__.write(p_aos_mat_pass_func_outer_single_indexed1);
       Eigen::Matrix<local_scalar_t__,-1,-1>
         p_aos_mat_pass_func_outer_single_indexed2 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_aos_mat_pass_func_outer_single_indexed2,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_aos_mat_pass_func_outer_single_indexed2",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_aos_mat_pass_func_outer_single_indexed2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_aos_mat_pass_func_outer_single_indexed2");
       out__.write(p_aos_mat_pass_func_outer_single_indexed2);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_fail_uni_uni_idx1 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_aos_mat_fail_uni_uni_idx1,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_aos_mat_fail_uni_uni_idx1",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_aos_mat_fail_uni_uni_idx1,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_aos_mat_fail_uni_uni_idx1");
       out__.write(p_aos_mat_fail_uni_uni_idx1);
       Eigen::Matrix<local_scalar_t__,-1,-1> p_aos_mat_fail_uni_uni_idx2 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, M, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= M; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= N; ++sym2__) {
-          stan::model::assign(p_aos_mat_fail_uni_uni_idx2,
-            in__.read<local_scalar_t__>(),
-            "assigning variable p_aos_mat_fail_uni_uni_idx2",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(p_aos_mat_fail_uni_uni_idx2,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(N, M),
+        "assigning variable p_aos_mat_fail_uni_uni_idx2");
       out__.write(p_aos_mat_fail_uni_uni_idx2);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4654,12 +4536,9 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
       out__.write(alpha);
       Eigen::Matrix<local_scalar_t__,-1,1> p_aos_loop_single_idx =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        stan::model::assign(p_aos_loop_single_idx,
-          in__.read<local_scalar_t__>(),
-          "assigning variable p_aos_loop_single_idx",
-          stan::model::index_uni(sym1__));
-      }
+      stan::model::assign(p_aos_loop_single_idx,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,1>>(10),
+        "assigning variable p_aos_loop_single_idx");
       out__.write(p_aos_loop_single_idx);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5102,33 +4981,21 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> soa_x =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(soa_x, in__.read<local_scalar_t__>(),
-            "assigning variable soa_x", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(soa_x,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
+        "assigning variable soa_x");
       out__.write(soa_x);
       Eigen::Matrix<local_scalar_t__,-1,-1> aos_x =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(aos_x, in__.read<local_scalar_t__>(),
-            "assigning variable aos_x", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(aos_x,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
+        "assigning variable aos_x");
       out__.write(aos_x);
       Eigen::Matrix<local_scalar_t__,-1,-1> aos_y =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(aos_y, in__.read<local_scalar_t__>(),
-            "assigning variable aos_y", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(aos_y,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
+        "assigning variable aos_y");
       out__.write(aos_y);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -5646,23 +5513,15 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> row_soa =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(row_soa, in__.read<local_scalar_t__>(),
-            "assigning variable row_soa", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(row_soa,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable row_soa");
       out__.write(row_soa);
       Eigen::Matrix<local_scalar_t__,-1,-1> udf_input_aos =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(udf_input_aos, in__.read<local_scalar_t__>(),
-            "assigning variable udf_input_aos",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(udf_input_aos,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable udf_input_aos");
       out__.write(udf_input_aos);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6141,23 +6000,15 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> aos_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(aos_p, in__.read<local_scalar_t__>(),
-            "assigning variable aos_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(aos_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable aos_p");
       out__.write(aos_p);
       Eigen::Matrix<local_scalar_t__,-1,-1> soa_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 10; ++sym2__) {
-          stan::model::assign(soa_p, in__.read<local_scalar_t__>(),
-            "assigning variable soa_p", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(soa_p,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(10, 10),
+        "assigning variable soa_p");
       out__.write(soa_p);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -6581,24 +6432,15 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
       pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> first_pass_soa_x =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(first_pass_soa_x,
-            in__.read<local_scalar_t__>(),
-            "assigning variable first_pass_soa_x",
-            stan::model::index_uni(sym2__), stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(first_pass_soa_x,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
+        "assigning variable first_pass_soa_x");
       out__.write(first_pass_soa_x);
       Eigen::Matrix<local_scalar_t__,-1,-1> aos_x =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
-      for (int sym1__ = 1; sym1__ <= 10; ++sym1__) {
-        for (int sym2__ = 1; sym2__ <= 5; ++sym2__) {
-          stan::model::assign(aos_x, in__.read<local_scalar_t__>(),
-            "assigning variable aos_x", stan::model::index_uni(sym2__),
-            stan::model::index_uni(sym1__));
-        }
-      }
+      stan::model::assign(aos_x,
+        in__.read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10),
+        "assigning variable aos_x");
       out__.write(aos_x);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -182,53 +182,14 @@ matrix[10, 10] A_p: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (A_p UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (A_p UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4007,29 +3968,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (high_low_est UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (high_low_est UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4056,29 +4000,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var K))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (b UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var K))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (b UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var K))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4099,29 +4026,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var Nr))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (h UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var Nr))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (h UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var Nr))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4142,29 +4052,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 2))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (ar UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Lit Int 2))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (ar UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 2))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4267,29 +4160,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (mean_price UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (mean_price UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4310,29 +4186,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (sigma_price UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (sigma_price UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4375,29 +4234,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (upper_test UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (upper_test UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4422,29 +4264,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (lower_upper_test UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (lower_upper_test UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4471,30 +4296,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (row_vec_lower_upper_test URowVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta
-                ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (row_vec_lower_upper_test URowVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4529,29 +4336,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (offset_mult_test UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (offset_mult_test UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4578,29 +4368,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (ordered_test UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (ordered_test UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4621,29 +4394,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (unit_vec_test UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (unit_vec_test UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4664,29 +4420,12 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (pos_ordered_test UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (pos_ordered_test UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4709,53 +4448,14 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (corr_matrix_test UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (corr_matrix_test UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4778,53 +4478,14 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (cov_matrix_test UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (cov_matrix_test UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4847,53 +4508,14 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var K))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var K))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (chol_fac_cov_test UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var K))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var K))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (chol_fac_cov_test UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var K))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var K))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -4916,53 +4538,14 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var K))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var K))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (chol_fac_corr_test UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var K))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var K))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (chol_fac_corr_test UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var K))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var K))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -5992,53 +5575,14 @@ matrix[10, 10] X_tp7: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (X_p UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (X_p UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9516,29 +9060,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_soa_vec_v UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var M))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_vec_v UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9561,53 +9088,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_soa_mat UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_mat UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9636,43 +9124,22 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Var N))
+       ((pattern (Lit Int 10))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
          (Block
           (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_soa_arr_vec_v UVector
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UVector) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
+             (Assignment
+              (p_soa_arr_vec_v UVector
+               ((Single
+                 ((pattern (Var sym1__))
+                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+              ((pattern
+                (FunApp (CompilerInternal FnReadDataSerializer)
+                 (((pattern (Var N))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))
@@ -9697,53 +9164,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_soa_mat_uni_col_idx UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_mat_uni_col_idx UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9764,29 +9192,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_soa_vec_uni_idx UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_vec_uni_idx UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9809,53 +9220,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_soa_loop_mat_uni_col_idx UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_loop_mat_uni_col_idx UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9876,30 +9248,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_soa_lhs_loop_mul URowVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta
-                ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_lhs_loop_mul URowVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9920,29 +9274,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_soa_rhs_loop_mul UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_rhs_loop_mul UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -9964,29 +9301,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var N))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_soa_used_with_aos_in_excluded_fun UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_used_with_aos_in_excluded_fun UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10010,53 +9330,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_soa_loop_mat_multi_uni_uni_idx UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_soa_loop_mat_multi_uni_uni_idx UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10077,29 +9358,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_aos_vec_v_assign_to_aos UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var M))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_vec_v_assign_to_aos UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10120,29 +9384,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_aos_vec_v_tp_fails_func UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var M))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_vec_v_tp_fails_func UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10163,29 +9410,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_aos_loop_vec_v_uni_idx UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var M))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_loop_vec_v_uni_idx UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10207,29 +9437,12 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_aos_fail_assign_from_top_idx UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Var M))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_fail_assign_from_top_idx UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10252,53 +9465,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_aos_loop_mat_uni_uni_idx UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_loop_mat_uni_uni_idx UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10321,53 +9495,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_aos_mat UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_mat UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10391,53 +9526,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_aos_mat_pass_func_outer_single_indexed1 UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_mat_pass_func_outer_single_indexed1 UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10461,53 +9557,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_aos_mat_pass_func_outer_single_indexed2 UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_mat_pass_func_outer_single_indexed2 UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10530,53 +9587,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_aos_mat_fail_uni_uni_idx1 UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_mat_fail_uni_uni_idx1 UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -10599,53 +9617,14 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Var M))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Var N))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (p_aos_mat_fail_uni_uni_idx2 UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Var N))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Var M))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_mat_fail_uni_uni_idx2 UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Var M))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -11313,29 +10292,12 @@ vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (Assignment
-              (p_aos_loop_single_idx UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
-                 (((pattern (Lit Int 10))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (p_aos_loop_single_idx UVector ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -11887,53 +10849,14 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (soa_x UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (soa_x UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -11956,53 +10879,14 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (aos_x UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (aos_x UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -12025,53 +10909,14 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (aos_y UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (aos_y UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -12687,53 +11532,14 @@ matrix[10, 10] mul_two_aos: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (row_soa UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (row_soa UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -12756,53 +11562,14 @@ matrix[10, 10] mul_two_aos: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (udf_input_aos UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (udf_input_aos UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -13322,53 +12089,14 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (aos_p UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (aos_p UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -13391,53 +12119,14 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 10))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (soa_p UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (soa_p UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -13785,53 +12474,14 @@ matrix[5, 10] tp_matrix_aos: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (first_pass_soa_x UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (first_pass_soa_x UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp
@@ -13854,53 +12504,14 @@ matrix[5, 10] tp_matrix_aos: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
-     (For (loopvar sym1__)
-      (lower
-       ((pattern (Lit Int 1))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (upper
-       ((pattern (Lit Int 10))
-        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-      (body
-       ((pattern
-         (Block
-          (((pattern
-             (For (loopvar sym2__)
-              (lower
-               ((pattern (Lit Int 1))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (upper
-               ((pattern (Lit Int 5))
-                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-              (body
-               ((pattern
-                 (Block
-                  (((pattern
-                     (Assignment
-                      (aos_x UMatrix
-                       ((Single
-                         ((pattern (Var sym2__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
-                        (Single
-                         ((pattern (Var sym1__))
-                          (meta
-                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                      ((pattern
-                        (FunApp (CompilerInternal FnReadDataSerializer)
-                         (((pattern (Lit Int 5))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
-                          ((pattern (Lit Int 10))
-                           (meta
-                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-                       (meta
-                        ((type_ UMatrix) (loc <opaque>)
-                         (adlevel AutoDiffable))))))
-                    (meta <opaque>)))))
-                (meta <opaque>)))))
-            (meta <opaque>)))))
-        (meta <opaque>)))))
+     (Assignment (aos_x UMatrix ())
+      ((pattern
+        (FunApp (CompilerInternal FnReadDataSerializer)
+         (((pattern (Lit Int 5))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+          ((pattern (Lit Int 10))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+       (meta ((type_ UMatrix) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
      (NRFunApp

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -302,7 +302,7 @@ matrix[10, 10] A_p: AoS
    ((pattern
      (Assignment (A_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -5769,7 +5769,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (high_low_est UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -5801,7 +5801,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (b UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var K))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -5827,7 +5827,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (h UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var Nr))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -5853,7 +5853,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (ar UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -5873,7 +5873,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (ma UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -5891,7 +5891,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (phi_beta UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -5915,7 +5915,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (sigma2 UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -5937,7 +5937,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (Intercept UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -5961,7 +5961,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (mean_price UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -5987,7 +5987,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (sigma_price UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6011,7 +6011,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (theta UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -6035,7 +6035,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (upper_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6065,7 +6065,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (lower_upper_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6097,7 +6097,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (row_vec_lower_upper_test URowVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6137,7 +6137,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (offset_mult_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6169,7 +6169,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (ordered_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6195,7 +6195,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (unit_vec_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6221,7 +6221,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (pos_ordered_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -6249,7 +6249,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (corr_matrix_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var N))
@@ -6279,7 +6279,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (cov_matrix_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var N))
@@ -6309,7 +6309,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (chol_fac_cov_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var K))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var K))
@@ -6339,7 +6339,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (chol_fac_corr_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var K))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var K))
@@ -7494,7 +7494,7 @@ matrix[10, 10] X_tp7: AoS
    ((pattern
      (Assignment (X_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -12946,7 +12946,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
     (meta <opaque>))
    ((pattern
      (Assignment (alpha UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -12970,7 +12970,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_vec_v UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -12998,7 +12998,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_mat UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13060,7 +13060,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
                           (meta
                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                       ((pattern
-                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                        (FunApp (CompilerInternal FnReadDeserializer) ()))
                        (meta
                         ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
                     (meta <opaque>)))))
@@ -13091,7 +13091,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_mat_uni_col_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13119,7 +13119,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_vec_uni_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13147,7 +13147,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_loop_mat_uni_col_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13175,7 +13175,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_lhs_loop_mul URowVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13201,7 +13201,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_rhs_loop_mul UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13228,7 +13228,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_used_with_aos_in_excluded_fun UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13257,7 +13257,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_loop_mat_multi_uni_uni_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13285,7 +13285,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_vec_v_assign_to_aos UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13311,7 +13311,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_vec_v_tp_fails_func UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13337,7 +13337,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_loop_vec_v_uni_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13364,7 +13364,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_fail_assign_from_top_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -13392,7 +13392,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_loop_mat_uni_uni_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13422,7 +13422,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13453,7 +13453,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_pass_func_outer_single_indexed1 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13484,7 +13484,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_pass_func_outer_single_indexed2 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13514,7 +13514,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_fail_uni_uni_idx1 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -13544,7 +13544,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_fail_uni_uni_idx2 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -14314,7 +14314,7 @@ vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (alpha UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadDeserializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -14338,7 +14338,7 @@ vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
    ((pattern
      (Assignment (p_aos_loop_single_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -15229,7 +15229,7 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
    ((pattern
      (Assignment (soa_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -15259,7 +15259,7 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
    ((pattern
      (Assignment (aos_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -15289,7 +15289,7 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
    ((pattern
      (Assignment (aos_y UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -16138,7 +16138,7 @@ matrix[10, 10] mul_two_aos: AoS
    ((pattern
      (Assignment (row_soa UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -16168,7 +16168,7 @@ matrix[10, 10] mul_two_aos: AoS
    ((pattern
      (Assignment (udf_input_aos UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -16921,7 +16921,7 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
    ((pattern
      (Assignment (aos_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -16951,7 +16951,7 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
    ((pattern
      (Assignment (soa_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -17532,7 +17532,7 @@ matrix[5, 10] tp_matrix_aos: AoS
    ((pattern
      (Assignment (first_pass_soa_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -17562,7 +17562,7 @@ matrix[5, 10] tp_matrix_aos: AoS
    ((pattern
      (Assignment (aos_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadSerializer)
+        (FunApp (CompilerInternal FnReadDeserializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -13032,22 +13032,39 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
        ((pattern (Lit Int 1))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (upper
-       ((pattern (Lit Int 10))
+       ((pattern (Var N))
         (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
       (body
        ((pattern
          (Block
           (((pattern
-             (Assignment
-              (p_soa_arr_vec_v UVector
-               ((Single
-                 ((pattern (Var sym1__))
-                  (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-              ((pattern
-                (FunApp (CompilerInternal FnReadSerializer)
-                 (((pattern (Var N))
-                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
-               (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
+             (For (loopvar sym2__)
+              (lower
+               ((pattern (Lit Int 1))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (upper
+               ((pattern (Lit Int 10))
+                (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+              (body
+               ((pattern
+                 (Block
+                  (((pattern
+                     (Assignment
+                      (p_soa_arr_vec_v UVector
+                       ((Single
+                         ((pattern (Var sym2__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                        (Single
+                         ((pattern (Var sym1__))
+                          (meta
+                           ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                      ((pattern
+                        (FunApp (CompilerInternal FnReadSerializer) ()))
+                       (meta
+                        ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
             (meta <opaque>)))))
         (meta <opaque>)))))
     (meta <opaque>))

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -182,9 +182,127 @@ matrix[10, 10] A_p: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id A_p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (A_p_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str A_p))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (A_p UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var A_p_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var A_p))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id A_p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (A_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -3968,9 +4086,1690 @@ vector[Nr] h_sigma: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id high_low_est_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (high_low_est_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str high_low_est))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (high_low_est UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var high_low_est_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Var diff_low_mid))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Var diff_high_mid))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var high_low_est))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id b)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var K))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id b_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (b_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str b))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (b UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var b_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var b))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id h)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var Nr))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id h_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (h_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str h))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var Nr))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (h UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var h_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var h))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id ar)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 2))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id ar_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (ar_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str ar))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 2))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (ar UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var ar_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var ar))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id ma) (decl_type (Sized SReal))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (ma UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str ma))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var ma))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id phi_beta)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (phi_beta UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str phi_beta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var phi_beta))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma2)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (sigma2 UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str sigma2))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Int 0))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma2))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id Intercept)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (Intercept UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str Intercept))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var Intercept))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id mean_price)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id mean_price_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (mean_price_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str mean_price))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (mean_price UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var mean_price_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var mean_price))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id sigma_price)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id sigma_price_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (sigma_price_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str sigma_price))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (sigma_price UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var sigma_price_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Lower
+           ((pattern (Lit Real 0.0))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+        (var
+         ((pattern (Var sigma_price))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id theta)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (theta UReal ())
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str theta))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var theta))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id upper_test)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id upper_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (upper_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str upper_test))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (upper_test UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var upper_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((Upper
+           ((pattern (Var ma))
+            (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable)))))))
+        (var
+         ((pattern (Var upper_test))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id lower_upper_test)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id lower_upper_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (lower_upper_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str lower_upper_test))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (lower_upper_test UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var lower_upper_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern (Var sigma_price))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+           ((pattern (Var upper_test))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+        (var
+         ((pattern (Var lower_upper_test))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id row_vec_lower_upper_test)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id row_vec_lower_upper_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (row_vec_lower_upper_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str row_vec_lower_upper_test))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (row_vec_lower_upper_test URowVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var row_vec_lower_upper_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((LowerUpper
+           ((pattern
+             (FunApp (StanLib Transpose__ FnPlain AoS)
+              (((pattern (Var sigma_price))
+                (meta
+                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+            (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))
+           ((pattern
+             (FunApp (StanLib Transpose__ FnPlain AoS)
+              (((pattern (Var upper_test))
+                (meta
+                 ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+            (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+        (var
+         ((pattern (Var row_vec_lower_upper_test))
+          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id offset_mult_test)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id offset_mult_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (offset_mult_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str offset_mult_test))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (offset_mult_test UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var offset_mult_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam
+        (unconstrain_opt
+         ((OffsetMultiplier
+           ((pattern (Var mean_price))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))
+           ((pattern (Var sigma_price))
+            (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable)))))))
+        (var
+         ((pattern (Var offset_mult_test))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id ordered_test)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id ordered_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (ordered_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str ordered_test))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (ordered_test UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var ordered_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Ordered))
+        (var
+         ((pattern (Var ordered_test))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id unit_vec_test)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id unit_vec_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (unit_vec_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str unit_vec_test))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (unit_vec_test UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var unit_vec_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (UnitVector))
+        (var
+         ((pattern (Var unit_vec_test))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id pos_ordered_test)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id pos_ordered_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos_ordered_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str pos_ordered_test))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (pos_ordered_test UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var pos_ordered_test_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (PositiveOrdered))
+        (var
+         ((pattern (Var pos_ordered_test))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id corr_matrix_test)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id corr_matrix_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (corr_matrix_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str corr_matrix_test))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (corr_matrix_test UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var corr_matrix_test_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Correlation))
+        (var
+         ((pattern (Var corr_matrix_test))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id cov_matrix_test)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id cov_matrix_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (cov_matrix_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str cov_matrix_test))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (cov_matrix_test UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var cov_matrix_test_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Covariance))
+        (var
+         ((pattern (Var cov_matrix_test))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id chol_fac_cov_test)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var K))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var K))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id chol_fac_cov_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (chol_fac_cov_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str chol_fac_cov_test))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var K))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (chol_fac_cov_test UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var chol_fac_cov_test_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (CholeskyCov))
+        (var
+         ((pattern (Var chol_fac_cov_test))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id chol_fac_corr_test)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var K))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var K))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id chol_fac_corr_test_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (chol_fac_corr_test_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str chol_fac_corr_test))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var K))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var K))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (chol_fac_corr_test UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var chol_fac_corr_test_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (CholeskyCorr))
+        (var
+         ((pattern (Var chol_fac_corr_test))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id high_low_est)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (high_low_est UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4002,7 +5801,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (b UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var K))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4028,7 +5827,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (h UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var Nr))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4054,7 +5853,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (ar UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 2))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4074,7 +5873,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (ma UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -4092,7 +5891,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (phi_beta UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -4116,7 +5915,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (sigma2 UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -4138,7 +5937,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (Intercept UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -4162,7 +5961,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (mean_price UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4188,7 +5987,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (sigma_price UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4212,7 +6011,7 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (theta UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -4236,7 +6035,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (upper_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4266,7 +6065,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (lower_upper_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4298,7 +6097,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (row_vec_lower_upper_test URowVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4338,7 +6137,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (offset_mult_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4370,7 +6169,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (ordered_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4396,7 +6195,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (unit_vec_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4422,7 +6221,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (pos_ordered_test UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -4450,7 +6249,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (corr_matrix_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var N))
@@ -4480,7 +6279,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (cov_matrix_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var N))
@@ -4510,7 +6309,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (chol_fac_cov_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var K))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var K))
@@ -4540,7 +6339,7 @@ vector[Nr] h_sigma: SoA
    ((pattern
      (Assignment (chol_fac_corr_test UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var K))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var K))
@@ -5575,9 +7374,127 @@ matrix[10, 10] X_tp7: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id X_p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (X_p_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str X_p))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (X_p UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var X_p_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var X_p))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id X_p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (X_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -9038,7 +10955,1998 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
     (meta <opaque>))
    ((pattern
      (Assignment (alpha UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_vec_v)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_soa_vec_v_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_vec_v_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_vec_v))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_soa_vec_v UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_soa_vec_v_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_vec_v))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_mat)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_soa_mat_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_mat_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_mat))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_soa_mat UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_soa_mat_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_mat))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_arr_vec_v)
+      (decl_type
+       (Sized
+        (SArray
+         (SVector AoS
+          ((pattern (Var N))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_soa_arr_vec_v_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_arr_vec_v_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_arr_vec_v))
+               (meta
+                ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_soa_arr_vec_v (UArray UVector)
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_soa_arr_vec_v_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_arr_vec_v))
+          (meta ((type_ (UArray UVector)) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_mat_uni_col_idx)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_soa_mat_uni_col_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_mat_uni_col_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_mat_uni_col_idx))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_soa_mat_uni_col_idx UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_soa_mat_uni_col_idx_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_mat_uni_col_idx))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_vec_uni_idx)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_soa_vec_uni_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_vec_uni_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_vec_uni_idx))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_soa_vec_uni_idx UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_soa_vec_uni_idx_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_vec_uni_idx))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_loop_mat_uni_col_idx)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_soa_loop_mat_uni_col_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_loop_mat_uni_col_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_loop_mat_uni_col_idx))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_soa_loop_mat_uni_col_idx UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var p_soa_loop_mat_uni_col_idx_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_loop_mat_uni_col_idx))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_lhs_loop_mul)
+      (decl_type
+       (Sized
+        (SRowVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_soa_lhs_loop_mul_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_lhs_loop_mul_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_lhs_loop_mul))
+               (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_soa_lhs_loop_mul URowVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_soa_lhs_loop_mul_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_lhs_loop_mul))
+          (meta ((type_ URowVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_soa_rhs_loop_mul)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_soa_rhs_loop_mul_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_soa_rhs_loop_mul_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_rhs_loop_mul))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_soa_rhs_loop_mul UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_soa_rhs_loop_mul_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_rhs_loop_mul))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable)
+      (decl_id p_soa_used_with_aos_in_excluded_fun)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_soa_used_with_aos_in_excluded_fun_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          (p_soa_used_with_aos_in_excluded_fun_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_used_with_aos_in_excluded_fun))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var N))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_soa_used_with_aos_in_excluded_fun UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern
+                       (Var p_soa_used_with_aos_in_excluded_fun_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_used_with_aos_in_excluded_fun))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable)
+      (decl_id p_soa_loop_mat_multi_uni_uni_idx)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_soa_loop_mat_multi_uni_uni_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          (p_soa_loop_mat_multi_uni_uni_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_soa_loop_mat_multi_uni_uni_idx))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_soa_loop_mat_multi_uni_uni_idx UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var p_soa_loop_mat_multi_uni_uni_idx_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_soa_loop_mat_multi_uni_uni_idx))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_vec_v_assign_to_aos)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_vec_v_assign_to_aos_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_vec_v_assign_to_aos_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_vec_v_assign_to_aos))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_aos_vec_v_assign_to_aos UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_aos_vec_v_assign_to_aos_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_vec_v_assign_to_aos))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_vec_v_tp_fails_func)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_vec_v_tp_fails_func_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_vec_v_tp_fails_func_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_vec_v_tp_fails_func))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_aos_vec_v_tp_fails_func UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_aos_vec_v_tp_fails_func_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_vec_v_tp_fails_func))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_loop_vec_v_uni_idx)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_loop_vec_v_uni_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_loop_vec_v_uni_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_loop_vec_v_uni_idx))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_aos_loop_vec_v_uni_idx UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_aos_loop_vec_v_uni_idx_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_loop_vec_v_uni_idx))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable)
+      (decl_id p_aos_fail_assign_from_top_idx)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_fail_assign_from_top_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          (p_aos_fail_assign_from_top_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_fail_assign_from_top_idx))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_aos_fail_assign_from_top_idx UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_aos_fail_assign_from_top_idx_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_fail_assign_from_top_idx))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_loop_mat_uni_uni_idx)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_loop_mat_uni_uni_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_loop_mat_uni_uni_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_loop_mat_uni_uni_idx))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_aos_loop_mat_uni_uni_idx UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var p_aos_loop_mat_uni_uni_idx_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_loop_mat_uni_uni_idx))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_mat)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id p_aos_mat_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_mat_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_mat))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_aos_mat UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var p_aos_mat_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_mat))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable)
+      (decl_id p_aos_mat_pass_func_outer_single_indexed1)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_mat_pass_func_outer_single_indexed1_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          (p_aos_mat_pass_func_outer_single_indexed1_flat__ (UArray UReal)
+           ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_mat_pass_func_outer_single_indexed1))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_aos_mat_pass_func_outer_single_indexed1 UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var
+                                p_aos_mat_pass_func_outer_single_indexed1_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_mat_pass_func_outer_single_indexed1))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable)
+      (decl_id p_aos_mat_pass_func_outer_single_indexed2)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_mat_pass_func_outer_single_indexed2_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment
+          (p_aos_mat_pass_func_outer_single_indexed2_flat__ (UArray UReal)
+           ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_mat_pass_func_outer_single_indexed2))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_aos_mat_pass_func_outer_single_indexed2 UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var
+                                p_aos_mat_pass_func_outer_single_indexed2_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_mat_pass_func_outer_single_indexed2))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_mat_fail_uni_uni_idx1)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_mat_fail_uni_uni_idx1_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_mat_fail_uni_uni_idx1_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_mat_fail_uni_uni_idx1))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_aos_mat_fail_uni_uni_idx1 UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var p_aos_mat_fail_uni_uni_idx1_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_mat_fail_uni_uni_idx1))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_mat_fail_uni_uni_idx2)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Var N))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Var M))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_mat_fail_uni_uni_idx2_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_mat_fail_uni_uni_idx2_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_mat_fail_uni_uni_idx2))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Var M))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Var N))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (p_aos_mat_fail_uni_uni_idx2 UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern
+                               (Var p_aos_mat_fail_uni_uni_idx2_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_mat_fail_uni_uni_idx2))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (alpha UReal ())
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -9062,7 +12970,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_vec_v UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9090,7 +12998,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_mat UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9136,7 +13044,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
                  ((pattern (Var sym1__))
                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
               ((pattern
-                (FunApp (CompilerInternal FnReadDataSerializer)
+                (FunApp (CompilerInternal FnReadSerializer)
                  (((pattern (Var N))
                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
                (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9166,7 +13074,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_mat_uni_col_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9194,7 +13102,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_vec_uni_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9222,7 +13130,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_loop_mat_uni_col_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9250,7 +13158,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_lhs_loop_mul URowVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ URowVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9276,7 +13184,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_rhs_loop_mul UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9303,7 +13211,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_used_with_aos_in_excluded_fun UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9332,7 +13240,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_soa_loop_mat_multi_uni_uni_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9360,7 +13268,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_vec_v_assign_to_aos UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9386,7 +13294,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_vec_v_tp_fails_func UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9412,7 +13320,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_loop_vec_v_uni_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9439,7 +13347,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_fail_assign_from_top_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var M))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -9467,7 +13375,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_loop_mat_uni_uni_idx UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9497,7 +13405,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9528,7 +13436,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_pass_func_outer_single_indexed1 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9559,7 +13467,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_pass_func_outer_single_indexed2 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9589,7 +13497,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_fail_uni_uni_idx1 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -9619,7 +13527,7 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
    ((pattern
      (Assignment (p_aos_mat_fail_uni_uni_idx2 UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Var N))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Var M))
@@ -10270,7 +14178,126 @@ vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
     (meta <opaque>))
    ((pattern
      (Assignment (alpha UReal ())
-      ((pattern (FunApp (CompilerInternal FnReadDataSerializer) ()))
+      ((pattern
+        (Indexed
+         ((pattern
+           (FunApp (CompilerInternal FnReadData)
+            (((pattern (Lit Str alpha))
+              (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+          (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))
+         ((Single
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+       (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var alpha))
+          (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id p_aos_loop_single_idx)
+      (decl_type
+       (Sized
+        (SVector AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable)
+          (decl_id p_aos_loop_single_idx_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (p_aos_loop_single_idx_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str p_aos_loop_single_idx))
+               (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (Assignment
+                  (p_aos_loop_single_idx UVector
+                   ((Single
+                     ((pattern (Var sym1__))
+                      (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                  ((pattern
+                    (Indexed
+                     ((pattern (Var p_aos_loop_single_idx_flat__))
+                      (meta
+                       ((type_ (UArray UReal)) (loc <opaque>)
+                        (adlevel DataOnly))))
+                     ((Single
+                       ((pattern (Var pos__))
+                        (meta
+                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
+                   (meta ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>))
+               ((pattern
+                 (Assignment (pos__ UInt ())
+                  ((pattern
+                    (FunApp (StanLib Plus__ FnPlain AoS)
+                     (((pattern (Var pos__))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+                      ((pattern (Lit Int 1))
+                       (meta
+                        ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+                   (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var p_aos_loop_single_idx))
+          (meta ((type_ UVector) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id alpha)
+      (decl_type (Sized SReal)) (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (alpha UReal ())
+      ((pattern (FunApp (CompilerInternal FnReadSerializer) ()))
        (meta ((type_ UReal) (loc <opaque>) (adlevel AutoDiffable))))))
     (meta <opaque>))
    ((pattern
@@ -10294,7 +14321,7 @@ vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
    ((pattern
      (Assignment (p_aos_loop_single_idx UVector ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
        (meta ((type_ UVector) (loc <opaque>) (adlevel AutoDiffable))))))
@@ -10849,9 +14876,343 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id soa_x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (soa_x_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str soa_x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (soa_x UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var soa_x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var soa_x))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id aos_x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id aos_x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (aos_x_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str aos_x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (aos_x UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var aos_x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var aos_x))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id aos_y)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id aos_y_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (aos_y_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str aos_y))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (aos_y UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var aos_y_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var aos_y))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id soa_x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (soa_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -10881,7 +15242,7 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
    ((pattern
      (Assignment (aos_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -10911,7 +15272,7 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
    ((pattern
      (Assignment (aos_y UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -11532,9 +15893,235 @@ matrix[10, 10] mul_two_aos: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id row_soa_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (row_soa_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str row_soa))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (row_soa UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var row_soa_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var row_soa))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id udf_input_aos)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id udf_input_aos_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (udf_input_aos_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str udf_input_aos))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (udf_input_aos UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var udf_input_aos_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var udf_input_aos))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id row_soa)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (row_soa UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -11564,7 +16151,7 @@ matrix[10, 10] mul_two_aos: AoS
    ((pattern
      (Assignment (udf_input_aos UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -12089,9 +16676,235 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id aos_p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (aos_p_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str aos_p))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (aos_p UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var aos_p_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var aos_p))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id soa_p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id soa_p_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (soa_p_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str soa_p))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 10))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (soa_p UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var soa_p_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var soa_p))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id aos_p)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (aos_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -12121,7 +16934,7 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
    ((pattern
      (Assignment (soa_p UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 10))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -12474,9 +17287,235 @@ matrix[5, 10] tp_matrix_aos: AoS
       (initialize true)))
     (meta <opaque>))
    ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id first_pass_soa_x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (first_pass_soa_x_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str first_pass_soa_x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (first_pass_soa_x UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var first_pass_soa_x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var first_pass_soa_x))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id aos_x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Block
+      (((pattern
+         (Decl (decl_adtype AutoDiffable) (decl_id aos_x_flat__)
+          (decl_type (Unsized (UArray UReal))) (initialize false)))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (aos_x_flat__ (UArray UReal) ())
+          ((pattern
+            (FunApp (CompilerInternal FnReadData)
+             (((pattern (Lit Str aos_x))
+               (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+           (meta ((type_ (UArray UReal)) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (Assignment (pos__ UInt ())
+          ((pattern (Lit Int 1))
+           (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+        (meta <opaque>))
+       ((pattern
+         (For (loopvar sym1__)
+          (lower
+           ((pattern (Lit Int 1))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (upper
+           ((pattern (Lit Int 10))
+            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+          (body
+           ((pattern
+             (Block
+              (((pattern
+                 (For (loopvar sym2__)
+                  (lower
+                   ((pattern (Lit Int 1))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (upper
+                   ((pattern (Lit Int 5))
+                    (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))
+                  (body
+                   ((pattern
+                     (Block
+                      (((pattern
+                         (Assignment
+                          (aos_x UMatrix
+                           ((Single
+                             ((pattern (Var sym2__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))
+                            (Single
+                             ((pattern (Var sym1__))
+                              (meta
+                               ((type_ UInt) (loc <opaque>)
+                                (adlevel DataOnly)))))))
+                          ((pattern
+                            (Indexed
+                             ((pattern (Var aos_x_flat__))
+                              (meta
+                               ((type_ (UArray UReal)) (loc <opaque>)
+                                (adlevel DataOnly))))
+                             ((Single
+                               ((pattern (Var pos__))
+                                (meta
+                                 ((type_ UInt) (loc <opaque>)
+                                  (adlevel DataOnly))))))))
+                           (meta
+                            ((type_ UReal) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>))
+                       ((pattern
+                         (Assignment (pos__ UInt ())
+                          ((pattern
+                            (FunApp (StanLib Plus__ FnPlain AoS)
+                             (((pattern (Var pos__))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly))))
+                              ((pattern (Lit Int 1))
+                               (meta
+                                ((type_ UInt) (loc <opaque>)
+                                 (adlevel DataOnly)))))))
+                           (meta
+                            ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+                        (meta <opaque>)))))
+                    (meta <opaque>)))))
+                (meta <opaque>)))))
+            (meta <opaque>)))))
+        (meta <opaque>)))))
+    (meta <opaque>))
+   ((pattern
+     (NRFunApp
+      (CompilerInternal
+       (FnWriteParam (unconstrain_opt (Identity))
+        (var
+         ((pattern (Var aos_x))
+          (meta ((type_ UMatrix) (loc <opaque>) (adlevel DataOnly)))))))
+      ()))
+    (meta <opaque>))))
+ (unconstrain_array
+  (((pattern
+     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
+     (Assignment (pos__ UInt ())
+      ((pattern (Lit Int 1))
+       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
+    (meta <opaque>))
+   ((pattern
+     (Decl (decl_adtype AutoDiffable) (decl_id first_pass_soa_x)
+      (decl_type
+       (Sized
+        (SMatrix AoS
+         ((pattern (Lit Int 5))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
+         ((pattern (Lit Int 10))
+          (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly)))))))
+      (initialize true)))
+    (meta <opaque>))
+   ((pattern
      (Assignment (first_pass_soa_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))
@@ -12506,7 +17545,7 @@ matrix[5, 10] tp_matrix_aos: AoS
    ((pattern
      (Assignment (aos_x UMatrix ())
       ((pattern
-        (FunApp (CompilerInternal FnReadDataSerializer)
+        (FunApp (CompilerInternal FnReadSerializer)
          (((pattern (Lit Int 5))
            (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
           ((pattern (Lit Int 10))

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -379,7 +379,8 @@ let%expect_test "list collapsing" =
        (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
       ((pattern (Return ())) (meta <opaque>)) ()))
     (meta <opaque>))))
- (transform_inits ()) (output_vars ()) (prog_name "") (prog_path ""))
+ (transform_inits ()) (unconstrain_array ()) (output_vars ()) (prog_name "")
+ (prog_path ""))
     |}]
 
 let%expect_test "recursive functions" =
@@ -3070,7 +3071,8 @@ let%expect_test "block fixing" =
              (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))
             ((pattern (Return ())) (meta <opaque>)) ()))
           (meta <opaque>))))
-       (transform_inits ()) (output_vars ()) (prog_name "") (prog_path "")) |}]
+       (transform_inits ()) (unconstrain_array ()) (output_vars ()) (prog_name "")
+       (prog_path "")) |}]
 
 let%expect_test "one-step loop unrolling" =
   let mir =


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Closes #1304.

This PR does a couple things:

1. Re-using the code gen we already have for the constructor, `transform_inits_impl` now takes in a var_context directly. This is what fixes #1304, and also will help out with #1100. The previous behavior of flattening it down to a flat vector was hacky, and for complex numbers or tuples, wrong.

2. Adds a new function called `unconstrain_array` which looks much more like the former `transform_inits`. This is the twin of `write_array` and can be eventually exposed/used in place of a lot of the places we're creating a `array_var_context`. The idea for a signature like this dates back to when the deserializer was added: https://github.com/stan-dev/stan/pull/3013#issuecomment-795906563. I added this here to keep the existing code for `transform_inits_impl` around rather than deleting it and re-coding it later, but it will currently be unused.

The second item was actually my original goal, but while working on it I uncovered #1304. The first nicely kills two birds with one stone, fixing that issue and helping out with something I had been stuck on in the tuples PR.

This was able to be done mostly by re-using code already in the compiler. Unfortunately, since the reading code is all generated in `Transform_mir` rather than lower down, the simplest solution was to add another (empty until the backend) item to the MIR.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
