### PR TITLE
--filename-in-msg updates wording of runtime exceptions, too

### DIFF
--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -885,12 +885,13 @@ let new_model_boilerplate prog_name =
       (IfNDef ("USING_R", [GlobalComment "Boilerplate"; new_model; profile_data])
       ) ]
 
-let lower_program (p : Program.Typed.t) : Cpp.program =
+let lower_program ?printed_filename (p : Program.Typed.t) : Cpp.program =
   (* First, do some transformations on the MIR itself before we begin printing it.*)
   let p, s, map_rect_calls = Numbering.prepare_prog p in
   let model_namespace_str = namespace p in
   let model_contents =
-    usings @ Numbering.gen_globals s
+    usings
+    @ Numbering.gen_globals ?printed_filename s
     @ collect_functors_functions p
     @ if !standalone_functions then [] else [lower_model p] in
   let model_namespace = Namespace (model_namespace_str, model_contents) in

--- a/src/stan_math_backend/Lower_program.mli
+++ b/src/stan_math_backend/Lower_program.mli
@@ -4,4 +4,4 @@ open Middle
 
 val standalone_functions : bool ref
 val stanc_args_to_print : string ref
-val lower_program : Program.Typed.t -> Cpp.program
+val lower_program : ?printed_filename:string -> Program.Typed.t -> Cpp.program

--- a/src/stan_math_backend/Numbering.ml
+++ b/src/stan_math_backend/Numbering.ml
@@ -59,12 +59,13 @@ let prepare_prog (mir : Program.Typed.t) :
   let map_rect_calls_list = List.sort ~compare (Queue.to_list map_rect_calls) in
   (mir, location_list, map_rect_calls_list)
 
-let gen_globals location_list =
+let gen_globals ?printed_filename location_list =
   let open Cpp in
   let location_list =
     " (found before start of program)"
     :: ( List.filter ~f:(fun x -> x <> Location_span.empty) location_list
-       |> List.map ~f:(fun x -> " (in " ^ Location_span.to_string x ^ ")") )
+       |> List.map ~f:(fun x ->
+              " (in " ^ Location_span.to_string ?printed_filename x ^ ")" ) )
     |> List.map ~f:Exprs.literal_string in
   let location_count = List.length location_list in
   let arr_type = Types.const_char_array location_count in

--- a/src/stan_math_backend/Numbering.mli
+++ b/src/stan_math_backend/Numbering.mli
@@ -17,7 +17,7 @@ val prepare_prog :
   Program.Typed.t -> Program.Numbered.t * state_t * map_rect_registration_t
 
 val no_span_num : Stmt.Numbered.Meta.t
-val gen_globals : state_t -> Cpp.defn list
+val gen_globals : ?printed_filename:string -> state_t -> Cpp.defn list
 val assign_loc : Stmt.Numbered.Meta.t -> Cpp.stmt list
 
 val register_map_rect_functors :

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -375,7 +375,7 @@ let use_file filename =
         [%sexp (opt_mir : Middle.Program.Typed.t)] ;
     if !dump_opt_mir_pretty then Program.Typed.pp Format.std_formatter opt_mir ;
     if !output_file = "" then output_file := remove_dotstan !model_file ^ ".hpp" ;
-    let cpp = Lower_program.lower_program opt_mir in
+    let cpp = Lower_program.lower_program ?printed_filename opt_mir in
     if !dump_lir then
       Sexp.pp_hum Format.std_formatter [%sexp (cpp : Cpp.program)] ;
     let cpp_str = Fmt.(to_to_string Cpp.Printing.pp_program) cpp in

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -131,7 +131,10 @@ let stan2cpp model_name model_string is_flag_set flag_val =
         if is_flag_set "debug-transformed-mir-pretty" then
           r.return
             (Result.Ok (Fmt.str "%a" Program.Typed.pp tx_mir), warnings, []) ;
-        let cpp = Lower_program.lower_program opt_mir in
+        let cpp =
+          Lower_program.lower_program
+            ?printed_filename:(flag_val "filename-in-msg")
+            opt_mir in
         if is_flag_set "debug-lir" then
           r.return
             ( Result.Ok (Sexp.to_string_hum [%sexp (cpp : Cpp.program)])

--- a/test/integration/cli-args/filename-in-msg/filename_good.expected
+++ b/test/integration/cli-args/filename-in-msg/filename_good.expected
@@ -7,8 +7,8 @@ using namespace stan::math;
 stan::math::profile_map profiles__;
 static constexpr std::array<const char*, 3> locations_array__ =
   {" (found before start of program)",
-  " (in 'filename_good.stan', line 2, column 4 to column 11)",
-  " (in 'filename_good.stan', line 3, column 4 to column 19)"};
+  " (in 'foo.stan', line 2, column 4 to column 11)",
+  " (in 'foo.stan', line 3, column 4 to column 19)"};
 class filename_good_model final : public model_base_crtp<filename_good_model> {
  private:
   double p;


### PR DESCRIPTION
Closes #1333 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

`--filename-in-msg` now also affects the name of the file shown in runtime exceptions. Useful for interfaces which use mangled or temporary names during compilation.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
