### PR TITLE
Add get_param_sizes function to generated C++

### DIFF
--- a/test/integration/cli-args/allow-undefined/cpp.expected
+++ b/test/integration/cli-args/allow-undefined/cpp.expected
@@ -177,6 +177,14 @@ class external_model final : public model_base_crtp<external_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool

--- a/test/integration/cli-args/filename-in-msg/filename_good.expected
+++ b/test/integration/cli-args/filename-in-msg/filename_good.expected
@@ -150,6 +150,14 @@ class filename_good_model final : public model_base_crtp<filename_good_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool

--- a/test/integration/good/code-gen/cl.expected
+++ b/test/integration/good/code-gen/cl.expected
@@ -1571,6 +1571,19 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(k), static_cast<size_t>(k),
+            static_cast<size_t>(k), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>((n * k)), static_cast<size_t>((n * k)),
+            static_cast<size_t>(n)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -199,8 +199,8 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = (N * N * 2) + (N * 2) + (N * 2) + 2 + (N * N) + N + N +
-      1;
+    num_params_r__ = (N * (N * 2)) + (N * 2) + (N * 2) + 2 + (N * N) + N + N
+      + 1;
   }
   inline std::string model_name() const final {
     return "basic_op_param_model";
@@ -1536,6 +1536,25 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((N * (N * 2))), static_cast<size_t>((N * 2)),
+            static_cast<size_t>((N * 2)), static_cast<size_t>(2),
+            static_cast<size_t>((N * N)), static_cast<size_t>(N),
+            static_cast<size_t>(N), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((N * (N * 2))),
+             static_cast<size_t>((N * 2)), static_cast<size_t>((N * 2)),
+             static_cast<size_t>(2), static_cast<size_t>((N * (N * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1745,10 +1764,10 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((((((((N * N) * 2) + (N * 2)) + (N * 2)) +
+    const size_t num_params__ = ((((((((N * (N * 2)) + (N * 2)) + (N * 2)) +
       2) + (N * N)) + N) + N) + 1);
-    const size_t num_transformed = emit_transformed_parameters * (((((((N *
-      N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2)));
+    const size_t num_transformed = emit_transformed_parameters * ((((((N * (N
+      * 2)) + (N * 2)) + (N * 2)) + 2) + (N * (N * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -1764,10 +1783,10 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((((((((N * N) * 2) + (N * 2)) + (N * 2)) +
+    const size_t num_params__ = ((((((((N * (N * 2)) + (N * 2)) + (N * 2)) +
       2) + (N * N)) + N) + N) + 1);
-    const size_t num_transformed = emit_transformed_parameters * (((((((N *
-      N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2)));
+    const size_t num_transformed = emit_transformed_parameters * ((((((N * (N
+      * 2)) + (N * 2)) + (N * 2)) + 2) + (N * (N * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -2770,6 +2789,21 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((N * (N * 2))),
+             static_cast<size_t>((N * 2)), static_cast<size_t>((N * 2)),
+             static_cast<size_t>(2), static_cast<size_t>((N * (N * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -2890,8 +2924,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
               pstream = nullptr) const {
     const size_t num_params__ = 0;
     const size_t num_transformed = emit_transformed_parameters * (0);
-    const size_t num_gen_quantities = emit_generated_quantities * (((((((N *
-      N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2)));
+    const size_t num_gen_quantities = emit_generated_quantities * ((((((N *
+      (N * 2)) + (N * 2)) + (N * 2)) + 2) + (N * (N * 2))));
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
     std::vector<int> params_i;
@@ -2908,8 +2942,8 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
               pstream = nullptr) const {
     const size_t num_params__ = 0;
     const size_t num_transformed = emit_transformed_parameters * (0);
-    const size_t num_gen_quantities = emit_generated_quantities * (((((((N *
-      N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2)));
+    const size_t num_gen_quantities = emit_generated_quantities * ((((((N *
+      (N * 2)) + (N * 2)) + (N * 2)) + 2) + (N * (N * 2))));
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
     vars = std::vector<double>(num_to_write,
@@ -3405,8 +3439,8 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = (N * N * 2) + (N * 2) + (N * 2) + 2 + (N * N) + N + N +
-      1;
+    num_params_r__ = (N * (N * 2)) + (N * 2) + (N * 2) + 2 + (N * N) + N + N
+      + 1;
   }
   inline std::string model_name() const final {
     return "basic_ops_mix_model";
@@ -4860,6 +4894,25 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((N * (N * 2))), static_cast<size_t>((N * 2)),
+            static_cast<size_t>((N * 2)), static_cast<size_t>(2),
+            static_cast<size_t>((N * N)), static_cast<size_t>(N),
+            static_cast<size_t>(N), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((N * (N * 2))),
+             static_cast<size_t>((N * 2)), static_cast<size_t>((N * 2)),
+             static_cast<size_t>(2), static_cast<size_t>((N * (N * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -5069,10 +5122,10 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((((((((N * N) * 2) + (N * 2)) + (N * 2)) +
+    const size_t num_params__ = ((((((((N * (N * 2)) + (N * 2)) + (N * 2)) +
       2) + (N * N)) + N) + N) + 1);
-    const size_t num_transformed = emit_transformed_parameters * (((((((N *
-      N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2)));
+    const size_t num_transformed = emit_transformed_parameters * ((((((N * (N
+      * 2)) + (N * 2)) + (N * 2)) + 2) + (N * (N * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -5088,10 +5141,10 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((((((((N * N) * 2) + (N * 2)) + (N * 2)) +
+    const size_t num_params__ = ((((((((N * (N * 2)) + (N * 2)) + (N * 2)) +
       2) + (N * N)) + N) + N) + 1);
-    const size_t num_transformed = emit_transformed_parameters * (((((((N *
-      N) * 2) + (N * 2)) + (N * 2)) + 2) + ((N * N) * 2)));
+    const size_t num_transformed = emit_transformed_parameters * ((((((N * (N
+      * 2)) + (N * 2)) + (N * 2)) + 2) + (N * (N * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -5608,6 +5661,14 @@ class complex_data_model final : public model_base_crtp<complex_data_model> {
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -6704,7 +6765,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = 1 + 2 + (2 * 2) + (2 * 3 * 2);
+    num_params_r__ = 1 + 2 + (2 * 2) + (2 * (3 * 2));
   }
   inline std::string model_name() const final {
     return "complex_scalar_model";
@@ -8087,6 +8148,32 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(2),
+            static_cast<size_t>((2 * 2)), static_cast<size_t>((2 * (3 * 2)))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(2),
+             static_cast<size_t>((2 * 2)), static_cast<size_t>((2 * (3 * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(2), static_cast<size_t>((2 * 2)),
+             static_cast<size_t>((2 * (3 * 2))), static_cast<size_t>(2),
+             static_cast<size_t>(2), static_cast<size_t>(0),
+             static_cast<size_t>(1), static_cast<size_t>(2),
+             static_cast<size_t>(2), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -8308,11 +8395,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((1 + 2) + (2 * 2)) + ((2 * 3) * 2));
+    const size_t num_params__ = (((1 + 2) + (2 * 2)) + (2 * (3 * 2)));
     const size_t num_transformed = emit_transformed_parameters * ((((1 + 2) +
-      (2 * 2)) + ((2 * 3) * 2)));
+      (2 * 2)) + (2 * (3 * 2))));
     const size_t num_gen_quantities = emit_generated_quantities *
-      ((((((((((((1 + 1) + 2) + (2 * 2)) + ((2 * 3) * 2)) + 2) + 2) + 0) + 1)
+      ((((((((((((1 + 1) + 2) + (2 * 2)) + (2 * (3 * 2))) + 2) + 2) + 0) + 1)
       + 2) + 2) + 1));
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -8328,11 +8415,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((1 + 2) + (2 * 2)) + ((2 * 3) * 2));
+    const size_t num_params__ = (((1 + 2) + (2 * 2)) + (2 * (3 * 2)));
     const size_t num_transformed = emit_transformed_parameters * ((((1 + 2) +
-      (2 * 2)) + ((2 * 3) * 2)));
+      (2 * 2)) + (2 * (3 * 2))));
     const size_t num_gen_quantities = emit_generated_quantities *
-      ((((((((((((1 + 1) + 2) + (2 * 2)) + ((2 * 3) * 2)) + 2) + 2) + 0) + 1)
+      ((((((((((((1 + 1) + 2) + (2 * 2)) + (2 * (3 * 2))) + 2) + 2) + 0) + 1)
       + 2) + 2) + 1));
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -8683,6 +8770,21 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((3 * 2)),
+             static_cast<size_t>((2 * (2 * 2))), static_cast<size_t>(2),
+             static_cast<size_t>((2 * 2)), static_cast<size_t>((2 * (2 * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -8807,7 +8909,7 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
               pstream = nullptr) const {
     const size_t num_params__ = 0;
     const size_t num_transformed = emit_transformed_parameters * ((((((3 * 2)
-      + ((2 * 2) * 2)) + 2) + (2 * 2)) + ((2 * 2) * 2)));
+      + (2 * (2 * 2))) + 2) + (2 * 2)) + (2 * (2 * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -8825,7 +8927,7 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
               pstream = nullptr) const {
     const size_t num_params__ = 0;
     const size_t num_transformed = emit_transformed_parameters * ((((((3 * 2)
-      + ((2 * 2) * 2)) + 2) + (2 * 2)) + ((2 * 2) * 2)));
+      + (2 * (2 * 2))) + 2) + (2 * 2)) + (2 * (2 * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -9326,6 +9428,14 @@ class user_function_templating_model final : public model_base_crtp<user_functio
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -311,6 +311,20 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(J)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(J)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -644,6 +658,14 @@ class _8start_with_number_model final : public model_base_crtp<_8start_with_numb
     names__ = std::vector<std::string>{"bar"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -1147,6 +1169,22 @@ class container_promotion_model final : public model_base_crtp<container_promoti
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(2), static_cast<size_t>((2 * 2)),
+             static_cast<size_t>((2 * 2)), static_cast<size_t>((2 * 2)),
+             static_cast<size_t>((2 * (2 * 2))),
+             static_cast<size_t>((2 * (2 * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1283,7 +1321,7 @@ class container_promotion_model final : public model_base_crtp<container_promoti
               pstream = nullptr) const {
     const size_t num_params__ = 1;
     const size_t num_transformed = emit_transformed_parameters * ((((((2 + (2
-      * 2)) + (2 * 2)) + (2 * 2)) + ((2 * 2) * 2)) + ((2 * 2) * 2)));
+      * 2)) + (2 * 2)) + (2 * 2)) + (2 * (2 * 2))) + (2 * (2 * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -1301,7 +1339,7 @@ class container_promotion_model final : public model_base_crtp<container_promoti
               pstream = nullptr) const {
     const size_t num_params__ = 1;
     const size_t num_transformed = emit_transformed_parameters * ((((((2 + (2
-      * 2)) + (2 * 2)) + (2 * 2)) + ((2 * 2) * 2)) + ((2 * 2) * 2)));
+      * 2)) + (2 * 2)) + (2 * 2)) + (2 * (2 * 2))) + (2 * (2 * 2))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -2190,6 +2228,34 @@ class cpp_reserved_words_model final : public model_base_crtp<cpp_reserved_words
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -2716,6 +2782,20 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(J)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(J)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -3100,6 +3180,14 @@ class funcall_type_promotion_model final : public model_base_crtp<funcall_type_p
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -3479,6 +3567,20 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(3)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((3 * 3)), static_cast<size_t>((3 * 3)),
+             static_cast<size_t>((3 * 3))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -8785,11 +8887,12 @@ class mother_model final : public model_base_crtp<mother_model> {
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = 1 + 1 + 1 + 5 + 5 + 5 + N + (N * M * K) + N + (N * N) +
-      (N * M * K * N) + N + (N * N) + (N * M * K * N) + (5 * 4) + (4 * 5 * 2
-      * 3) + (N - 1) + (N * (N - 1)) + (N * M * K * (N - 1)) + ((((4 * (4 -
-      1)) / 2) + 4) + ((5 - 4) * 4)) + ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3)
-      * 3)) + (K * ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3) * 3))) + 2 + 2;
+    num_params_r__ = 1 + 1 + 1 + 5 + 5 + 5 + N + (N * (M * K)) + N + (N * N)
+      + (N * (M * (K * N))) + N + (N * N) + (N * (M * (K * N))) + (5 * 4) +
+      (4 * (5 * (2 * 3))) + (N - 1) + (N * (N - 1)) + (N * (M * (K * (N -
+      1)))) + ((((4 * (4 - 1)) / 2) + 4) + ((5 - 4) * 4)) + ((((3 * (3 - 1))
+      / 2) + 3) + ((3 - 3) * 3)) + (K * ((((3 * (3 - 1)) / 2) + 3) + ((3 - 3)
+      * 3))) + 2 + 2;
   }
   inline std::string model_name() const final {
     return "mother_model";
@@ -11316,6 +11419,68 @@ class mother_model final : public model_base_crtp<mother_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(5),
+            static_cast<size_t>(5), static_cast<size_t>(5),
+            static_cast<size_t>(N), static_cast<size_t>((N * (M * K))),
+            static_cast<size_t>(N), static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * (M * (K * N)))), static_cast<size_t>(N),
+            static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * (M * (K * N)))),
+            static_cast<size_t>((5 * 4)),
+            static_cast<size_t>((4 * (5 * (2 * 3)))), static_cast<size_t>(N),
+            static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * (M * (K * N)))),
+            static_cast<size_t>((5 * 4)), static_cast<size_t>((3 * 3)),
+            static_cast<size_t>((K * (3 * 3))), static_cast<size_t>(2),
+            static_cast<size_t>(2)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(N), static_cast<size_t>((N * (M * K))),
+             static_cast<size_t>(N), static_cast<size_t>((N * N)),
+             static_cast<size_t>((N * (M * (K * N)))),
+             static_cast<size_t>(N), static_cast<size_t>((N * N)),
+             static_cast<size_t>((N * (M * (K * N)))),
+             static_cast<size_t>((5 * 4)),
+             static_cast<size_t>((4 * (5 * (2 * 3)))),
+             static_cast<size_t>(N), static_cast<size_t>((N * N)),
+             static_cast<size_t>((N * (M * (K * N)))),
+             static_cast<size_t>((5 * 4)), static_cast<size_t>((3 * 3)),
+             static_cast<size_t>((K * (3 * 3))), static_cast<size_t>(2),
+             static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(N), static_cast<size_t>((N * (M * K))),
+             static_cast<size_t>(N), static_cast<size_t>((N * N)),
+             static_cast<size_t>((N * (M * (K * N)))),
+             static_cast<size_t>(N), static_cast<size_t>((N * N)),
+             static_cast<size_t>((N * (M * (K * N)))),
+             static_cast<size_t>((4 * (5 * (2 * 3)))),
+             static_cast<size_t>(N), static_cast<size_t>((N * N)),
+             static_cast<size_t>((N * (M * (K * N)))),
+             static_cast<size_t>((5 * 4)), static_cast<size_t>((3 * 3)),
+             static_cast<size_t>((K * (3 * 3))), static_cast<size_t>(3),
+             static_cast<size_t>((5 * (3 * 4))),
+             static_cast<size_t>((3 * (3 * 4))),
+             static_cast<size_t>((5 * (3 * 4))),
+             static_cast<size_t>((3 * (3 * 3))),
+             static_cast<size_t>((3 * (3 * 4))),
+             static_cast<size_t>((5 * (3 * 4))),
+             static_cast<size_t>((3 * (3 * 3))),
+             static_cast<size_t>((3 * 4)), static_cast<size_t>((2 * 2))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -12364,22 +12529,22 @@ class mother_model final : public model_base_crtp<mother_model> {
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
     const size_t num_params__ = (((((((((((((((((((((((1 + 1) + 1) + 5) + 5)
-      + 5) + N) + ((N * M) * K)) + N) + (N * N)) + (((N * M) * K) * N)) + N)
-      + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (((4 * 5) * 2) * 3)) +
-      N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 * 3)) + ((K * 3) *
-      3)) + 2) + 2);
+      + 5) + N) + (N * (M * K))) + N) + (N * N)) + (N * (M * (K * N)))) + N)
+      + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (4 * (5 * (2 * 3)))) +
+      N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (3 * 3)) + (K * (3 *
+      3))) + 2) + 2);
     const size_t num_transformed = emit_transformed_parameters *
-      ((((((((((((((((((N + ((N * M) * K)) + N) + (N * N)) + (((N * M) * K) *
-      N)) + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (((4 * 5) * 2)
-      * 3)) + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 * 3)) +
-      ((K * 3) * 3)) + 2) + 1));
+      ((((((((((((((((((N + (N * (M * K))) + N) + (N * N)) + (N * (M * (K *
+      N)))) + N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (4 * (5 * (2
+      * 3)))) + N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (3 * 3)) +
+      (K * (3 * 3))) + 2) + 1));
     const size_t num_gen_quantities = emit_generated_quantities *
-      (((((((((((((((((((((((((((1 + 1) + N) + ((N * M) * K)) + N) + (N * N))
-      + (((N * M) * K) * N)) + N) + (N * N)) + (((N * M) * K) * N)) + (((4 *
-      5) * 2) * 3)) + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 *
-      3)) + ((K * 3) * 3)) + 3) + ((5 * 3) * 4)) + ((3 * 3) * 4)) + ((5 * 3)
-      * 4)) + ((3 * 3) * 3)) + ((3 * 3) * 4)) + ((5 * 3) * 4)) + ((3 * 3) *
-      3)) + (3 * 4)) + (2 * 2)));
+      (((((((((((((((((((((((((((1 + 1) + N) + (N * (M * K))) + N) + (N * N))
+      + (N * (M * (K * N)))) + N) + (N * N)) + (N * (M * (K * N)))) + (4 * (5
+      * (2 * 3)))) + N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (3 *
+      3)) + (K * (3 * 3))) + 3) + (5 * (3 * 4))) + (3 * (3 * 4))) + (5 * (3 *
+      4))) + (3 * (3 * 3))) + (3 * (3 * 4))) + (5 * (3 * 4))) + (3 * (3 *
+      3))) + (3 * 4)) + (2 * 2)));
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
     std::vector<int> params_i;
@@ -12395,22 +12560,22 @@ class mother_model final : public model_base_crtp<mother_model> {
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
     const size_t num_params__ = (((((((((((((((((((((((1 + 1) + 1) + 5) + 5)
-      + 5) + N) + ((N * M) * K)) + N) + (N * N)) + (((N * M) * K) * N)) + N)
-      + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (((4 * 5) * 2) * 3)) +
-      N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 * 3)) + ((K * 3) *
-      3)) + 2) + 2);
+      + 5) + N) + (N * (M * K))) + N) + (N * N)) + (N * (M * (K * N)))) + N)
+      + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (4 * (5 * (2 * 3)))) +
+      N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (3 * 3)) + (K * (3 *
+      3))) + 2) + 2);
     const size_t num_transformed = emit_transformed_parameters *
-      ((((((((((((((((((N + ((N * M) * K)) + N) + (N * N)) + (((N * M) * K) *
-      N)) + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (((4 * 5) * 2)
-      * 3)) + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 * 3)) +
-      ((K * 3) * 3)) + 2) + 1));
+      ((((((((((((((((((N + (N * (M * K))) + N) + (N * N)) + (N * (M * (K *
+      N)))) + N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (4 * (5 * (2
+      * 3)))) + N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (3 * 3)) +
+      (K * (3 * 3))) + 2) + 1));
     const size_t num_gen_quantities = emit_generated_quantities *
-      (((((((((((((((((((((((((((1 + 1) + N) + ((N * M) * K)) + N) + (N * N))
-      + (((N * M) * K) * N)) + N) + (N * N)) + (((N * M) * K) * N)) + (((4 *
-      5) * 2) * 3)) + N) + (N * N)) + (((N * M) * K) * N)) + (5 * 4)) + (3 *
-      3)) + ((K * 3) * 3)) + 3) + ((5 * 3) * 4)) + ((3 * 3) * 4)) + ((5 * 3)
-      * 4)) + ((3 * 3) * 3)) + ((3 * 3) * 4)) + ((5 * 3) * 4)) + ((3 * 3) *
-      3)) + (3 * 4)) + (2 * 2)));
+      (((((((((((((((((((((((((((1 + 1) + N) + (N * (M * K))) + N) + (N * N))
+      + (N * (M * (K * N)))) + N) + (N * N)) + (N * (M * (K * N)))) + (4 * (5
+      * (2 * 3)))) + N) + (N * N)) + (N * (M * (K * N)))) + (5 * 4)) + (3 *
+      3)) + (K * (3 * 3))) + 3) + (5 * (3 * 4))) + (3 * (3 * 4))) + (5 * (3 *
+      4))) + (3 * (3 * 3))) + (3 * (3 * 4))) + (5 * (3 * 4))) + (3 * (3 *
+      3))) + (3 * 4)) + (2 * 2)));
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
     vars = std::vector<double>(num_to_write,
@@ -14107,6 +14272,35 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(2), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(2),
+            static_cast<size_t>(3), static_cast<size_t>((3 * 3)),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(3),
+             static_cast<size_t>(3), static_cast<size_t>(3),
+             static_cast<size_t>(2), static_cast<size_t>(2),
+             static_cast<size_t>(2), static_cast<size_t>(2)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((T * 2)), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(3),
+             static_cast<size_t>(3), static_cast<size_t>(2)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -18848,6 +19042,24 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(N),
+            static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((N * N))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>((N * N))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -19547,6 +19759,21 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(2), static_cast<size_t>(2)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((N * 2))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -21135,6 +21362,19 @@ class optimize_glm_model final : public model_base_crtp<optimize_glm_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(k), static_cast<size_t>(k),
+            static_cast<size_t>(k), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>((n * k)), static_cast<size_t>((n * k)),
+            static_cast<size_t>(n)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -21883,6 +22123,14 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22320,6 +22568,15 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((nt * (2 * 2))), static_cast<size_t>(NS)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22383,7 +22640,7 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((nt * 2) * 2) + NS);
+    const size_t num_params__ = ((nt * (2 * 2)) + NS);
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
@@ -22400,7 +22657,7 @@ class param_constraint_model final : public model_base_crtp<param_constraint_mod
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (((nt * 2) * 2) + NS);
+    const size_t num_params__ = ((nt * (2 * 2)) + NS);
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
@@ -22627,6 +22884,14 @@ class print_unicode_model final : public model_base_crtp<print_unicode_model> {
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -22966,6 +23231,20 @@ class promotion_model final : public model_base_crtp<promotion_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(2),
+             static_cast<size_t>(4), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -23734,6 +24013,19 @@ class recursive_slicing_model final : public model_base_crtp<recursive_slicing_m
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(times)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(N), static_cast<size_t>(3)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -24279,6 +24571,16 @@ class reduce_sum_m1_model final : public model_base_crtp<reduce_sum_m1_model> {
     names__ = std::vector<std::string>{"y1", "y2", "y3"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -25513,9 +25815,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = (N * N * N * N) + (N * N * N) + (N * N * N) + (N * N) +
-      (N * N * N) + (N * N) + (N * N) + N + (N * N * N * N) + (N * N * N) +
-      (N * N * N) + (N * N) + (N * N * N) + (N * N) + (N * N) + N;
+    num_params_r__ = (N * (N * (N * N))) + (N * (N * N)) + (N * (N * N)) + (N
+      * N) + (N * (N * N)) + (N * N) + (N * N) + N + (N * (N * (N * N))) + (N
+      * (N * N)) + (N * (N * N)) + (N * N) + (N * (N * N)) + (N * N) + (N *
+      N) + N;
   }
   inline std::string model_name() const final {
     return "reduce_sum_m2_model";
@@ -26699,6 +27002,24 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((N * (N * (N * N)))),
+            static_cast<size_t>((N * (N * N))),
+            static_cast<size_t>((N * (N * N))), static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * (N * N))), static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * N)), static_cast<size_t>(N),
+            static_cast<size_t>((N * (N * (N * N)))),
+            static_cast<size_t>((N * (N * N))),
+            static_cast<size_t>((N * (N * N))), static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * (N * N))), static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * N)), static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -27007,10 +27328,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = ((((((((((((((((((N * N) * N) * N) + ((N * N)
-      * N)) + ((N * N) * N)) + (N * N)) + ((N * N) * N)) + (N * N)) + (N *
-      N)) + N) + (((N * N) * N) * N)) + ((N * N) * N)) + ((N * N) * N)) + (N
-      * N)) + ((N * N) * N)) + (N * N)) + (N * N)) + N);
+    const size_t num_params__ = ((((((((((((((((N * (N * (N * N))) + (N * (N
+      * N))) + (N * (N * N))) + (N * N)) + (N * (N * N))) + (N * N)) + (N *
+      N)) + N) + (N * (N * (N * N)))) + (N * (N * N))) + (N * (N * N))) + (N
+      * N)) + (N * (N * N))) + (N * N)) + (N * N)) + N);
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
@@ -27027,10 +27348,10 @@ class reduce_sum_m2_model final : public model_base_crtp<reduce_sum_m2_model> {
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = ((((((((((((((((((N * N) * N) * N) + ((N * N)
-      * N)) + ((N * N) * N)) + (N * N)) + ((N * N) * N)) + (N * N)) + (N *
-      N)) + N) + (((N * N) * N) * N)) + ((N * N) * N)) + ((N * N) * N)) + (N
-      * N)) + ((N * N) * N)) + (N * N)) + (N * N)) + N);
+    const size_t num_params__ = ((((((((((((((((N * (N * (N * N))) + (N * (N
+      * N))) + (N * (N * N))) + (N * N)) + (N * (N * N))) + (N * N)) + (N *
+      N)) + N) + (N * (N * (N * N)))) + (N * (N * N))) + (N * (N * N))) + (N
+      * N)) + (N * (N * N))) + (N * N)) + (N * N)) + N);
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
@@ -29480,8 +29801,9 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = N + (N * N) + (N * N) + (N * N * N) + (N * N) + (N * N *
-      N) + (N * N * N) + (N * N * N * N) + 1 + N + N + (N * N) + (N * N * N);
+    num_params_r__ = N + (N * N) + (N * N) + (N * (N * N)) + (N * N) + (N *
+      (N * N)) + (N * (N * N)) + (N * (N * (N * N))) + 1 + N + N + (N * N) +
+      (N * (N * N));
   }
   inline std::string model_name() const final {
     return "reduce_sum_m3_model";
@@ -30518,6 +30840,38 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(N), static_cast<size_t>((N * N)),
+            static_cast<size_t>((N * N)), static_cast<size_t>((N * (N * N))),
+            static_cast<size_t>((N * N)), static_cast<size_t>((N * (N * N))),
+            static_cast<size_t>((N * (N * N))),
+            static_cast<size_t>((N * (N * (N * N)))), static_cast<size_t>(1),
+            static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>((N * N)), static_cast<size_t>((N * (N * N)))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -30814,9 +31168,9 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = ((((((((((((N + (N * N)) + (N * N)) + ((N *
-      N) * N)) + (N * N)) + ((N * N) * N)) + ((N * N) * N)) + (((N * N) * N)
-      * N)) + 1) + N) + N) + (N * N)) + ((N * N) * N));
+    const size_t num_params__ = ((((((((((((N + (N * N)) + (N * N)) + (N * (N
+      * N))) + (N * N)) + (N * (N * N))) + (N * (N * N))) + (N * (N * (N *
+      N)))) + 1) + N) + N) + (N * N)) + (N * (N * N)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities *
       ((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
@@ -30836,9 +31190,9 @@ class reduce_sum_m3_model final : public model_base_crtp<reduce_sum_m3_model> {
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = ((((((((((((N + (N * N)) + (N * N)) + ((N *
-      N) * N)) + (N * N)) + ((N * N) * N)) + ((N * N) * N)) + (((N * N) * N)
-      * N)) + 1) + N) + N) + (N * N)) + ((N * N) * N));
+    const size_t num_params__ = ((((((((((((N + (N * N)) + (N * N)) + (N * (N
+      * N))) + (N * N)) + (N * (N * N))) + (N * (N * N))) + (N * (N * (N *
+      N)))) + 1) + N) + N) + (N * N)) + (N * (N * N)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities *
       ((((((((((((((((((((((((((1 + 1) + 1) + 1) + 1) + 1) + 1) + 1) + 1) +
@@ -31965,6 +32319,37 @@ class shadowing_model final : public model_base_crtp<shadowing_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(5),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(4), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>((1 * 4)),
+             static_cast<size_t>(result_1dim__)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -32488,6 +32873,14 @@ class single_argument_lpmf_model final : public model_base_crtp<single_argument_
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -32825,6 +33218,14 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
     names__ = std::vector<std::string>{"x"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -33400,9 +33801,9 @@ class transform_model final : public model_base_crtp<transform_model> {
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = k + k + k + k + k + k + k + k + (m * k) + (n * m * k) +
-      k + (m * k) + (n * m * k) + k + (m * k) + (n * m * k) + (m * k) + (n *
-      m * k);
+    num_params_r__ = k + k + k + k + k + k + k + k + (m * k) + (n * (m * k))
+      + k + (m * k) + (n * (m * k)) + k + (m * k) + (n * (m * k)) + (m * k) +
+      (n * (m * k));
   }
   inline std::string model_name() const final {
     return "transform_model";
@@ -35151,6 +35552,38 @@ class transform_model final : public model_base_crtp<transform_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(k), static_cast<size_t>(k),
+            static_cast<size_t>(k), static_cast<size_t>(k),
+            static_cast<size_t>(k), static_cast<size_t>(k),
+            static_cast<size_t>(k), static_cast<size_t>(k),
+            static_cast<size_t>((m * k)), static_cast<size_t>((n * (m * k))),
+            static_cast<size_t>(k), static_cast<size_t>((m * k)),
+            static_cast<size_t>((n * (m * k))), static_cast<size_t>(k),
+            static_cast<size_t>((m * k)), static_cast<size_t>((n * (m * k))),
+            static_cast<size_t>((m * k)), static_cast<size_t>((n * (m * k)))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(k), static_cast<size_t>(k),
+             static_cast<size_t>(k), static_cast<size_t>(k),
+             static_cast<size_t>(k), static_cast<size_t>(k),
+             static_cast<size_t>(k), static_cast<size_t>(k),
+             static_cast<size_t>((m * k)),
+             static_cast<size_t>((n * (m * k))), static_cast<size_t>(k),
+             static_cast<size_t>((m * k)),
+             static_cast<size_t>((n * (m * k))), static_cast<size_t>(k),
+             static_cast<size_t>((m * k)),
+             static_cast<size_t>((n * (m * k))),
+             static_cast<size_t>((m * k)), static_cast<size_t>((n * (m * k)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -35645,12 +36078,12 @@ class transform_model final : public model_base_crtp<transform_model> {
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
     const size_t num_params__ = (((((((((((((((((k + k) + k) + k) + k) + k) +
-      k) + k) + (m * k)) + ((n * m) * k)) + k) + (m * k)) + ((n * m) * k)) +
-      k) + (m * k)) + ((n * m) * k)) + (m * k)) + ((n * m) * k));
+      k) + k) + (m * k)) + (n * (m * k))) + k) + (m * k)) + (n * (m * k))) +
+      k) + (m * k)) + (n * (m * k))) + (m * k)) + (n * (m * k)));
     const size_t num_transformed = emit_transformed_parameters *
-      ((((((((((((((((((k + k) + k) + k) + k) + k) + k) + k) + (m * k)) + ((n
-      * m) * k)) + k) + (m * k)) + ((n * m) * k)) + k) + (m * k)) + ((n * m)
-      * k)) + (m * k)) + ((n * m) * k)));
+      ((((((((((((((((((k + k) + k) + k) + k) + k) + k) + k) + (m * k)) + (n
+      * (m * k))) + k) + (m * k)) + (n * (m * k))) + k) + (m * k)) + (n * (m
+      * k))) + (m * k)) + (n * (m * k))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -35667,12 +36100,12 @@ class transform_model final : public model_base_crtp<transform_model> {
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
     const size_t num_params__ = (((((((((((((((((k + k) + k) + k) + k) + k) +
-      k) + k) + (m * k)) + ((n * m) * k)) + k) + (m * k)) + ((n * m) * k)) +
-      k) + (m * k)) + ((n * m) * k)) + (m * k)) + ((n * m) * k));
+      k) + k) + (m * k)) + (n * (m * k))) + k) + (m * k)) + (n * (m * k))) +
+      k) + (m * k)) + (n * (m * k))) + (m * k)) + (n * (m * k)));
     const size_t num_transformed = emit_transformed_parameters *
-      ((((((((((((((((((k + k) + k) + k) + k) + k) + k) + k) + (m * k)) + ((n
-      * m) * k)) + k) + (m * k)) + ((n * m) * k)) + k) + (m * k)) + ((n * m)
-      * k)) + (m * k)) + ((n * m) * k)));
+      ((((((((((((((((((k + k) + k) + k) + k) + k) + k) + k) + (m * k)) + (n
+      * (m * k))) + k) + (m * k)) + (n * (m * k))) + k) + (m * k)) + (n * (m
+      * k))) + (m * k)) + (n * (m * k))));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -36051,6 +36484,14 @@ class truncate_model final : public model_base_crtp<truncate_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -36376,6 +36817,14 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
     names__ = std::vector<std::string>{"x"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -36706,6 +37155,14 @@ class user_constrain_model final : public model_base_crtp<user_constrain_model> 
     names__ = std::vector<std::string>{"x"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -37071,6 +37528,14 @@ class variable_named_context_model final : public model_base_crtp<variable_named
     names__ = std::vector<std::string>{"mu", "sigma"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -38078,6 +38543,16 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
                 "vector_sigma"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(N), static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -352,6 +352,23 @@ class operators_model final : public model_base_crtp<operators_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>((N * N))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(N),
+             static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -892,6 +909,14 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1372,6 +1397,22 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(2), static_cast<size_t>(2),
+            static_cast<size_t>(1), static_cast<size_t>(2)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(2), static_cast<size_t>(2),
+             static_cast<size_t>(2)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -11688,6 +11688,248 @@
                   (MethodCall (Var temp) end () ()))))))
              ()))))))
        (FunDef
+        ((templates_init ((()) false)) (inline true)
+         (return_type (StdVector (TypeLiteral size_t)))
+         (name get_param_sizes)
+         (args
+          (((Const (TypeLiteral bool))
+            "emit_transformed_parameters__ = true")
+           ((Const (TypeLiteral bool)) "emit_generated_quantities__ = true")))
+         (cv_qualifiers (Const))
+         (body
+          (((VariableDefn
+             ((static false) (constexpr false)
+              (type_ (StdVector (TypeLiteral size_t))) (name sizes)
+              (init
+               (InitializerList
+                ((FunCall static_cast ((TypeLiteral size_t)) ((Literal 1)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 1)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 1)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 5)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 5)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 5)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens
+                    (BinOp (Var N) Multiply
+                     (Parens (BinOp (Var M) Multiply (Var K)))))))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens (BinOp (Var N) Multiply (Var N)))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens
+                    (BinOp (Var N) Multiply
+                     (Parens
+                      (BinOp (Var M) Multiply
+                       (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens (BinOp (Var N) Multiply (Var N)))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens
+                    (BinOp (Var N) Multiply
+                     (Parens
+                      (BinOp (Var M) Multiply
+                       (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens (BinOp (Literal 5) Multiply (Literal 4)))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens
+                    (BinOp (Literal 4) Multiply
+                     (Parens
+                      (BinOp (Literal 5) Multiply
+                       (Parens (BinOp (Literal 2) Multiply (Literal 3)))))))))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens (BinOp (Var N) Multiply (Var N)))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens
+                    (BinOp (Var N) Multiply
+                     (Parens
+                      (BinOp (Var M) Multiply
+                       (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens (BinOp (Literal 5) Multiply (Literal 4)))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens (BinOp (Literal 3) Multiply (Literal 3)))))
+                 (FunCall static_cast ((TypeLiteral size_t))
+                  ((Parens
+                    (BinOp (Var K) Multiply
+                     (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 2)))
+                 (FunCall static_cast ((TypeLiteral size_t)) ((Literal 2))))))))
+            (IfElse (Var emit_transformed_parameters__)
+             (Block
+              ((VariableDefn
+                ((static false) (constexpr false)
+                 (type_ (StdVector (TypeLiteral size_t))) (name temp)
+                 (init
+                  (InitializerList
+                   ((FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens (BinOp (Var M) Multiply (Var K)))))))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Var N) Multiply (Var N)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Var N) Multiply (Var N)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 5) Multiply (Literal 4)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 4) Multiply
+                        (Parens
+                         (BinOp (Literal 5) Multiply
+                          (Parens (BinOp (Literal 2) Multiply (Literal 3)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Var N) Multiply (Var N)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 5) Multiply (Literal 4)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 3) Multiply (Literal 3)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var K) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Literal 2)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Literal 1))))))))
+               (Expression
+                (MethodCall (Var sizes) reserve ()
+                 ((BinOp (MethodCall (Var sizes) size () ()) Add
+                   (MethodCall (Var temp) size () ())))))
+               (Expression
+                (MethodCall (Var sizes) insert ()
+                 ((MethodCall (Var sizes) end () ())
+                  (MethodCall (Var temp) begin () ())
+                  (MethodCall (Var temp) end () ()))))))
+             ())
+            (IfElse (Var emit_generated_quantities__)
+             (Block
+              ((VariableDefn
+                ((static false) (constexpr false)
+                 (type_ (StdVector (TypeLiteral size_t))) (name temp)
+                 (init
+                  (InitializerList
+                   ((FunCall static_cast ((TypeLiteral size_t))
+                     ((Literal 1)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Literal 1)))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens (BinOp (Var M) Multiply (Var K)))))))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Var N) Multiply (Var N)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Var N) Multiply (Var N)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 4) Multiply
+                        (Parens
+                         (BinOp (Literal 5) Multiply
+                          (Parens (BinOp (Literal 2) Multiply (Literal 3)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t)) ((Var N)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Var N) Multiply (Var N)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N)))))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 5) Multiply (Literal 4)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 3) Multiply (Literal 3)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Var K) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Literal 3)))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 5) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 3) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 5) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 3) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 3) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 5) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens
+                       (BinOp (Literal 3) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 3) Multiply (Literal 4)))))
+                    (FunCall static_cast ((TypeLiteral size_t))
+                     ((Parens (BinOp (Literal 2) Multiply (Literal 2))))))))))
+               (Expression
+                (MethodCall (Var sizes) reserve ()
+                 ((BinOp (MethodCall (Var sizes) size () ()) Add
+                   (MethodCall (Var temp) size () ())))))
+               (Expression
+                (MethodCall (Var sizes) insert ()
+                 ((MethodCall (Var sizes) end () ())
+                  (MethodCall (Var temp) begin () ())
+                  (MethodCall (Var temp) end () ()))))))
+             ())
+            (Return ((Var sizes))))))))
+       (FunDef
         ((templates_init ((()) false)) (inline true) (return_type Void)
          (name get_dims)
          (args
@@ -15459,11 +15701,10 @@
                                                     Add (Var N)))
                                                   Add
                                                   (Parens
-                                                   (BinOp
+                                                   (BinOp (Var N) Multiply
                                                     (Parens
-                                                     (BinOp (Var N) Multiply
-                                                      (Var M)))
-                                                    Multiply (Var K)))))
+                                                     (BinOp (Var M) Multiply
+                                                      (Var K)))))))
                                                 Add (Var N)))
                                               Add
                                               (Parens
@@ -15471,58 +15712,50 @@
                                                 (Var N)))))
                                             Add
                                             (Parens
-                                             (BinOp
+                                             (BinOp (Var N) Multiply
                                               (Parens
-                                               (BinOp
+                                               (BinOp (Var M) Multiply
                                                 (Parens
-                                                 (BinOp (Var N) Multiply
-                                                  (Var M)))
-                                                Multiply (Var K)))
-                                              Multiply (Var N)))))
+                                                 (BinOp (Var K) Multiply
+                                                  (Var N)))))))))
                                           Add (Var N)))
                                         Add
                                         (Parens
                                          (BinOp (Var N) Multiply (Var N)))))
                                       Add
                                       (Parens
-                                       (BinOp
+                                       (BinOp (Var N) Multiply
                                         (Parens
-                                         (BinOp
+                                         (BinOp (Var M) Multiply
                                           (Parens
-                                           (BinOp (Var N) Multiply (Var M)))
-                                          Multiply (Var K)))
-                                        Multiply (Var N)))))
+                                           (BinOp (Var K) Multiply (Var N)))))))))
                                     Add
                                     (Parens
                                      (BinOp (Literal 5) Multiply (Literal 4)))))
                                   Add
                                   (Parens
-                                   (BinOp
+                                   (BinOp (Literal 4) Multiply
                                     (Parens
-                                     (BinOp
+                                     (BinOp (Literal 5) Multiply
                                       (Parens
-                                       (BinOp (Literal 4) Multiply
-                                        (Literal 5)))
-                                      Multiply (Literal 2)))
-                                    Multiply (Literal 3)))))
+                                       (BinOp (Literal 2) Multiply
+                                        (Literal 3)))))))))
                                 Add (Var N)))
                               Add (Parens (BinOp (Var N) Multiply (Var N)))))
                             Add
                             (Parens
-                             (BinOp
+                             (BinOp (Var N) Multiply
                               (Parens
-                               (BinOp
-                                (Parens (BinOp (Var N) Multiply (Var M)))
-                                Multiply (Var K)))
-                              Multiply (Var N)))))
+                               (BinOp (Var M) Multiply
+                                (Parens (BinOp (Var K) Multiply (Var N)))))))))
                           Add
                           (Parens (BinOp (Literal 5) Multiply (Literal 4)))))
                         Add
                         (Parens (BinOp (Literal 3) Multiply (Literal 3)))))
                       Add
                       (Parens
-                       (BinOp (Parens (BinOp (Var K) Multiply (Literal 3)))
-                        Multiply (Literal 3)))))
+                       (BinOp (Var K) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
                     Add (Literal 2)))
                   Add (Literal 2)))))))
             (VariableDefn
@@ -15567,11 +15800,10 @@
                                                   (Parens
                                                    (BinOp (Var N) Add
                                                     (Parens
-                                                     (BinOp
+                                                     (BinOp (Var N) Multiply
                                                       (Parens
-                                                       (BinOp (Var N)
-                                                        Multiply (Var M)))
-                                                      Multiply (Var K)))))
+                                                       (BinOp (Var M)
+                                                        Multiply (Var K)))))))
                                                   Add (Var N)))
                                                 Add
                                                 (Parens
@@ -15579,60 +15811,52 @@
                                                   (Var N)))))
                                               Add
                                               (Parens
-                                               (BinOp
+                                               (BinOp (Var N) Multiply
                                                 (Parens
-                                                 (BinOp
+                                                 (BinOp (Var M) Multiply
                                                   (Parens
-                                                   (BinOp (Var N) Multiply
-                                                    (Var M)))
-                                                  Multiply (Var K)))
-                                                Multiply (Var N)))))
+                                                   (BinOp (Var K) Multiply
+                                                    (Var N)))))))))
                                             Add (Var N)))
                                           Add
                                           (Parens
                                            (BinOp (Var N) Multiply (Var N)))))
                                         Add
                                         (Parens
-                                         (BinOp
+                                         (BinOp (Var N) Multiply
                                           (Parens
-                                           (BinOp
+                                           (BinOp (Var M) Multiply
                                             (Parens
-                                             (BinOp (Var N) Multiply (Var M)))
-                                            Multiply (Var K)))
-                                          Multiply (Var N)))))
+                                             (BinOp (Var K) Multiply (Var N)))))))))
                                       Add
                                       (Parens
                                        (BinOp (Literal 5) Multiply
                                         (Literal 4)))))
                                     Add
                                     (Parens
-                                     (BinOp
+                                     (BinOp (Literal 4) Multiply
                                       (Parens
-                                       (BinOp
+                                       (BinOp (Literal 5) Multiply
                                         (Parens
-                                         (BinOp (Literal 4) Multiply
-                                          (Literal 5)))
-                                        Multiply (Literal 2)))
-                                      Multiply (Literal 3)))))
+                                         (BinOp (Literal 2) Multiply
+                                          (Literal 3)))))))))
                                   Add (Var N)))
                                 Add
                                 (Parens (BinOp (Var N) Multiply (Var N)))))
                               Add
                               (Parens
-                               (BinOp
+                               (BinOp (Var N) Multiply
                                 (Parens
-                                 (BinOp
-                                  (Parens (BinOp (Var N) Multiply (Var M)))
-                                  Multiply (Var K)))
-                                Multiply (Var N)))))
+                                 (BinOp (Var M) Multiply
+                                  (Parens (BinOp (Var K) Multiply (Var N)))))))))
                             Add
                             (Parens (BinOp (Literal 5) Multiply (Literal 4)))))
                           Add
                           (Parens (BinOp (Literal 3) Multiply (Literal 3)))))
                         Add
                         (Parens
-                         (BinOp (Parens (BinOp (Var K) Multiply (Literal 3)))
-                          Multiply (Literal 3)))))
+                         (BinOp (Var K) Multiply
+                          (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
                       Add (Literal 2)))
                     Add (Literal 1)))))))))
             (VariableDefn
@@ -15702,13 +15926,13 @@
                                                                   Add
                                                                   (Parens
                                                                    (BinOp
-                                                                    (Parens
-                                                                    (BinOp
                                                                     (Var N)
                                                                     Multiply
-                                                                    (Var M)))
+                                                                    (Parens
+                                                                    (BinOp
+                                                                    (Var M)
                                                                     Multiply
-                                                                    (Var K)))))
+                                                                    (Var K)))))))
                                                                 Add (Var N)))
                                                               Add
                                                               (Parens
@@ -15718,18 +15942,17 @@
                                                                 (Var N)))))
                                                             Add
                                                             (Parens
-                                                             (BinOp
+                                                             (BinOp (Var N)
+                                                              Multiply
                                                               (Parens
-                                                               (BinOp
+                                                               (BinOp 
+                                                                (Var M)
+                                                                Multiply
                                                                 (Parens
                                                                  (BinOp
-                                                                  (Var N)
+                                                                  (Var K)
                                                                   Multiply
-                                                                  (Var M)))
-                                                                Multiply
-                                                                (Var K)))
-                                                              Multiply
-                                                              (Var N)))))
+                                                                  (Var N)))))))))
                                                           Add (Var N)))
                                                         Add
                                                         (Parens
@@ -15737,26 +15960,26 @@
                                                           Multiply (Var N)))))
                                                       Add
                                                       (Parens
-                                                       (BinOp
+                                                       (BinOp (Var N)
+                                                        Multiply
                                                         (Parens
-                                                         (BinOp
+                                                         (BinOp (Var M)
+                                                          Multiply
                                                           (Parens
-                                                           (BinOp (Var N)
+                                                           (BinOp (Var K)
                                                             Multiply 
-                                                            (Var M)))
-                                                          Multiply (Var K)))
-                                                        Multiply (Var N)))))
+                                                            (Var N)))))))))
                                                     Add
                                                     (Parens
-                                                     (BinOp
+                                                     (BinOp (Literal 4)
+                                                      Multiply
                                                       (Parens
-                                                       (BinOp
+                                                       (BinOp (Literal 5)
+                                                        Multiply
                                                         (Parens
-                                                         (BinOp (Literal 4)
+                                                         (BinOp (Literal 2)
                                                           Multiply
-                                                          (Literal 5)))
-                                                        Multiply (Literal 2)))
-                                                      Multiply (Literal 3)))))
+                                                          (Literal 3)))))))))
                                                   Add (Var N)))
                                                 Add
                                                 (Parens
@@ -15764,14 +15987,12 @@
                                                   (Var N)))))
                                               Add
                                               (Parens
-                                               (BinOp
+                                               (BinOp (Var N) Multiply
                                                 (Parens
-                                                 (BinOp
+                                                 (BinOp (Var M) Multiply
                                                   (Parens
-                                                   (BinOp (Var N) Multiply
-                                                    (Var M)))
-                                                  Multiply (Var K)))
-                                                Multiply (Var N)))))
+                                                   (BinOp (Var K) Multiply
+                                                    (Var N)))))))))
                                             Add
                                             (Parens
                                              (BinOp (Literal 5) Multiply
@@ -15782,53 +16003,45 @@
                                             (Literal 3)))))
                                         Add
                                         (Parens
-                                         (BinOp
+                                         (BinOp (Var K) Multiply
                                           (Parens
-                                           (BinOp (Var K) Multiply
-                                            (Literal 3)))
-                                          Multiply (Literal 3)))))
+                                           (BinOp (Literal 3) Multiply
+                                            (Literal 3)))))))
                                       Add (Literal 3)))
                                     Add
                                     (Parens
-                                     (BinOp
+                                     (BinOp (Literal 5) Multiply
                                       (Parens
-                                       (BinOp (Literal 5) Multiply
-                                        (Literal 3)))
-                                      Multiply (Literal 4)))))
+                                       (BinOp (Literal 3) Multiply
+                                        (Literal 4)))))))
                                   Add
                                   (Parens
-                                   (BinOp
+                                   (BinOp (Literal 3) Multiply
                                     (Parens
-                                     (BinOp (Literal 3) Multiply (Literal 3)))
-                                    Multiply (Literal 4)))))
+                                     (BinOp (Literal 3) Multiply (Literal 4)))))))
                                 Add
                                 (Parens
-                                 (BinOp
+                                 (BinOp (Literal 5) Multiply
                                   (Parens
-                                   (BinOp (Literal 5) Multiply (Literal 3)))
-                                  Multiply (Literal 4)))))
+                                   (BinOp (Literal 3) Multiply (Literal 4)))))))
                               Add
                               (Parens
-                               (BinOp
+                               (BinOp (Literal 3) Multiply
                                 (Parens
-                                 (BinOp (Literal 3) Multiply (Literal 3)))
-                                Multiply (Literal 3)))))
+                                 (BinOp (Literal 3) Multiply (Literal 3)))))))
                             Add
                             (Parens
-                             (BinOp
+                             (BinOp (Literal 3) Multiply
                               (Parens
-                               (BinOp (Literal 3) Multiply (Literal 3)))
-                              Multiply (Literal 4)))))
+                               (BinOp (Literal 3) Multiply (Literal 4)))))))
                           Add
                           (Parens
-                           (BinOp
-                            (Parens (BinOp (Literal 5) Multiply (Literal 3)))
-                            Multiply (Literal 4)))))
+                           (BinOp (Literal 5) Multiply
+                            (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
                         Add
                         (Parens
-                         (BinOp
-                          (Parens (BinOp (Literal 3) Multiply (Literal 3)))
-                          Multiply (Literal 3)))))
+                         (BinOp (Literal 3) Multiply
+                          (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
                       Add (Parens (BinOp (Literal 3) Multiply (Literal 4)))))
                     Add (Parens (BinOp (Literal 2) Multiply (Literal 2)))))))))))
             (VariableDefn
@@ -15923,11 +16136,10 @@
                                                     Add (Var N)))
                                                   Add
                                                   (Parens
-                                                   (BinOp
+                                                   (BinOp (Var N) Multiply
                                                     (Parens
-                                                     (BinOp (Var N) Multiply
-                                                      (Var M)))
-                                                    Multiply (Var K)))))
+                                                     (BinOp (Var M) Multiply
+                                                      (Var K)))))))
                                                 Add (Var N)))
                                               Add
                                               (Parens
@@ -15935,58 +16147,50 @@
                                                 (Var N)))))
                                             Add
                                             (Parens
-                                             (BinOp
+                                             (BinOp (Var N) Multiply
                                               (Parens
-                                               (BinOp
+                                               (BinOp (Var M) Multiply
                                                 (Parens
-                                                 (BinOp (Var N) Multiply
-                                                  (Var M)))
-                                                Multiply (Var K)))
-                                              Multiply (Var N)))))
+                                                 (BinOp (Var K) Multiply
+                                                  (Var N)))))))))
                                           Add (Var N)))
                                         Add
                                         (Parens
                                          (BinOp (Var N) Multiply (Var N)))))
                                       Add
                                       (Parens
-                                       (BinOp
+                                       (BinOp (Var N) Multiply
                                         (Parens
-                                         (BinOp
+                                         (BinOp (Var M) Multiply
                                           (Parens
-                                           (BinOp (Var N) Multiply (Var M)))
-                                          Multiply (Var K)))
-                                        Multiply (Var N)))))
+                                           (BinOp (Var K) Multiply (Var N)))))))))
                                     Add
                                     (Parens
                                      (BinOp (Literal 5) Multiply (Literal 4)))))
                                   Add
                                   (Parens
-                                   (BinOp
+                                   (BinOp (Literal 4) Multiply
                                     (Parens
-                                     (BinOp
+                                     (BinOp (Literal 5) Multiply
                                       (Parens
-                                       (BinOp (Literal 4) Multiply
-                                        (Literal 5)))
-                                      Multiply (Literal 2)))
-                                    Multiply (Literal 3)))))
+                                       (BinOp (Literal 2) Multiply
+                                        (Literal 3)))))))))
                                 Add (Var N)))
                               Add (Parens (BinOp (Var N) Multiply (Var N)))))
                             Add
                             (Parens
-                             (BinOp
+                             (BinOp (Var N) Multiply
                               (Parens
-                               (BinOp
-                                (Parens (BinOp (Var N) Multiply (Var M)))
-                                Multiply (Var K)))
-                              Multiply (Var N)))))
+                               (BinOp (Var M) Multiply
+                                (Parens (BinOp (Var K) Multiply (Var N)))))))))
                           Add
                           (Parens (BinOp (Literal 5) Multiply (Literal 4)))))
                         Add
                         (Parens (BinOp (Literal 3) Multiply (Literal 3)))))
                       Add
                       (Parens
-                       (BinOp (Parens (BinOp (Var K) Multiply (Literal 3)))
-                        Multiply (Literal 3)))))
+                       (BinOp (Var K) Multiply
+                        (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
                     Add (Literal 2)))
                   Add (Literal 2)))))))
             (VariableDefn
@@ -16031,11 +16235,10 @@
                                                   (Parens
                                                    (BinOp (Var N) Add
                                                     (Parens
-                                                     (BinOp
+                                                     (BinOp (Var N) Multiply
                                                       (Parens
-                                                       (BinOp (Var N)
-                                                        Multiply (Var M)))
-                                                      Multiply (Var K)))))
+                                                       (BinOp (Var M)
+                                                        Multiply (Var K)))))))
                                                   Add (Var N)))
                                                 Add
                                                 (Parens
@@ -16043,60 +16246,52 @@
                                                   (Var N)))))
                                               Add
                                               (Parens
-                                               (BinOp
+                                               (BinOp (Var N) Multiply
                                                 (Parens
-                                                 (BinOp
+                                                 (BinOp (Var M) Multiply
                                                   (Parens
-                                                   (BinOp (Var N) Multiply
-                                                    (Var M)))
-                                                  Multiply (Var K)))
-                                                Multiply (Var N)))))
+                                                   (BinOp (Var K) Multiply
+                                                    (Var N)))))))))
                                             Add (Var N)))
                                           Add
                                           (Parens
                                            (BinOp (Var N) Multiply (Var N)))))
                                         Add
                                         (Parens
-                                         (BinOp
+                                         (BinOp (Var N) Multiply
                                           (Parens
-                                           (BinOp
+                                           (BinOp (Var M) Multiply
                                             (Parens
-                                             (BinOp (Var N) Multiply (Var M)))
-                                            Multiply (Var K)))
-                                          Multiply (Var N)))))
+                                             (BinOp (Var K) Multiply (Var N)))))))))
                                       Add
                                       (Parens
                                        (BinOp (Literal 5) Multiply
                                         (Literal 4)))))
                                     Add
                                     (Parens
-                                     (BinOp
+                                     (BinOp (Literal 4) Multiply
                                       (Parens
-                                       (BinOp
+                                       (BinOp (Literal 5) Multiply
                                         (Parens
-                                         (BinOp (Literal 4) Multiply
-                                          (Literal 5)))
-                                        Multiply (Literal 2)))
-                                      Multiply (Literal 3)))))
+                                         (BinOp (Literal 2) Multiply
+                                          (Literal 3)))))))))
                                   Add (Var N)))
                                 Add
                                 (Parens (BinOp (Var N) Multiply (Var N)))))
                               Add
                               (Parens
-                               (BinOp
+                               (BinOp (Var N) Multiply
                                 (Parens
-                                 (BinOp
-                                  (Parens (BinOp (Var N) Multiply (Var M)))
-                                  Multiply (Var K)))
-                                Multiply (Var N)))))
+                                 (BinOp (Var M) Multiply
+                                  (Parens (BinOp (Var K) Multiply (Var N)))))))))
                             Add
                             (Parens (BinOp (Literal 5) Multiply (Literal 4)))))
                           Add
                           (Parens (BinOp (Literal 3) Multiply (Literal 3)))))
                         Add
                         (Parens
-                         (BinOp (Parens (BinOp (Var K) Multiply (Literal 3)))
-                          Multiply (Literal 3)))))
+                         (BinOp (Var K) Multiply
+                          (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
                       Add (Literal 2)))
                     Add (Literal 1)))))))))
             (VariableDefn
@@ -16166,13 +16361,13 @@
                                                                   Add
                                                                   (Parens
                                                                    (BinOp
-                                                                    (Parens
-                                                                    (BinOp
                                                                     (Var N)
                                                                     Multiply
-                                                                    (Var M)))
+                                                                    (Parens
+                                                                    (BinOp
+                                                                    (Var M)
                                                                     Multiply
-                                                                    (Var K)))))
+                                                                    (Var K)))))))
                                                                 Add (Var N)))
                                                               Add
                                                               (Parens
@@ -16182,18 +16377,17 @@
                                                                 (Var N)))))
                                                             Add
                                                             (Parens
-                                                             (BinOp
+                                                             (BinOp (Var N)
+                                                              Multiply
                                                               (Parens
-                                                               (BinOp
+                                                               (BinOp 
+                                                                (Var M)
+                                                                Multiply
                                                                 (Parens
                                                                  (BinOp
-                                                                  (Var N)
+                                                                  (Var K)
                                                                   Multiply
-                                                                  (Var M)))
-                                                                Multiply
-                                                                (Var K)))
-                                                              Multiply
-                                                              (Var N)))))
+                                                                  (Var N)))))))))
                                                           Add (Var N)))
                                                         Add
                                                         (Parens
@@ -16201,26 +16395,26 @@
                                                           Multiply (Var N)))))
                                                       Add
                                                       (Parens
-                                                       (BinOp
+                                                       (BinOp (Var N)
+                                                        Multiply
                                                         (Parens
-                                                         (BinOp
+                                                         (BinOp (Var M)
+                                                          Multiply
                                                           (Parens
-                                                           (BinOp (Var N)
+                                                           (BinOp (Var K)
                                                             Multiply 
-                                                            (Var M)))
-                                                          Multiply (Var K)))
-                                                        Multiply (Var N)))))
+                                                            (Var N)))))))))
                                                     Add
                                                     (Parens
-                                                     (BinOp
+                                                     (BinOp (Literal 4)
+                                                      Multiply
                                                       (Parens
-                                                       (BinOp
+                                                       (BinOp (Literal 5)
+                                                        Multiply
                                                         (Parens
-                                                         (BinOp (Literal 4)
+                                                         (BinOp (Literal 2)
                                                           Multiply
-                                                          (Literal 5)))
-                                                        Multiply (Literal 2)))
-                                                      Multiply (Literal 3)))))
+                                                          (Literal 3)))))))))
                                                   Add (Var N)))
                                                 Add
                                                 (Parens
@@ -16228,14 +16422,12 @@
                                                   (Var N)))))
                                               Add
                                               (Parens
-                                               (BinOp
+                                               (BinOp (Var N) Multiply
                                                 (Parens
-                                                 (BinOp
+                                                 (BinOp (Var M) Multiply
                                                   (Parens
-                                                   (BinOp (Var N) Multiply
-                                                    (Var M)))
-                                                  Multiply (Var K)))
-                                                Multiply (Var N)))))
+                                                   (BinOp (Var K) Multiply
+                                                    (Var N)))))))))
                                             Add
                                             (Parens
                                              (BinOp (Literal 5) Multiply
@@ -16246,53 +16438,45 @@
                                             (Literal 3)))))
                                         Add
                                         (Parens
-                                         (BinOp
+                                         (BinOp (Var K) Multiply
                                           (Parens
-                                           (BinOp (Var K) Multiply
-                                            (Literal 3)))
-                                          Multiply (Literal 3)))))
+                                           (BinOp (Literal 3) Multiply
+                                            (Literal 3)))))))
                                       Add (Literal 3)))
                                     Add
                                     (Parens
-                                     (BinOp
+                                     (BinOp (Literal 5) Multiply
                                       (Parens
-                                       (BinOp (Literal 5) Multiply
-                                        (Literal 3)))
-                                      Multiply (Literal 4)))))
+                                       (BinOp (Literal 3) Multiply
+                                        (Literal 4)))))))
                                   Add
                                   (Parens
-                                   (BinOp
+                                   (BinOp (Literal 3) Multiply
                                     (Parens
-                                     (BinOp (Literal 3) Multiply (Literal 3)))
-                                    Multiply (Literal 4)))))
+                                     (BinOp (Literal 3) Multiply (Literal 4)))))))
                                 Add
                                 (Parens
-                                 (BinOp
+                                 (BinOp (Literal 5) Multiply
                                   (Parens
-                                   (BinOp (Literal 5) Multiply (Literal 3)))
-                                  Multiply (Literal 4)))))
+                                   (BinOp (Literal 3) Multiply (Literal 4)))))))
                               Add
                               (Parens
-                               (BinOp
+                               (BinOp (Literal 3) Multiply
                                 (Parens
-                                 (BinOp (Literal 3) Multiply (Literal 3)))
-                                Multiply (Literal 3)))))
+                                 (BinOp (Literal 3) Multiply (Literal 3)))))))
                             Add
                             (Parens
-                             (BinOp
+                             (BinOp (Literal 3) Multiply
                               (Parens
-                               (BinOp (Literal 3) Multiply (Literal 3)))
-                              Multiply (Literal 4)))))
+                               (BinOp (Literal 3) Multiply (Literal 4)))))))
                           Add
                           (Parens
-                           (BinOp
-                            (Parens (BinOp (Literal 5) Multiply (Literal 3)))
-                            Multiply (Literal 4)))))
+                           (BinOp (Literal 5) Multiply
+                            (Parens (BinOp (Literal 3) Multiply (Literal 4)))))))
                         Add
                         (Parens
-                         (BinOp
-                          (Parens (BinOp (Literal 3) Multiply (Literal 3)))
-                          Multiply (Literal 3)))))
+                         (BinOp (Literal 3) Multiply
+                          (Parens (BinOp (Literal 3) Multiply (Literal 3)))))))
                       Add (Parens (BinOp (Literal 3) Multiply (Literal 4)))))
                     Add (Parens (BinOp (Literal 2) Multiply (Literal 2)))))))))))
             (VariableDefn
@@ -20881,31 +21065,31 @@
                              Add (Var N))
                             Add
                             (Parens
-                             (BinOp (BinOp (Var N) Multiply (Var M)) Multiply
-                              (Var K))))
+                             (BinOp (Var N) Multiply
+                              (Parens (BinOp (Var M) Multiply (Var K))))))
                            Add (Var N))
                           Add (Parens (BinOp (Var N) Multiply (Var N))))
                          Add
                          (Parens
-                          (BinOp
-                           (BinOp (BinOp (Var N) Multiply (Var M)) Multiply
-                            (Var K))
-                           Multiply (Var N))))
+                          (BinOp (Var N) Multiply
+                           (Parens
+                            (BinOp (Var M) Multiply
+                             (Parens (BinOp (Var K) Multiply (Var N))))))))
                         Add (Var N))
                        Add (Parens (BinOp (Var N) Multiply (Var N))))
                       Add
                       (Parens
-                       (BinOp
-                        (BinOp (BinOp (Var N) Multiply (Var M)) Multiply
-                         (Var K))
-                        Multiply (Var N))))
+                       (BinOp (Var N) Multiply
+                        (Parens
+                         (BinOp (Var M) Multiply
+                          (Parens (BinOp (Var K) Multiply (Var N))))))))
                      Add (Parens (BinOp (Literal 5) Multiply (Literal 4))))
                     Add
                     (Parens
-                     (BinOp
-                      (BinOp (BinOp (Literal 4) Multiply (Literal 5))
-                       Multiply (Literal 2))
-                      Multiply (Literal 3))))
+                     (BinOp (Literal 4) Multiply
+                      (Parens
+                       (BinOp (Literal 5) Multiply
+                        (Parens (BinOp (Literal 2) Multiply (Literal 3))))))))
                    Add (Parens (BinOp (Var N) Subtract (Literal 1))))
                   Add
                   (Parens
@@ -20913,9 +21097,12 @@
                     (Parens (BinOp (Var N) Subtract (Literal 1))))))
                  Add
                  (Parens
-                  (BinOp
-                   (BinOp (BinOp (Var N) Multiply (Var M)) Multiply (Var K))
-                   Multiply (Parens (BinOp (Var N) Subtract (Literal 1))))))
+                  (BinOp (Var N) Multiply
+                   (Parens
+                    (BinOp (Var M) Multiply
+                     (Parens
+                      (BinOp (Var K) Multiply
+                       (Parens (BinOp (Var N) Subtract (Literal 1))))))))))
                 Add
                 (Parens
                  (BinOp

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -555,6 +555,20 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(N),
+            static_cast<size_t>(1), static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((M * N))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1400,6 +1414,21 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((N_t * 4)), static_cast<size_t>((N_t * 4))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -7220,6 +7220,21 @@ class distributions_model final : public model_base_crtp<distributions_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(d_int),
+            static_cast<size_t>((d_int * d_int)), static_cast<size_t>(d_int),
+            static_cast<size_t>(d_int), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -7993,6 +8008,21 @@ class restricted_model final : public model_base_crtp<restricted_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(d_int),
+            static_cast<size_t>((d_int * d_int)), static_cast<size_t>(d_int),
+            static_cast<size_t>(d_int), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -353,6 +353,16 @@ class simple_function_model final : public model_base_crtp<simple_function_model
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -1935,6 +1935,22 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -2751,6 +2767,20 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((N_t * 4))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -4774,6 +4804,19 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -5240,6 +5283,14 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     names__ = std::vector<std::string>{"X"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((N * N))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -6825,6 +6876,22 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(max_age)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -8094,6 +8161,23 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(n_age),
+            static_cast<size_t>(n_edu), static_cast<size_t>(n_region),
+            static_cast<size_t>((n_age * n_edu)),
+            static_cast<size_t>(n_state)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -8481,6 +8565,14 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -8783,6 +8875,14 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -9268,6 +9368,16 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(2), static_cast<size_t>(2),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -9679,6 +9789,16 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     names__ = std::vector<std::string>{"mu", "theta", "tau"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(J),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -10936,6 +11056,24 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(n_age), static_cast<size_t>(n_edu),
+            static_cast<size_t>(n_age_edu), static_cast<size_t>(n_state),
+            static_cast<size_t>(n_region_full), static_cast<size_t>(5),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -11711,6 +11849,28 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(phi_std_raw_1dim__)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(N), static_cast<size_t>(N),
+             static_cast<size_t>(N), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -13322,6 +13482,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(nind), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions)),
+             static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -16467,6 +16649,34 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(n_occasions),
+            static_cast<size_t>(M), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((M * phi_2dim__)),
+             static_cast<size_t>((M * n_occasions)),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -17012,7 +17222,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = (K - 1) + (J * K * (K - 1));
+    num_params_r__ = (K - 1) + (J * (K * (K - 1)));
   }
   inline std::string model_name() const final {
     return "expr_prop_fail7_model";
@@ -17675,6 +17885,19 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(K), static_cast<size_t>((J * (K * K)))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>((I * K))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -17759,7 +17982,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (K + ((J * K) * K));
+    const size_t num_params__ = (K + (J * (K * K)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * ((I * K));
     const size_t num_to_write = num_params__ + num_transformed +
@@ -17776,7 +17999,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (K + ((J * K) * K));
+    const size_t num_params__ = (K + (J * (K * K)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * ((I * K));
     const size_t num_to_write = num_params__ + num_transformed +
@@ -18361,6 +18584,22 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(N), static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -19978,6 +20217,22 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(max_age)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -20477,6 +20732,14 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -20915,6 +21178,14 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -21277,6 +21548,18 @@ class initialize_SoA_model final : public model_base_crtp<initialize_SoA_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(3)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(3)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -21889,6 +22172,19 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(5), static_cast<size_t>(5)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(5), static_cast<size_t>(5)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22294,6 +22590,14 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22668,6 +22972,19 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(N), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -25794,6 +26111,33 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(n_occasions),
+            static_cast<size_t>(epsilon_1dim__), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((M * phi_2dim__)),
+             static_cast<size_t>((M * n_occasions)),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -26233,6 +26577,14 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -26551,6 +26903,14 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     names__ = std::vector<std::string>{"x"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -26886,6 +27246,14 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     names__ = std::vector<std::string>{"theta"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(J)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -28308,6 +28676,21 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -28809,6 +29192,23 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -29636,6 +30036,27 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(R), static_cast<size_t>((R * T))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(R),
+             static_cast<size_t>(R)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -30532,6 +30953,24 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(J),
+            static_cast<size_t>(J), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(J), static_cast<size_t>(J),
+             static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -31763,6 +32202,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>((3 * 2)), static_cast<size_t>(2),
+            static_cast<size_t>((2 * 2))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -32125,6 +32575,14 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -32480,6 +32938,14 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -33209,6 +33675,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(n_pair), static_cast<size_t>(2),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -36898,6 +37379,15 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -37860,6 +38350,21 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>((I * K))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -38450,6 +38955,18 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((2 * 5))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -38907,6 +39424,21 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -39490,6 +40022,18 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -330,6 +330,22 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1071,6 +1087,20 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((N_t * 4))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1495,6 +1525,19 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -1938,6 +1981,14 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     names__ = std::vector<std::string>{"X"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((N * N))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -2800,6 +2851,22 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(max_age)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -3896,6 +3963,23 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(n_age),
+            static_cast<size_t>(n_edu), static_cast<size_t>(n_region),
+            static_cast<size_t>((n_age * n_edu)),
+            static_cast<size_t>(n_state)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -4281,6 +4365,14 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -4580,6 +4672,14 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -5020,6 +5120,16 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(2), static_cast<size_t>(2),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -5428,6 +5538,16 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     names__ = std::vector<std::string>{"mu", "theta", "tau"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(J),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -6450,6 +6570,24 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(n_age), static_cast<size_t>(n_edu),
+            static_cast<size_t>(n_age_edu), static_cast<size_t>(n_state),
+            static_cast<size_t>(n_region_full), static_cast<size_t>(5),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -7150,6 +7288,28 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(phi_std_raw_1dim__)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(N), static_cast<size_t>(N),
+             static_cast<size_t>(N), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -8101,6 +8261,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(nind), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions)),
+             static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -9596,6 +9778,34 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(n_occasions),
+            static_cast<size_t>(M), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((M * phi_2dim__)),
+             static_cast<size_t>((M * n_occasions)),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -10068,7 +10278,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = (K - 1) + (J * K * (K - 1));
+    num_params_r__ = (K - 1) + (J * (K * (K - 1)));
   }
   inline std::string model_name() const final {
     return "expr_prop_fail7_model";
@@ -10393,6 +10603,19 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(K), static_cast<size_t>((J * (K * K)))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>((I * K))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -10477,7 +10700,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (K + ((J * K) * K));
+    const size_t num_params__ = (K + (J * (K * K)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * ((I * K));
     const size_t num_to_write = num_params__ + num_transformed +
@@ -10494,7 +10717,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (K + ((J * K) * K));
+    const size_t num_params__ = (K + (J * (K * K)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * ((I * K));
     const size_t num_to_write = num_params__ + num_transformed +
@@ -11033,6 +11256,22 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(N), static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -11928,6 +12167,22 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(max_age)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -12344,6 +12599,14 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -12717,6 +12980,14 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -13058,6 +13329,18 @@ class initialize_SoA_model final : public model_base_crtp<initialize_SoA_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(3)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(3)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -13551,6 +13834,19 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(5), static_cast<size_t>(5)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(5), static_cast<size_t>(5)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -13947,6 +14243,14 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -14297,6 +14601,19 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(N), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -15704,6 +16021,33 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(n_occasions),
+            static_cast<size_t>(epsilon_1dim__), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((M * phi_2dim__)),
+             static_cast<size_t>((M * n_occasions)),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -16142,6 +16486,14 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -16459,6 +16811,14 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     names__ = std::vector<std::string>{"x"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -16792,6 +17152,14 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     names__ = std::vector<std::string>{"theta"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(J)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -17566,6 +17934,21 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -18027,6 +18410,23 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -18697,6 +19097,27 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(R), static_cast<size_t>((R * T))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(R),
+             static_cast<size_t>(R)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -19484,6 +19905,24 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(J),
+            static_cast<size_t>(J), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(J), static_cast<size_t>(J),
+             static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -20454,6 +20893,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>((3 * 2)), static_cast<size_t>(2),
+            static_cast<size_t>((2 * 2))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -20805,6 +21255,14 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -21145,6 +21603,14 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -21772,6 +22238,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(n_pair), static_cast<size_t>(2),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22289,6 +22770,15 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     names__ = std::vector<std::string>{"m2", "m3"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -22934,6 +23424,21 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>((I * K))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -23333,6 +23838,18 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((2 * 5))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -23719,6 +24236,21 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -24053,6 +24585,18 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -329,6 +329,22 @@ class ad_level_deep_dependence_model final : public model_base_crtp<ad_level_dee
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1068,6 +1084,20 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((N_t * 4))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -1491,6 +1521,19 @@ class ad_levels_deep_model final : public model_base_crtp<ad_levels_deep_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -1927,6 +1970,14 @@ class copy_prop_profile_model final : public model_base_crtp<copy_prop_profile_m
     names__ = std::vector<std::string>{"X"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((N * N))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -2901,6 +2952,22 @@ class copy_fail_model final : public model_base_crtp<copy_fail_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(max_age)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -3979,6 +4046,23 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(n_age),
+            static_cast<size_t>(n_edu), static_cast<size_t>(n_region),
+            static_cast<size_t>((n_age * n_edu)),
+            static_cast<size_t>(n_state)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -4364,6 +4448,14 @@ class expr_prop_experiment_model final : public model_base_crtp<expr_prop_experi
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -4663,6 +4755,14 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -5096,6 +5196,16 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(2), static_cast<size_t>(2),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -5501,6 +5611,16 @@ class expr_prop_fail2_model final : public model_base_crtp<expr_prop_fail2_model
     names__ = std::vector<std::string>{"mu", "theta", "tau"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(J),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -6517,6 +6637,24 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(n_age), static_cast<size_t>(n_edu),
+            static_cast<size_t>(n_age_edu), static_cast<size_t>(n_state),
+            static_cast<size_t>(n_region_full), static_cast<size_t>(5),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -7218,6 +7356,28 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(phi_std_raw_1dim__)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(N), static_cast<size_t>(N),
+             static_cast<size_t>(N), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -8281,6 +8441,28 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(nind), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions)),
+             static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -10159,6 +10341,34 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(n_occasions),
+            static_cast<size_t>(M), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((M * phi_2dim__)),
+             static_cast<size_t>((M * n_occasions)),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -10631,7 +10841,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
-    num_params_r__ = (K - 1) + (J * K * (K - 1));
+    num_params_r__ = (K - 1) + (J * (K * (K - 1)));
   }
   inline std::string model_name() const final {
     return "expr_prop_fail7_model";
@@ -10945,6 +11155,19 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(K), static_cast<size_t>((J * (K * K)))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>((I * K))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -11029,7 +11252,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               emit_transformed_parameters = true, const bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (K + ((J * K) * K));
+    const size_t num_params__ = (K + (J * (K * K)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * ((I * K));
     const size_t num_to_write = num_params__ + num_transformed +
@@ -11046,7 +11269,7 @@ class expr_prop_fail7_model final : public model_base_crtp<expr_prop_fail7_model
               emit_transformed_parameters = true, bool
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
-    const size_t num_params__ = (K + ((J * K) * K));
+    const size_t num_params__ = (K + (J * (K * K)));
     const size_t num_transformed = emit_transformed_parameters * (0);
     const size_t num_gen_quantities = emit_generated_quantities * ((I * K));
     const size_t num_to_write = num_params__ + num_transformed +
@@ -11586,6 +11809,22 @@ class expr_prop_fail8_model final : public model_base_crtp<expr_prop_fail8_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(N), static_cast<size_t>(N)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -12593,6 +12832,22 @@ class fails_test_model final : public model_base_crtp<fails_test_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(max_age)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -13018,6 +13273,14 @@ class function_in_function_inline_model final : public model_base_crtp<function_
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -13412,6 +13675,14 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -13755,6 +14026,18 @@ class initialize_SoA_model final : public model_base_crtp<initialize_SoA_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(3)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(3)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -14300,6 +14583,19 @@ class inline_functions_varmat_model final : public model_base_crtp<inline_functi
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(5), static_cast<size_t>(5)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(5), static_cast<size_t>(5)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -14697,6 +14993,14 @@ class inline_tdata_model final : public model_base_crtp<inline_tdata_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -15079,6 +15383,19 @@ class inliner_same_names_model final : public model_base_crtp<inliner_same_names
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(N), static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -16902,6 +17219,33 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(n_occasions),
+            static_cast<size_t>(epsilon_1dim__), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((M * phi_2dim__)),
+             static_cast<size_t>((M * n_occasions)),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions), static_cast<size_t>(1),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>(n_occasions),
+             static_cast<size_t>((M * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -17340,6 +17684,14 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -17656,6 +18008,14 @@ class lcm_experiment2_model final : public model_base_crtp<lcm_experiment2_model
     names__ = std::vector<std::string>{"x"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -17986,6 +18346,14 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
     names__ = std::vector<std::string>{"theta"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(J)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -18876,6 +19244,21 @@ class lcm_fails2_model final : public model_base_crtp<lcm_fails2_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occ_minus_1)),
+             static_cast<size_t>((nind * n_occasions))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -19379,6 +19762,23 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -20043,6 +20443,27 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(R), static_cast<size_t>((R * T))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(R),
+             static_cast<size_t>(R)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -20826,6 +21247,24 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(J),
+            static_cast<size_t>(J), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(J), static_cast<size_t>(J),
+             static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -21781,6 +22220,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>((3 * 2)), static_cast<size_t>(2),
+            static_cast<size_t>((2 * 2))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22132,6 +22582,14 @@ class overloaded_fn_model final : public model_base_crtp<overloaded_fn_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -22473,6 +22931,14 @@ class overloaded_fn2_model final : public model_base_crtp<overloaded_fn2_model> 
     names__ = std::vector<std::string>{};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -23097,6 +23563,21 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(n_pair), static_cast<size_t>(2),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(N)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -23607,6 +24088,15 @@ class partial_eval_multiply_model final : public model_base_crtp<partial_eval_mu
     names__ = std::vector<std::string>{"m2", "m3"};
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -24254,6 +24744,21 @@ class stalled1_failure_model final : public model_base_crtp<stalled1_failure_mod
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>((I * K))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -24653,6 +25158,18 @@ class unenforce_initialize_should_fail_model final : public model_base_crtp<unen
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((2 * 5))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -25036,6 +25553,21 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>(1)};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(1), static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -25370,6 +25902,18 @@ class unroll_limit_model final : public model_base_crtp<unroll_limit_model> {
       names__.reserve(names__.size() + temp.size());
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -215,6 +215,18 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((10 * (10 * 2)))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -294,8 +306,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
     const size_t num_params__ = (10 * 10);
-    const size_t num_transformed = emit_transformed_parameters * (((10 * 10)
-      * 2));
+    const size_t num_transformed = emit_transformed_parameters * ((10 * (10 *
+      2)));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -312,8 +324,8 @@ class complex_fails_model final : public model_base_crtp<complex_fails_model> {
               emit_generated_quantities = true, std::ostream*
               pstream = nullptr) const {
     const size_t num_params__ = (10 * 10);
-    const size_t num_transformed = emit_transformed_parameters * (((10 * 10)
-      * 2));
+    const size_t num_transformed = emit_transformed_parameters * ((10 * (10 *
+      2)));
     const size_t num_gen_quantities = emit_generated_quantities * (0);
     const size_t num_to_write = num_params__ + num_transformed +
       num_gen_quantities;
@@ -2162,6 +2174,34 @@ class constraints_model final : public model_base_crtp<constraints_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(N), static_cast<size_t>(K),
+            static_cast<size_t>(Nr), static_cast<size_t>(2),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(1), static_cast<size_t>(1),
+            static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>(1), static_cast<size_t>(N),
+            static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>((N * N)), static_cast<size_t>((N * N)),
+            static_cast<size_t>((K * K)), static_cast<size_t>((K * K))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(1),
+             static_cast<size_t>(N), static_cast<size_t>(Nr),
+             static_cast<size_t>(Nr), static_cast<size_t>(Nr),
+             static_cast<size_t>(Nr), static_cast<size_t>(Nr),
+             static_cast<size_t>(Nr)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -2867,6 +2907,22 @@ class deep_dependence_model final : public model_base_crtp<deep_dependence_model
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t> sizes{static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -4969,6 +5025,32 @@ class indexing_model final : public model_base_crtp<indexing_model> {
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(M),
+            static_cast<size_t>((N * M)), static_cast<size_t>((10 * N)),
+            static_cast<size_t>((N * M)), static_cast<size_t>(N),
+            static_cast<size_t>((N * M)), static_cast<size_t>(N),
+            static_cast<size_t>(N), static_cast<size_t>(N),
+            static_cast<size_t>((N * M)), static_cast<size_t>(M),
+            static_cast<size_t>(M), static_cast<size_t>(M),
+            static_cast<size_t>(M), static_cast<size_t>((N * M)),
+            static_cast<size_t>((N * M)), static_cast<size_t>((N * M)),
+            static_cast<size_t>((N * M)), static_cast<size_t>((N * M)),
+            static_cast<size_t>((N * M))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>(M),
+             static_cast<size_t>(M), static_cast<size_t>(M),
+             static_cast<size_t>(M)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -5699,6 +5781,15 @@ class indexing2_model final : public model_base_crtp<indexing2_model> {
     if (emit_transformed_parameters__) {}
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>(1), static_cast<size_t>(10)};
+    if (emit_transformed_parameters__) {}
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -6257,6 +6348,22 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((5 * 10)), static_cast<size_t>((5 * 10)),
+            static_cast<size_t>((5 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>(1), static_cast<size_t>((5 * 10)),
+             static_cast<size_t>((5 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
@@ -6852,6 +6959,22 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t>
+        temp{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10)),
+             static_cast<size_t>((10 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -7403,6 +7526,19 @@ class single_indexing_model final : public model_base_crtp<single_indexing_model
     }
     if (emit_generated_quantities__) {}
   }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((10 * 10)), static_cast<size_t>((10 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>(1)};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
+  }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool
            emit_transformed_parameters__ = true, const bool
@@ -7906,6 +8042,19 @@ class tp_reused_model final : public model_base_crtp<tp_reused_model> {
       names__.insert(names__.end(), temp.begin(), temp.end());
     }
     if (emit_generated_quantities__) {}
+  }
+  inline std::vector<size_t>
+  get_param_sizes(const bool emit_transformed_parameters__ = true, const bool
+                  emit_generated_quantities__ = true) const {
+    std::vector<size_t>
+      sizes{static_cast<size_t>((5 * 10)), static_cast<size_t>((5 * 10))};
+    if (emit_transformed_parameters__) {
+      std::vector<size_t> temp{static_cast<size_t>((5 * 10))};
+      sizes.reserve(sizes.size() + temp.size());
+      sizes.insert(sizes.end(), temp.begin(), temp.end());
+    }
+    if (emit_generated_quantities__) {}
+    return sizes;
   }
   inline void
   get_dims(std::vector<std::vector<size_t>>& dimss__, const bool


### PR DESCRIPTION
This PR splits off some small changes from #1100 and adds a new function called `get_param_sizes` with signature:

```C++
std::vector<size_t> get_param_sizes(const bool emit_transformed_parameters__ = true,
                                    const bool emit_generated_quantities__ = true)
```

This function is forward-compatible with all future types we have discussed for Stan (they will always have a size), and makes it possible to re-write things like `random_var_context` to not depend on `get_dims`, which is _not_ forward compatible and assumes rectangular dimensions.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Added code-generation for a new function `get_param_sizes`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
