### PR TITLE
Clean and speed up Location.of_string_opt

### DIFF
--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -29,15 +29,14 @@ type t = info list String.Map.t
 
 let stan_math_environment =
   let functions =
-    Hashtbl.to_alist Stan_math_signatures.stan_math_signatures
-    |> List.map ~f:(fun (key, values) ->
-           ( key
-           , List.map values ~f:(fun (rt, args, mem) ->
-                 let type_ =
-                   UnsizedType.UFun
-                     (args, rt, Fun_kind.suffix_from_name key, mem) in
-                 {type_; kind= `StanMath} ) ) )
-    |> String.Map.of_alist_exn in
+    Stan_math_signatures.stan_math_signatures
+    |> Hashtbl.mapi ~f:(fun ~key ~data ->
+           List.map data ~f:(fun (rt, args, mem) ->
+               let type_ =
+                 UnsizedType.UFun (args, rt, Fun_kind.suffix_from_name key, mem)
+               in
+               {type_; kind= `StanMath} ) )
+    |> String.Map.of_hashtbl_exn in
   functions
 
 let add env key type_ kind = Map.add_multi env ~key ~data:{type_; kind}

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -5,11 +5,7 @@ open Lexing
 open Debugging
 module Str = Re.Str
 
-let dup_exists l =
-  match List.find_a_dup ~compare:String.compare l with
-  | Some _ -> true
-  | None -> false
-
+let dup_exists l = Option.is_some @@ List.find_a_dup ~compare:String.compare l
 let include_stack = Stack.create ()
 let include_paths : string list ref = ref []
 let included_files : string list ref = ref []

--- a/src/middle/Location.ml
+++ b/src/middle/Location.ml
@@ -1,14 +1,6 @@
-(** Storing locations in the original source *)
-
 open Core_kernel
-
-(**/**)
-
 module Str = Re.Str
 
-(**/**)
-
-(** Source code locations *)
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
 [@@deriving sexp, hash]
 
@@ -41,11 +33,6 @@ let pp_context_list ppf (lines, {line_num; col_num; _}) =
      %s%s%s%s%s%s   -------------------------------------------------\n"
     line_2_before line_before our_line cursor_line line_after line_2_after
 
-(** Turn the given location into a string holding the code of that location.
-    Code is retrieved by calling context_cb, which may do IO.
-    Exceptions in the callback or in the creation of the string
-    (possible if the context is incorrectly too short for the given location)
-    return [None] *)
 let context_to_string (context_cb : unit -> string list) (loc : t) :
     string option =
   Option.try_with (fun () ->
@@ -53,12 +40,6 @@ let context_to_string (context_cb : unit -> string list) (loc : t) :
 
 let empty = {filename= ""; line_num= 0; col_num= 0; included_from= None}
 
-(**
-Format the location for error messaging.
-
-If printed_filename is passed, it replaces the highest-level name and
-leaves the filenames of included files intact.
-*)
 let rec to_string ?printed_filename ?(print_file = true) ?(print_line = true)
     loc =
   let open Format in

--- a/src/middle/Location.mli
+++ b/src/middle/Location.mli
@@ -1,0 +1,29 @@
+(** Storing locations in the original source *)
+
+(** Source code locations *)
+type t = {filename: string; line_num: int; col_num: int; included_from: t option}
+[@@deriving sexp, hash]
+
+val empty : t
+val compare : t -> t -> int
+
+val to_string :
+     ?printed_filename:string
+  -> ?print_file:bool
+  -> ?print_line:bool
+  -> t
+  -> string
+(** Format the location for error messaging.
+
+    If printed_filename is passed, it replaces the highest-level name and
+    leaves the filenames of included files intact. *)
+
+val context_to_string : (unit -> string list) -> t -> string option
+(** Turn the given location into a string holding the code of that location.
+    Code is retrieved by calling context_cb, which may do IO.
+    Exceptions in the callback or in the creation of the string
+    (possible if the context is incorrectly too short for the given location)
+    return [None] *)
+
+val of_position_opt : Lexing.position -> t option
+val of_position_exn : Lexing.position -> t

--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -1,5 +1,3 @@
-(** Delimited locations in source code *)
-
 open Core_kernel
 
 type t = {begin_loc: Location.t; end_loc: Location.t}
@@ -8,7 +6,6 @@ type t = {begin_loc: Location.t; end_loc: Location.t}
 let empty = {begin_loc= Location.empty; end_loc= Location.empty}
 let merge left right = {begin_loc= left.begin_loc; end_loc= right.end_loc}
 
-(** Render a location_span as a string *)
 let to_string ?printed_filename {begin_loc; end_loc} =
   let end_loc_str =
     match begin_loc.included_from with
@@ -21,7 +18,6 @@ let to_string ?printed_filename {begin_loc; end_loc} =
     | Some _ -> "" in
   Location.to_string ?printed_filename begin_loc ^ end_loc_str
 
-(** Take the Middle.location_span corresponding to a pair of Lexing.position's *)
 let of_positions_opt start_pos end_pos =
   Option.(
     Location.of_position_opt start_pos
@@ -31,21 +27,3 @@ let of_positions_opt start_pos end_pos =
 
 let of_positions_exn (start_pos, end_pos) =
   Option.value_exn (of_positions_opt start_pos end_pos)
-
-module Comparator = Comparator.Make (struct
-  type nonrec t = t
-
-  let compare = compare
-  let sexp_of_t = sexp_of_t
-end)
-
-include Comparator
-
-include Comparable.Make_using_comparator (struct
-  type nonrec t = t
-
-  let sexp_of_t = sexp_of_t
-  let t_of_sexp = t_of_sexp
-
-  include Comparator
-end)

--- a/src/middle/Location_span.mli
+++ b/src/middle/Location_span.mli
@@ -1,0 +1,15 @@
+(** Delimited locations in source code *)
+
+type t = {begin_loc: Location.t; end_loc: Location.t}
+[@@deriving sexp, hash, compare]
+
+val empty : t
+val merge : t -> t -> t
+
+val to_string : ?printed_filename:string -> t -> string
+(** Render a location_span as a string *)
+
+val of_positions_opt : Lexing.position -> Lexing.position -> t option
+(** Take the Middle.location_span corresponding to a pair of Lexing.position's *)
+
+val of_positions_exn : Lexing.position * Lexing.position -> t


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Similar to #1302. This is not quite as big a speed up and it is only really called when you have `#include`d code, but it is still nice.

I originally tried @nhuurre's suggestion of storing positions in the preprocessor rather than re-parsing them from strings, this ended up being too complicated and stateful in my initial attempt.

On a contrived example (a file which contains only an `include` of the `motherHOF.stan` file) this decreased the total cost of `Location.of_string_opt` from 3394 calls taking 160.31M cycles to 3394 calls taking 7.83M cycles.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
