### PR TITLE
Move version string so format doesn't change based on length

### DIFF
--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -737,6 +737,7 @@ let lower_model_public p =
   @ gen_overloads p
 
 let model_public_basics name =
+  let version_string = "stanc_version = %%NAME%%3 %%VERSION%%" in
   [ FunDef
       (make_fun_defn ~inline:true ~return_type:Types.string ~name:"model_name"
          ~cv_qualifiers:[Const; Final]
@@ -750,8 +751,7 @@ let model_public_basics name =
            [ Return
                (Some
                   (Exprs.std_vector_init_expr Types.string
-                     [ Exprs.literal_string
-                         "stanc_version = %%NAME%%3 %%VERSION%%"
+                     [ Exprs.literal_string version_string
                      ; Exprs.literal_string
                          ("stancflags = " ^ !stanc_args_to_print) ] ) ) ]
          ~cv_qualifiers:[Const; NoExcept] () ) ]


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fixes an issue in the [release pipeline](https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FStanc3/detail/v2.32.0/2/pipeline/) where a shorter version string (`v2.32.0` vs `v2.31.0 GIT_SHA`) caused the auto-formatter to want one fewer newlines and complain.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
