### PR TITLE
Add ability to generate mock initial values, mirrors debug-generate-data

### DIFF
--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -300,7 +300,7 @@ let generate_json_entries (name, expr) : string * t =
           [%message "Could not evaluate expression " (e : Expr.Typed.t)] in
   (name, expr_to_json expr)
 
-let print_data_prog data =
+let print_declarations_json data =
   let ids_and_values = generate_expressions data in
   let json_entries = List.map ~f:generate_json_entries ids_and_values in
   let json = `Assoc json_entries in

--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -300,8 +300,8 @@ let generate_json_entries (name, expr) : string * t =
           [%message "Could not evaluate expression " (e : Expr.Typed.t)] in
   (name, expr_to_json expr)
 
-let print_declarations_json data =
-  let ids_and_values = generate_expressions data in
+let gen_values_json decls =
+  let ids_and_values = generate_expressions decls in
   let json_entries = List.map ~f:generate_json_entries ids_and_values in
   let json = `Assoc json_entries in
   pretty_to_string json

--- a/src/analysis_and_optimization/Debug_data_generation.mli
+++ b/src/analysis_and_optimization/Debug_data_generation.mli
@@ -1,5 +1,5 @@
 open Middle
 
-val print_data_prog :
+val print_declarations_json :
      (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
   -> string

--- a/src/analysis_and_optimization/Debug_data_generation.mli
+++ b/src/analysis_and_optimization/Debug_data_generation.mli
@@ -1,5 +1,5 @@
 open Middle
 
-val print_declarations_json :
+val gen_values_json :
      (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
   -> string

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -771,7 +771,7 @@ let migrate_checks_to_end_of_block stmts =
   let checks, not_checks = List.partition_tf ~f:stmt_contains_check stmts in
   not_checks @ checks
 
-let gather_data (b : Ast.typed_statement Ast.block option) =
+let gather_declarations (b : Ast.typed_statement Ast.block option) =
   let data = Ast.get_stmts b in
   List.concat_map data ~f:(function
     | {stmt= VarDecl {decl_type= sizedtype; transformation; variables; _}; _} ->

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -771,8 +771,8 @@ let migrate_checks_to_end_of_block stmts =
   let checks, not_checks = List.partition_tf ~f:stmt_contains_check stmts in
   not_checks @ checks
 
-let gather_data (p : Ast.typed_program) =
-  let data = Ast.get_stmts p.datablock in
+let gather_data (b : Ast.typed_statement Ast.block option) =
+  let data = Ast.get_stmts b in
   List.concat_map data ~f:(function
     | {stmt= VarDecl {decl_type= sizedtype; transformation; variables; _}; _} ->
         List.map

--- a/src/frontend/Ast_to_Mir.mli
+++ b/src/frontend/Ast_to_Mir.mli
@@ -2,7 +2,7 @@
 open Middle
 
 val gather_data :
-     Ast.typed_program
+     Ast.typed_statement Ast.block option
   -> (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
 
 val trans_prog : string -> Ast.typed_program -> Program.Typed.t

--- a/src/frontend/Ast_to_Mir.mli
+++ b/src/frontend/Ast_to_Mir.mli
@@ -1,7 +1,7 @@
 (** Translate from the AST to the MIR *)
 open Middle
 
-val gather_data :
+val gather_declarations :
      Ast.typed_statement Ast.block option
   -> (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
 

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -308,11 +308,11 @@ let use_file filename =
   if !generate_data then
     print_endline
       (Debug_data_generation.print_declarations_json
-         (Ast_to_Mir.gather_data typed_ast.datablock) ) ;
+         (Ast_to_Mir.gather_declarations typed_ast.datablock) ) ;
   if !generate_inits then
     print_endline
       (Debug_data_generation.print_declarations_json
-         (Ast_to_Mir.gather_data typed_ast.parametersblock) ) ;
+         (Ast_to_Mir.gather_declarations typed_ast.parametersblock) ) ;
   Debugging.typed_ast_logger typed_ast ;
   if not !pretty_print_program then (
     let mir = Ast_to_Mir.trans_prog filename typed_ast in

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -307,11 +307,11 @@ let use_file filename =
       (Deprecation_analysis.collect_warnings typed_ast) ;
   if !generate_data then
     print_endline
-      (Debug_data_generation.print_declarations_json
+      (Debug_data_generation.gen_values_json
          (Ast_to_Mir.gather_declarations typed_ast.datablock) ) ;
   if !generate_inits then
     print_endline
-      (Debug_data_generation.print_declarations_json
+      (Debug_data_generation.gen_values_json
          (Ast_to_Mir.gather_declarations typed_ast.parametersblock) ) ;
   Debugging.typed_ast_logger typed_ast ;
   if not !pretty_print_program then (

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -37,6 +37,7 @@ let no_soa_opt = ref false
 let soa_opt = ref false
 let output_file = ref ""
 let generate_data = ref false
+let generate_inits = ref false
 let warn_uninitialized = ref false
 let warn_pedantic = ref false
 let bare_functions = ref false
@@ -77,6 +78,10 @@ let options =
       , Arg.Set generate_data
       , " For debugging purposes: generate a mock dataset to run the model on"
       )
+    ; ( "--debug-generate-inits"
+      , Arg.Set generate_inits
+      , " For debugging purposes: generate a mock initial value for each \
+         parameter" )
     ; ( "--debug-mir"
       , Arg.Set dump_mir
       , " For debugging purposes: print the MIR as an S-expression." )
@@ -302,8 +307,12 @@ let use_file filename =
       (Deprecation_analysis.collect_warnings typed_ast) ;
   if !generate_data then
     print_endline
-      (Debug_data_generation.print_data_prog
-         (Ast_to_Mir.gather_data typed_ast) ) ;
+      (Debug_data_generation.print_declarations_json
+         (Ast_to_Mir.gather_data typed_ast.datablock) ) ;
+  if !generate_inits then
+    print_endline
+      (Debug_data_generation.print_declarations_json
+         (Ast_to_Mir.gather_data typed_ast.parametersblock) ) ;
   Debugging.typed_ast_logger typed_ast ;
   if not !pretty_print_program then (
     let mir = Ast_to_Mir.trans_prog filename typed_ast in

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -83,14 +83,14 @@ let stan2cpp model_name model_string is_flag_set flag_val =
         if is_flag_set "debug-generate-data" then
           r.return
             ( Result.Ok
-                (Debug_data_generation.print_declarations_json
+                (Debug_data_generation.gen_values_json
                    (Ast_to_Mir.gather_declarations typed_ast.datablock) )
             , warnings
             , [] ) ;
         if is_flag_set "debug-generate-inits" then
           r.return
             ( Result.Ok
-                (Debug_data_generation.print_declarations_json
+                (Debug_data_generation.gen_values_json
                    (Ast_to_Mir.gather_declarations typed_ast.parametersblock) )
             , warnings
             , [] ) ;

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -83,8 +83,15 @@ let stan2cpp model_name model_string is_flag_set flag_val =
         if is_flag_set "debug-generate-data" then
           r.return
             ( Result.Ok
-                (Debug_data_generation.print_data_prog
-                   (Ast_to_Mir.gather_data typed_ast) )
+                (Debug_data_generation.print_declarations_json
+                   (Ast_to_Mir.gather_data typed_ast.datablock) )
+            , warnings
+            , [] ) ;
+        if is_flag_set "debug-generate-inits" then
+          r.return
+            ( Result.Ok
+                (Debug_data_generation.print_declarations_json
+                   (Ast_to_Mir.gather_data typed_ast.parametersblock) )
             , warnings
             , [] ) ;
         let opt_mir =

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -84,14 +84,14 @@ let stan2cpp model_name model_string is_flag_set flag_val =
           r.return
             ( Result.Ok
                 (Debug_data_generation.print_declarations_json
-                   (Ast_to_Mir.gather_data typed_ast.datablock) )
+                   (Ast_to_Mir.gather_declarations typed_ast.datablock) )
             , warnings
             , [] ) ;
         if is_flag_set "debug-generate-inits" then
           r.return
             ( Result.Ok
                 (Debug_data_generation.print_declarations_json
-                   (Ast_to_Mir.gather_data typed_ast.parametersblock) )
+                   (Ast_to_Mir.gather_declarations typed_ast.parametersblock) )
             , warnings
             , [] ) ;
         let opt_mir =

--- a/test/integration/cli-args/canonicalize/canonicalize.t
+++ b/test/integration/cli-args/canonicalize/canonicalize.t
@@ -8,6 +8,7 @@ Test that a nonsense argument is caught
     --debug-ast                     For debugging purposes: print the undecorated AST, before semantic checking
     --debug-decorated-ast           For debugging purposes: print the decorated AST, after semantic checking
     --debug-generate-data           For debugging purposes: generate a mock dataset to run the model on
+    --debug-generate-inits          For debugging purposes: generate a mock initial value for each parameter
     --debug-mir                     For debugging purposes: print the MIR as an S-expression.
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
@@ -53,6 +54,7 @@ Test capitalization - this should fail due to the lack of model_name, not the ca
     --debug-ast                     For debugging purposes: print the undecorated AST, before semantic checking
     --debug-decorated-ast           For debugging purposes: print the decorated AST, after semantic checking
     --debug-generate-data           For debugging purposes: generate a mock dataset to run the model on
+    --debug-generate-inits          For debugging purposes: generate a mock initial value for each parameter
     --debug-mir                     For debugging purposes: print the MIR as an S-expression.
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -6,6 +6,7 @@ Show help
     --debug-ast                     For debugging purposes: print the undecorated AST, before semantic checking
     --debug-decorated-ast           For debugging purposes: print the decorated AST, after semantic checking
     --debug-generate-data           For debugging purposes: generate a mock dataset to run the model on
+    --debug-generate-inits          For debugging purposes: generate a mock initial value for each parameter
     --debug-mir                     For debugging purposes: print the MIR as an S-expression.
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
@@ -52,6 +53,7 @@ Error when no file passed
     --debug-ast                     For debugging purposes: print the undecorated AST, before semantic checking
     --debug-decorated-ast           For debugging purposes: print the decorated AST, after semantic checking
     --debug-generate-data           For debugging purposes: generate a mock dataset to run the model on
+    --debug-generate-inits          For debugging purposes: generate a mock initial value for each parameter
     --debug-mir                     For debugging purposes: print the MIR as an S-expression.
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.
@@ -96,6 +98,7 @@ Error when multiple files passed
     --debug-ast                     For debugging purposes: print the undecorated AST, before semantic checking
     --debug-decorated-ast           For debugging purposes: print the decorated AST, after semantic checking
     --debug-generate-data           For debugging purposes: generate a mock dataset to run the model on
+    --debug-generate-inits          For debugging purposes: generate a mock initial value for each parameter
     --debug-mir                     For debugging purposes: print the MIR as an S-expression.
     --debug-mir-pretty              For debugging purposes: pretty-print the MIR.
     --debug-optimized-mir           For debugging purposes: print the MIR after it's been optimized. Only has an effect when optimizations are turned on.

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -4,7 +4,7 @@ open Frontend
 open Debug_data_generation
 
 let print_data_prog ast =
-  print_declarations_json (Ast_to_Mir.gather_data ast.Ast.datablock)
+  print_declarations_json (Ast_to_Mir.gather_declarations ast.Ast.datablock)
 
 let%expect_test "whole program data generation check" =
   let ast =

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -4,7 +4,7 @@ open Frontend
 open Debug_data_generation
 
 let print_data_prog ast =
-  print_declarations_json (Ast_to_Mir.gather_declarations ast.Ast.datablock)
+  gen_values_json (Ast_to_Mir.gather_declarations ast.Ast.datablock)
 
 let%expect_test "whole program data generation check" =
   let ast =

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -3,7 +3,8 @@ open Core_kernel
 open Frontend
 open Debug_data_generation
 
-let print_data_prog ast = print_data_prog (Ast_to_Mir.gather_data ast)
+let print_data_prog ast =
+  print_declarations_json (Ast_to_Mir.gather_data ast.Ast.datablock)
 
 let%expect_test "whole program data generation check" =
   let ast =


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Adds a `--debug-generate-inits` flag to stanc which behaves like `--debug-generate-data` but for declarations in the `parameters` block.

This is useful for debugging in issues such as #1304 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
