### PR TITLE
Consider a return statement in an otherwise infinite loop as 'complete'

### DIFF
--- a/test/integration/bad/noninfinite_loop_return1.stan
+++ b/test/integration/bad/noninfinite_loop_return1.stan
@@ -1,0 +1,20 @@
+functions {
+  int bin_search(real x, int min_val, int max_val) {
+    if (min_val > x || max_val < x)
+      reject("require min < x < max, found min = ", min_val, "; max = ",
+             max_val, "; x = ", x);
+    real y = round(x);
+    int range = max_val - min_val;
+    int mid_pt = min_val;
+    while (00_00) {
+      if (range == 0)
+        return mid_pt;
+      range = (range + 1) %/% 2;
+      mid_pt += y > mid_pt ? range : -range;
+    }
+  }
+}
+transformed data {
+  int N = bin_search(34.5, 0, 50);
+  print(N);
+}

--- a/test/integration/bad/noninfinite_loop_return2.stan
+++ b/test/integration/bad/noninfinite_loop_return2.stan
@@ -1,0 +1,20 @@
+functions {
+  int bin_search(real x, int min_val, int max_val) {
+    if (min_val > x || max_val < x)
+      reject("require min < x < max, found min = ", min_val, "; max = ",
+             max_val, "; x = ", x);
+    real y = round(x);
+    int range = max_val - min_val;
+    int mid_pt = min_val;
+    while (1 - 1) {
+      if (range == 0)
+        return mid_pt;
+      range = (range + 1) %/% 2;
+      mid_pt += y > mid_pt ? range : -range;
+    }
+  }
+}
+transformed data {
+  int N = bin_search(34.5, 0, 50);
+  print(N);
+}

--- a/test/integration/bad/noninfinite_loop_return3.stan
+++ b/test/integration/bad/noninfinite_loop_return3.stan
@@ -1,0 +1,13 @@
+functions {
+  real not_endless() {
+    while (1) {
+      if (0) return 1.0;
+      if (0)
+      break;
+    }
+  }
+}
+
+transformed parameters {
+  real a = not_endless();
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1584,6 +1584,28 @@ Semantic error in 'multiply_sample.stan', line 5, column 2 to column 18:
    -------------------------------------------------
 
 Ill-typed arguments to '~' statement. No distribution 'multiply' was found.
+  $ ../../../../install/default/bin/stanc noninfinite_loop_return1.stan
+Semantic error in 'noninfinite_loop_return1.stan', line 2, column 2 to line 15, column 3:
+   -------------------------------------------------
+     1:  functions {
+     2:    int bin_search(real x, int min_val, int max_val) {
+           ^
+     3:      if (min_val > x || max_val < x)
+     4:        reject("require min < x < max, found min = ", min_val, "; max = ",
+   -------------------------------------------------
+
+Function bodies must contain a return statement of correct type in every branch.
+  $ ../../../../install/default/bin/stanc noninfinite_loop_return2.stan
+Semantic error in 'noninfinite_loop_return2.stan', line 2, column 2 to line 15, column 3:
+   -------------------------------------------------
+     1:  functions {
+     2:    int bin_search(real x, int min_val, int max_val) {
+           ^
+     3:      if (min_val > x || max_val < x)
+     4:        reject("require min < x < max, found min = ", min_val, "; max = ",
+   -------------------------------------------------
+
+Function bodies must contain a return statement of correct type in every branch.
   $ ../../../../install/default/bin/stanc oneline-error.stan
 Syntax error in 'oneline-error.stan', line 1, column 20 to column 21, parsing error:
    -------------------------------------------------

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1606,6 +1606,17 @@ Semantic error in 'noninfinite_loop_return2.stan', line 2, column 2 to line 15, 
    -------------------------------------------------
 
 Function bodies must contain a return statement of correct type in every branch.
+  $ ../../../../install/default/bin/stanc noninfinite_loop_return3.stan
+Semantic error in 'noninfinite_loop_return3.stan', line 2, column 2 to line 8, column 3:
+   -------------------------------------------------
+     1:  functions {
+     2:    real not_endless() {
+           ^
+     3:      while (1) {
+     4:        if (0) return 1.0;
+   -------------------------------------------------
+
+Function bodies must contain a return statement of correct type in every branch.
   $ ../../../../install/default/bin/stanc oneline-error.stan
 Syntax error in 'oneline-error.stan', line 1, column 20 to column 21, parsing error:
    -------------------------------------------------

--- a/test/integration/good/infinite_loop_return.stan
+++ b/test/integration/good/infinite_loop_return.stan
@@ -1,0 +1,20 @@
+functions {
+  int bin_search(real x, int min_val, int max_val) {
+    if (min_val > x || max_val < x) 
+      reject("require min < x < max, found min = ", min_val, "; max = ",
+             max_val, "; x = ", x);
+    real y = round(x);
+    int range = max_val - min_val;
+    int mid_pt = min_val;
+    while (1) {
+      if (range == 0) 
+        return mid_pt;
+      range = (range + 1) %/% 2;
+      mid_pt += y > mid_pt ? range : -range;
+    }
+  }
+}
+transformed data {
+  int N = bin_search(34.5, 0, 50);
+  print(N);
+}

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -3486,6 +3486,28 @@ model {
   target += h;
 }
 
+  $ ../../../../install/default/bin/stanc --auto-format infinite_loop_return.stan
+functions {
+  int bin_search(real x, int min_val, int max_val) {
+    if (min_val > x || max_val < x) 
+      reject("require min < x < max, found min = ", min_val, "; max = ",
+             max_val, "; x = ", x);
+    real y = round(x);
+    int range = max_val - min_val;
+    int mid_pt = min_val;
+    while (1) {
+      if (range == 0) 
+        return mid_pt;
+      range = (range + 1) %/% 2;
+      mid_pt += y > mid_pt ? range : -range;
+    }
+  }
+}
+transformed data {
+  int N = bin_search(34.5, 0, 50);
+  print(N);
+}
+
   $ ../../../../install/default/bin/stanc --auto-format int_fun.stan
 functions {
   int foo(int x) {


### PR DESCRIPTION
This fixes an issue that @bob-carpenter pointed out in (at least) October 2019 [on the forums](https://discourse.mc-stan.org/t/real-to-integer-conversion/5622/9?u=wardbrian) where a function with an infinite loop which obviously is the only way out of the function still requires a dummy return statement after the loop to typecheck.

The solution here is pretty narrow: loops are considered infinite if and only if they have a nonzero integer literal as their loop expression. If a loop is infinite, we treat what would normally be considered an "incomplete" return as a full one.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Hard-coded infinite loops like `while (1)` which contain a return statement are now considered valid without needing to put a dummy return statement afterwards.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
