### PR TITLE
sort type errors by comparing to input type

### DIFF
--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -94,12 +94,19 @@ type match_result =
   , signature_error list * bool )
   generic_match_result
 
-let rec compare_types t1 t2 =
-  match (t1, t2) with
-  | UnsizedType.(UArray t1, UArray t2) -> compare_types t1 t2
-  | _, UArray _ -> -1
-  | UArray _, _ -> 1
-  | t1, t2 -> UnsizedType.compare t1 t2
+let compare_types x t1 t2 =
+  let open UnsizedType in
+  let dx, dt1, dt2 = (count_dims x, count_dims t1, count_dims t2) in
+  match Int.(dx = dt1, dx = dt2) with
+  | true, false -> -1
+  | false, true -> 1
+  | true, true | false, false -> (
+      let sx, st1, st2 =
+        (internal_scalar x, internal_scalar t1, internal_scalar t2) in
+      match (sx = st1, sx = st2) with
+      | true, false -> -1
+      | false, true -> 1
+      | true, true | false, false -> compare t1 t2 )
 
 let rec compare_errors e1 e2 =
   match (e1, e2) with
@@ -113,8 +120,8 @@ let rec compare_errors e1 e2 =
     | DataOnlyError, TypeMismatch _ -> -1
     | TypeMismatch _, DataOnlyError -> 1
     | TypeMismatch (t1, x1, None), TypeMismatch (t2, x2, None) ->
-        let c = compare_types t1 t2 in
-        if c <> 0 then c else compare_types x1 x2
+        let c = UnsizedType.compare x1 x2 in
+        if c <> 0 then c else compare_types x1 t1 t2
     | TypeMismatch (_, _, Some _), TypeMismatch (_, _, None) -> 1
     | TypeMismatch (_, _, None), TypeMismatch (_, _, Some _) -> -1
     | TypeMismatch (_, _, Some e1), TypeMismatch (_, _, Some e2) -> (

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -39,8 +39,8 @@ let unsized_array_depth unsized_ty =
 let count_dims unsized_ty =
   let rec aux dims = function
     | UArray t -> aux (dims + 1) t
-    | UMatrix -> dims + 2
-    | UVector | URowVector -> dims + 1
+    | UMatrix | UComplexMatrix -> dims + 2
+    | UVector | URowVector | UComplexVector | UComplexRowVector -> dims + 1
     | _ -> dims in
   aux 0 unsized_ty
 
@@ -159,9 +159,7 @@ let rec internal_scalar ut =
   | UInt -> UInt
   | UComplex | UComplexVector | UComplexMatrix | UComplexRowVector -> UComplex
   | UArray ut -> internal_scalar ut
-  | _ ->
-      Common.FatalError.fatal_error_msg
-        [%message "Tried to get scalar type of " (ut : t)]
+  | UFun _ | UMathLibraryFunction -> ut
 
 let is_eigen_type ut =
   match ut with

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -223,10 +223,10 @@ Ill-typed arguments supplied to function 'cov_exp_quad':
 Available signatures:
 (array[] vector, array[] vector, real, real) => matrix
   The fourth argument must be real but got array[] real
-(array[] real, array[] real, real, real) => matrix
-  The first argument must be array[] real but got array[] vector
 (array[] row_vector, array[] row_vector, real, real) => matrix
   The first argument must be array[] row_vector but got array[] vector
+(array[] real, array[] real, real, real) => matrix
+  The first argument must be array[] real but got array[] vector
 (array[] real, real, real) => matrix
   Expected 3 arguments but found 4 arguments.
 (array[] vector, real, real) => matrix
@@ -333,10 +333,10 @@ Ill-typed arguments supplied to function 'cov_exp_quad':
 Available signatures:
 (array[] row_vector, array[] row_vector, real, real) => matrix
   The second argument must be array[] row_vector but got array[] vector
-(array[] real, array[] real, real, real) => matrix
-  The first argument must be array[] real but got array[] row_vector
 (array[] vector, array[] vector, real, real) => matrix
   The first argument must be array[] vector but got array[] row_vector
+(array[] real, array[] real, real, real) => matrix
+  The first argument must be array[] real but got array[] row_vector
 (array[] real, real, real) => matrix
   Expected 3 arguments but found 4 arguments.
 (array[] vector, real, real) => matrix
@@ -370,10 +370,10 @@ Ill-typed arguments supplied to function 'cov_exp_quad':
 Available signatures:
 (array[] vector, array[] vector, real, real) => matrix
   The third argument must be real but got array[] real
-(array[] real, array[] real, real, real) => matrix
-  The first argument must be array[] real but got array[] vector
 (array[] row_vector, array[] row_vector, real, real) => matrix
   The first argument must be array[] row_vector but got array[] vector
+(array[] real, array[] real, real, real) => matrix
+  The first argument must be array[] real but got array[] vector
 (array[] real, real, real) => matrix
   Expected 3 arguments but found 4 arguments.
 (array[] vector, real, real) => matrix
@@ -480,10 +480,10 @@ Ill-typed arguments supplied to function 'cov_exp_quad':
 Available signatures:
 (array[] vector, array[] vector, real, real) => matrix
   The second argument must be array[] vector but got array[] row_vector
-(array[] real, array[] real, real, real) => matrix
-  The first argument must be array[] real but got array[] vector
 (array[] row_vector, array[] row_vector, real, real) => matrix
   The first argument must be array[] row_vector but got array[] vector
+(array[] real, array[] real, real, real) => matrix
+  The first argument must be array[] real but got array[] vector
 (array[] real, real, real) => matrix
   Expected 3 arguments but found 4 arguments.
 (array[] vector, real, real) => matrix

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -176,14 +176,14 @@ Available signatures:
   The first argument must be data-only. (Local variables are assumed to
   depend on parameters; same goes for function inputs unless they are marked
   with the keyword 'data'.)
-(data int) => int
-  The first argument must be int but got array[] real
-(data real) => int
-  The first argument must be real but got array[] real
 (data array[] int) => array[] int
   The first argument must be array[] int but got array[] real
-(data array[,] int) => array[,] int
-  The first argument must be array[,] int but got array[] real
+(data real) => int
+  The first argument must be real but got array[] real
+(data array[,] real) => array[,] int
+  The first argument must be array[,] real but got array[] real
+(data array[,,] real) => array[,,] int
+  The first argument must be array[,,] real but got array[] real
 (Additional signatures omitted)
   $ ../../../../install/default/bin/stanc bad_to_int2.stan
 Semantic error in 'bad_to_int2.stan', line 3, column 19 to column 28:
@@ -202,14 +202,14 @@ Available signatures:
   The first argument must be data-only. (Local variables are assumed to
   depend on parameters; same goes for function inputs unless they are marked
   with the keyword 'data'.)
-(data int) => int
-  The first argument must be int but got array[] real
-(data real) => int
-  The first argument must be real but got array[] real
 (data array[] int) => array[] int
   The first argument must be array[] int but got array[] real
-(data array[,] int) => array[,] int
-  The first argument must be array[,] int but got array[] real
+(data real) => int
+  The first argument must be real but got array[] real
+(data array[,] real) => array[,] int
+  The first argument must be array[,] real but got array[] real
+(data array[,,] real) => array[,,] int
+  The first argument must be array[,,] real but got array[] real
 (Additional signatures omitted)
   $ ../../../../install/default/bin/stanc bad_var_assignment_type1.stan
 Semantic error in 'bad_var_assignment_type1.stan', line 4, column 2 to column 8:
@@ -2199,16 +2199,16 @@ Semantic error in 'signature_function_known.stan', line 8, column 12 to column 4
 Ill-typed arguments supplied to function 'bernoulli_logit_lpmf':
 (vector, vector)
 Available signatures:
-(int, row_vector) => real
-  The first argument must be int but got vector
-(int, vector) => real
-  The first argument must be int but got vector
-(int, array[] real) => real
-  The first argument must be int but got vector
-(int, real) => real
-  The first argument must be int but got vector
 (array[] int, row_vector) => real
   The first argument must be array[] int but got vector
+(array[] int, vector) => real
+  The first argument must be array[] int but got vector
+(array[] int, array[] real) => real
+  The first argument must be array[] int but got vector
+(array[] int, real) => real
+  The first argument must be array[] int but got vector
+(int, row_vector) => real
+  The first argument must be int but got vector
 (Additional signatures omitted)
   $ ../../../../install/default/bin/stanc signature_function_unknown.stan
 Semantic error in 'signature_function_unknown.stan', line 8, column 12 to column 37:
@@ -2234,16 +2234,16 @@ Semantic error in 'signature_sampling_known.stan', line 8, column 2 to column 29
 Ill-typed arguments supplied to function 'bernoulli_logit':
 (vector, vector)
 Available signatures:
-(int, row_vector) => real
-  The first argument must be int but got vector
-(int, vector) => real
-  The first argument must be int but got vector
-(int, array[] real) => real
-  The first argument must be int but got vector
-(int, real) => real
-  The first argument must be int but got vector
 (array[] int, row_vector) => real
   The first argument must be array[] int but got vector
+(array[] int, vector) => real
+  The first argument must be array[] int but got vector
+(array[] int, array[] real) => real
+  The first argument must be array[] int but got vector
+(array[] int, real) => real
+  The first argument must be array[] int but got vector
+(int, row_vector) => real
+  The first argument must be int but got vector
 (Additional signatures omitted)
   $ ../../../../install/default/bin/stanc signature_sampling_udf.stan
 Semantic error in 'signature_sampling_udf.stan', line 8, column 2 to column 19:


### PR DESCRIPTION
When typecheck fails for an overloaded Stan Math function, the five signatures listed aren't always the most relevant ones. This PR changes the error sorting heuristic to prefer the types that have a similar shape to the one supplied by the user. See `bernoulli_logit` in the tests for an example of how it looks.

#### Submission Checklist

- [X] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: 
    - [X] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

Copyright holder: Niko Huurre
By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
