### PR TITLE
[CI] Fix intermittent failures during build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -625,7 +625,7 @@ pipeline {
                             image 'stanorg/stanc3:debianfi'
                             //Forces image to ignore entrypoint
                             args "--entrypoint=\'\'"
-                            label 'linux'
+                            label 'linux && k40'
                         }
                     }
                     steps {
@@ -655,7 +655,7 @@ pipeline {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
                             args "--entrypoint=\'\'"
-                            label 'linux'
+                            label 'linux && k40'
                         }
                     }
                     steps {
@@ -685,7 +685,7 @@ pipeline {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
                             args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
-                            label 'linux'
+                            label 'linux && k40'
                         }
                     }
                     steps {
@@ -714,7 +714,7 @@ pipeline {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
                             args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
-                            label 'linux'
+                            label 'linux && k40'
                         }
                     }
                     steps {
@@ -741,7 +741,7 @@ pipeline {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
                             args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
-                            label 'linux'
+                            label 'linux && k40'
                         }
                     }
                     steps {
@@ -767,7 +767,7 @@ pipeline {
                         docker {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
-                            label 'linux'
+                            label 'linux && k40'
                             args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
                     }
@@ -794,7 +794,7 @@ pipeline {
                         docker {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
-                            label 'linux'
+                            label 'linux && k40'
                             args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
                     }
@@ -821,7 +821,7 @@ pipeline {
                         docker {
                             image 'stanorg/stanc3:staticfi'
                             //Forces image to ignore entrypoint
-                            label 'linux'
+                            label 'linux && k40'
                             args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                         }
                     }
@@ -847,7 +847,7 @@ pipeline {
                     agent {
                         docker {
                             image 'stanorg/stanc3:debian-windowsfi'
-                            label 'linux'
+                            label 'linux && k40'
                             //Forces image to ignore entrypoint
                             args "--group-add=987 --group-add=988 --entrypoint=\'\'"
                         }


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

A failure has been reported for [stanc3 master builds](https://jenkins.flatironinstitute.org/job/Stan/job/Stanc3/job/master/218/) in which, sometime the build fails with a permission issue.
Since each build runs in its own directory `dir("${env.WORKSPACE}/stancjs")` that leads me to think it's a user/group permission issue as it only fails when running on `jenkins2`. 
Thus a simple fix would be to simply use only `jenkins` as a build agent.


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
