### PR TITLE
Clean-up unused variables and prevent some unused variable warnings

### DIFF
--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -209,7 +209,6 @@ type stmt =
   | Throw of expr
   | Break
   | Continue
-  | Semicolon
   | Using of string * type_ option
   | Comment of string
 [@@deriving sexp]
@@ -225,16 +224,21 @@ module Stmts = struct
   (** Set up the try/catch logic for throwing an exception with
       its location set to the Stan program location. *)
   let rethrow_located stmts =
-    TryCatch
-      ( unblock stmts
-      , (Types.const_ref (TypeLiteral "std::exception"), "e")
-      , [ Expression
-            (FunCall
-               ( "stan::lang::rethrow_located"
-               , []
-               , [ Var "e"
-                 ; Index (Var "locations_array__", Var "current_statement__") ]
-               ) ) ] )
+    let stmts = unblock stmts in
+    match stmts with
+    | [] -> []
+    | _ ->
+        [ TryCatch
+            ( stmts
+            , (Types.const_ref (TypeLiteral "std::exception"), "e")
+            , [ Expression
+                  (FunCall
+                     ( "stan::lang::rethrow_located"
+                     , []
+                     , [ Var "e"
+                       ; Index
+                           (Var "locations_array__", Var "current_statement__")
+                       ] ) ) ] ) ]
 
   let fori loopvar lower upper body =
     let init =
@@ -501,7 +505,6 @@ module Printing = struct
     | Throw e -> pf ppf "throw %a;" pp_expr e
     | Break -> string ppf "break;"
     | Continue -> string ppf "continue;"
-    | Semicolon -> string ppf ";"
     | VariableDefn vd -> pf ppf "%a;" pp_variable_defn vd
     | For (init, cond, incr, s) ->
         let pp ppf () =
@@ -524,6 +527,7 @@ module Printing = struct
         pf ppf "%a %a" (pp_with_block pp_if) thn
           (pp_with_block ~indent:0 (any "else"))
           els
+    | Block [] -> ()
     | Block stmts ->
         pf ppf "@[<v>@[<v 2>{@,%a@]@,}@]" (list ~sep:cut pp_stmt) stmts
     | Using (s, init) ->
@@ -661,7 +665,7 @@ module Tests = struct
            on one line"; Comment "A potentially \n multiline comment"
       ; Expression (Assign (Var "foo", Literal "3")) ] in
     let rethrow = Stmts.rethrow_located s in
-    Printing.pp_stmt Fmt.stdout rethrow ;
+    Fmt.list Printing.pp_stmt Fmt.stdout rethrow ;
     [%expect
       {|
       try {
@@ -756,7 +760,7 @@ module Tests = struct
          make_fun_defn
            ~templates_init:
              ([[Typename "T0__"; RequireIs ("stan::is_foobar", "T0__")]], false)
-           ~name:"foobar" ~return_type:Void ~inline:true ~body:[rethrow] () ) ]
+           ~name:"foobar" ~return_type:Void ~inline:true ~body:rethrow () ) ]
     in
     let open Fmt in
     pf stdout "@[<v>%a@]" (list ~sep:cut Printing.pp_fun_defn) funs ;

--- a/src/stan_math_backend/Lower_functions.ml
+++ b/src/stan_math_backend/Lower_functions.ml
@@ -151,8 +151,7 @@ let lower_fun_body fdargs fdsuffix fdbody =
         :: Stmts.unused "propto__" in
   let body = lower_statement fdbody in
   (local_scalar :: Decls.current_statement :: to_refs)
-  @ propto @ Decls.dummy_var
-  @ [Stmts.rethrow_located body]
+  @ propto @ Decls.dummy_var @ Stmts.rethrow_located body
 
 let mk_extra_args templates args =
   List.map

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -180,9 +180,8 @@ let lower_constructor
       | Unsized _ -> [] )
     | _ -> lower_statement s in
   let data =
-    [ Stmts.rethrow_located
-        (List.concat_map ~f:lower_data prepare_data @ Stmts.unused "pos__") ]
-  in
+    Stmts.rethrow_located
+      (List.concat_map ~f:lower_data prepare_data @ Stmts.unused "pos__") in
   let set_num_params =
     let output_params =
       List.filter_map ~f:get_unconstrained_param_st output_vars in
@@ -230,8 +229,7 @@ let gen_log_prob Program.{prog_name; log_prob; _} =
        ~inline:true
        ~return_type:(TypeTrait ("stan::scalar_type_t", [TemplateType "VecR"]))
        ~name:"log_prob_impl" ~args
-       ~body:
-         (intro @ (Stmts.rethrow_located (lower_statements log_prob) :: outro))
+       ~body:(intro @ Stmts.rethrow_located (lower_statements log_prob) @ outro)
        ~cv_qualifiers:[Const] () )
 
 let gen_write_array {Program.prog_name; generate_quantities; _} =
@@ -273,7 +271,7 @@ let gen_write_array {Program.prog_name; generate_quantities; _} =
        ~templates_init:([templates], true)
        ~inline:true ~return_type:Void ~name:"write_array_impl" ~args
        ~body:
-         (intro @ [Stmts.rethrow_located (lower_statements generate_quantities)])
+         (intro @ Stmts.rethrow_located (lower_statements generate_quantities))
        ~cv_qualifiers:[Const] () )
 
 let gen_transform_inits_impl {Program.transform_inits; output_vars; _} =
@@ -300,16 +298,15 @@ let gen_transform_inits_impl {Program.transform_inits; output_vars; _} =
     | _ -> None in
   let validation =
     List.filter_map ~f:validate_params output_vars |> List.concat in
+  let read_inits = validation @ lower_statements transform_inits in
+  let read_inits =
+    if List.is_empty read_inits then [] else read_inits @ Stmts.unused "pos__"
+  in
   FunDef
     (make_fun_defn
        ~templates_init:([templates], true)
        ~inline:true ~return_type:Void ~name:"transform_inits_impl" ~args
-       ~body:
-         ( intro
-         @ [ Stmts.rethrow_located
-               ( validation
-               @ lower_statements transform_inits
-               @ Stmts.unused "pos__" ) ] )
+       ~body:(intro @ Stmts.rethrow_located read_inits)
        ~cv_qualifiers:[Const] () )
 
 let gen_unconstrain_array_impl {Program.unconstrain_array; _} =
@@ -331,8 +328,7 @@ let gen_unconstrain_array_impl {Program.unconstrain_array; _} =
     (make_fun_defn
        ~templates_init:([templates], true)
        ~inline:true ~return_type:Void ~name:"unconstrain_array_impl" ~args
-       ~body:
-         (intro @ [Stmts.rethrow_located (lower_statements unconstrain_array)])
+       ~body:(intro @ Stmts.rethrow_located (lower_statements unconstrain_array))
        ~cv_qualifiers:[Const] () )
 
 let gen_extend_vector name type_ elts =

--- a/src/stan_math_backend/Lower_stmt.ml
+++ b/src/stan_math_backend/Lower_stmt.ml
@@ -272,7 +272,7 @@ let rec lower_statement Stmt.Fixed.{pattern; meta} : stmt list =
       Exprs.fun_call (stan_namespace_qualify fname) (lower_exprs args) |> wrap_e
   | NRFunApp (UserDefined (fname, suffix), args) ->
       lower_user_defined_fun fname suffix args |> wrap_e
-  | Skip -> [Semicolon]
+  | Skip -> []
   | IfElse (cond, ifbranch, elsebranch) ->
       [ IfElse
           ( lower_bool_expr cond

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -709,7 +709,10 @@ let trans_prog (p : Program.Typed.t) =
         @ (p.prepare_data |> add_reads p.input_vars var_context_read)
         @ to_matrix_cl_stmts
     ; transform_inits=
-        init_pos @ List.concat_map ~f:var_context_unconstrain_transform params
+        ( if List.is_empty params then []
+        else
+          init_pos @ List.concat_map ~f:var_context_unconstrain_transform params
+        )
     ; unconstrain_array= List.concat_map ~f:array_unconstrain_transform params
     ; generate_quantities } in
   Program.(

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -710,8 +710,7 @@ let trans_prog (p : Program.Typed.t) =
         @ to_matrix_cl_stmts
     ; transform_inits=
         init_pos @ List.concat_map ~f:var_context_unconstrain_transform params
-    ; unconstrain_array=
-        init_pos @ List.concat_map ~f:array_unconstrain_transform params
+    ; unconstrain_array= List.concat_map ~f:array_unconstrain_transform params
     ; generate_quantities } in
   Program.(
     p

--- a/test/integration/cli-args/allow-undefined/cpp.expected
+++ b/test/integration/cli-args/allow-undefined/cpp.expected
@@ -71,6 +71,8 @@ class external_model final : public model_base_crtp<external_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -136,6 +138,8 @@ class external_model final : public model_base_crtp<external_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "external_model_namespace::write_array";
     // suppress unused var warning
@@ -167,8 +171,7 @@ class external_model final : public model_base_crtp<external_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -186,6 +189,8 @@ class external_model final : public model_base_crtp<external_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/cli-args/allow-undefined/cpp.expected
+++ b/test/integration/cli-args/allow-undefined/cpp.expected
@@ -104,11 +104,6 @@ class external_model final : public model_base_crtp<external_model> {
       "external_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -170,11 +165,6 @@ class external_model final : public model_base_crtp<external_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -186,14 +176,6 @@ class external_model final : public model_base_crtp<external_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/cli-args/filename-in-msg/filename_good.expected
+++ b/test/integration/cli-args/filename-in-msg/filename_good.expected
@@ -73,11 +73,6 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
       "filename_good_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -139,11 +134,6 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -155,14 +145,6 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/cli-args/filename-in-msg/filename_good.expected
+++ b/test/integration/cli-args/filename-in-msg/filename_good.expected
@@ -40,6 +40,8 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
       q = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 2;
       q = (p + 5);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -105,6 +107,8 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "filename_good_model_namespace::write_array";
     // suppress unused var warning
@@ -136,8 +140,7 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -155,6 +158,8 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -498,6 +498,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       y_v_d_td_opencl__ = stan::math::to_matrix_cl(y_v_d_td);
       y_vi_d_opencl__ = stan::math::to_matrix_cl(y_vi_d);
       y_vi_d_td_opencl__ = stan::math::to_matrix_cl(y_vi_d_td);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1249,6 +1251,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "optimize_glm_model_namespace::write_array";
     // suppress unused var warning
@@ -1330,8 +1334,6 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> alpha_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
       current_statement__ = 1;
@@ -1558,6 +1560,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
         }
       }
       out__.write(X_rv_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -2252,11 +2252,6 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       "basic_operations_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -2758,11 +2753,6 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -2774,14 +2764,6 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -5560,11 +5542,6 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
       "complex_data_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -5626,11 +5603,6 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -5642,14 +5614,6 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -8721,11 +8685,6 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -8737,14 +8696,6 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -9386,11 +9337,6 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -9402,14 +9348,6 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -198,6 +198,8 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       stan::math::validate_non_negative_index("carray", "N", N);
       current_statement__ = 133;
       stan::math::validate_non_negative_index("carray", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -747,6 +749,8 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "basic_op_param_model_namespace::write_array";
     // suppress unused var warning
@@ -1293,8 +1297,6 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1> cmat =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>::Constant(N, N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
@@ -1520,6 +1522,8 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       current_statement__ = 8;
       r = context__.vals_r("r")[(1 - 1)];
       out__.write(r);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2215,6 +2219,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       stan::math::validate_non_negative_index("carray", "N", N);
       current_statement__ = 132;
       stan::math::validate_non_negative_index("carray", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2280,6 +2286,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "basic_operations_model_namespace::write_array";
     // suppress unused var warning
@@ -2751,8 +2759,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2770,6 +2777,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3419,6 +3428,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       stan::math::validate_non_negative_index("carray", "N", N);
       current_statement__ = 164;
       stan::math::validate_non_negative_index("carray", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4027,6 +4038,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "basic_ops_mix_model_namespace::write_array";
     // suppress unused var warning
@@ -4632,8 +4645,6 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1> cvmat =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>::Constant(N, N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
@@ -4859,6 +4870,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       current_statement__ = 8;
       v = context__.vals_r("v")[(1 - 1)];
       out__.write(v);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5514,6 +5527,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5579,6 +5594,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "complex_data_model_namespace::write_array";
     // suppress unused var warning
@@ -5610,8 +5627,7 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5629,6 +5645,8 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6733,6 +6751,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::math::validate_non_negative_index("i_arr", "0", 0);
       current_statement__ = 405;
       stan::math::validate_non_negative_index("i_arr_1", "1", 1);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7022,6 +7042,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "complex_scalar_model_namespace::write_array";
     // suppress unused var warning
@@ -7967,8 +7989,6 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ p_r = DUMMY_VAR__;
       current_statement__ = 1;
       p_r = in__.read<local_scalar_t__>();
@@ -8094,6 +8114,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         }
       }
       out__.write(p_complex_array_2d);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8473,6 +8495,8 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8595,6 +8619,8 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "complex_vectors_model_namespace::write_array";
     // suppress unused var warning
@@ -8696,8 +8722,7 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8715,6 +8740,8 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9222,6 +9249,8 @@ class user_function_templating_model final : public model_base_crtp<user_functio
       N = std::numeric_limits<int>::min();
       current_statement__ = 14;
       N = 3;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9325,6 +9354,8 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "user_function_templating_model_namespace::write_array";
     // suppress unused var warning
@@ -9356,8 +9387,7 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9375,6 +9405,8 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -1506,11 +1506,6 @@ void _stan_alignas(const int& _stan_asm, std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_alignof(const int& _stan_char, std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1521,11 +1516,6 @@ void _stan_alignof(const int& _stan_char, std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 int _stan_and(const int& _stan_STAN_MAJOR, std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1553,11 +1543,6 @@ void _stan_and_eq(const T0__& _stan_STAN_MINOR, std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 template <typename T0__,
           stan::require_all_t<stan::is_col_vector<T0__>,
@@ -1572,11 +1557,6 @@ void _stan_asm(const T0__& _stan_class_arg__, std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_bitand(const int& _stan_constexpr, std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1587,11 +1567,6 @@ void _stan_bitand(const int& _stan_constexpr, std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_bitor(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1602,11 +1577,6 @@ void _stan_bitor(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_bool(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1617,11 +1587,6 @@ void _stan_bool(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_case(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1632,11 +1597,6 @@ void _stan_case(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_catch(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1647,11 +1607,6 @@ void _stan_catch(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_char(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1662,11 +1617,6 @@ void _stan_char(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_char16_t(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1677,11 +1627,6 @@ void _stan_char16_t(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 void _stan_char32_t(std::ostream* pstream__) {
   using local_scalar_t__ = double;
@@ -1692,11 +1637,6 @@ void _stan_char32_t(std::ostream* pstream__) {
   local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
   // suppress unused var warning
   (void) DUMMY_VAR__;
-  try {
-    
-  } catch (const std::exception& e) {
-    stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-  }
 }
 class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words_model> {
  private:
@@ -3178,11 +3118,6 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -3194,14 +3129,6 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -22704,11 +22631,6 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
       "print_unicode_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -22770,11 +22692,6 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -22786,14 +22703,6 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -23045,11 +22954,6 @@ class promotion_model final : public model_base_crtp<promotion_model> {
       "promotion_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -23131,11 +23035,6 @@ class promotion_model final : public model_base_crtp<promotion_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -23147,14 +23046,6 @@ class promotion_model final : public model_base_crtp<promotion_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -32644,11 +32535,6 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
       "single_argument_lpmf_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -32710,11 +32596,6 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -32726,14 +32607,6 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -79,6 +79,8 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
       stan::math::validate_non_negative_index("theta_tilde", "J", J);
       current_statement__ = 15;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -171,6 +173,8 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "_8_schools_ncp_model_namespace::write_array";
     // suppress unused var warning
@@ -228,8 +232,6 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -297,6 +299,8 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
         }
       }
       out__.write(theta_tilde);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -507,6 +511,8 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       good_model = std::numeric_limits<int>::min();
       current_statement__ = 2;
       good_model = context__.vals_i("good_model")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -574,6 +580,8 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "_8start_with_number_model_namespace::write_array";
     // suppress unused var warning
@@ -609,8 +617,6 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ bar = DUMMY_VAR__;
       current_statement__ = 1;
       bar = in__.read<local_scalar_t__>();
@@ -639,6 +645,8 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
       current_statement__ = 1;
       bar = context__.vals_r("bar")[(1 - 1)];
       out__.write(bar);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -833,6 +841,8 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       stan::model::assign(Arr,
         std::vector<std::vector<double>>{std::vector<double>{1, 2},
           std::vector<double>{3, 4.5}}, "assigning variable Arr");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -969,6 +979,8 @@ class container_promotion_model final : public model_base_crtp<container_promoti
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "container_promotion_model_namespace::write_array";
     // suppress unused var warning
@@ -1108,8 +1120,6 @@ class container_promotion_model final : public model_base_crtp<container_promoti
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ y = DUMMY_VAR__;
       current_statement__ = 1;
       y = in__.read<local_scalar_t__>();
@@ -1138,6 +1148,8 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       current_statement__ = 1;
       y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1793,6 +1805,8 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       _stan_enum = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 64;
       _stan_enum = context__.vals_r("enum")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1920,6 +1934,8 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "cpp_reserved_words_model_namespace::write_array";
     // suppress unused var warning
@@ -2057,8 +2073,6 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ _stan_explicit = DUMMY_VAR__;
       current_statement__ = 1;
       _stan_explicit = in__.read<local_scalar_t__>();
@@ -2241,6 +2255,8 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       current_statement__ = 15;
       _stan_or = context__.vals_r("or")[(1 - 1)];
       out__.write(_stan_or);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2556,6 +2572,8 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
       stan::math::validate_non_negative_index("theta_tilde", "J", J);
       current_statement__ = 15;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2648,6 +2666,8 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "eight_schools_ncp_model_namespace::write_array";
     // suppress unused var warning
@@ -2705,8 +2725,6 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -2774,6 +2792,8 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
         }
       }
       out__.write(theta_tilde);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3049,6 +3069,8 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
       }
       current_statement__ = 6;
       bar(static_cast<double>(1), static_cast<double>(2), pstream__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3124,6 +3146,8 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "funcall_type_promotion_model_namespace::write_array";
     // suppress unused var warning
@@ -3155,8 +3179,7 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3174,6 +3197,8 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3350,6 +3375,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       pos__ = 1;
       current_statement__ = 5;
       x = std::vector<double>(3, std::numeric_limits<double>::quiet_NaN());
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3443,6 +3470,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "mixed_type_arrays_model_namespace::write_array";
     // suppress unused var warning
@@ -3521,8 +3550,6 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<local_scalar_t__> xx =
         std::vector<local_scalar_t__>(3, DUMMY_VAR__);
       current_statement__ = 1;
@@ -3554,6 +3581,8 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       current_statement__ = 1;
       xx = context__.vals_r("xx");
       out__.write(xx);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8872,6 +8901,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       stan::math::validate_non_negative_index("gq_3d_simplex", "N", N);
       current_statement__ = 592;
       stan::math::validate_non_negative_index("gq_cfcov_33_ar", "K", K);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9429,6 +9460,8 @@ class mother_model final : public model_base_crtp<mother_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "mother_model_namespace::write_array";
     // suppress unused var warning
@@ -10513,8 +10546,6 @@ class mother_model final : public model_base_crtp<mother_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ p_real = DUMMY_VAR__;
       current_statement__ = 1;
       p_real = in__.read<local_scalar_t__>();
@@ -11369,6 +11400,8 @@ class mother_model final : public model_base_crtp<mother_model> {
         }
       }
       out__.write(y_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13241,6 +13274,8 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       stan::math::validate_non_negative_index("x_p", "1", 1);
       current_statement__ = 139;
       stan::math::validate_non_negative_index("y_hat", "T", T);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13592,6 +13627,8 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "motherHOF_model_namespace::write_array";
     // suppress unused var warning
@@ -14002,8 +14039,6 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<local_scalar_t__> y0_p =
         std::vector<local_scalar_t__>(2, DUMMY_VAR__);
       current_statement__ = 1;
@@ -14173,6 +14208,8 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       current_statement__ = 7;
       x_r = context__.vals_r("x_r")[(1 - 1)];
       out__.write(x_r);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15523,6 +15560,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       stan::math::validate_non_negative_index("zg", "N", N);
       current_statement__ = 627;
       stan::math::validate_non_negative_index("zg", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17196,6 +17235,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "new_integrate_interface_model_namespace::write_array";
     // suppress unused var warning
@@ -18846,8 +18887,6 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ r = DUMMY_VAR__;
       current_statement__ = 1;
       r = in__.read<local_scalar_t__>();
@@ -18918,6 +18957,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
         }
       }
       out__.write(v);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19315,6 +19356,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       stan::math::check_greater_or_equal(function__, "y", y, 0);
       current_statement__ = 24;
       stan::math::validate_non_negative_index("z", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19452,6 +19495,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "old_integrate_interface_model_namespace::write_array";
     // suppress unused var warning
@@ -19531,8 +19576,6 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ alpha = DUMMY_VAR__;
       current_statement__ = 1;
       alpha = in__.read<local_scalar_t__>();
@@ -19623,6 +19666,8 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       current_statement__ = 6;
       sigma = context__.vals_r("sigma");
       out__.write_free_lb(0, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20304,6 +20349,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
       stan::math::validate_non_negative_index("beta_m", "k", k);
       current_statement__ = 216;
       stan::math::validate_non_negative_index("X_rv_p", "n", n);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20905,6 +20952,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "optimize_glm_model_namespace::write_array";
     // suppress unused var warning
@@ -20986,8 +21035,6 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> alpha_v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(k, DUMMY_VAR__);
       current_statement__ = 1;
@@ -21214,6 +21261,8 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
         }
       }
       out__.write(X_rv_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21768,6 +21817,8 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
             stan::math::transpose(a), stan::math::transpose(a),
             stan::math::transpose(a), stan::math::transpose(a)}),
         "assigning variable M");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21885,6 +21936,8 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloading_templating_model_namespace::write_array";
     // suppress unused var warning
@@ -21924,8 +21977,6 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ y = DUMMY_VAR__;
       current_statement__ = 1;
       y = in__.read<local_scalar_t__>();
@@ -21965,6 +22016,8 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
       current_statement__ = 2;
       z = context__.vals_r("z")[(1 - 1)];
       out__.write(z);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22162,6 +22215,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
       stan::math::validate_non_negative_index("L_Omega", "nt", nt);
       current_statement__ = 6;
       stan::math::validate_non_negative_index("z1", "NS", NS);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22242,6 +22297,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "param_constraint_model_namespace::write_array";
     // suppress unused var warning
@@ -22302,8 +22359,6 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> L_Omega =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(nt,
           Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__));
@@ -22404,6 +22459,8 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
                             stan::model::index_uni(1),
                             stan::model::index_uni(1),
                             stan::model::index_uni(2)), z1);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22614,6 +22671,8 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
           "\316\273 \316\262 \316\266 \317\200");
         *(pstream__) << std::endl;
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22679,6 +22738,8 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "print_unicode_model_namespace::write_array";
     // suppress unused var warning
@@ -22710,8 +22771,7 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22729,6 +22789,8 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22950,6 +23012,8 @@ class promotion_model final : public model_base_crtp<promotion_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23015,6 +23079,8 @@ class promotion_model final : public model_base_crtp<promotion_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "promotion_model_namespace::write_array";
     // suppress unused var warning
@@ -23066,8 +23132,7 @@ class promotion_model final : public model_base_crtp<promotion_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23085,6 +23150,8 @@ class promotion_model final : public model_base_crtp<promotion_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23674,6 +23741,8 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
       stan::math::validate_non_negative_index("gamma", "times", times);
       current_statement__ = 7;
       stan::math::validate_non_negative_index("z_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23753,6 +23822,8 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "recursive_slicing_model_namespace::write_array";
     // suppress unused var warning
@@ -23807,8 +23878,6 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> gamma =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(times, DUMMY_VAR__);
       current_statement__ = 1;
@@ -23854,6 +23923,8 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
         }
       }
       out__.write(gamma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24212,6 +24283,8 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       stan::math::validate_non_negative_index("y2", "N", N);
       current_statement__ = 11;
       stan::math::validate_non_negative_index("y3", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24301,6 +24374,8 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "reduce_sum_m1_model_namespace::write_array";
     // suppress unused var warning
@@ -24347,8 +24422,6 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<local_scalar_t__> y1 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
       current_statement__ = 1;
@@ -24408,6 +24481,8 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
       current_statement__ = 3;
       y3 = context__.vals_r("y3");
       out__.write(y3);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25652,6 +25727,8 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       stan::math::validate_non_negative_index("y2", "N", N);
       current_statement__ = 75;
       stan::math::validate_non_negative_index("y1", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25874,6 +25951,8 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "reduce_sum_m2_model_namespace::write_array";
     // suppress unused var warning
@@ -26127,8 +26206,6 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>> a8 =
         std::vector<std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>>(N,
           std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(N,
@@ -26828,6 +26905,8 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
       current_statement__ = 16;
       y1 = context__.vals_r("y1");
       out__.write(y1);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -29619,6 +29698,8 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       stan::math::validate_non_negative_index("y17", "N", N);
       current_statement__ = 170;
       stan::math::validate_non_negative_index("y17", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -29846,6 +29927,8 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "reduce_sum_m3_model_namespace::write_array";
     // suppress unused var warning
@@ -30132,8 +30215,6 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<local_scalar_t__> y1 =
         std::vector<local_scalar_t__>(N, DUMMY_VAR__);
       current_statement__ = 1;
@@ -30640,6 +30721,8 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
         }
       }
       out__.write(y17);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -31221,6 +31304,8 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
       current_statement__ = 48;
       stan::math::validate_non_negative_index("result", "num_elements(x)",
         result_1dim__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -31438,6 +31523,8 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "shadowing_model_namespace::write_array";
     // suppress unused var warning
@@ -31661,8 +31748,6 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ e = DUMMY_VAR__;
       current_statement__ = 1;
       e = in__.read<local_scalar_t__>();
@@ -32083,6 +32168,8 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
       current_statement__ = 33;
       ode_bdf_tol = context__.vals_r("ode_bdf_tol")[(1 - 1)];
       out__.write(ode_bdf_tol);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32524,6 +32611,8 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32589,6 +32678,8 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "single_argument_lpmf_model_namespace::write_array";
     // suppress unused var warning
@@ -32620,8 +32711,7 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32639,6 +32729,8 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32821,6 +32913,8 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       t = std::numeric_limits<int>::min();
       current_statement__ = 7;
       t = context__.vals_i("t")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32915,6 +33009,8 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "tilde_block_model_namespace::write_array";
     // suppress unused var warning
@@ -32951,8 +33047,6 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       current_statement__ = 1;
       x = in__.read<local_scalar_t__>();
@@ -32981,6 +33075,8 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
       out__.write_free_lb(0, x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -33564,6 +33660,8 @@ class transform_model final : public model_base_crtp<transform_model> {
       stan::math::validate_non_negative_index("tpm_2", "m", m);
       current_statement__ = 115;
       stan::math::validate_non_negative_index("tpm_2", "k", k);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -34082,6 +34180,8 @@ class transform_model final : public model_base_crtp<transform_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "transform_model_namespace::write_array";
     // suppress unused var warning
@@ -34697,8 +34797,6 @@ class transform_model final : public model_base_crtp<transform_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<local_scalar_t__> p_1 =
         std::vector<local_scalar_t__>(k, DUMMY_VAR__);
       current_statement__ = 1;
@@ -35297,6 +35395,8 @@ class transform_model final : public model_base_crtp<transform_model> {
         }
       }
       out__.write_free_ub(dm, pm_2);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -35976,6 +36076,8 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       x = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 20;
       x = context__.vals_r("x")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -36129,6 +36231,8 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "truncate_model_namespace::write_array";
     // suppress unused var warning
@@ -36169,8 +36273,6 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ m = DUMMY_VAR__;
       current_statement__ = 1;
       m = in__.read<local_scalar_t__>();
@@ -36210,6 +36312,8 @@ class truncate_model final : public model_base_crtp<truncate_model> {
       current_statement__ = 2;
       y = context__.vals_r("y")[(1 - 1)];
       out__.write_free_lb(0, y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -36408,6 +36512,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -36479,6 +36585,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "udf_tilde_stmt_conflict_model_namespace::write_array";
     // suppress unused var warning
@@ -36514,8 +36622,6 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       current_statement__ = 1;
       x = in__.read<local_scalar_t__>();
@@ -36544,6 +36650,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -36744,6 +36852,8 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -36816,6 +36926,8 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "user_constrain_model_namespace::write_array";
     // suppress unused var warning
@@ -36852,8 +36964,6 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       current_statement__ = 1;
       x = in__.read<local_scalar_t__>();
@@ -36882,6 +36992,8 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
       out__.write_free_lb(0, x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -37093,6 +37205,8 @@ class variable_named_context_model final : public model_base_crtp<variable_named
           pos__ = (pos__ + 1);
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -37168,6 +37282,8 @@ class variable_named_context_model final : public model_base_crtp<variable_named
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "variable_named_context_model_namespace::write_array";
     // suppress unused var warning
@@ -37208,8 +37324,6 @@ class variable_named_context_model final : public model_base_crtp<variable_named
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -37249,6 +37363,8 @@ class variable_named_context_model final : public model_base_crtp<variable_named
       current_statement__ = 2;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lb(0, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -37557,6 +37673,8 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
       stan::math::validate_non_negative_index("vector_mu", "N", N);
       current_statement__ = 93;
       stan::math::validate_non_negative_index("vector_sigma", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -38107,6 +38225,8 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "vector_truncate_model_namespace::write_array";
     // suppress unused var warning
@@ -38160,8 +38280,6 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -38257,6 +38375,8 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
         }
       }
       out__.write(vector_sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -819,11 +819,6 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       "simple_function_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -885,11 +880,6 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -901,14 +891,6 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -75,6 +75,8 @@ class operators_model final : public model_base_crtp<operators_model> {
       stan::math::validate_non_negative_index("drv", "N", N);
       current_statement__ = 19;
       stan::math::validate_non_negative_index("dv", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -151,6 +153,8 @@ class operators_model final : public model_base_crtp<operators_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "operators_model_namespace::write_array";
     // suppress unused var warning
@@ -231,8 +235,6 @@ class operators_model final : public model_base_crtp<operators_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> v =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       current_statement__ = 1;
@@ -338,6 +340,8 @@ class operators_model final : public model_base_crtp<operators_model> {
         }
       }
       out__.write(A);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -782,6 +786,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -847,6 +853,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "simple_function_model_namespace::write_array";
     // suppress unused var warning
@@ -878,8 +886,7 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -897,6 +904,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1082,6 +1091,8 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       y = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 10;
       y = context__.vals_r("y")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1193,6 +1204,8 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ternary_if_model_namespace::write_array";
     // suppress unused var warning
@@ -1277,8 +1290,6 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
       current_statement__ = 1;
@@ -1376,6 +1387,8 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       current_statement__ = 4;
       zp = context__.vals_c("zp")[(1 - 1)];
       out__.write(zp);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -6742,6 +6742,8 @@
             (VariableDefn
              ((static false) (constexpr true) (type_ (TypeLiteral bool))
               (name jacobian__) (init (Assignment (Literal false)))))
+            (Comment "suppress unused var warning")
+            (Expression (Cast Void (Var jacobian__)))
             (VariableDefn
              ((static true) (constexpr true)
               (type_ (Const (Pointer (TypeLiteral char)))) (name function__)
@@ -9465,11 +9467,6 @@
             (Expression (Cast Void (Var DUMMY_VAR__)))
             (TryCatch
              ((VariableDefn
-               ((static false) (constexpr false) (type_ Int) (name pos__)
-                (init
-                 (Assignment (FunCall std::numeric_limits<int>::min () ())))))
-              (Expression (Assign (Var pos__) (Literal 1)))
-              (VariableDefn
                ((static false) (constexpr false)
                 (type_ (TypeLiteral local_scalar_t__)) (name p_real)
                 (init (Assignment (Var DUMMY_VAR__)))))
@@ -11598,7 +11595,9 @@
                    (Expression
                     (Assign (Var pos__)
                      (Parens (BinOp (Var pos__) Add (Literal 1))))))))))
-              (Expression (MethodCall (Var out__) write () ((Var y_p)))))
+              (Expression (MethodCall (Var out__) write () ((Var y_p))))
+              (Comment "suppress unused var warning")
+              (Expression (Cast Void (Var pos__))))
              ((Const (Ref (TypeLiteral std::exception))) e)
              ((Expression
                (FunCall stan::lang::rethrow_located ()
@@ -20847,7 +20846,9 @@
            (Expression (Assign (Var current_statement__) (Literal 592)))
            (Expression
             (FunCall stan::math::validate_non_negative_index ()
-             ((Literal "\"gq_cfcov_33_ar\"") (Literal "\"K\"") (Var K)))))
+             ((Literal "\"gq_cfcov_33_ar\"") (Literal "\"K\"") (Var K))))
+           (Comment "suppress unused var warning")
+           (Expression (Cast Void (Var pos__))))
           ((Const (Ref (TypeLiteral std::exception))) e)
           ((Expression
             (FunCall stan::lang::rethrow_located ()

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -268,6 +268,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 29;
       stan::math::validate_non_negative_index("z", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -374,6 +376,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ode_adjoint_test_model_model_namespace::write_array";
     // suppress unused var warning
@@ -456,8 +460,6 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ y = DUMMY_VAR__;
       current_statement__ = 1;
       y = in__.read<local_scalar_t__>();
@@ -539,6 +541,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
       current_statement__ = 4;
       times = context__.vals_r("times");
       out__.write(times);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1073,6 +1077,8 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       stan::math::validate_non_negative_index("y", "N_t", N_t);
       current_statement__ = 39;
       stan::math::validate_non_negative_index("y2", "N_t", N_t);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1239,6 +1245,8 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_ode_model_namespace::write_array";
     // suppress unused var warning
@@ -1324,8 +1332,6 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ beta = DUMMY_VAR__;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -1387,6 +1393,8 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       current_statement__ = 4;
       delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -904,6 +904,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       d_real_array_opencl__ = stan::math::to_matrix_cl(d_real_array);
       d_row_vector_opencl__ = stan::math::to_matrix_cl(d_row_vector);
       d_vector_opencl__ = stan::math::to_matrix_cl(d_vector);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3994,6 +3996,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "distributions_model_namespace::write_array";
     // suppress unused var warning
@@ -7055,8 +7059,6 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ p_real = DUMMY_VAR__;
       current_statement__ = 1;
       p_real = in__.read<local_scalar_t__>();
@@ -7203,6 +7205,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 6;
       y_p = context__.vals_r("y_p")[(1 - 1)];
       out__.write(y_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7569,6 +7573,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       current_statement__ = 39;
       stan::math::validate_non_negative_index("p_row_vector", "d_int", d_int);
       d_vector_opencl__ = stan::math::to_matrix_cl(d_vector);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7712,6 +7718,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "restricted_model_namespace::write_array";
     // suppress unused var warning
@@ -7829,8 +7837,6 @@ class restricted_model final : public model_base_crtp<restricted_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ p_real = DUMMY_VAR__;
       current_statement__ = 1;
       p_real = in__.read<local_scalar_t__>();
@@ -7977,6 +7983,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       current_statement__ = 6;
       y_p = context__.vals_r("y_p")[(1 - 1)];
       out__.write(y_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -111,6 +111,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
         current_statement__ = 27;
         sum_y = stan::math::sum(y);
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -245,6 +247,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "simple_function_model_namespace::write_array";
     // suppress unused var warning
@@ -291,8 +295,6 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ rho = DUMMY_VAR__;
       current_statement__ = 1;
       rho = in__.read<local_scalar_t__>();
@@ -343,6 +345,8 @@ class simple_function_model final : public model_base_crtp<simple_function_model
       current_statement__ = 3;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lb(0, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/code-gen/profiling/transformed_mir.expected
+++ b/test/integration/good/code-gen/profiling/transformed_mir.expected
@@ -663,15 +663,6 @@
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id rho) (decl_type (Sized SReal))
       (initialize true)))
     (meta <opaque>))

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -22459,15 +22459,6 @@
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id p_real)
       (decl_type (Sized SReal)) (initialize true)))
     (meta <opaque>))

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -863,6 +863,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -979,6 +981,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_level_deep_dependence_model_namespace::write_array";
     // suppress unused var warning
@@ -1074,8 +1078,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
       current_statement__ = 1;
       stan::model::assign(X_p,
@@ -1918,6 +1920,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2396,6 +2400,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "kappa", 1000000, 0);
       current_statement__ = 28;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2553,6 +2559,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_level_failing_model_namespace::write_array";
     // suppress unused var warning
@@ -2677,8 +2685,6 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ beta;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -2740,6 +2746,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       current_statement__ = 4;
       delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3773,6 +3781,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3861,6 +3871,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_levels_deep_model_namespace::write_array";
     // suppress unused var warning
@@ -3918,8 +3930,6 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
       current_statement__ = 1;
       stan::model::assign(X_p,
@@ -4762,6 +4772,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5013,6 +5025,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       stan::math::validate_non_negative_index("X", "N", N);
       current_statement__ = 15;
       stan::math::validate_non_negative_index("X", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5117,6 +5131,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "copy_prop_profile_model_namespace::write_array";
     // suppress unused var warning
@@ -5154,8 +5170,6 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X;
       current_statement__ = 1;
       stan::model::assign(X,
@@ -5236,6 +5250,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
         }
       }
       out__.write(X);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5951,6 +5967,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 56;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6418,6 +6436,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "copy_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -6746,8 +6766,6 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.read<local_scalar_t__>();
@@ -6816,6 +6834,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         }
       }
       out__.write_free_lub(0, 1, beta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7302,6 +7322,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       stan::math::validate_non_negative_index("b_age_edu", "n_edu", n_edu);
       current_statement__ = 65;
       stan::math::validate_non_negative_index("b_hat", "n_state", n_state);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7618,6 +7640,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "dce_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -7724,8 +7748,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ sigma;
       current_statement__ = 1;
       sigma = in__.read<local_scalar_t__>();
@@ -8086,6 +8108,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         }
       }
       out__.write(b_hat);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8376,6 +8400,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       i = stan::math::normal_rng(5, 1, base_rng__);
       current_statement__ = 8;
       y = stan::math::normal_rng(z, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8441,6 +8467,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_experiment_model_namespace::write_array";
     // suppress unused var warning
@@ -8474,8 +8502,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8493,6 +8520,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8696,6 +8725,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       }
       current_statement__ = 7;
       y = stan::math::normal_rng(z, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8761,6 +8792,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_experiment2_model_namespace::write_array";
     // suppress unused var warning
@@ -8794,8 +8827,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8813,6 +8845,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9039,6 +9073,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9167,6 +9203,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -9216,8 +9254,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> mu;
       current_statement__ = 1;
       stan::model::assign(mu,
@@ -9297,6 +9333,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       current_statement__ = 3;
       theta = context__.vals_r("theta")[(1 - 1)];
       out__.write_free_lub(0, 1, theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9529,6 +9567,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       stan::math::check_greater_or_equal(function__, "sigma", sigma, 0);
       current_statement__ = 11;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9612,6 +9652,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail2_model_namespace::write_array";
     // suppress unused var warning
@@ -9659,8 +9701,6 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mu;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -9713,6 +9753,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       current_statement__ = 3;
       tau = context__.vals_r("tau")[(1 - 1)];
       out__.write_free_lb(0, tau);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10218,6 +10260,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         n_region_full);
       current_statement__ = 51;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10446,6 +10490,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail3_model_namespace::write_array";
     // suppress unused var warning
@@ -10634,8 +10680,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       stan::model::assign(a,
@@ -10964,6 +11008,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       current_statement__ = 11;
       sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_e);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11381,6 +11427,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       stan::math::validate_non_negative_index("x", "N", N);
       current_statement__ = 42;
       stan::math::validate_non_negative_index("y", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11498,6 +11546,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail4_model_namespace::write_array";
     // suppress unused var warning
@@ -11662,8 +11712,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ tau_phi;
       current_statement__ = 1;
       tau_phi = in__.read<local_scalar_t__>();
@@ -11735,6 +11783,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         }
       }
       out__.write(phi_std_raw);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12456,6 +12506,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 58;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12922,6 +12974,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail5_model_namespace::write_array";
     // suppress unused var warning
@@ -13255,8 +13309,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -13347,6 +13399,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 4;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14715,6 +14769,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 137;
       stan::math::validate_non_negative_index("z", "n_occasions", n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15676,6 +15732,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail6_model_namespace::write_array";
     // suppress unused var warning
@@ -16348,8 +16406,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -16491,6 +16547,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       current_statement__ = 6;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17054,6 +17112,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       stan::math::validate_non_negative_index("log_Pr_z", "I", I);
       current_statement__ = 36;
       stan::math::validate_non_negative_index("log_Pr_z", "K", K);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17280,6 +17340,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail7_model_namespace::write_array";
     // suppress unused var warning
@@ -17518,8 +17580,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> pi;
       current_statement__ = 1;
       stan::model::assign(pi,
@@ -17704,6 +17764,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         }
       }
       out__.write_free_simplex(theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18048,6 +18110,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       stan::math::validate_non_negative_index("phi_std_raw", "N", N);
       current_statement__ = 24;
       stan::math::validate_non_negative_index("phi", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18166,6 +18230,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail8_model_namespace::write_array";
     // suppress unused var warning
@@ -18248,8 +18314,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ beta0;
       current_statement__ = 1;
       beta0 = in__.read<local_scalar_t__>();
@@ -18390,6 +18454,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         }
       }
       out__.write(phi_std_raw);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19142,6 +19208,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 56;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19609,6 +19677,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "fails_test_model_namespace::write_array";
     // suppress unused var warning
@@ -19937,8 +20007,6 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.read<local_scalar_t__>();
@@ -20007,6 +20075,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         }
       }
       out__.write_free_lub(0, 1, beta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20391,6 +20461,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20468,6 +20540,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "function_in_function_inline_model_namespace::write_array";
     // suppress unused var warning
@@ -20501,8 +20575,7 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20520,6 +20593,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20786,6 +20861,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
       N = std::numeric_limits<int>::min();
       current_statement__ = 12;
       N = context__.vals_i("N")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20918,6 +20995,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "function_in_function_loops_model_namespace::write_array";
     // suppress unused var warning
@@ -20951,8 +21030,7 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20970,6 +21048,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21217,6 +21297,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21337,6 +21419,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inline_functions_varmat_model_namespace::write_array";
     // suppress unused var warning
@@ -21420,8 +21504,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec;
       current_statement__ = 1;
       stan::model::assign(p_single_ret_vec,
@@ -21568,6 +21650,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
         }
       }
       out__.write(p_multi_ret_vec);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21839,6 +21923,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       current_statement__ = 7;
       stan::model::assign(bar, foo(10, 11, pstream__),
         "assigning variable bar");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21912,6 +21998,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inline_tdata_model_namespace::write_array";
     // suppress unused var warning
@@ -21949,8 +22037,6 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ alpha;
       current_statement__ = 1;
       alpha = in__.read<local_scalar_t__>();
@@ -21979,6 +22065,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       current_statement__ = 1;
       alpha = context__.vals_r("alpha")[(1 - 1)];
       out__.write(alpha);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22206,6 +22294,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
       stan::math::validate_non_negative_index("R", "N", N);
       current_statement__ = 8;
       stan::math::validate_non_negative_index("out", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22288,6 +22378,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inliner_same_names_model_namespace::write_array";
     // suppress unused var warning
@@ -22343,8 +22435,7 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22362,6 +22453,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23736,6 +23829,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 135;
       stan::math::validate_non_negative_index("z", "n_occasions", n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24667,6 +24762,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inlining_fail2_model_namespace::write_array";
     // suppress unused var warning
@@ -25347,8 +25444,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -25481,6 +25576,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 5;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25830,6 +25927,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       i = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 6;
       i = stan::math::normal_rng(lcm_sym3__, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25895,6 +25994,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_experiment_model_namespace::write_array";
     // suppress unused var warning
@@ -25928,8 +26029,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25947,6 +26047,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -26123,6 +26225,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -26207,6 +26311,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_experiment2_model_namespace::write_array";
     // suppress unused var warning
@@ -26244,8 +26350,6 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ x;
       current_statement__ = 1;
       x = in__.read<local_scalar_t__>();
@@ -26274,6 +26378,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -26470,6 +26576,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       y = context__.vals_r("y");
       current_statement__ = 6;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -26543,6 +26651,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_fails_model_namespace::write_array";
     // suppress unused var warning
@@ -26581,8 +26691,6 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       std::vector<local_scalar_t__> theta;
       current_statement__ = 1;
       stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
@@ -26613,6 +26721,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       current_statement__ = 1;
       theta = context__.vals_r("theta");
       out__.write(theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -27242,6 +27352,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       current_statement__ = 52;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -27686,6 +27798,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_fails2_model_namespace::write_array";
     // suppress unused var warning
@@ -27991,8 +28105,6 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -28032,6 +28144,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
       out__.write_free_lub(0, 1, mean_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -28347,6 +28461,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       n = std::numeric_limits<int>::min();
       current_statement__ = 6;
       n = context__.vals_i("n")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -28438,6 +28554,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lupdf_inlining_model_namespace::write_array";
     // suppress unused var warning
@@ -28504,8 +28622,6 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mu;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -28534,6 +28650,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       current_statement__ = 1;
       mu = context__.vals_r("mu")[(1 - 1)];
       out__.write(mu);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -28962,6 +29080,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       stan::math::validate_non_negative_index("psi_con", "R", R);
       current_statement__ = 51;
       stan::math::validate_non_negative_index("z", "R", R);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -29121,6 +29241,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "off_dce_model_namespace::write_array";
     // suppress unused var warning
@@ -29299,8 +29421,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ alpha_occ;
       current_statement__ = 1;
       alpha_occ = in__.read<local_scalar_t__>();
@@ -29362,6 +29482,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       current_statement__ = 4;
       beta_p = context__.vals_r("beta_p")[(1 - 1)];
       out__.write(beta_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -29796,6 +29918,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       stan::math::validate_non_negative_index("a2", "J", J);
       current_statement__ = 34;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -29965,6 +30089,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "off_small_model_namespace::write_array";
     // suppress unused var warning
@@ -30099,8 +30225,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ beta;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -30262,6 +30386,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       current_statement__ = 8;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -30673,6 +30799,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -31252,6 +31380,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "optimizations_model_namespace::write_array";
     // suppress unused var warning
@@ -31307,8 +31437,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ theta;
       current_statement__ = 1;
       theta = in__.read<local_scalar_t__>();
@@ -31515,6 +31643,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
       }
       out__.write_free_cov_matrix(x_cov);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -31773,6 +31903,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -31842,6 +31974,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_fn_model_namespace::write_array";
     // suppress unused var warning
@@ -31875,8 +32009,7 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -31894,6 +32027,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32144,6 +32279,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32214,6 +32351,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_fn2_model_namespace::write_array";
     // suppress unused var warning
@@ -32247,8 +32386,7 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32266,6 +32404,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32613,6 +32753,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       stan::math::validate_non_negative_index("a", "n_pair", n_pair);
       current_statement__ = 27;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -32763,6 +32905,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "partial_eval_model_namespace::write_array";
     // suppress unused var warning
@@ -32861,8 +33005,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       stan::model::assign(a,
@@ -32990,6 +33132,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       current_statement__ = 5;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -34872,6 +35016,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       idy = std::vector<int>(10, std::numeric_limits<int>::min());
       current_statement__ = 10;
       idy = context__.vals_i("idy");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -34974,6 +35120,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "partial_eval_multiply_model_namespace::write_array";
     // suppress unused var warning
@@ -35015,8 +35163,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> m2;
       current_statement__ = 1;
       stan::model::assign(m2,
@@ -36683,6 +36829,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
         }
       }
       out__.write(m3);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -37040,6 +37188,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       stan::math::validate_non_negative_index("b", "I", I);
       current_statement__ = 32;
       stan::math::validate_non_negative_index("b", "K", 8);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -37212,6 +37362,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "stalled1_failure_model_namespace::write_array";
     // suppress unused var warning
@@ -37381,8 +37533,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ alpha0;
       current_statement__ = 1;
       alpha0 = in__.read<local_scalar_t__>();
@@ -37640,6 +37790,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         }
       }
       out__.write(b);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -37865,6 +38017,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       stan::model::assign(inputs,
         stan::math::rep_array(stan::math::zeros_vector(5), 2),
         "assigning variable inputs");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -38029,6 +38183,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unenforce_initialize_should_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -38203,8 +38359,6 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ param;
       current_statement__ = 1;
       param = in__.read<local_scalar_t__>();
@@ -38233,6 +38387,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       current_statement__ = 1;
       param = context__.vals_r("param")[(1 - 1)];
       out__.write(param);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -38439,6 +38595,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -38564,6 +38722,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unenforce_initialize_model_namespace::write_array";
     // suppress unused var warning
@@ -38667,8 +38827,6 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ y;
       current_statement__ = 1;
       y = in__.read<local_scalar_t__>();
@@ -38697,6 +38855,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 1;
       y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -38910,6 +39070,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -38975,6 +39137,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unroll_limit_model_namespace::write_array";
     // suppress unused var warning
@@ -39284,8 +39448,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -39303,6 +39466,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -8433,11 +8433,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       "expr_prop_experiment_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -8501,11 +8496,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -8517,14 +8507,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -8758,11 +8740,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       "expr_prop_experiment2_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -8826,11 +8803,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -8842,14 +8814,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -20574,11 +20538,6 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -20590,14 +20549,6 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -21029,11 +20980,6 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -21045,14 +20991,6 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -22434,11 +22372,6 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -22450,14 +22383,6 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -25960,11 +25885,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       "lcm_experiment_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -26028,11 +25948,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -26044,14 +25959,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -32008,11 +31915,6 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -32024,14 +31926,6 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -32385,11 +32279,6 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -32401,14 +32290,6 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -39103,11 +38984,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       "unroll_limit_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -39447,11 +39323,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -39463,14 +39334,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -4234,11 +4234,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       "expr_prop_experiment_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -4300,11 +4295,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -4316,14 +4306,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -4556,11 +4538,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       "expr_prop_experiment2_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -4622,11 +4599,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -4638,14 +4610,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -12440,11 +12404,6 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -12456,14 +12415,6 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -12830,11 +12781,6 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -12846,14 +12792,6 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -14074,11 +14012,6 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -14090,14 +14023,6 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -15882,11 +15807,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       "lcm_experiment_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -15948,11 +15868,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -15964,14 +15879,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -20005,23 +19912,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 73;
         if ((24 * 2)) {} else {}
         current_statement__ = 76;
-        if ((24 * 2)) {
-          ;
-        } else {
-          ;
-        }
+        if ((24 * 2)) {} else {}
         current_statement__ = 78;
         if ((24 * 2)) {}
         current_statement__ = 80;
-        if ((20 * 2)) {
-          ;
-        }
+        if ((20 * 2)) {}
         current_statement__ = 83;
-        if (rfun_lp<propto__>(lp__, lp_accum__, pstream__)) {
-          ;
-        } else {
-          ;
-        }
+        if (rfun_lp<propto__>(lp__, lp_accum__, pstream__)) {} else {}
         current_statement__ = 86;
         while (0) {
           current_statement__ = 84;
@@ -20044,9 +19941,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           break;
         }
         current_statement__ = 96;
-        for (int i = 31; i <= 225; ++i) {
-          ;
-        }
+        for (int i = 31; i <= 225; ++i) {}
         current_statement__ = 98;
         for (int i = rfun_lp<propto__>(lp__, lp_accum__, pstream__); i <=
              225; ++i) {
@@ -20059,14 +19954,10 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         current_statement__ = 102;
         for (int i = rfun_lp<propto__>(lp__, lp_accum__, pstream__); i <=
-             225; ++i) {
-          ;
-        }
+             225; ++i) {}
         {
           current_statement__ = 103;
           lp_accum__.add(1);
-          ;
-          ;
           current_statement__ = 106;
           lp_accum__.add(24);
         }
@@ -20074,15 +19965,9 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           {
             current_statement__ = 108;
             lp_accum__.add(1);
-            ;
           }
-          ;
-          {
-            ;
-          }
-          {
-            
-          }
+          
+          
         }
         local_scalar_t__ temp = DUMMY_VAR__;
         current_statement__ = 119;
@@ -20708,11 +20593,6 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -20724,14 +20604,6 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -21070,11 +20942,6 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -21086,14 +20953,6 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -23937,11 +23796,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       "unroll_limit_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -24030,11 +23884,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -24046,14 +23895,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -69,6 +69,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -173,6 +175,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_level_deep_dependence_model_namespace::write_array";
     // suppress unused var warning
@@ -262,8 +266,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -313,6 +315,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -787,6 +791,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "kappa", kappa, 0);
       current_statement__ = 29;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -921,6 +927,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_level_failing_model_namespace::write_array";
     // suppress unused var warning
@@ -996,8 +1004,6 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ beta = DUMMY_VAR__;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -1059,6 +1065,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       current_statement__ = 4;
       delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1298,6 +1306,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1378,6 +1388,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_levels_deep_model_namespace::write_array";
     // suppress unused var warning
@@ -1433,8 +1445,6 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -1484,6 +1494,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1738,6 +1750,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       stan::math::validate_non_negative_index("X", "N", N);
       current_statement__ = 18;
       stan::math::validate_non_negative_index("X", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1845,6 +1859,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "copy_prop_profile_model_namespace::write_array";
     // suppress unused var warning
@@ -1882,8 +1898,6 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(N, N, DUMMY_VAR__);
       current_statement__ = 1;
@@ -1933,6 +1947,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
         }
       }
       out__.write(X);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2466,6 +2482,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 50;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2630,6 +2648,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "copy_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -2733,8 +2753,6 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mean_p = DUMMY_VAR__;
       current_statement__ = 1;
       mean_p = in__.read<local_scalar_t__>();
@@ -2791,6 +2809,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         }
       }
       out__.write_free_lub(0, 1, beta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3264,6 +3284,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       stan::math::validate_non_negative_index("b_age_edu", "n_edu", n_edu);
       current_statement__ = 65;
       stan::math::validate_non_negative_index("b_hat", "n_state", n_state);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3485,6 +3507,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "dce_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -3599,8 +3623,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ sigma = DUMMY_VAR__;
       current_statement__ = 1;
       sigma = in__.read<local_scalar_t__>();
@@ -3887,6 +3909,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         }
       }
       out__.write(b_hat);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4177,6 +4201,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       i = stan::math::normal_rng(5, 1, base_rng__);
       current_statement__ = 9;
       y = stan::math::normal_rng(z, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4242,6 +4268,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_experiment_model_namespace::write_array";
     // suppress unused var warning
@@ -4273,8 +4301,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4292,6 +4319,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4494,6 +4523,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       }
       current_statement__ = 8;
       y = stan::math::normal_rng(z, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4559,6 +4590,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_experiment2_model_namespace::write_array";
     // suppress unused var warning
@@ -4590,8 +4623,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4609,6 +4641,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4822,6 +4856,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           pos__ = (pos__ + 1);
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4927,6 +4963,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -4976,8 +5014,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> mu =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
       current_statement__ = 1;
@@ -5048,6 +5084,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       current_statement__ = 3;
       theta = context__.vals_r("theta")[(1 - 1)];
       out__.write_free_lub(0, 1, theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5280,6 +5318,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       stan::math::check_greater_or_equal(function__, "sigma", sigma, 0);
       current_statement__ = 11;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5361,6 +5401,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail2_model_namespace::write_array";
     // suppress unused var warning
@@ -5406,8 +5448,6 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -5461,6 +5501,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       current_statement__ = 3;
       tau = context__.vals_r("tau")[(1 - 1)];
       out__.write_free_lb(0, tau);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5930,6 +5972,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         n_region_full);
       current_statement__ = 51;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6096,6 +6140,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail3_model_namespace::write_array";
     // suppress unused var warning
@@ -6231,8 +6277,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_age, DUMMY_VAR__);
       current_statement__ = 1;
@@ -6477,6 +6521,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       current_statement__ = 11;
       sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_e);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6881,6 +6927,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       stan::math::validate_non_negative_index("x", "N", N);
       current_statement__ = 45;
       stan::math::validate_non_negative_index("y", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6983,6 +7031,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail4_model_namespace::write_array";
     // suppress unused var warning
@@ -7112,8 +7162,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ tau_phi = DUMMY_VAR__;
       current_statement__ = 1;
       tau_phi = in__.read<local_scalar_t__>();
@@ -7173,6 +7221,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         }
       }
       out__.write(phi_std_raw);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7749,6 +7799,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 53;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7924,6 +7976,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail5_model_namespace::write_array";
     // suppress unused var warning
@@ -8045,8 +8099,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mean_phi = DUMMY_VAR__;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -8125,6 +8177,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 4;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9043,6 +9097,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 94;
       stan::math::validate_non_negative_index("z", "n_occasions", n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9217,6 +9273,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail6_model_namespace::write_array";
     // suppress unused var warning
@@ -9498,8 +9556,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mean_phi = DUMMY_VAR__;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -9619,6 +9675,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       current_statement__ = 6;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10109,6 +10167,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       stan::math::validate_non_negative_index("log_Pr_z", "I", I);
       current_statement__ = 38;
       stan::math::validate_non_negative_index("log_Pr_z", "K", K);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10231,6 +10291,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail7_model_namespace::write_array";
     // suppress unused var warning
@@ -10324,8 +10386,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> pi =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(K, DUMMY_VAR__);
       current_statement__ = 1;
@@ -10421,6 +10481,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         }
       }
       out__.write_free_simplex(theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10752,6 +10814,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       stan::math::validate_non_negative_index("phi_std_raw", "N", N);
       current_statement__ = 24;
       stan::math::validate_non_negative_index("phi", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10860,6 +10924,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail8_model_namespace::write_array";
     // suppress unused var warning
@@ -10942,8 +11008,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ beta0 = DUMMY_VAR__;
       current_statement__ = 1;
       beta0 = in__.read<local_scalar_t__>();
@@ -11061,6 +11125,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         }
       }
       out__.write(phi_std_raw);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11631,6 +11697,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 50;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11795,6 +11863,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "fails_test_model_namespace::write_array";
     // suppress unused var warning
@@ -11898,8 +11968,6 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mean_p = DUMMY_VAR__;
       current_statement__ = 1;
       mean_p = in__.read<local_scalar_t__>();
@@ -11956,6 +12024,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         }
       }
       out__.write_free_lub(0, 1, beta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12267,6 +12337,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
           pos__ = (pos__ + 1);
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12336,6 +12408,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "function_in_function_inline_model_namespace::write_array";
     // suppress unused var warning
@@ -12367,8 +12441,7 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12386,6 +12459,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12645,6 +12720,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
       N = std::numeric_limits<int>::min();
       current_statement__ = 5;
       N = context__.vals_i("N")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12721,6 +12798,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "function_in_function_loops_model_namespace::write_array";
     // suppress unused var warning
@@ -12752,8 +12831,7 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12771,6 +12849,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13014,6 +13094,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13100,6 +13182,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inline_functions_varmat_model_namespace::write_array";
     // suppress unused var warning
@@ -13163,8 +13247,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(5, DUMMY_VAR__);
       current_statement__ = 1;
@@ -13241,6 +13323,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
         }
       }
       out__.write(p_multi_ret_vec);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13506,6 +13590,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
         N, M);
       current_statement__ = 7;
       stan::model::assign(bar, foo(N, M, pstream__), "assigning variable bar");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13578,6 +13664,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inline_tdata_model_namespace::write_array";
     // suppress unused var warning
@@ -13613,8 +13701,6 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ alpha = DUMMY_VAR__;
       current_statement__ = 1;
       alpha = in__.read<local_scalar_t__>();
@@ -13643,6 +13729,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       current_statement__ = 1;
       alpha = context__.vals_r("alpha")[(1 - 1)];
       out__.write(alpha);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13870,6 +13958,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
       stan::math::validate_non_negative_index("R", "N", N);
       current_statement__ = 6;
       stan::math::validate_non_negative_index("out", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13940,6 +14030,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inliner_same_names_model_namespace::write_array";
     // suppress unused var warning
@@ -13983,8 +14075,7 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14002,6 +14093,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14912,6 +15005,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 85;
       stan::math::validate_non_negative_index("z", "n_occasions", n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15047,6 +15142,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inlining_fail2_model_namespace::write_array";
     // suppress unused var warning
@@ -15290,8 +15387,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mean_phi = DUMMY_VAR__;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -15402,6 +15497,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 5;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15752,6 +15849,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       current_statement__ = 7;
       i = stan::math::normal_rng(((stan::math::sqrt(j) * 2) + 1), 1,
             base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15817,6 +15916,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_experiment_model_namespace::write_array";
     // suppress unused var warning
@@ -15848,8 +15949,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15867,6 +15967,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -16044,6 +16146,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -16128,6 +16232,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_experiment2_model_namespace::write_array";
     // suppress unused var warning
@@ -16163,8 +16269,6 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ x = DUMMY_VAR__;
       current_statement__ = 1;
       x = in__.read<local_scalar_t__>();
@@ -16193,6 +16297,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -16389,6 +16495,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       y = context__.vals_r("y");
       current_statement__ = 6;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -16461,6 +16569,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_fails_model_namespace::write_array";
     // suppress unused var warning
@@ -16497,8 +16607,6 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       std::vector<local_scalar_t__> theta =
         std::vector<local_scalar_t__>(J, DUMMY_VAR__);
       current_statement__ = 1;
@@ -16530,6 +16638,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       current_statement__ = 1;
       theta = context__.vals_r("theta");
       out__.write(theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17006,6 +17116,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       current_statement__ = 45;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17164,6 +17276,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_fails2_model_namespace::write_array";
     // suppress unused var warning
@@ -17260,8 +17374,6 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mean_phi = DUMMY_VAR__;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -17301,6 +17413,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
       out__.write_free_lub(0, 1, mean_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17608,6 +17722,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       n = std::numeric_limits<int>::min();
       current_statement__ = 7;
       n = context__.vals_i("n")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17684,6 +17800,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lupdf_inlining_model_namespace::write_array";
     // suppress unused var warning
@@ -17733,8 +17851,6 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ mu = DUMMY_VAR__;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -17763,6 +17879,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       current_statement__ = 1;
       mu = context__.vals_r("mu")[(1 - 1)];
       out__.write(mu);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18131,6 +18249,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       stan::math::validate_non_negative_index("psi_con", "R", R);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("z", "R", R);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18250,6 +18370,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "off_dce_model_namespace::write_array";
     // suppress unused var warning
@@ -18371,8 +18493,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ alpha_occ = DUMMY_VAR__;
       current_statement__ = 1;
       alpha_occ = in__.read<local_scalar_t__>();
@@ -18434,6 +18554,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       current_statement__ = 4;
       beta_p = context__.vals_r("beta_p")[(1 - 1)];
       out__.write(beta_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18835,6 +18957,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       stan::math::validate_non_negative_index("a2", "J", J);
       current_statement__ = 36;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18974,6 +19098,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "off_small_model_namespace::write_array";
     // suppress unused var warning
@@ -19084,8 +19210,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ beta = DUMMY_VAR__;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -19225,6 +19349,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       current_statement__ = 8;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19681,6 +19807,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20033,6 +20161,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "optimizations_model_namespace::write_array";
     // suppress unused var warning
@@ -20092,8 +20222,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ theta = DUMMY_VAR__;
       current_statement__ = 1;
       theta = in__.read<local_scalar_t__>();
@@ -20226,6 +20354,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
       }
       out__.write_free_cov_matrix(x_cov);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20478,6 +20608,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20544,6 +20676,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_fn_model_namespace::write_array";
     // suppress unused var warning
@@ -20575,8 +20709,7 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20594,6 +20727,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20835,6 +20970,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20901,6 +21038,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_fn2_model_namespace::write_array";
     // suppress unused var warning
@@ -20932,8 +21071,7 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20951,6 +21089,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21264,6 +21404,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       stan::math::validate_non_negative_index("a", "n_pair", n_pair);
       current_statement__ = 28;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21387,6 +21529,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "partial_eval_model_namespace::write_array";
     // suppress unused var warning
@@ -21464,8 +21608,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_pair, DUMMY_VAR__);
       current_statement__ = 1;
@@ -21572,6 +21714,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       current_statement__ = 5;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21867,6 +22011,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       idy = std::vector<int>(10, std::numeric_limits<int>::min());
       current_statement__ = 10;
       idy = context__.vals_i("idy");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21969,6 +22115,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "partial_eval_multiply_model_namespace::write_array";
     // suppress unused var warning
@@ -22012,8 +22160,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> m2 =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -22095,6 +22241,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
         }
       }
       out__.write(m3);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22427,6 +22575,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       stan::math::validate_non_negative_index("b", "I", I);
       current_statement__ = 33;
       stan::math::validate_non_negative_index("b", "K", K);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22550,6 +22700,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "stalled1_failure_model_namespace::write_array";
     // suppress unused var warning
@@ -22620,8 +22772,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ alpha0 = DUMMY_VAR__;
       current_statement__ = 1;
       alpha0 = in__.read<local_scalar_t__>();
@@ -22734,6 +22884,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         }
       }
       out__.write(b);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22960,6 +23112,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       stan::model::assign(inputs,
         stan::math::rep_array(stan::math::zeros_vector(5), 2),
         "assigning variable inputs");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23047,6 +23201,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unenforce_initialize_should_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -23106,8 +23262,6 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ param = DUMMY_VAR__;
       current_statement__ = 1;
       param = in__.read<local_scalar_t__>();
@@ -23136,6 +23290,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       current_statement__ = 1;
       param = context__.vals_r("param")[(1 - 1)];
       out__.write(param);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23344,6 +23500,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23433,6 +23591,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unenforce_initialize_model_namespace::write_array";
     // suppress unused var warning
@@ -23498,8 +23658,6 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ y = DUMMY_VAR__;
       current_statement__ = 1;
       y = in__.read<local_scalar_t__>();
@@ -23528,6 +23686,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 1;
       y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23744,6 +23904,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23809,6 +23971,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unroll_limit_model_namespace::write_array";
     // suppress unused var warning
@@ -23867,8 +24031,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23886,6 +24049,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -4318,11 +4318,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       "expr_prop_experiment_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -4384,11 +4379,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -4400,14 +4390,6 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -4640,11 +4622,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       "expr_prop_experiment2_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -4706,11 +4683,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -4722,14 +4694,6 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -13115,11 +13079,6 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -13131,14 +13090,6 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -13526,11 +13477,6 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -13542,14 +13488,6 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -14856,11 +14794,6 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -14872,14 +14805,6 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -17080,11 +17005,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       "lcm_experiment_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -17146,11 +17066,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -17162,14 +17077,6 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -22014,11 +21921,6 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -22030,14 +21932,6 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -22377,11 +22271,6 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -22393,14 +22282,6 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool
@@ -25233,11 +25114,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       "unroll_limit_model_namespace::log_prob";
     // suppress unused var warning
     (void) function__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
     lp_accum__.add(lp__);
     return lp_accum__.sum();
   }
@@ -25326,11 +25202,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   template <typename VecVar, stan::require_vector_t<VecVar>* = nullptr>
   inline void
@@ -25342,14 +25213,6 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
     // suppress unused var warning
     (void) DUMMY_VAR__;
-    try {
-      int pos__;
-      pos__ = 1;
-      // suppress unused var warning
-      (void) pos__;
-    } catch (const std::exception& e) {
-      stan::lang::rethrow_located(e, locations_array__[current_statement__]);
-    }
   }
   inline void
   get_param_names(std::vector<std::string>& names__, const bool

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -69,6 +69,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -175,6 +177,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_level_deep_dependence_model_namespace::write_array";
     // suppress unused var warning
@@ -262,8 +266,6 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
       current_statement__ = 1;
       stan::model::assign(X_p,
@@ -312,6 +314,8 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -786,6 +790,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "kappa", 1000000, 0);
       current_statement__ = 29;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -919,6 +925,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_level_failing_model_namespace::write_array";
     // suppress unused var warning
@@ -993,8 +1001,6 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ beta;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -1056,6 +1062,8 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       current_statement__ = 4;
       delta = context__.vals_r("delta")[(1 - 1)];
       out__.write_free_lb(0, delta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1295,6 +1303,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
           }
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1377,6 +1387,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "ad_levels_deep_model_namespace::write_array";
     // suppress unused var warning
@@ -1430,8 +1442,6 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p;
       current_statement__ = 1;
       stan::model::assign(X_p,
@@ -1480,6 +1490,8 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1734,6 +1746,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
       stan::math::validate_non_negative_index("X", "N", N);
       current_statement__ = 18;
       stan::math::validate_non_negative_index("X", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1838,6 +1852,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "copy_prop_profile_model_namespace::write_array";
     // suppress unused var warning
@@ -1873,8 +1889,6 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X;
       current_statement__ = 1;
       stan::model::assign(X,
@@ -1923,6 +1937,8 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
         }
       }
       out__.write(X);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2456,6 +2472,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       current_statement__ = 61;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2678,6 +2696,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "copy_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -2836,8 +2856,6 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.read<local_scalar_t__>();
@@ -2893,6 +2911,8 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
         }
       }
       out__.write_free_lub(0, 1, beta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3366,6 +3386,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
       stan::math::validate_non_negative_index("b_age_edu", "n_edu", n_edu);
       current_statement__ = 65;
       stan::math::validate_non_negative_index("b_hat", "n_state", n_state);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3585,6 +3607,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "dce_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -3689,8 +3713,6 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ sigma;
       current_statement__ = 1;
       sigma = in__.read<local_scalar_t__>();
@@ -3971,6 +3993,8 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
         }
       }
       out__.write(b_hat);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4261,6 +4285,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
       i = stan::math::normal_rng(5, 1, base_rng__);
       current_statement__ = 9;
       y = stan::math::normal_rng(z, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4326,6 +4352,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_experiment_model_namespace::write_array";
     // suppress unused var warning
@@ -4357,8 +4385,7 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4376,6 +4403,8 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4578,6 +4607,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       }
       current_statement__ = 8;
       y = stan::math::normal_rng(z, 1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4643,6 +4674,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_experiment2_model_namespace::write_array";
     // suppress unused var warning
@@ -4674,8 +4707,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4693,6 +4725,8 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4906,6 +4940,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           pos__ = (pos__ + 1);
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5009,6 +5045,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -5055,8 +5093,6 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> mu;
       current_statement__ = 1;
       stan::model::assign(mu,
@@ -5125,6 +5161,8 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
       current_statement__ = 3;
       theta = context__.vals_r("theta")[(1 - 1)];
       out__.write_free_lub(0, 1, theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5357,6 +5395,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       stan::math::check_greater_or_equal(function__, "sigma", sigma, 0);
       current_statement__ = 11;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5437,6 +5477,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail2_model_namespace::write_array";
     // suppress unused var warning
@@ -5481,8 +5523,6 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mu;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -5535,6 +5575,8 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
       current_statement__ = 3;
       tau = context__.vals_r("tau")[(1 - 1)];
       out__.write_free_lb(0, tau);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6004,6 +6046,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
         n_region_full);
       current_statement__ = 51;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6173,6 +6217,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail3_model_namespace::write_array";
     // suppress unused var warning
@@ -6307,8 +6353,6 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       stan::model::assign(a,
@@ -6545,6 +6589,8 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       current_statement__ = 11;
       sigma_e = context__.vals_r("sigma_e")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_e);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6949,6 +6995,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       stan::math::validate_non_negative_index("x", "N", N);
       current_statement__ = 45;
       stan::math::validate_non_negative_index("y", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7055,6 +7103,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail4_model_namespace::write_array";
     // suppress unused var warning
@@ -7183,8 +7233,6 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ tau_phi;
       current_statement__ = 1;
       tau_phi = in__.read<local_scalar_t__>();
@@ -7242,6 +7290,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
         }
       }
       out__.write(phi_std_raw);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7814,6 +7864,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 66;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -8049,6 +8101,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail5_model_namespace::write_array";
     // suppress unused var warning
@@ -8227,8 +8281,6 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -8306,6 +8358,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       current_statement__ = 4;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9220,6 +9274,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 145;
       stan::math::validate_non_negative_index("z", "n_occasions", n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -9700,6 +9756,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail6_model_namespace::write_array";
     // suppress unused var warning
@@ -10065,8 +10123,6 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -10183,6 +10239,8 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       current_statement__ = 6;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10673,6 +10731,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       stan::math::validate_non_negative_index("log_Pr_z", "I", I);
       current_statement__ = 38;
       stan::math::validate_non_negative_index("log_Pr_z", "K", K);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -10793,6 +10853,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail7_model_namespace::write_array";
     // suppress unused var warning
@@ -10878,8 +10940,6 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> pi;
       current_statement__ = 1;
       stan::model::assign(pi,
@@ -10974,6 +11034,8 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
         }
       }
       out__.write_free_simplex(theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11305,6 +11367,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       stan::math::validate_non_negative_index("phi_std_raw", "N", N);
       current_statement__ = 24;
       stan::math::validate_non_negative_index("phi", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -11420,6 +11484,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "expr_prop_fail8_model_namespace::write_array";
     // suppress unused var warning
@@ -11498,8 +11564,6 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ beta0;
       current_statement__ = 1;
       beta0 = in__.read<local_scalar_t__>();
@@ -11615,6 +11679,8 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
         }
       }
       out__.write(phi_std_raw);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12185,6 +12251,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
       current_statement__ = 61;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12407,6 +12475,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "fails_test_model_namespace::write_array";
     // suppress unused var warning
@@ -12565,8 +12635,6 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_p;
       current_statement__ = 1;
       mean_p = in__.read<local_scalar_t__>();
@@ -12622,6 +12690,8 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
         }
       }
       out__.write_free_lub(0, 1, beta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -12933,6 +13003,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
           pos__ = (pos__ + 1);
         }
       }
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13011,6 +13083,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "function_in_function_inline_model_namespace::write_array";
     // suppress unused var warning
@@ -13042,8 +13116,7 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13061,6 +13134,8 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13313,6 +13388,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
       N = std::numeric_limits<int>::min();
       current_statement__ = 12;
       N = context__.vals_i("N")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13417,6 +13494,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "function_in_function_loops_model_namespace::write_array";
     // suppress unused var warning
@@ -13448,8 +13527,7 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13467,6 +13545,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13710,6 +13790,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -13835,6 +13917,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inline_functions_varmat_model_namespace::write_array";
     // suppress unused var warning
@@ -13914,8 +13998,6 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> p_single_ret_vec;
       current_statement__ = 1;
       stan::model::assign(p_single_ret_vec,
@@ -13990,6 +14072,8 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
         }
       }
       out__.write(p_multi_ret_vec);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14256,6 +14340,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       current_statement__ = 7;
       stan::model::assign(bar, foo(10, 11, pstream__),
         "assigning variable bar");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14328,6 +14414,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inline_tdata_model_namespace::write_array";
     // suppress unused var warning
@@ -14363,8 +14451,6 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ alpha;
       current_statement__ = 1;
       alpha = in__.read<local_scalar_t__>();
@@ -14393,6 +14479,8 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
       current_statement__ = 1;
       alpha = context__.vals_r("alpha")[(1 - 1)];
       out__.write(alpha);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14618,6 +14706,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
       stan::math::validate_non_negative_index("R", "N", N);
       current_statement__ = 8;
       stan::math::validate_non_negative_index("out", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14711,6 +14801,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inliner_same_names_model_namespace::write_array";
     // suppress unused var warning
@@ -14765,8 +14857,7 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -14784,6 +14875,8 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -15690,6 +15783,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::validate_non_negative_index("z", "M", M);
       current_statement__ = 144;
       stan::math::validate_non_negative_index("z", "n_occasions", n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -16135,6 +16230,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "inlining_fail2_model_namespace::write_array";
     // suppress unused var warning
@@ -16492,8 +16589,6 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -16600,6 +16695,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       current_statement__ = 5;
       sigma = context__.vals_r("sigma")[(1 - 1)];
       out__.write_free_lub(0, 5, sigma);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -16950,6 +17047,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       current_statement__ = 7;
       i = stan::math::normal_rng(stan::math::fma(stan::math::sqrt(j), 2, 1),
             1, base_rng__);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17015,6 +17114,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_experiment_model_namespace::write_array";
     // suppress unused var warning
@@ -17046,8 +17147,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17065,6 +17165,8 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17242,6 +17344,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17325,6 +17429,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_experiment2_model_namespace::write_array";
     // suppress unused var warning
@@ -17360,8 +17466,6 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ x;
       current_statement__ = 1;
       x = in__.read<local_scalar_t__>();
@@ -17390,6 +17494,8 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
       current_statement__ = 1;
       x = context__.vals_r("x")[(1 - 1)];
       out__.write(x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17586,6 +17692,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       y = context__.vals_r("y");
       current_statement__ = 6;
       stan::math::validate_non_negative_index("theta", "J", J);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -17657,6 +17765,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_fails_model_namespace::write_array";
     // suppress unused var warning
@@ -17692,8 +17802,6 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       std::vector<local_scalar_t__> theta;
       current_statement__ = 1;
       stan::model::assign(theta, in__.read<std::vector<local_scalar_t__>>(J),
@@ -17724,6 +17832,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       current_statement__ = 1;
       theta = context__.vals_r("theta");
       out__.write(theta);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18200,6 +18310,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       current_statement__ = 56;
       stan::math::validate_non_negative_index("chi", "n_occasions",
         n_occasions);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18417,6 +18529,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lcm_fails2_model_namespace::write_array";
     // suppress unused var warning
@@ -18570,8 +18684,6 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mean_phi;
       current_statement__ = 1;
       mean_phi = in__.read<local_scalar_t__>();
@@ -18611,6 +18723,8 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
       current_statement__ = 2;
       mean_p = context__.vals_r("mean_p")[(1 - 1)];
       out__.write_free_lub(0, 1, mean_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -18917,6 +19031,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       n = std::numeric_limits<int>::min();
       current_statement__ = 8;
       n = context__.vals_i("n")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19015,6 +19131,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "lupdf_inlining_model_namespace::write_array";
     // suppress unused var warning
@@ -19085,8 +19203,6 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ mu;
       current_statement__ = 1;
       mu = in__.read<local_scalar_t__>();
@@ -19115,6 +19231,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       current_statement__ = 1;
       mu = context__.vals_r("mu")[(1 - 1)];
       out__.write(mu);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19483,6 +19601,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       stan::math::validate_non_negative_index("psi_con", "R", R);
       current_statement__ = 54;
       stan::math::validate_non_negative_index("z", "R", R);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -19600,6 +19720,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "off_dce_model_namespace::write_array";
     // suppress unused var warning
@@ -19717,8 +19839,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ alpha_occ;
       current_statement__ = 1;
       alpha_occ = in__.read<local_scalar_t__>();
@@ -19780,6 +19900,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       current_statement__ = 4;
       beta_p = context__.vals_r("beta_p")[(1 - 1)];
       out__.write(beta_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20181,6 +20303,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       stan::math::validate_non_negative_index("a2", "J", J);
       current_statement__ = 36;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20320,6 +20444,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "off_small_model_namespace::write_array";
     // suppress unused var warning
@@ -20428,8 +20554,6 @@ class off_small_model final : public model_base_crtp<off_small_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ beta;
       current_statement__ = 1;
       beta = in__.read<local_scalar_t__>();
@@ -20567,6 +20691,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       current_statement__ = 8;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -20975,6 +21101,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21348,6 +21476,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "optimizations_model_namespace::write_array";
     // suppress unused var warning
@@ -21401,8 +21531,6 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ theta;
       current_statement__ = 1;
       theta = in__.read<local_scalar_t__>();
@@ -21532,6 +21660,8 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
       }
       out__.write_free_cov_matrix(x_cov);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21784,6 +21914,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21850,6 +21982,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_fn_model_namespace::write_array";
     // suppress unused var warning
@@ -21881,8 +22015,7 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21900,6 +22033,8 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22141,6 +22276,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22208,6 +22345,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "overloaded_fn2_model_namespace::write_array";
     // suppress unused var warning
@@ -22239,8 +22378,7 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22258,6 +22396,8 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22571,6 +22711,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       stan::math::validate_non_negative_index("a", "n_pair", n_pair);
       current_statement__ = 28;
       stan::math::validate_non_negative_index("y_hat", "N", N);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -22694,6 +22836,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "partial_eval_model_namespace::write_array";
     // suppress unused var warning
@@ -22770,8 +22914,6 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> a;
       current_statement__ = 1;
       stan::model::assign(a,
@@ -22876,6 +23018,8 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       current_statement__ = 5;
       sigma_y = context__.vals_r("sigma_y")[(1 - 1)];
       out__.write_free_lub(0, 100, sigma_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23171,6 +23315,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
       idy = std::vector<int>(10, std::numeric_limits<int>::min());
       current_statement__ = 10;
       idy = context__.vals_i("idy");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23272,6 +23418,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "partial_eval_multiply_model_namespace::write_array";
     // suppress unused var warning
@@ -23311,8 +23459,6 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> m2;
       current_statement__ = 1;
       stan::model::assign(m2,
@@ -23392,6 +23538,8 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
         }
       }
       out__.write(m3);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23724,6 +23872,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
       stan::math::validate_non_negative_index("b", "I", I);
       current_statement__ = 33;
       stan::math::validate_non_negative_index("b", "K", 8);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -23852,6 +24002,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "stalled1_failure_model_namespace::write_array";
     // suppress unused var warning
@@ -23919,8 +24071,6 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ alpha0;
       current_statement__ = 1;
       alpha0 = in__.read<local_scalar_t__>();
@@ -24033,6 +24183,8 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
         }
       }
       out__.write(b);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24259,6 +24411,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       stan::model::assign(inputs,
         stan::math::rep_array(stan::math::zeros_vector(5), 2),
         "assigning variable inputs");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24346,6 +24500,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unenforce_initialize_should_fail_model_namespace::write_array";
     // suppress unused var warning
@@ -24405,8 +24561,6 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ param;
       current_statement__ = 1;
       param = in__.read<local_scalar_t__>();
@@ -24435,6 +24589,8 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
       current_statement__ = 1;
       param = context__.vals_r("param")[(1 - 1)];
       out__.write(param);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24642,6 +24798,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -24730,6 +24888,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unenforce_initialize_model_namespace::write_array";
     // suppress unused var warning
@@ -24794,8 +24954,6 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
       local_scalar_t__ y;
       current_statement__ = 1;
       y = in__.read<local_scalar_t__>();
@@ -24824,6 +24982,8 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 1;
       y = context__.vals_r("y")[(1 - 1)];
       out__.write(y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25040,6 +25200,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25105,6 +25267,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "unroll_limit_model_namespace::write_array";
     // suppress unused var warning
@@ -25163,8 +25327,7 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__;
-      pos__ = 1;
+      
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -25182,6 +25345,8 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
     try {
       int pos__;
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -33,6 +33,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -107,6 +109,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "complex_fails_model_namespace::write_array";
     // suppress unused var warning
@@ -154,8 +158,6 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> A_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -205,6 +207,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
         }
       }
       out__.write(A_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -764,6 +768,8 @@ class constraints_model final : public model_base_crtp<constraints_model> {
       stan::math::validate_non_negative_index("h_i_sigma", "Nr", Nr);
       current_statement__ = 91;
       stan::math::validate_non_negative_index("h_sigma", "Nr", Nr);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1225,6 +1231,8 @@ class constraints_model final : public model_base_crtp<constraints_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "constraints_model_namespace::write_array";
     // suppress unused var warning
@@ -1556,8 +1564,6 @@ class constraints_model final : public model_base_crtp<constraints_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,1> high_low_est =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       current_statement__ = 1;
@@ -2144,6 +2150,8 @@ class constraints_model final : public model_base_crtp<constraints_model> {
         }
       }
       out__.write_free_cholesky_factor_corr(chol_fac_corr_test);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2597,6 +2605,8 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -2712,6 +2722,8 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "deep_dependence_model_namespace::write_array";
     // suppress unused var warning
@@ -2812,8 +2824,6 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> X_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -2863,6 +2873,8 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
         }
       }
       out__.write(X_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -3487,6 +3499,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
       current_statement__ = 111;
       stan::math::validate_non_negative_index(
         "tp_aos_fail_assign_from_top_idx", "M", M);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -4016,6 +4030,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "indexing_model_namespace::write_array";
     // suppress unused var warning
@@ -4255,8 +4271,6 @@ class indexing_model final : public model_base_crtp<indexing_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ alpha = DUMMY_VAR__;
       current_statement__ = 1;
       alpha = in__.read<local_scalar_t__>();
@@ -4952,6 +4966,8 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         }
       }
       out__.write(p_aos_mat_fail_uni_uni_idx2);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5478,6 +5494,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
       Idx = std::vector<int>(N, std::numeric_limits<int>::min());
       current_statement__ = 16;
       Idx = context__.vals_i("Idx");
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5598,6 +5616,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "indexing2_model_namespace::write_array";
     // suppress unused var warning
@@ -5640,8 +5660,6 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       local_scalar_t__ alpha = DUMMY_VAR__;
       current_statement__ = 1;
       alpha = in__.read<local_scalar_t__>();
@@ -5701,6 +5719,8 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
         }
       }
       out__.write(p_aos_loop_single_idx);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -5955,6 +5975,8 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
       data_r = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 7;
       data_r = context__.vals_r("data_r")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6061,6 +6083,8 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "reductions_allowed_model_namespace::write_array";
     // suppress unused var warning
@@ -6141,8 +6165,6 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> soa_x =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -6256,6 +6278,8 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
         }
       }
       out__.write(aos_y);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6572,6 +6596,8 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -6683,6 +6709,8 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "return_types_and_udfs_demotes_model_namespace::write_array";
     // suppress unused var warning
@@ -6771,8 +6799,6 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> row_soa =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -6856,6 +6882,8 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
         }
       }
       out__.write(udf_input_aos);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7147,6 +7175,8 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7259,6 +7289,8 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "single_indexing_model_namespace::write_array";
     // suppress unused var warning
@@ -7332,8 +7364,6 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> aos_p =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -7415,6 +7445,8 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
         }
       }
       out__.write(soa_p);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7697,6 +7729,8 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
       data_r = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 5;
       data_r = context__.vals_r("data_r")[(1 - 1)];
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -7779,6 +7813,8 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     constexpr bool jacobian__ = false;
+    // suppress unused var warning
+    (void) jacobian__;
     static constexpr const char* function__ =
       "tp_reused_model_namespace::write_array";
     // suppress unused var warning
@@ -7836,8 +7872,6 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      int pos__ = std::numeric_limits<int>::min();
-      pos__ = 1;
       Eigen::Matrix<local_scalar_t__,-1,-1> first_pass_soa_x =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
       current_statement__ = 1;
@@ -7921,6 +7955,8 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
         }
       }
       out__.write(aos_x);
+      // suppress unused var warning
+      (void) pos__;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }

--- a/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/transformed_mir.expected
@@ -280,15 +280,6 @@ matrix[10, 10] A_p: AoS
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id A_p)
       (decl_type
        (Sized
@@ -5846,15 +5837,6 @@ vector[Nr] h_sigma: SoA
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id high_low_est)
       (decl_type
        (Sized
@@ -7755,15 +7737,6 @@ matrix[10, 10] X_tp7: AoS
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id X_p)
       (decl_type
        (Sized
@@ -13289,15 +13262,6 @@ vector[N] tp_aos_loop_vec_v_multi_uni_idx: AoS
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id alpha)
       (decl_type (Sized SReal)) (initialize true)))
     (meta <opaque>))
@@ -14803,15 +14767,6 @@ vector[N] tp_soa_single_idx_in_upfrom_idx: SoA
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id alpha)
       (decl_type (Sized SReal)) (initialize true)))
     (meta <opaque>))
@@ -15728,15 +15683,6 @@ matrix[5, 10] tp_matrix_from_udf_reduced_soa: AoS
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id soa_x)
       (decl_type
        (Sized
@@ -16673,15 +16619,6 @@ matrix[10, 10] mul_two_aos: AoS
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id row_soa)
       (decl_type
        (Sized
@@ -17498,15 +17435,6 @@ matrix[10, 10] tp_matrix_from_soa_loop: SoA
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id aos_p)
       (decl_type
        (Sized
@@ -18135,15 +18063,6 @@ matrix[5, 10] tp_matrix_aos: AoS
     (meta <opaque>))))
  (unconstrain_array
   (((pattern
-     (Decl (decl_adtype DataOnly) (decl_id pos__) (decl_type (Sized SInt))
-      (initialize true)))
-    (meta <opaque>))
-   ((pattern
-     (Assignment (pos__ UInt ())
-      ((pattern (Lit Int 1))
-       (meta ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))
-    (meta <opaque>))
-   ((pattern
      (Decl (decl_adtype AutoDiffable) (decl_id first_pass_soa_x)
       (decl_type
        (Sized


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Removed some unused variables in the generated C++ code and prevented some additional `-Wunused-variable` warnings

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
