### PR TITLE
Stop reserved words in parser to prevent worse parse errors later

### DIFF
--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -91,14 +91,10 @@ let has_int_or_real_type ue =
 
 (* -- General checks ---------------------------------------------- *)
 let reserved_keywords =
-  [ "for"; "in"; "while"; "repeat"; "until"; "if"; "then"; "else"; "true"
-  ; "false"; "target"; "int"; "real"; "complex"; "void"; "vector"; "simplex"
-  ; "unit_vector"; "ordered"; "positive_ordered"; "row_vector"; "matrix"
-  ; "cholesky_factor_corr"; "cholesky_factor_cov"; "corr_matrix"; "cov_matrix"
-  ; "functions"; "model"; "data"; "parameters"; "quantities"; "transformed"
-  ; "generated"; "profile"; "return"; "break"; "continue"; "increment_log_prob"
-  ; "get_lp"; "print"; "reject"; "typedef"; "struct"; "var"; "export"; "extern"
-  ; "static"; "auto" ]
+  (* parser stops most keywords currently in use, but we still have some extra
+     reserved for the future *)
+  [ "generated"; "quantities"; "transformed"; "repeat"; "until"; "then"; "true"
+  ; "false"; "typedef"; "struct"; "var"; "export"; "extern"; "static"; "auto" ]
 
 let verify_identifier id : unit =
   if id.name = !model_name then

--- a/src/frontend/parser.messages
+++ b/src/frontend/parser.messages
@@ -2,7 +2,7 @@ program: WHILE
 ##
 ## Concrete syntax: while
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 609.
 ##
 ## program' -> . program [ # ]
 ##
@@ -22,7 +22,7 @@ program: DATABLOCK LBRACE CHOLESKYFACTORCORR WHILE
 ##
 ## Concrete syntax: data { cholesky_factor_corr while
 ##
-## Ends in an error in state: 791.
+## Ends in an error in state: 801.
 ##
 ## top_var_type -> CHOLESKYFACTORCORR . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> CHOLESKYFACTORCORR . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -49,7 +49,7 @@ program: DATABLOCK LBRACE CHOLESKYFACTORCOV LBRACK WHILE
 ##
 ## Concrete syntax: data { cholesky_factor_cov [ while
 ##
-## Ends in an error in state: 781.
+## Ends in an error in state: 791.
 ##
 ## top_var_type -> CHOLESKYFACTORCOV LBRACK . lhs option(pair(COMMA,expression)) RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> CHOLESKYFACTORCOV LBRACK . non_lhs option(pair(COMMA,expression)) RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -70,7 +70,7 @@ program: DATABLOCK LBRACE CORRMATRIX WHILE
 ##
 ## Concrete syntax: data { corr_matrix while
 ##
-## Ends in an error in state: 743.
+## Ends in an error in state: 753.
 ##
 ## top_var_type -> CORRMATRIX . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> CORRMATRIX . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -91,7 +91,7 @@ program: DATABLOCK LBRACE COVMATRIX WHILE
 ##
 ## Concrete syntax: data { cov_matrix while
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 747.
 ##
 ## top_var_type -> COVMATRIX . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> COVMATRIX . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -106,7 +106,7 @@ program: DATABLOCK LBRACE INT LABRACK WHILE
 ##
 ## Concrete syntax: data { int < while
 ##
-## Ends in an error in state: 735.
+## Ends in an error in state: 745.
 ##
 ## range_constraint -> LABRACK . range RABRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ##
@@ -120,7 +120,7 @@ program: DATABLOCK LBRACE INT LBRACE
 ##
 ## Concrete syntax: data { int {
 ##
-## Ends in an error in state: 734.
+## Ends in an error in state: 744.
 ##
 ## top_var_type -> INT . range_constraint [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ##
@@ -140,7 +140,7 @@ program: DATABLOCK LBRACE ORDERED WHILE
 ##
 ## Concrete syntax: data { ordered while
 ##
-## Ends in an error in state: 713.
+## Ends in an error in state: 723.
 ##
 ## top_var_type -> ORDERED . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> ORDERED . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -161,7 +161,7 @@ program: DATABLOCK LBRACE POSITIVEORDERED WHILE
 ##
 ## Concrete syntax: data { positive_ordered while
 ##
-## Ends in an error in state: 707.
+## Ends in an error in state: 717.
 ##
 ## top_var_type -> POSITIVEORDERED . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> POSITIVEORDERED . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -176,7 +176,7 @@ program: DATABLOCK LBRACE RBRACE WHILE
 ##
 ## Concrete syntax: data { } while
 ##
-## Ends in an error in state: 849.
+## Ends in an error in state: 867.
 ##
 ## program -> option(function_block) option(data_block) . option(transformed_data_block) option(parameters_block) option(transformed_parameters_block) option(model_block) option(generated_quantities_block) EOF [ # ]
 ##
@@ -190,7 +190,7 @@ program: DATABLOCK LBRACE REAL IDENTIFIER SEMICOLON WHILE
 ##
 ## Concrete syntax: data { real foo ; while
 ##
-## Ends in an error in state: 841.
+## Ends in an error in state: 858.
 ##
 ## list(top_var_decl_no_assign) -> top_var_decl_no_assign . list(top_var_decl_no_assign) [ RBRACE ]
 ##
@@ -200,26 +200,11 @@ program: DATABLOCK LBRACE REAL IDENTIFIER SEMICOLON WHILE
 
 Only top-level variable declarations allowed in data and parameters blocks.
 
-program: DATABLOCK LBRACE REAL IDENTIFIER WHILE
-##
-## Concrete syntax: data { real foo while
-##
-## Ends in an error in state: 837.
-##
-## decl(top_var_type,no_assign) -> top_var_type decl_identifier . dims optional_assignment(no_assign) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
-## id_and_optional_assignment(no_assign) -> decl_identifier . optional_assignment(no_assign) [ SEMICOLON COMMA ]
-##
-## The known suffix of the stack is as follows:
-## top_var_type decl_identifier
-##
-
-";" is expected after a top-level variable declaration.
-
 program: DATABLOCK LBRACE REAL LBRACE
 ##
 ## Concrete syntax: data { real {
 ##
-## Ends in an error in state: 705.
+## Ends in an error in state: 715.
 ##
 ## top_var_type -> REAL . type_constraint [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ##
@@ -233,7 +218,7 @@ program: DATABLOCK LBRACE ROWVECTOR LABRACK MULTIPLIER ASSIGN IDENTIFIER RABRACK
 ##
 ## Concrete syntax: data { row_vector < multiplier = foo > while
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 709.
 ##
 ## top_var_type -> ROWVECTOR type_constraint . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> ROWVECTOR type_constraint . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -248,7 +233,7 @@ program: DATABLOCK LBRACE ROWVECTOR LBRACK IDENTIFIER TILDE
 ##
 ## Concrete syntax: data { row_vector [ foo ~
 ##
-## Ends in an error in state: 703.
+## Ends in an error in state: 713.
 ##
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES RBRACK RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
 ## lhs -> lhs . DOTNUMERAL [ TRANSPOSE TIMES RBRACK RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -313,7 +298,7 @@ program: DATABLOCK LBRACE ROWVECTOR LBRACK WHILE
 ##
 ## Concrete syntax: data { row_vector [ while
 ##
-## Ends in an error in state: 700.
+## Ends in an error in state: 710.
 ##
 ## top_var_type -> ROWVECTOR type_constraint LBRACK . lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> ROWVECTOR type_constraint LBRACK . non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -328,7 +313,7 @@ program: DATABLOCK LBRACE ROWVECTOR WHILE
 ##
 ## Concrete syntax: data { row_vector while
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 708.
 ##
 ## top_var_type -> ROWVECTOR . type_constraint LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> ROWVECTOR . type_constraint LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -349,7 +334,7 @@ program: DATABLOCK LBRACE SIMPLEX WHILE
 ##
 ## Concrete syntax: data { simplex while
 ##
-## Ends in an error in state: 692.
+## Ends in an error in state: 702.
 ##
 ## top_var_type -> SIMPLEX . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> SIMPLEX . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -370,7 +355,7 @@ program: DATABLOCK LBRACE UNITVECTOR WHILE
 ##
 ## Concrete syntax: data { unit_vector while
 ##
-## Ends in an error in state: 684.
+## Ends in an error in state: 694.
 ##
 ## top_var_type -> UNITVECTOR . LBRACK lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## top_var_type -> UNITVECTOR . LBRACK non_lhs RBRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -385,7 +370,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET ASSIGN IDENTIFIER COMMA MULTIPLI
 ##
 ## Concrete syntax: data { vector < offset = foo , multiplier = foo ,
 ##
-## Ends in an error in state: 658.
+## Ends in an error in state: 668.
 ##
 ## constr_expression -> constr_expression . PLUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
 ## constr_expression -> constr_expression . MINUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
@@ -409,7 +394,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET ASSIGN IDENTIFIER COMMA MULTIPLI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 615, spurious reduction of production constr_expression -> identifier
+## In state 625, spurious reduction of production constr_expression -> identifier
 ##
 
 Expected ">" after "multiplier = " expression.
@@ -418,7 +403,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET ASSIGN IDENTIFIER COMMA MULTIPLI
 ##
 ## Concrete syntax: data { vector < offset = foo , multiplier = while
 ##
-## Ends in an error in state: 657.
+## Ends in an error in state: 667.
 ##
 ## offset_mult -> OFFSET ASSIGN constr_expression COMMA MULTIPLIER ASSIGN . constr_expression [ RABRACK ]
 ##
@@ -432,7 +417,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET ASSIGN IDENTIFIER COMMA MULTIPLI
 ##
 ## Concrete syntax: data { vector < offset = foo , multiplier while
 ##
-## Ends in an error in state: 656.
+## Ends in an error in state: 666.
 ##
 ## offset_mult -> OFFSET ASSIGN constr_expression COMMA MULTIPLIER . ASSIGN constr_expression [ RABRACK ]
 ##
@@ -448,7 +433,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET ASSIGN IDENTIFIER COMMA WHILE
 ##
 ## Concrete syntax: data { vector < offset = foo , while
 ##
-## Ends in an error in state: 655.
+## Ends in an error in state: 665.
 ##
 ## offset_mult -> OFFSET ASSIGN constr_expression COMMA . MULTIPLIER ASSIGN constr_expression [ RABRACK ]
 ##
@@ -462,7 +447,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET ASSIGN WHILE
 ##
 ## Concrete syntax: data { vector < offset = while
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 663.
 ##
 ## offset_mult -> OFFSET ASSIGN . constr_expression COMMA MULTIPLIER ASSIGN constr_expression [ RABRACK ]
 ## offset_mult -> OFFSET ASSIGN . constr_expression [ RABRACK ]
@@ -477,7 +462,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK OFFSET WHILE
 ##
 ## Concrete syntax: data { vector < offset while
 ##
-## Ends in an error in state: 652.
+## Ends in an error in state: 662.
 ##
 ## offset_mult -> OFFSET . ASSIGN constr_expression COMMA MULTIPLIER ASSIGN constr_expression [ RABRACK ]
 ## offset_mult -> OFFSET . ASSIGN constr_expression [ RABRACK ]
@@ -521,7 +506,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER ASSIGN IDENTIFIER COMMA UPPER ASS
 ##
 ## Concrete syntax: data { vector < lower = foo , upper = foo ,
 ##
-## Ends in an error in state: 672.
+## Ends in an error in state: 682.
 ##
 ## constr_expression -> constr_expression . PLUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
 ## constr_expression -> constr_expression . MINUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
@@ -545,7 +530,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER ASSIGN IDENTIFIER COMMA UPPER ASS
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 615, spurious reduction of production constr_expression -> identifier
+## In state 625, spurious reduction of production constr_expression -> identifier
 ##
 
 Expected ">" after "upper = " expression.
@@ -556,7 +541,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER ASSIGN IDENTIFIER COMMA UPPER ASS
 ##
 ## Concrete syntax: data { vector < lower = foo , upper = while
 ##
-## Ends in an error in state: 671.
+## Ends in an error in state: 681.
 ##
 ## range -> LOWER ASSIGN constr_expression COMMA UPPER ASSIGN . constr_expression [ RABRACK ]
 ##
@@ -570,7 +555,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER ASSIGN IDENTIFIER COMMA UPPER WHI
 ##
 ## Concrete syntax: data { vector < lower = foo , upper while
 ##
-## Ends in an error in state: 670.
+## Ends in an error in state: 680.
 ##
 ## range -> LOWER ASSIGN constr_expression COMMA UPPER . ASSIGN constr_expression [ RABRACK ]
 ##
@@ -584,7 +569,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER ASSIGN IDENTIFIER COMMA WHILE
 ##
 ## Concrete syntax: data { vector < lower = foo , while
 ##
-## Ends in an error in state: 669.
+## Ends in an error in state: 679.
 ##
 ## range -> LOWER ASSIGN constr_expression COMMA . UPPER ASSIGN constr_expression [ RABRACK ]
 ##
@@ -598,7 +583,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER ASSIGN WHILE
 ##
 ## Concrete syntax: data { vector < lower = while
 ##
-## Ends in an error in state: 667.
+## Ends in an error in state: 677.
 ##
 ## range -> LOWER ASSIGN . constr_expression COMMA UPPER ASSIGN constr_expression [ RABRACK ]
 ## range -> LOWER ASSIGN . constr_expression [ RABRACK ]
@@ -613,7 +598,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK LOWER WHILE
 ##
 ## Concrete syntax: data { vector < lower while
 ##
-## Ends in an error in state: 666.
+## Ends in an error in state: 676.
 ##
 ## range -> LOWER . ASSIGN constr_expression COMMA UPPER ASSIGN constr_expression [ RABRACK ]
 ## range -> LOWER . ASSIGN constr_expression [ RABRACK ]
@@ -628,7 +613,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER ASSIGN WHILE
 ##
 ## Concrete syntax: data { vector < multiplier = while
 ##
-## Ends in an error in state: 660.
+## Ends in an error in state: 670.
 ##
 ## offset_mult -> MULTIPLIER ASSIGN . constr_expression COMMA OFFSET ASSIGN constr_expression [ RABRACK ]
 ## offset_mult -> MULTIPLIER ASSIGN . constr_expression [ RABRACK ]
@@ -643,7 +628,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER WHILE
 ##
 ## Concrete syntax: data { vector < multiplier while
 ##
-## Ends in an error in state: 659.
+## Ends in an error in state: 669.
 ##
 ## offset_mult -> MULTIPLIER . ASSIGN constr_expression COMMA OFFSET ASSIGN constr_expression [ RABRACK ]
 ## offset_mult -> MULTIPLIER . ASSIGN constr_expression [ RABRACK ]
@@ -660,7 +645,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN BANG WHILE
 ##
 ## Concrete syntax: data { vector < upper = ! while
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 624.
 ##
 ## constr_expression -> BANG . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -674,7 +659,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN MINUS WHILE
 ##
 ## Concrete syntax: data { vector < upper = - while
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 623.
 ##
 ## constr_expression -> MINUS . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -688,7 +673,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN PLUS WHILE
 ##
 ## Concrete syntax: data { vector < upper = + while
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 622.
 ##
 ## constr_expression -> PLUS . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -702,7 +687,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER DIVIDE WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo / while
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 654.
 ##
 ## constr_expression -> constr_expression DIVIDE . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -716,7 +701,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER ELTDIVIDE WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo ./ while
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 652.
 ##
 ## constr_expression -> constr_expression ELTDIVIDE . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -730,7 +715,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER ELTTIMES WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo .* while
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 650.
 ##
 ## constr_expression -> constr_expression ELTTIMES . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -744,7 +729,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER HAT WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo ^ while
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 632.
 ##
 ## constr_expression -> constr_expression HAT . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -758,7 +743,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER LBRACK WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo [ while
 ##
-## Ends in an error in state: 619.
+## Ends in an error in state: 629.
 ##
 ## constr_expression -> constr_expression LBRACK . indexes RBRACK [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -772,7 +757,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER LDIVIDE WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo \ while
 ##
-## Ends in an error in state: 632.
+## Ends in an error in state: 642.
 ##
 ## constr_expression -> constr_expression LDIVIDE . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -786,7 +771,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER MINUS WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo - while
 ##
-## Ends in an error in state: 646.
+## Ends in an error in state: 656.
 ##
 ## constr_expression -> constr_expression MINUS . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -800,7 +785,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER MODULO WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo % while
 ##
-## Ends in an error in state: 638.
+## Ends in an error in state: 648.
 ##
 ## constr_expression -> constr_expression MODULO . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -814,7 +799,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER PLUS WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo + while
 ##
-## Ends in an error in state: 636.
+## Ends in an error in state: 646.
 ##
 ## constr_expression -> constr_expression PLUS . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -828,7 +813,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER TIMES WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo * while
 ##
-## Ends in an error in state: 630.
+## Ends in an error in state: 640.
 ##
 ## constr_expression -> constr_expression TIMES . constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ##
@@ -842,7 +827,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo while
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 625.
 ##
 ## common_expression -> identifier . LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA ]
 ## common_expression -> identifier . LPAREN lhs BAR loption(separated_nonempty_list(COMMA,expression)) RPAREN [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA ]
@@ -860,7 +845,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN WHILE
 ##
 ## Concrete syntax: data { vector < upper = while
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 621.
 ##
 ## range -> UPPER ASSIGN . constr_expression COMMA LOWER ASSIGN constr_expression [ RABRACK ]
 ## range -> UPPER ASSIGN . constr_expression [ RABRACK ]
@@ -875,7 +860,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER WHILE
 ##
 ## Concrete syntax: data { vector < upper while
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 620.
 ##
 ## range -> UPPER . ASSIGN constr_expression COMMA LOWER ASSIGN constr_expression [ RABRACK ]
 ## range -> UPPER . ASSIGN constr_expression [ RABRACK ]
@@ -890,7 +875,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK WHILE
 ##
 ## Concrete syntax: data { vector < while
 ##
-## Ends in an error in state: 609.
+## Ends in an error in state: 619.
 ##
 ## range_constraint -> LABRACK . range RABRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER LBRACK INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## type_constraint -> LABRACK . offset_mult RABRACK [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER LBRACK INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -905,10 +890,10 @@ program: DATABLOCK LBRACE VECTOR LBRACK INTNUMERAL RBRACK HAT
 ##
 ## Concrete syntax: data { vector [ 24 ] ^
 ##
-## Ends in an error in state: 834.
+## Ends in an error in state: 850.
 ##
 ## decl(top_var_type,no_assign) -> top_var_type . decl_identifier dims optional_assignment(no_assign) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
-## decl(top_var_type,no_assign) -> top_var_type . separated_nonempty_list(COMMA,id_and_optional_assignment(no_assign)) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
+## decl(top_var_type,no_assign) -> top_var_type . id_and_optional_assignment(no_assign,decl_identifier) option(remaining_declarations(no_assign)) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## top_var_type
@@ -920,7 +905,7 @@ program: DATABLOCK LBRACE IDENTIFIER
 ##
 ## Concrete syntax: data { foo
 ##
-## Ends in an error in state: 607.
+## Ends in an error in state: 617.
 ##
 ## data_block -> DATABLOCK LBRACE . list(top_var_decl_no_assign) RBRACE [ TRANSFORMEDPARAMETERSBLOCK TRANSFORMEDDATABLOCK PARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -939,7 +924,7 @@ program: DATABLOCK WHILE
 ##
 ## Concrete syntax: data while
 ##
-## Ends in an error in state: 606.
+## Ends in an error in state: 616.
 ##
 ## data_block -> DATABLOCK . LBRACE list(top_var_decl_no_assign) RBRACE [ TRANSFORMEDPARAMETERSBLOCK TRANSFORMEDDATABLOCK PARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -953,7 +938,7 @@ program: FUNCTIONBLOCK LBRACE RBRACE COVMATRIX
 ##
 ## Concrete syntax: functions { } cov_matrix
 ##
-## Ends in an error in state: 605.
+## Ends in an error in state: 615.
 ##
 ## program -> option(function_block) . option(data_block) option(transformed_data_block) option(parameters_block) option(transformed_parameters_block) option(model_block) option(generated_quantities_block) EOF [ # ]
 ##
@@ -1011,7 +996,7 @@ program: FUNCTIONBLOCK LBRACE VOID IDENTIFIER LPAREN RPAREN SEMICOLON WHILE
 ##
 ## Concrete syntax: functions { void foo ( ) ; while
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 607.
 ##
 ## list(function_def) -> function_def . list(function_def) [ RBRACE EOF ]
 ##
@@ -1055,7 +1040,7 @@ program: FUNCTIONBLOCK LBRACE VOID IDENTIFIER LPAREN VECTOR IDENTIFIER COMMA WHI
 ##
 ## Concrete syntax: functions { void foo ( vector foo , while
 ##
-## Ends in an error in state: 592.
+## Ends in an error in state: 602.
 ##
 ## separated_nonempty_list(COMMA,arg_decl) -> arg_decl COMMA . separated_nonempty_list(COMMA,arg_decl) [ RPAREN ]
 ##
@@ -1069,7 +1054,7 @@ program: FUNCTIONBLOCK LBRACE VOID IDENTIFIER LPAREN VECTOR IDENTIFIER WHILE
 ##
 ## Concrete syntax: functions { void foo ( vector foo while
 ##
-## Ends in an error in state: 591.
+## Ends in an error in state: 601.
 ##
 ## separated_nonempty_list(COMMA,arg_decl) -> arg_decl . [ RPAREN ]
 ## separated_nonempty_list(COMMA,arg_decl) -> arg_decl . COMMA separated_nonempty_list(COMMA,arg_decl) [ RPAREN ]
@@ -1126,7 +1111,7 @@ program: FUNCTIONBLOCK LBRACE WHILE
 ##
 ## Concrete syntax: functions { while
 ##
-## Ends in an error in state: 601.
+## Ends in an error in state: 611.
 ##
 ## function_block -> FUNCTIONBLOCK LBRACE . list(function_def) RBRACE [ TRANSFORMEDPARAMETERSBLOCK TRANSFORMEDDATABLOCK PARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF DATABLOCK ]
 ##
@@ -1140,7 +1125,7 @@ program: FUNCTIONBLOCK WHILE
 ##
 ## Concrete syntax: functions while
 ##
-## Ends in an error in state: 600.
+## Ends in an error in state: 610.
 ##
 ## function_block -> FUNCTIONBLOCK . LBRACE list(function_def) RBRACE [ TRANSFORMEDPARAMETERSBLOCK TRANSFORMEDDATABLOCK PARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF DATABLOCK ]
 ##
@@ -1154,7 +1139,7 @@ program: GENERATEDQUANTITIESBLOCK LBRACE RBRACE ELTTIMESASSIGN
 ##
 ## Concrete syntax: generated quantities { } .*=
 ##
-## Ends in an error in state: 895.
+## Ends in an error in state: 916.
 ##
 ## program -> option(function_block) option(data_block) option(transformed_data_block) option(parameters_block) option(transformed_parameters_block) option(model_block) option(generated_quantities_block) . EOF [ # ]
 ##
@@ -1168,7 +1153,7 @@ program: GENERATEDQUANTITIESBLOCK LBRACE VOID
 ##
 ## Concrete syntax: generated quantities { void
 ##
-## Ends in an error in state: 892.
+## Ends in an error in state: 913.
 ##
 ## generated_quantities_block -> GENERATEDQUANTITIESBLOCK LBRACE . list(top_vardecl_or_statement) RBRACE [ EOF ]
 ##
@@ -1182,7 +1167,7 @@ program: GENERATEDQUANTITIESBLOCK WHILE
 ##
 ## Concrete syntax: generated quantities while
 ##
-## Ends in an error in state: 891.
+## Ends in an error in state: 912.
 ##
 ## generated_quantities_block -> GENERATEDQUANTITIESBLOCK . LBRACE list(top_vardecl_or_statement) RBRACE [ EOF ]
 ##
@@ -1295,7 +1280,7 @@ program: MODELBLOCK LBRACE RBRACE ELTTIMESASSIGN
 ##
 ## Concrete syntax: model { } .*=
 ##
-## Ends in an error in state: 890.
+## Ends in an error in state: 911.
 ##
 ## program -> option(function_block) option(data_block) option(transformed_data_block) option(parameters_block) option(transformed_parameters_block) option(model_block) . option(generated_quantities_block) EOF [ # ]
 ##
@@ -1313,7 +1298,7 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER ASSIGN WHILE
 ##
 ## Concrete syntax: model { real foo = while
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 464.
 ##
 ## option(pair(ASSIGN,expression)) -> ASSIGN . lhs [ SEMICOLON COMMA ]
 ## option(pair(ASSIGN,expression)) -> ASSIGN . non_lhs [ SEMICOLON COMMA ]
@@ -1328,7 +1313,7 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACE
 ##
 ## Concrete syntax: model { real foo [ foo }
 ##
-## Ends in an error in state: 472.
+## Ends in an error in state: 481.
 ##
 ## dims -> LBRACK separated_nonempty_list(COMMA,expression) . RBRACK [ SEMICOLON ASSIGN ]
 ##
@@ -1349,7 +1334,7 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK WHILE
 ##
 ## Concrete syntax: model { real foo [ while
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 480.
 ##
 ## dims -> LBRACK . separated_nonempty_list(COMMA,expression) RBRACK [ SEMICOLON ASSIGN ]
 ##
@@ -1359,29 +1344,14 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK WHILE
 
 Ill-formed array sizes. "[" (non-empty comma separated list of expressions) "]" expected to specify array sizes.
 
-program: MODELBLOCK LBRACE REAL IDENTIFIER WHILE
-##
-## Concrete syntax: model { real foo while
-##
-## Ends in an error in state: 470.
-##
-## decl(sized_basic_type,expression) -> sized_basic_type decl_identifier . dims optional_assignment(expression) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
-## id_and_optional_assignment(expression) -> decl_identifier . optional_assignment(expression) [ SEMICOLON COMMA ]
-##
-## The known suffix of the stack is as follows:
-## sized_basic_type decl_identifier
-##
-
-";" or plain assignment expected after variable declaration.
-
 program: MODELBLOCK LBRACE REAL LBRACK
 ##
 ## Concrete syntax: model { real [
 ##
-## Ends in an error in state: 467.
+## Ends in an error in state: 475.
 ##
 ## decl(sized_basic_type,expression) -> sized_basic_type . decl_identifier dims optional_assignment(expression) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
-## decl(sized_basic_type,expression) -> sized_basic_type . separated_nonempty_list(COMMA,id_and_optional_assignment(expression)) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
+## decl(sized_basic_type,expression) -> sized_basic_type . id_and_optional_assignment(expression,decl_identifier) option(remaining_declarations(expression)) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## sized_basic_type
@@ -1434,7 +1404,7 @@ program: MODELBLOCK LBRACE SEMICOLON VOID
 ##
 ## Concrete syntax: model { ; void
 ##
-## Ends in an error in state: 578.
+## Ends in an error in state: 588.
 ##
 ## list(vardecl_or_statement) -> vardecl_or_statement . list(vardecl_or_statement) [ RBRACE ]
 ##
@@ -1497,7 +1467,7 @@ program: MODELBLOCK LBRACE VOID
 ##
 ## Concrete syntax: model { void
 ##
-## Ends in an error in state: 887.
+## Ends in an error in state: 908.
 ##
 ## model_block -> MODELBLOCK LBRACE . list(vardecl_or_statement) RBRACE [ GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -1511,7 +1481,7 @@ program: MODELBLOCK WHILE
 ##
 ## Concrete syntax: model while
 ##
-## Ends in an error in state: 886.
+## Ends in an error in state: 907.
 ##
 ## model_block -> MODELBLOCK . LBRACE list(vardecl_or_statement) RBRACE [ GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -1525,7 +1495,7 @@ program: PARAMETERSBLOCK LBRACE RBRACE ELTTIMESASSIGN
 ##
 ## Concrete syntax: parameters { } .*=
 ##
-## Ends in an error in state: 879.
+## Ends in an error in state: 900.
 ##
 ## program -> option(function_block) option(data_block) option(transformed_data_block) option(parameters_block) . option(transformed_parameters_block) option(model_block) option(generated_quantities_block) EOF [ # ]
 ##
@@ -1539,7 +1509,7 @@ program: PARAMETERSBLOCK LBRACE WHILE
 ##
 ## Concrete syntax: parameters { while
 ##
-## Ends in an error in state: 875.
+## Ends in an error in state: 896.
 ##
 ## parameters_block -> PARAMETERSBLOCK LBRACE . list(top_var_decl_no_assign) RBRACE [ TRANSFORMEDPARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -1553,7 +1523,7 @@ program: PARAMETERSBLOCK WHILE
 ##
 ## Concrete syntax: parameters while
 ##
-## Ends in an error in state: 874.
+## Ends in an error in state: 895.
 ##
 ## parameters_block -> PARAMETERSBLOCK . LBRACE list(top_var_decl_no_assign) RBRACE [ TRANSFORMEDPARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -1614,7 +1584,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN REALNUMERAL COLON 
 ##
 ## Concrete syntax: transformed data { for ( foo in 3.1415 : 3.1415 ) void
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 565.
 ##
 ## nested_statement -> FOR LPAREN identifier IN non_lhs COLON non_lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -1628,7 +1598,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN REALNUMERAL COLON 
 ##
 ## Concrete syntax: transformed data { for ( foo in 3.1415 : foo ) void
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 568.
 ##
 ## nested_statement -> FOR LPAREN identifier IN non_lhs COLON lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -1648,7 +1618,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN REALNUMERAL COLON 
 ##
 ## Concrete syntax: transformed data { for ( foo in 3.1415 : while
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 563.
 ##
 ## nested_statement -> FOR LPAREN identifier IN non_lhs COLON . lhs RPAREN vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## nested_statement -> FOR LPAREN identifier IN non_lhs COLON . non_lhs RPAREN vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -1677,7 +1647,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN IDENTIFIER COLON R
 ##
 ## Concrete syntax: transformed data { for ( foo in foo : 3.1415 ) void
 ##
-## Ends in an error in state: 565.
+## Ends in an error in state: 575.
 ##
 ## nested_statement -> FOR LPAREN identifier IN lhs COLON non_lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -1691,7 +1661,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN IDENTIFIER COLON I
 ##
 ## Concrete syntax: transformed data { for ( foo in foo : foo ) void
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 578.
 ##
 ## nested_statement -> FOR LPAREN identifier IN lhs COLON lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -1705,7 +1675,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN IDENTIFIER COLON I
 ##
 ## Concrete syntax: transformed data { for ( foo in foo : foo ~
 ##
-## Ends in an error in state: 567.
+## Ends in an error in state: 577.
 ##
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES RPAREN RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
 ## lhs -> lhs . DOTNUMERAL [ TRANSPOSE TIMES RPAREN RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -1770,7 +1740,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN IDENTIFIER COLON W
 ##
 ## Concrete syntax: transformed data { for ( foo in foo : while
 ##
-## Ends in an error in state: 563.
+## Ends in an error in state: 573.
 ##
 ## nested_statement -> FOR LPAREN identifier IN lhs COLON . lhs RPAREN vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## nested_statement -> FOR LPAREN identifier IN lhs COLON . non_lhs RPAREN vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -1785,7 +1755,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN IDENTIFIER RPAREN 
 ##
 ## Concrete syntax: transformed data { for ( foo in foo ) void
 ##
-## Ends in an error in state: 561.
+## Ends in an error in state: 571.
 ##
 ## nested_statement -> FOR LPAREN identifier IN lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -1801,7 +1771,7 @@ program: TRANSFORMEDDATABLOCK LBRACE FOR LPAREN IDENTIFIER IN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { for ( foo in foo ~
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 570.
 ##
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES RPAREN RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COLON AND ]
 ## lhs -> lhs . DOTNUMERAL [ TRANSPOSE TIMES RPAREN RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COLON AND ]
@@ -1972,7 +1942,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IF LPAREN REALNUMERAL RPAREN SEMICOLON ELSE
 ##
 ## Concrete syntax: transformed data { if ( 3.1415 ) ; else void
 ##
-## Ends in an error in state: 571.
+## Ends in an error in state: 581.
 ##
 ## nested_statement -> IF LPAREN non_lhs RPAREN vardecl_or_statement ELSE . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -1988,7 +1958,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IF LPAREN REALNUMERAL RPAREN SEMICOLON UNRE
 ##
 ## Concrete syntax: transformed data { if ( 3.1415 ) ; <<<<UNREACHABLE>>>
 ##
-## Ends in an error in state: 570.
+## Ends in an error in state: 580.
 ##
 ## nested_statement -> IF LPAREN non_lhs RPAREN vardecl_or_statement . ELSE vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## nested_statement -> IF LPAREN non_lhs RPAREN vardecl_or_statement . [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -2018,7 +1988,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IF LPAREN IDENTIFIER RPAREN SEMICOLON ELSE 
 ##
 ## Concrete syntax: transformed data { if ( foo ) ; else void
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 586.
 ##
 ## nested_statement -> IF LPAREN lhs RPAREN vardecl_or_statement ELSE . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -2032,7 +2002,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IF LPAREN IDENTIFIER RPAREN VOID
 ##
 ## Concrete syntax: transformed data { if ( foo ) void
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 584.
 ##
 ## nested_statement -> IF LPAREN lhs RPAREN . vardecl_or_statement ELSE vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## nested_statement -> IF LPAREN lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -2049,7 +2019,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IF LPAREN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { if ( foo ~
 ##
-## Ends in an error in state: 573.
+## Ends in an error in state: 583.
 ##
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES RPAREN RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
 ## lhs -> lhs . DOTNUMERAL [ TRANSPOSE TIMES RPAREN RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -2696,7 +2666,7 @@ program: TRANSFORMEDDATABLOCK LBRACE RBRACE ELTTIMESASSIGN
 ##
 ## Concrete syntax: transformed data { } .*=
 ##
-## Ends in an error in state: 873.
+## Ends in an error in state: 894.
 ##
 ## program -> option(function_block) option(data_block) option(transformed_data_block) . option(parameters_block) option(transformed_parameters_block) option(model_block) option(generated_quantities_block) EOF [ # ]
 ##
@@ -2705,21 +2675,6 @@ program: TRANSFORMEDDATABLOCK LBRACE RBRACE ELTTIMESASSIGN
 ##
 
 Expected "parameters {", "transformed parameters {", "model {", "generated quantities {" or end-of-file after end of transformed data block.
-
-program: TRANSFORMEDDATABLOCK LBRACE REAL IDENTIFIER WHILE
-##
-## Concrete syntax: transformed data { real foo while
-##
-## Ends in an error in state: 859.
-##
-## decl(top_var_type,expression) -> top_var_type decl_identifier . dims optional_assignment(expression) SEMICOLON [ WHILE VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
-## id_and_optional_assignment(expression) -> decl_identifier . optional_assignment(expression) [ SEMICOLON COMMA ]
-##
-## The known suffix of the stack is as follows:
-## top_var_type decl_identifier
-##
-
-";" or plain assignment is expected after a top-level variable declaration.
 
 program: TRANSFORMEDDATABLOCK LBRACE UPPER QMARK UPPER COLON UPPER TRANSPOSE WHILE
 ## Concrete syntax: transformed data { upper ? upper : upper ' while
@@ -3352,7 +3307,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T [ , ] multiplier
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 501.
 ##
 ## atomic_statement -> non_lhs TILDE identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -3366,7 +3321,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T [ , foo ,
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 496.
 ##
 ## truncation -> TRUNCATE LBRACK option(expression) COMMA option(expression) . RBRACK [ SEMICOLON ]
 ##
@@ -3378,7 +3333,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 145, spurious reduction of production lhs -> identifier
-## In state 490, spurious reduction of production option(expression) -> lhs
+## In state 499, spurious reduction of production option(expression) -> lhs
 ##
 
 Ill-formed truncation. Expect the format "T[" optional expression "," optional expression "];".
@@ -3387,7 +3342,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T [ , while
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 495.
 ##
 ## truncation -> TRUNCATE LBRACK option(expression) COMMA . option(expression) RBRACK [ SEMICOLON ]
 ##
@@ -3401,7 +3356,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T [ foo ]
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 494.
 ##
 ## truncation -> TRUNCATE LBRACK option(expression) . COMMA option(expression) RBRACK [ SEMICOLON ]
 ##
@@ -3413,7 +3368,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 145, spurious reduction of production lhs -> identifier
-## In state 490, spurious reduction of production option(expression) -> lhs
+## In state 499, spurious reduction of production option(expression) -> lhs
 ##
 
 Ill-formed truncation. Expect the format "T[" optional expression "," optional expression "];".
@@ -3422,7 +3377,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T [ foo ~
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 499.
 ##
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES RBRACK RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA AND ]
 ## lhs -> lhs . DOTNUMERAL [ TRANSPOSE TIMES RBRACK RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA AND ]
@@ -3487,7 +3442,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T [ while
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 493.
 ##
 ## truncation -> TRUNCATE LBRACK . option(expression) COMMA option(expression) RBRACK [ SEMICOLON ]
 ##
@@ -3501,7 +3456,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) T while
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 492.
 ##
 ## truncation -> TRUNCATE . LBRACK option(expression) COMMA option(expression) RBRACK [ SEMICOLON ]
 ##
@@ -3515,7 +3470,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN RPAREN 
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( ) while
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 491.
 ##
 ## atomic_statement -> non_lhs TILDE identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN . option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -3529,7 +3484,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN IDENTIF
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( foo ]
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 490.
 ##
 ## atomic_statement -> non_lhs TILDE identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) . RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -3551,7 +3506,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER LPAREN WHILE
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo ( while
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 489.
 ##
 ## atomic_statement -> non_lhs TILDE identifier LPAREN . loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -3565,7 +3520,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE IDENTIFIER WHILE
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ foo while
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 488.
 ##
 ## atomic_statement -> non_lhs TILDE identifier . LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -3579,7 +3534,7 @@ program: TRANSFORMEDDATABLOCK LBRACE REALNUMERAL TILDE WHILE
 ##
 ## Concrete syntax: transformed data { 3.1415 ~ while
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 487.
 ##
 ## atomic_statement -> non_lhs TILDE . identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -3933,7 +3888,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ARROWASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo <- foo ~
 ##
-## Ends in an error in state: 541.
+## Ends in an error in state: 550.
 ##
 ## atomic_statement -> lhs ARROWASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -3998,7 +3953,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ARROWASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo <- while
 ##
-## Ends in an error in state: 538.
+## Ends in an error in state: 547.
 ##
 ## atomic_statement -> lhs ARROWASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs ARROWASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4015,7 +3970,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo = foo ~
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 545.
 ##
 ## atomic_statement -> lhs ASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4080,7 +4035,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo = while
 ##
-## Ends in an error in state: 533.
+## Ends in an error in state: 542.
 ##
 ## atomic_statement -> lhs ASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs ASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4097,7 +4052,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER DIVIDEASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo /= foo ~
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 540.
 ##
 ## atomic_statement -> lhs DIVIDEASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4162,7 +4117,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER DIVIDEASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo /= while
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 537.
 ##
 ## atomic_statement -> lhs DIVIDEASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs DIVIDEASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4179,7 +4134,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ELTDIVIDEASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo ./= foo ~
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 535.
 ##
 ## atomic_statement -> lhs ELTDIVIDEASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4244,7 +4199,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ELTDIVIDEASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo ./= while
 ##
-## Ends in an error in state: 523.
+## Ends in an error in state: 532.
 ##
 ## atomic_statement -> lhs ELTDIVIDEASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs ELTDIVIDEASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4261,7 +4216,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER ELTTIMESASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo .*= foo ~
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 530.
 ##
 ## atomic_statement -> lhs ELTTIMESASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4362,7 +4317,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER LPAREN RPAREN WHILE
 ##
 ## Concrete syntax: transformed data { foo ( ) while
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 555.
 ##
 ## atomic_statement -> identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## common_expression -> identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN . [ TRANSPOSE TIMES TILDE RBRACE RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA AND ]
@@ -4415,7 +4370,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER LPAREN IDENTIFIER COMMA IDENTIFI
 ##
 ## Concrete syntax: transformed data { foo ( foo , foo ]
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 554.
 ##
 ## atomic_statement -> identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) . RPAREN SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## common_expression -> identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) . RPAREN [ TRANSPOSE TIMES TILDE RBRACE RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA AND ]
@@ -4506,7 +4461,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER LPAREN WHILE
 ##
 ## Concrete syntax: transformed data { foo ( while
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 553.
 ##
 ## atomic_statement -> identifier LPAREN . loption(separated_nonempty_list(COMMA,expression)) RPAREN SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## common_expression -> identifier LPAREN . loption(separated_nonempty_list(COMMA,expression)) RPAREN [ TRANSPOSE TIMES TILDE RBRACE RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA AND ]
@@ -4523,7 +4478,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER MINUSASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo -= foo ~
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 525.
 ##
 ## atomic_statement -> lhs MINUSASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4588,7 +4543,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER MINUSASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo -= while
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 522.
 ##
 ## atomic_statement -> lhs MINUSASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs MINUSASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4605,7 +4560,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER PLUSASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo += foo ~
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 520.
 ##
 ## atomic_statement -> lhs PLUSASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4670,7 +4625,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER PLUSASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo += while
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 517.
 ##
 ## atomic_statement -> lhs PLUSASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs PLUSASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4685,7 +4640,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER RBRACE
 ##
 ## Concrete syntax: transformed data { foo }
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 504.
 ##
 ## atomic_statement -> lhs . ASSIGN lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs . ASSIGN non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4757,7 +4712,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 543, spurious reduction of production lhs -> identifier
+## In state 552, spurious reduction of production lhs -> identifier
 ##
 
 Ill-formed phrase. Found L-value. This can be completed in many ways.
@@ -4766,7 +4721,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TILDE IDENTIFIER LPAREN RPAREN T
 ##
 ## Concrete syntax: transformed data { foo ~ foo ( ) T [ , ] multiplier
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 515.
 ##
 ## atomic_statement -> lhs TILDE identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -4780,7 +4735,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TILDE IDENTIFIER LPAREN RPAREN W
 ##
 ## Concrete syntax: transformed data { foo ~ foo ( ) while
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 514.
 ##
 ## atomic_statement -> lhs TILDE identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN . option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -4794,7 +4749,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TILDE IDENTIFIER LPAREN IDENTIFI
 ##
 ## Concrete syntax: transformed data { foo ~ foo ( foo ]
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 513.
 ##
 ## atomic_statement -> lhs TILDE identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) . RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -4816,7 +4771,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TILDE IDENTIFIER LPAREN WHILE
 ##
 ## Concrete syntax: transformed data { foo ~ foo ( while
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 512.
 ##
 ## atomic_statement -> lhs TILDE identifier LPAREN . loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -4830,7 +4785,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TILDE IDENTIFIER WHILE
 ##
 ## Concrete syntax: transformed data { foo ~ foo while
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 511.
 ##
 ## atomic_statement -> lhs TILDE identifier . LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -4844,7 +4799,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TILDE WHILE
 ##
 ## Concrete syntax: transformed data { foo ~ while
 ##
-## Ends in an error in state: 501.
+## Ends in an error in state: 510.
 ##
 ## atomic_statement -> lhs TILDE . identifier LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN option(truncation) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -4860,7 +4815,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TIMESASSIGN IDENTIFIER TILDE
 ##
 ## Concrete syntax: transformed data { foo *= foo ~
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 508.
 ##
 ## atomic_statement -> lhs TIMESASSIGN lhs . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## lhs -> lhs . LBRACK indexes RBRACK [ TRANSPOSE TIMES SEMICOLON RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE AND ]
@@ -4925,7 +4880,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IDENTIFIER TIMESASSIGN WHILE
 ##
 ## Concrete syntax: transformed data { foo *= while
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 505.
 ##
 ## atomic_statement -> lhs TIMESASSIGN . lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## atomic_statement -> lhs TIMESASSIGN . non_lhs SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -4940,10 +4895,10 @@ program: TRANSFORMEDDATABLOCK LBRACE VECTOR LBRACK INTNUMERAL RBRACK HAT
 ##
 ## Concrete syntax: transformed data { vector [ 24 ] ^
 ##
-## Ends in an error in state: 856.
+## Ends in an error in state: 875.
 ##
 ## decl(top_var_type,expression) -> top_var_type . decl_identifier dims optional_assignment(expression) SEMICOLON [ WHILE VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
-## decl(top_var_type,expression) -> top_var_type . separated_nonempty_list(COMMA,id_and_optional_assignment(expression)) SEMICOLON [ WHILE VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
+## decl(top_var_type,expression) -> top_var_type . id_and_optional_assignment(expression,decl_identifier) option(remaining_declarations(expression)) SEMICOLON [ WHILE VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## top_var_type
@@ -4955,7 +4910,7 @@ program: TRANSFORMEDDATABLOCK LBRACE VOID
 ##
 ## Concrete syntax: transformed data { void
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 869.
 ##
 ## transformed_data_block -> TRANSFORMEDDATABLOCK LBRACE . list(top_vardecl_or_statement) RBRACE [ TRANSFORMEDPARAMETERSBLOCK PARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -4983,7 +4938,7 @@ program: TRANSFORMEDDATABLOCK LBRACE WHILE LPAREN IDENTIFIER RPAREN VOID
 ##
 ## Concrete syntax: transformed data { while ( foo ) void
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 598.
 ##
 ## nested_statement -> WHILE LPAREN lhs RPAREN . vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -5031,7 +4986,7 @@ program: TRANSFORMEDDATABLOCK WHILE
 ##
 ## Concrete syntax: transformed data while
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 868.
 ##
 ## transformed_data_block -> TRANSFORMEDDATABLOCK . LBRACE list(top_vardecl_or_statement) RBRACE [ TRANSFORMEDPARAMETERSBLOCK PARAMETERSBLOCK MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -5045,7 +5000,7 @@ program: TRANSFORMEDPARAMETERSBLOCK LBRACE RBRACE ELTTIMESASSIGN
 ##
 ## Concrete syntax: transformed parameters { } .*=
 ##
-## Ends in an error in state: 885.
+## Ends in an error in state: 906.
 ##
 ## program -> option(function_block) option(data_block) option(transformed_data_block) option(parameters_block) option(transformed_parameters_block) . option(model_block) option(generated_quantities_block) EOF [ # ]
 ##
@@ -5059,7 +5014,7 @@ program: TRANSFORMEDPARAMETERSBLOCK LBRACE VOID
 ##
 ## Concrete syntax: transformed parameters { void
 ##
-## Ends in an error in state: 881.
+## Ends in an error in state: 902.
 ##
 ## transformed_parameters_block -> TRANSFORMEDPARAMETERSBLOCK LBRACE . list(top_vardecl_or_statement) RBRACE [ MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -5073,7 +5028,7 @@ program: TRANSFORMEDPARAMETERSBLOCK WHILE
 ##
 ## Concrete syntax: transformed parameters while
 ##
-## Ends in an error in state: 880.
+## Ends in an error in state: 901.
 ##
 ## transformed_parameters_block -> TRANSFORMEDPARAMETERSBLOCK . LBRACE list(top_vardecl_or_statement) RBRACE [ MODELBLOCK GENERATEDQUANTITIESBLOCK EOF ]
 ##
@@ -5087,7 +5042,7 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK ARROWASSIGN
 ##
 ## Concrete syntax: model { real foo [ foo ] <-
 ##
-## Ends in an error in state: 474.
+## Ends in an error in state: 483.
 ##
 ## decl(sized_basic_type,expression) -> sized_basic_type decl_identifier dims . optional_assignment(expression) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -5097,25 +5052,11 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK ARROWASSIGN
 
 Expected  ";" or assignment.
 
-program: DATABLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK WHILE
-##
-## Concrete syntax: data { real foo [ foo ] while
-##
-## Ends in an error in state: 838.
-##
-## decl(top_var_type,no_assign) -> top_var_type decl_identifier dims . optional_assignment(no_assign) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
-##
-## The known suffix of the stack is as follows:
-## top_var_type decl_identifier dims
-##
-
-Expected ";".
-
 program: TRANSFORMEDDATABLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK ARROWASSIGN
 ##
 ## Concrete syntax: transformed data { real foo [ foo ] <-
 ##
-## Ends in an error in state: 860.
+## Ends in an error in state: 880.
 ##
 ## decl(top_var_type,expression) -> top_var_type decl_identifier dims . optional_assignment(expression) SEMICOLON [ WHILE VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -5129,7 +5070,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER COMMA WHILE
 ##
 ## Concrete syntax: data { vector < upper = foo , while
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 658.
 ##
 ## range -> UPPER ASSIGN constr_expression COMMA . LOWER ASSIGN constr_expression [ RABRACK ]
 ##
@@ -5143,7 +5084,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER COMMA LOWER WHI
 ##
 ## Concrete syntax: data { vector < upper = foo , lower while
 ##
-## Ends in an error in state: 649.
+## Ends in an error in state: 659.
 ##
 ## range -> UPPER ASSIGN constr_expression COMMA LOWER . ASSIGN constr_expression [ RABRACK ]
 ##
@@ -5157,7 +5098,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER COMMA LOWER ASS
 ##
 ## Concrete syntax: data { vector < upper = foo , lower = while
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 660.
 ##
 ## range -> UPPER ASSIGN constr_expression COMMA LOWER ASSIGN . constr_expression [ RABRACK ]
 ##
@@ -5171,7 +5112,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER COMMA LOWER ASS
 ##
 ## Concrete syntax: data { vector < upper = foo , lower = foo ,
 ##
-## Ends in an error in state: 651.
+## Ends in an error in state: 661.
 ##
 ## constr_expression -> constr_expression . PLUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
 ## constr_expression -> constr_expression . MINUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
@@ -5195,7 +5136,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK UPPER ASSIGN IDENTIFIER COMMA LOWER ASS
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 615, spurious reduction of production constr_expression -> identifier
+## In state 625, spurious reduction of production constr_expression -> identifier
 ##
 
 Expected '>' after lower expression.
@@ -5206,7 +5147,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER ASSIGN IDENTIFIER COMMA WHIL
 ##
 ## Concrete syntax: data { vector < multiplier = foo , while
 ##
-## Ends in an error in state: 662.
+## Ends in an error in state: 672.
 ##
 ## offset_mult -> MULTIPLIER ASSIGN constr_expression COMMA . OFFSET ASSIGN constr_expression [ RABRACK ]
 ##
@@ -5220,7 +5161,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER ASSIGN IDENTIFIER COMMA OFFS
 ##
 ## Concrete syntax: data { vector < multiplier = foo , offset while
 ##
-## Ends in an error in state: 663.
+## Ends in an error in state: 673.
 ##
 ## offset_mult -> MULTIPLIER ASSIGN constr_expression COMMA OFFSET . ASSIGN constr_expression [ RABRACK ]
 ##
@@ -5234,7 +5175,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER ASSIGN IDENTIFIER COMMA OFFS
 ##
 ## Concrete syntax: data { vector < multiplier = foo , offset = while
 ##
-## Ends in an error in state: 664.
+## Ends in an error in state: 674.
 ##
 ## offset_mult -> MULTIPLIER ASSIGN constr_expression COMMA OFFSET ASSIGN . constr_expression [ RABRACK ]
 ##
@@ -5248,7 +5189,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER ASSIGN IDENTIFIER COMMA OFFS
 ##
 ## Concrete syntax: data { vector < multiplier = foo , offset = foo ,
 ##
-## Ends in an error in state: 665.
+## Ends in an error in state: 675.
 ##
 ## constr_expression -> constr_expression . PLUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
 ## constr_expression -> constr_expression . MINUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE ]
@@ -5272,7 +5213,7 @@ program: DATABLOCK LBRACE VECTOR LABRACK MULTIPLIER ASSIGN IDENTIFIER COMMA OFFS
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 615, spurious reduction of production constr_expression -> identifier
+## In state 625, spurious reduction of production constr_expression -> identifier
 ##
 
 Expected '>' after multiplier expression.
@@ -5281,7 +5222,7 @@ program: TRANSFORMEDDATABLOCK LBRACE IF LPAREN UPPER RPAREN SEMICOLON UNREACHABL
 ##
 ## Concrete syntax: transformed data { if ( upper ) ; <<<<UNREACHABLE>>>
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 585.
 ##
 ## nested_statement -> IF LPAREN lhs RPAREN vardecl_or_statement . ELSE vardecl_or_statement [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## nested_statement -> IF LPAREN lhs RPAREN vardecl_or_statement . [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
@@ -5309,6 +5250,12 @@ Expected an expression inside "[" and "]" but found a statement. Indexing should
 not
   var[for (n in 1:N) ...]
 
+program: DATABLOCK LBRACE ARRAY LBRACK ARRAY RBRACK REAL WHILE ASSIGN UNREACHABLE WHILE
+## Concrete syntax: data { array [ array ] real while = <<<<UNREACHABLE>>> while
+program: DATABLOCK LBRACE REAL WHILE COMMA WHILE ASSIGN UNREACHABLE WHILE
+## Concrete syntax: data { real while , while = <<<<UNREACHABLE>>> while
+program: DATABLOCK LBRACE TUPLE LPAREN COMPLEX COMMA COMPLEX RPAREN WHILE ASSIGN UNREACHABLE WHILE
+## Concrete syntax: data { tuple ( complex , complex ) while = <<<<UNREACHABLE>>> while
 program: DATABLOCK LBRACE REAL IDENTIFIER ASSIGN WHILE
 ## Concrete syntax: data { real foo = while
 program: DATABLOCK LBRACE REAL IDENTIFIER ASSIGN UNREACHABLE WHILE
@@ -5317,7 +5264,7 @@ program: DATABLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK ASSIGN UNREAC
 ##
 ## Concrete syntax: data { real foo [ foo ] = <<<<UNREACHABLE>>> while
 ##
-## Ends in an error in state: 839.
+## Ends in an error in state: 856.
 ##
 ## decl(top_var_type,no_assign) -> top_var_type decl_identifier dims optional_assignment(no_assign) . SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
 ##
@@ -5338,12 +5285,12 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER COMMA UNREACHABLE
 ##
 ## Concrete syntax: model { real foo , <<<<UNREACHABLE>>>
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 456.
 ##
-## separated_nonempty_list(COMMA,id_and_optional_assignment(expression)) -> id_and_optional_assignment(expression) COMMA . separated_nonempty_list(COMMA,id_and_optional_assignment(expression)) [ SEMICOLON ]
+## remaining_declarations(expression) -> COMMA . separated_nonempty_list(COMMA,id_and_optional_assignment(expression,decl_identifier_after_comma)) [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## id_and_optional_assignment(expression) COMMA
+## COMMA
 ##
 
 Expected a new identifier after comma in declaration.
@@ -5355,7 +5302,7 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK ASSIGN ARRAY
 ##
 ## Concrete syntax: model { real foo [ foo ] = array ,
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 484.
 ##
 ## decl(sized_basic_type,expression) -> sized_basic_type decl_identifier dims optional_assignment(expression) . SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
@@ -5367,8 +5314,8 @@ program: MODELBLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK ASSIGN ARRAY
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 145, spurious reduction of production lhs -> identifier
-## In state 463, spurious reduction of production option(pair(ASSIGN,expression)) -> ASSIGN lhs
-## In state 465, spurious reduction of production optional_assignment(expression) -> option(pair(ASSIGN,expression))
+## In state 466, spurious reduction of production option(pair(ASSIGN,expression)) -> ASSIGN lhs
+## In state 468, spurious reduction of production optional_assignment(expression) -> option(pair(ASSIGN,expression))
 ##
 
 Multiple declarations are not allowed when array dimensions are given in TYPE IDENTIFIER[DIMENSIONS] form.
@@ -5450,7 +5397,7 @@ program: DATABLOCK LBRACE COMPLEX UNREACHABLE
 ##
 ## Concrete syntax: data { complex <<<<UNREACHABLE>>>
 ##
-## Ends in an error in state: 778.
+## Ends in an error in state: 788.
 ##
 ## top_var_type -> COMPLEX . type_constraint [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ##
@@ -5479,7 +5426,7 @@ functions_only: VOID ARRAY LPAREN RPAREN SEMICOLON RBRACE
 ##
 ## Concrete syntax: void array ( ) ; }
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 604.
 ##
 ## functions_only -> list(function_def) . EOF [ # ]
 ##
@@ -5490,8 +5437,8 @@ functions_only: VOID ARRAY LPAREN RPAREN SEMICOLON RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 597, spurious reduction of production list(function_def) ->
-## In state 598, spurious reduction of production list(function_def) -> function_def list(function_def)
+## In state 607, spurious reduction of production list(function_def) ->
+## In state 608, spurious reduction of production list(function_def) -> function_def list(function_def)
 ##
 
 Only function definitions/declarations are expected in '.stanfunctions' file
@@ -5524,9 +5471,9 @@ program: DATABLOCK LBRACE ARRAY LBRACK IDENTIFIER RBRACK VECTOR LBRACK INTNUMERA
 ##
 ## Concrete syntax: data { array [ foo ] vector [ 24 ] &&
 ##
-## Ends in an error in state: 844.
+## Ends in an error in state: 861.
 ##
-## decl(top_var_type,no_assign) -> array_type(top_var_type) . separated_nonempty_list(COMMA,id_and_optional_assignment(no_assign)) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
+## decl(top_var_type,no_assign) -> array_type(top_var_type) . id_and_optional_assignment(no_assign,decl_identifier) option(remaining_declarations(no_assign)) SEMICOLON [ VECTOR UNITVECTOR TUPLE SIMPLEX SEMICOLON ROWVECTOR REAL RBRACE POSITIVEORDERED ORDERED MATRIX INT COVMATRIX CORRMATRIX COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## array_type(top_var_type)
@@ -5540,7 +5487,7 @@ program: TRANSFORMEDDATABLOCK LBRACE UPPER WHILE
 ##
 ## Concrete syntax: transformed data { upper while
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 552.
 ##
 ## atomic_statement -> identifier . LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ## common_expression -> identifier . LPAREN loption(separated_nonempty_list(COMMA,expression)) RPAREN [ TRANSPOSE TIMES TILDE RBRACE RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DOTNUMERAL DIVIDE COMMA AND ]
@@ -5580,7 +5527,7 @@ program: DATABLOCK LBRACE TUPLE LPAREN REAL COMMA WHILE
 ##
 ## Concrete syntax: data { tuple ( real , while
 ##
-## Ends in an error in state: 814.
+## Ends in an error in state: 824.
 ##
 ## tuple_type(top_var_type) -> TUPLE LPAREN top_var_type COMMA . separated_nonempty_list(COMMA,higher_type(top_var_type)) RPAREN [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ##
@@ -5604,7 +5551,7 @@ program: DATABLOCK LBRACE TUPLE LPAREN REAL WHILE
 ##
 ## Concrete syntax: data { tuple ( real while
 ##
-## Ends in an error in state: 813.
+## Ends in an error in state: 823.
 ##
 ## tuple_type(top_var_type) -> TUPLE LPAREN top_var_type . COMMA separated_nonempty_list(COMMA,higher_type(top_var_type)) RPAREN [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ##
@@ -5615,9 +5562,9 @@ program: DATABLOCK LBRACE TUPLE LPAREN REAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 705, spurious reduction of production range_constraint ->
-## In state 683, spurious reduction of production type_constraint -> range_constraint
-## In state 706, spurious reduction of production top_var_type -> REAL type_constraint
+## In state 715, spurious reduction of production range_constraint ->
+## In state 693, spurious reduction of production type_constraint -> range_constraint
+## In state 716, spurious reduction of production top_var_type -> REAL type_constraint
 ##
 
 Invalid type specification, unmatched "(".
@@ -5637,7 +5584,7 @@ program: DATABLOCK LBRACE TUPLE LPAREN REAL COMMA TUPLE LPAREN COMPLEX COMMA COM
 ##
 ## Concrete syntax: data { tuple ( real , tuple ( complex , complex ) while
 ##
-## Ends in an error in state: 799.
+## Ends in an error in state: 809.
 ##
 ## separated_nonempty_list(COMMA,higher_type(top_var_type)) -> tuple_type(top_var_type) . [ RPAREN ]
 ## separated_nonempty_list(COMMA,higher_type(top_var_type)) -> tuple_type(top_var_type) . COMMA separated_nonempty_list(COMMA,higher_type(top_var_type)) [ RPAREN ]
@@ -5655,7 +5602,7 @@ program: DATABLOCK LBRACE TUPLE LPAREN WHILE
 ##
 ## Concrete syntax: data { tuple ( while
 ##
-## Ends in an error in state: 691.
+## Ends in an error in state: 701.
 ##
 ## tuple_type(top_var_type) -> TUPLE LPAREN . array_type(top_var_type) COMMA separated_nonempty_list(COMMA,higher_type(top_var_type)) RPAREN [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## tuple_type(top_var_type) -> TUPLE LPAREN . tuple_type(top_var_type) COMMA separated_nonempty_list(COMMA,higher_type(top_var_type)) RPAREN [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -5829,7 +5776,7 @@ program: TRANSFORMEDDATABLOCK LBRACE DOTNUMERAL TILDE UPPER LPAREN RPAREN TRUNCA
 ##
 ## Concrete syntax: transformed data { .2 ~ upper ( ) T [ .2 ~
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 498.
 ##
 ## non_lhs -> non_lhs . QMARK lhs COLON lhs [ TRANSPOSE TIMES RBRACK RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA AND ]
 ## non_lhs -> non_lhs . QMARK lhs COLON non_lhs [ TRANSPOSE TIMES RBRACK RABRACK QMARK PLUS OR NEQUALS MODULO MINUS LEQ LDIVIDE LBRACK LABRACK IDIVIDE HAT GEQ EQUALS ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA AND ]
@@ -5940,7 +5887,7 @@ program: DATABLOCK LBRACE ARRAY LBRACK INTNUMERAL RBRACK IDENTIFIER
 ##
 ## Concrete syntax: data { array [ 24 ] foo
 ##
-## Ends in an error in state: 807.
+## Ends in an error in state: 817.
 ##
 ## array_type(top_var_type) -> arr_dims . top_var_type [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## array_type(top_var_type) -> arr_dims . tuple_type(top_var_type) [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -5969,7 +5916,7 @@ program: DATABLOCK LBRACE ROWVECTOR LABRACK LOWER ASSIGN UPPER TRANSPOSE WHILE
 ##
 ## Concrete syntax: data { row_vector < lower = upper ' while
 ##
-## Ends in an error in state: 668.
+## Ends in an error in state: 678.
 ##
 ## constr_expression -> constr_expression . PLUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
 ## constr_expression -> constr_expression . MINUS constr_expression [ TRANSPOSE TIMES RABRACK PLUS MODULO MINUS LDIVIDE LBRACK IDIVIDE HAT ELTTIMES ELTPOW ELTDIVIDE DIVIDE COMMA ]
@@ -5993,6 +5940,8 @@ program: DATABLOCK LBRACE ROWVECTOR LABRACK LOWER ASSIGN UPPER TRANSPOSE WHILE
 
 Expected ">" or ", upper = expression>" (with expression not containing binary logical operators) expected after specifying lower bound for type.
 
+program: DATABLOCK LBRACE REAL WHILE COMMA WHILE COMMA UNREACHABLE
+## Concrete syntax: data { real while , while , <<<<UNREACHABLE>>>
 program: TRANSFORMEDDATABLOCK LBRACE TUPLE LPAREN REAL COMMA COMPLEX RPAREN UNREACHABLE
 ## Concrete syntax: transformed data { tuple ( real , complex ) <<<<UNREACHABLE>>>
 program: DATABLOCK LBRACE TUPLE LPAREN REAL COMMA COMPLEX RPAREN UNREACHABLE
@@ -6003,7 +5952,7 @@ program: MODELBLOCK LBRACE TUPLE LPAREN COMPLEX COMMA COMPLEX RPAREN UNREACHABLE
 ##
 ## Ends in an error in state: 454.
 ##
-## decl(sized_basic_type,expression) -> tuple_type(sized_basic_type) . separated_nonempty_list(COMMA,id_and_optional_assignment(expression)) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
+## decl(sized_basic_type,expression) -> tuple_type(sized_basic_type) . id_and_optional_assignment(expression,decl_identifier) option(remaining_declarations(expression)) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## tuple_type(sized_basic_type)
@@ -6021,7 +5970,7 @@ program: DATABLOCK LBRACE TUPLE WHILE
 ##
 ## Concrete syntax: data { tuple while
 ##
-## Ends in an error in state: 690.
+## Ends in an error in state: 700.
 ##
 ## tuple_type(top_var_type) -> TUPLE . LPAREN array_type(top_var_type) COMMA separated_nonempty_list(COMMA,higher_type(top_var_type)) RPAREN [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
 ## tuple_type(top_var_type) -> TUPLE . LPAREN tuple_type(top_var_type) COMMA separated_nonempty_list(COMMA,higher_type(top_var_type)) RPAREN [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX RPAREN ROWVECTOR RETURN REJECT REAL PROFILE PRINT POSITIVEORDERED PARAMETERSBLOCK ORDERED OFFSET MULTIPLIER MODELBLOCK MATRIX LOWER INT IN IF IDENTIFIER GETLP FUNCTIONBLOCK FOR ELSE DATABLOCK COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX COMMA CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK ARRAY ]
@@ -6033,3 +5982,42 @@ program: DATABLOCK LBRACE TUPLE WHILE
 
 Invalid type specification.
 Expected "(" followed by further types and ")" to complete tuple.
+
+program: MODELBLOCK LBRACE REAL IDENTIFIER COMMA IDENTIFIER COMMA UNREACHABLE
+## Concrete syntax: model { real foo , foo , <<<<UNREACHABLE>>>
+program: TRANSFORMEDDATABLOCK LBRACE REAL WHILE IDENTIFIER
+## Concrete syntax: transformed data { real while foo
+program: TRANSFORMEDDATABLOCK LBRACE ARRAY LBRACK IDENTIFIER RBRACK REAL WHILE IDENTIFIER
+## Concrete syntax: transformed data { array [ foo ] real while foo
+program: MODELBLOCK LBRACE REAL IDENTIFIER IDENTIFIER
+##
+## Concrete syntax: model { real foo foo
+##
+## Ends in an error in state: 479.
+##
+## decl(sized_basic_type,expression) -> sized_basic_type decl_identifier . dims optional_assignment(expression) SEMICOLON [ WHILE VOID VECTOR UPPER UNITVECTOR TUPLE TRUNCATE TARGET SIMPLEX SEMICOLON ROWVECTOR RETURN REJECT REALNUMERAL REAL RBRACE PROFILE PRINT POSITIVEORDERED PLUS ORDERED OFFSET MULTIPLIER MINUS MATRIX LPAREN LOWER LBRACK LBRACE INTNUMERAL INT INCREMENTLOGPROB IMAGNUMERAL IF IDENTIFIER GETLP FOR EOF ELSE DOTNUMERAL COVMATRIX CORRMATRIX CONTINUE COMPLEXVECTOR COMPLEXROWVECTOR COMPLEXMATRIX COMPLEX CHOLESKYFACTORCOV CHOLESKYFACTORCORR BREAK BANG ARRAY ]
+## id_and_optional_assignment(expression,decl_identifier) -> decl_identifier . optional_assignment(expression) [ SEMICOLON COMMA ]
+##
+## The known suffix of the stack is as follows:
+## sized_basic_type decl_identifier
+##
+
+";" or plain assignment expected after variable declaration.
+
+program: DATABLOCK LBRACE REAL IDENTIFIER LBRACK IDENTIFIER RBRACK IDENTIFIER
+## Concrete syntax: data { real foo [ foo ] foo
+program: DATABLOCK LBRACE REAL WHILE IDENTIFIER
+## Concrete syntax: data { real while foo
+program: DATABLOCK LBRACE ARRAY LBRACK ARRAY RBRACK REAL IDENTIFIER IDENTIFIER
+##
+## Concrete syntax: data { array [ array ] real foo foo
+##
+## Ends in an error in state: 848.
+##
+## id_and_optional_assignment(no_assign,decl_identifier) -> decl_identifier . optional_assignment(no_assign) [ SEMICOLON COMMA ]
+##
+## The known suffix of the stack is as follows:
+## decl_identifier
+##
+
+";" expected after variable declaration.

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -103,7 +103,6 @@ let nest_unsized_array basic_type n =
 %nonassoc below_ELSE
 %nonassoc ELSE
 
-
 (* Top level rule *)
 %start <Ast.untyped_program> program functions_only
 %%
@@ -214,7 +213,6 @@ decl_identifier:
 decl_identifier_after_comma:
   | id=identifier { id }
   | err=reserved_word { reserved_decl err }
-
 
 reserved_word:
   (* Keywords cannot be identifiers but it is nice to
@@ -594,7 +592,6 @@ lhs:
          build_expr (TupleProjection (l, ix)) $loc
     }
 
-
 (* This is separated so that it can be reused, e.g. to match array[ixs] type syntax *)
 %inline indexed(expr_type):
   | l=expr_type LBRACK indices=indexes RBRACK
@@ -662,7 +659,6 @@ constr_expression:
       grammar_logger "constr_expression_identifier" ;
       build_expr (Variable id) $loc
     }
-
 
 common_expression:
   | i=INTNUMERAL

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -16,6 +16,11 @@ let build_id id loc =
   grammar_logger ("identifier " ^ id);
   {name=id; id_loc=location_span_of_positions loc}
 
+let reserved id loc =
+  raise (Errors.SyntaxError (Errors.Parsing
+          ("Identifier '" ^ id ^ "' clashes with reserved keyword.\n",
+            location_span_of_positions loc)))
+
 let build_expr expr loc =
   {expr; emeta={loc=location_span_of_positions loc}}
 
@@ -196,44 +201,44 @@ decl_identifier:
   | id=reserved_word { id }
 
 reserved_word:
-  (* Keywords cannot be identifiers but
-     semantic check produces a better error message. *)
-  | FUNCTIONBLOCK { build_id "functions" $loc }
-  | DATABLOCK { build_id "data" $loc }
-  | PARAMETERSBLOCK { build_id "parameters" $loc }
-  | MODELBLOCK { build_id "model" $loc }
-  | RETURN { build_id "return" $loc }
-  | IF { build_id "if" $loc }
-  | ELSE { build_id "else" $loc }
-  | WHILE { build_id "while" $loc }
-  | FOR { build_id "for" $loc }
-  | IN { build_id "in" $loc }
-  | BREAK { build_id "break" $loc }
-  | CONTINUE { build_id "continue" $loc }
-  | VOID { build_id "void" $loc }
-  | INT { build_id "int" $loc }
-  | REAL { build_id "real" $loc }
-  | COMPLEX { build_id "complex" $loc }
-  | VECTOR { build_id "vector" $loc }
-  | ROWVECTOR { build_id "row_vector" $loc }
-  | MATRIX { build_id "matrix" $loc }
-  | COMPLEXVECTOR { build_id "complex_vector" $loc }
-  | COMPLEXROWVECTOR { build_id "complex_row_vector" $loc }
-  | COMPLEXMATRIX { build_id "complex_matrix" $loc }
-  | ORDERED { build_id "ordered" $loc }
-  | POSITIVEORDERED { build_id "positive_ordered" $loc }
-  | SIMPLEX { build_id "simplex" $loc }
-  | UNITVECTOR { build_id "unit_vector" $loc }
-  | CHOLESKYFACTORCORR { build_id "cholesky_factor_corr" $loc }
-  | CHOLESKYFACTORCOV { build_id "cholesky_factor_cov" $loc }
-  | CORRMATRIX { build_id "corr_matrix" $loc }
-  | COVMATRIX { build_id "cov_matrix" $loc }
-  | PRINT { build_id "print" $loc }
-  | REJECT { build_id "reject" $loc }
-  | TARGET { build_id "target" $loc }
-  | GETLP { build_id "get_lp" $loc }
-  | PROFILE { build_id "profile" $loc }
-  | TUPLE { build_id "tuple" $loc }
+  (* Keywords cannot be identifiers but it is nice to
+    let them parse as such to provide a better error *)
+  | FUNCTIONBLOCK { reserved "functions" $loc }
+  | DATABLOCK { reserved "data" $loc }
+  | PARAMETERSBLOCK { reserved "parameters" $loc }
+  | MODELBLOCK { reserved "model" $loc }
+  | RETURN { reserved "return" $loc }
+  | IF { reserved "if" $loc }
+  | ELSE { reserved "else" $loc }
+  | WHILE { reserved "while" $loc }
+  | FOR { reserved "for" $loc }
+  | IN { reserved "in" $loc }
+  | BREAK { reserved "break" $loc }
+  | CONTINUE { reserved "continue" $loc }
+  | VOID { reserved "void" $loc }
+  | INT { reserved "int" $loc }
+  | REAL { reserved "real" $loc }
+  | COMPLEX { reserved "complex" $loc }
+  | VECTOR { reserved "vector" $loc }
+  | ROWVECTOR { reserved "row_vector" $loc }
+  | MATRIX { reserved "matrix" $loc }
+  | COMPLEXVECTOR { reserved "complex_vector" $loc }
+  | COMPLEXROWVECTOR { reserved "complex_row_vector" $loc }
+  | COMPLEXMATRIX { reserved "complex_matrix" $loc }
+  | ORDERED { reserved "ordered" $loc }
+  | POSITIVEORDERED { reserved "positive_ordered" $loc }
+  | SIMPLEX { reserved "simplex" $loc }
+  | UNITVECTOR { reserved "unit_vector" $loc }
+  | CHOLESKYFACTORCORR { reserved "cholesky_factor_corr" $loc }
+  | CHOLESKYFACTORCOV { reserved "cholesky_factor_cov" $loc }
+  | CORRMATRIX { reserved "corr_matrix" $loc }
+  | COVMATRIX { reserved "cov_matrix" $loc  }
+  | PRINT { reserved "print" $loc }
+  | REJECT { reserved "reject" $loc }
+  | TARGET { reserved "target" $loc }
+  | GETLP { reserved "get_lp" $loc }
+  | PROFILE { reserved "profile" $loc }
+  | TUPLE { reserved "tuple" $loc }
 
 
 function_def:

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -13,32 +13,34 @@ let reducearray (sbt, l) =
   List.fold_right l ~f:(fun z y -> SizedType.SArray (y, z)) ~init:sbt
 
 let build_id id loc =
-  grammar_logger ("identifier " ^ id);
-  {name=id; id_loc=location_span_of_positions loc}
+  grammar_logger ("identifier " ^ id) ;
+  {name= id; id_loc= location_span_of_positions loc}
 
-let reserved id =
-  raise (Errors.SyntaxError (Errors.Parsing
-          ("Expected a new identifier but found reserved keyword '" ^ id.name ^ "'.\n",
-            id.id_loc)))
+let reserved (name, loc, _) =
+  raise
+    (Errors.SyntaxError
+       (Errors.Parsing
+          ( "Expected a new identifier but found reserved keyword '" ^ name
+            ^ "'.\n"
+          , location_span_of_positions loc ) ) )
 
-let reserved_decl (id, is_type) =
+let reserved_decl (name, loc, is_type) =
   if is_type then
-    raise (Errors.SyntaxError (Errors.Parsing
-          ("Found a type ('"^id.name^
-            "') where an identifier was expected.\nAll variables declared in a comma-separated list must be of the same type.\n",
-            id.id_loc)))
-  else
-    reserved id
+    raise
+      (Errors.SyntaxError
+         (Errors.Parsing
+            ( "Found a type ('" ^ name
+              ^ "') where an identifier was expected.\n\
+                 All variables declared in a comma-separated list must be of \
+                 the same type.\n"
+            , location_span_of_positions loc ) ) )
+  else reserved (name, loc, is_type)
 
-let build_expr expr loc =
-  {expr; emeta={loc=location_span_of_positions loc}}
+let build_expr expr loc = {expr; emeta= {loc= location_span_of_positions loc}}
+let rec iterate_n f x = function 0 -> x | n -> iterate_n f (f x) (n - 1)
 
-let rec iterate_n f x = function
-  | 0 -> x
-  | n -> iterate_n f (f x) (n - 1)
 let nest_unsized_array basic_type n =
   iterate_n (fun t -> UnsizedType.UArray t) basic_type n
-
 %}
 
 (* Token definitions. The quoted strings are aliases, used in the examples generated in
@@ -207,52 +209,52 @@ future_keyword:
 
 decl_identifier:
   | id=identifier { id }
-  | id_flag=reserved_word { reserved (fst id_flag) }
+  | err=reserved_word { reserved err }
 
 decl_identifier_after_comma:
   | id=identifier { id }
-  | id_flag=reserved_word { reserved_decl id_flag }
+  | err=reserved_word { reserved_decl err }
+
 
 reserved_word:
   (* Keywords cannot be identifiers but it is nice to
     let them parse as such to provide a better error *)
-  | FUNCTIONBLOCK { build_id "functions" $loc, false }
-  | DATABLOCK { build_id "data" $loc, false }
-  | PARAMETERSBLOCK { build_id "parameters" $loc, false }
-  | MODELBLOCK { build_id "model" $loc, false }
-  | RETURN { build_id "return" $loc, false }
-  | IF { build_id "if" $loc, false }
-  | ELSE { build_id "else" $loc, false }
-  | WHILE { build_id "while" $loc, false }
-  | FOR { build_id "for" $loc, false }
-  | IN { build_id "in" $loc, false }
-  | BREAK { build_id "break" $loc, false }
-  | CONTINUE { build_id "continue" $loc, false }
-  | VOID { build_id "void" $loc, false }
-  | INT { build_id "int" $loc, true }
-  | REAL { build_id "real" $loc, true }
-  | COMPLEX { build_id "complex" $loc, true }
-  | VECTOR { build_id "vector" $loc, true }
-  | ROWVECTOR { build_id "row_vector" $loc, true }
-  | MATRIX { build_id "matrix" $loc, true }
-  | COMPLEXVECTOR { build_id "complex_vector" $loc, true }
-  | COMPLEXROWVECTOR { build_id "complex_row_vector" $loc, true }
-  | COMPLEXMATRIX { build_id "complex_matrix" $loc, true }
-  | ORDERED { build_id "ordered" $loc, true }
-  | POSITIVEORDERED { build_id "positive_ordered" $loc, true }
-  | SIMPLEX { build_id "simplex" $loc, true }
-  | UNITVECTOR { build_id "unit_vector" $loc, true }
-  | CHOLESKYFACTORCORR { build_id "cholesky_factor_corr" $loc, true }
-  | CHOLESKYFACTORCOV { build_id "cholesky_factor_cov" $loc, true }
-  | CORRMATRIX { build_id "corr_matrix" $loc, true }
-  | COVMATRIX { build_id "cov_matrix" $loc, true  }
-  | PRINT { build_id "print" $loc, false }
-  | REJECT { build_id "reject" $loc, false }
-  | TARGET { build_id "target" $loc, false }
-  | GETLP { build_id "get_lp" $loc, false }
-  | PROFILE { build_id "profile" $loc, false }
-  | TUPLE { build_id "tuple" $loc, true }
-
+  | FUNCTIONBLOCK { "functions", $loc, false }
+  | DATABLOCK { "data", $loc, false }
+  | PARAMETERSBLOCK { "parameters", $loc, false }
+  | MODELBLOCK { "model", $loc, false }
+  | RETURN { "return", $loc, false }
+  | IF { "if", $loc, false }
+  | ELSE { "else", $loc, false }
+  | WHILE { "while", $loc, false }
+  | FOR { "for", $loc, false }
+  | IN { "in", $loc, false }
+  | BREAK { "break", $loc, false }
+  | CONTINUE { "continue", $loc, false }
+  | VOID { "void", $loc, false }
+  | INT { "int", $loc, true }
+  | REAL { "real", $loc, true }
+  | COMPLEX { "complex", $loc, true }
+  | VECTOR { "vector", $loc, true }
+  | ROWVECTOR { "row_vector", $loc, true }
+  | MATRIX { "matrix", $loc, true }
+  | COMPLEXVECTOR { "complex_vector", $loc, true }
+  | COMPLEXROWVECTOR { "complex_row_vector", $loc, true }
+  | COMPLEXMATRIX { "complex_matrix", $loc, true }
+  | ORDERED { "ordered", $loc, true }
+  | POSITIVEORDERED { "positive_ordered", $loc, true }
+  | SIMPLEX { "simplex", $loc, true }
+  | UNITVECTOR { "unit_vector", $loc, true }
+  | CHOLESKYFACTORCORR { "cholesky_factor_corr", $loc, true }
+  | CHOLESKYFACTORCOV { "cholesky_factor_cov", $loc, true }
+  | CORRMATRIX { "corr_matrix", $loc, true }
+  | COVMATRIX { "cov_matrix", $loc, true  }
+  | PRINT { "print", $loc, false }
+  | REJECT { "reject", $loc, false }
+  | TARGET { "target", $loc, false }
+  | GETLP { "get_lp", $loc, false }
+  | PROFILE { "profile", $loc, false }
+  | TUPLE { "tuple", $loc, true }
 
 function_def:
   | rt=return_type name=decl_identifier LPAREN args=separated_list(COMMA, arg_decl)
@@ -339,7 +341,6 @@ id_and_optional_assignment(rhs, decl):
 remaining_declarations(rhs):
   | COMMA decls=separated_nonempty_list(COMMA, id_and_optional_assignment(rhs, decl_identifier_after_comma))
     { decls }
-
 
 (*
  * All rules for declaration statements.

--- a/test/integration/bad/compound-assign/stanc.expected
+++ b/test/integration/bad/compound-assign/stanc.expected
@@ -34,7 +34,7 @@ Syntax error in 'plus_equals_bad_init.stan', line 3, column 20 to column 22, par
      4:  }
    -------------------------------------------------
 
-";" or plain assignment is expected after a top-level variable declaration.
+";" or plain assignment expected after variable declaration.
   $ ../../../../../install/default/bin/stanc plus_equals_bad_lhs_idxs.stan
 Semantic error in 'plus_equals_bad_lhs_idxs.stan', line 4, column 2 to column 8:
    -------------------------------------------------

--- a/test/integration/bad/lang/bad_decl1.stan
+++ b/test/integration/bad/lang/bad_decl1.stan
@@ -1,3 +1,4 @@
 data {
+  // unfortunately the error here got much worse
   real x, int y;
 }

--- a/test/integration/bad/lang/bad_decl1.stan
+++ b/test/integration/bad/lang/bad_decl1.stan
@@ -1,4 +1,3 @@
 data {
-  // unfortunately the error here got much worse
   real x, int y;
 }

--- a/test/integration/bad/lang/bad_decl4.stan
+++ b/test/integration/bad/lang/bad_decl4.stan
@@ -1,0 +1,3 @@
+data {
+  real x, reject;
+}

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -502,16 +502,16 @@ Syntax error in 'bad_cov_exp_quad_vec_rvec_param.stan', line 17, column 0 to col
 
 "model {" or "generated quantities {" expected after end of transformed parameters block.
   $ ../../../../../install/default/bin/stanc bad_decl1.stan
-Syntax error in 'bad_decl1.stan', line 2, column 14 to column 15, parsing error:
+Syntax error in 'bad_decl1.stan', line 3, column 10 to column 13, parsing error:
    -------------------------------------------------
      1:  data {
-     2:    real x, int y;
-                       ^
-     3:  }
+     2:    // unfortunately the error here got much worse
+     3:    real x, int y;
+                   ^
+     4:  }
    -------------------------------------------------
 
-Expected a new identifier after comma in declaration.
-All variables declared must be of the same type, and any initializing assignment must follow the identifier before the next comma.
+Identifier 'int' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc bad_decl2.stan
 Syntax error in 'bad_decl2.stan', line 2, column 13 to column 14, parsing error:
    -------------------------------------------------

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -502,16 +502,16 @@ Syntax error in 'bad_cov_exp_quad_vec_rvec_param.stan', line 17, column 0 to col
 
 "model {" or "generated quantities {" expected after end of transformed parameters block.
   $ ../../../../../install/default/bin/stanc bad_decl1.stan
-Syntax error in 'bad_decl1.stan', line 3, column 10 to column 13, parsing error:
+Syntax error in 'bad_decl1.stan', line 2, column 10 to column 13, parsing error:
    -------------------------------------------------
      1:  data {
-     2:    // unfortunately the error here got much worse
-     3:    real x, int y;
+     2:    real x, int y;
                    ^
-     4:  }
+     3:  }
    -------------------------------------------------
 
-Identifier 'int' clashes with reserved keyword.
+Found a type ('int') where an identifier was expected.
+All variables declared in a comma-separated list must be of the same type.
   $ ../../../../../install/default/bin/stanc bad_decl2.stan
 Syntax error in 'bad_decl2.stan', line 2, column 13 to column 14, parsing error:
    -------------------------------------------------
@@ -535,6 +535,16 @@ Syntax error in 'bad_decl3.stan', line 3, column 28 to column 29, parsing error:
 
 Expected a new identifier after comma in declaration.
 All variables declared must be of the same type, and any initializing assignment must follow the identifier before the next comma.
+  $ ../../../../../install/default/bin/stanc bad_decl4.stan
+Syntax error in 'bad_decl4.stan', line 2, column 10 to column 16, parsing error:
+   -------------------------------------------------
+     1:  data {
+     2:    real x, reject;
+                   ^
+     3:  }
+   -------------------------------------------------
+
+Expected a new identifier but found reserved keyword 'reject'.
   $ ../../../../../install/default/bin/stanc bad_function.stan
 Semantic error in 'bad_function.stan', line 3, column 3 to column 7:
    -------------------------------------------------

--- a/test/integration/bad/new/fundef-bad2.stan
+++ b/test/integration/bad/new/fundef-bad2.stan
@@ -1,1 +1,1 @@
-functions { vector while }
+functions { vector foo }

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -258,7 +258,7 @@ Syntax error in 'fundef-bad6.stan', line 1, column 37 to column 42, parsing erro
                                               ^
    -------------------------------------------------
 
-Identifier 'while' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'while'.
   $ ../../../../../install/default/bin/stanc fundef-bad7.stan
 Syntax error in 'fundef-bad7.stan', line 1, column 21 to column 26, parsing error:
    -------------------------------------------------
@@ -274,7 +274,7 @@ Syntax error in 'fundef-bad8.stan', line 1, column 17 to column 22, parsing erro
                           ^
    -------------------------------------------------
 
-Identifier 'while' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'while'.
   $ ../../../../../install/default/bin/stanc fundef-bad9.stan
 Syntax error in 'fundef-bad9.stan', line 1, column 23 to column 27, parsing error:
    -------------------------------------------------
@@ -3603,7 +3603,7 @@ Syntax error in 'variable-decl-bad3.stan', line 1, column 17 to column 22, parsi
                           ^
    -------------------------------------------------
 
-Expected ";".
+";" expected after variable declaration.
   $ ../../../../../install/default/bin/stanc variable-decl-bad4.stan
 Syntax error in 'variable-decl-bad4.stan', line 1, column 32 to column 37, parsing error:
    -------------------------------------------------

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -220,10 +220,10 @@ Syntax error in 'fundef-bad10.stan', line 2, column 12 to column 23, parsing err
 
 An argument declaration (unsized and unconstrained type followed by identifier) is expected.
   $ ../../../../../install/default/bin/stanc fundef-bad2.stan
-Syntax error in 'fundef-bad2.stan', line 1, column 25 to column 26, parsing error:
+Syntax error in 'fundef-bad2.stan', line 1, column 23 to column 24, parsing error:
    -------------------------------------------------
-     1:  functions { vector while }
-                                  ^
+     1:  functions { vector foo }
+                                ^
    -------------------------------------------------
 
 "(" expected after function name.
@@ -252,7 +252,7 @@ Syntax error in 'fundef-bad5.stan', line 1, column 22 to column 26, parsing erro
 
 Either "{" statement "}" is expected for a function definition or ";" for a function forward declaration.
   $ ../../../../../install/default/bin/stanc fundef-bad6.stan
-Semantic error in 'fundef-bad6.stan', line 1, column 37 to column 42:
+Syntax error in 'fundef-bad6.stan', line 1, column 37 to column 42, parsing error:
    -------------------------------------------------
      1:  functions { void T ( array [] vector while);}
                                               ^
@@ -268,7 +268,7 @@ Syntax error in 'fundef-bad7.stan', line 1, column 21 to column 26, parsing erro
 
 An argument declaration (unsized and unconstrained type followed by identifier) is expected.
   $ ../../../../../install/default/bin/stanc fundef-bad8.stan
-Semantic error in 'fundef-bad8.stan', line 1, column 17 to column 22:
+Syntax error in 'fundef-bad8.stan', line 1, column 17 to column 22, parsing error:
    -------------------------------------------------
      1:  functions { void while();}
                           ^

--- a/test/integration/bad/profiling/stanc.expected
+++ b/test/integration/bad/profiling/stanc.expected
@@ -43,7 +43,7 @@ Syntax error in 'profile-bad4.stan', line 2, column 13 to column 18, parsing err
 
 Expected profile name as string in parenthesis
   $ ../../../../../install/default/bin/stanc profile-bad5.stan
-Semantic error in 'profile-bad5.stan', line 2, column 9 to column 16:
+Syntax error in 'profile-bad5.stan', line 2, column 9 to column 16, parsing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real profile;
@@ -53,7 +53,7 @@ Semantic error in 'profile-bad5.stan', line 2, column 9 to column 16:
 
 Identifier 'profile' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc profile-bad6.stan
-Semantic error in 'profile-bad6.stan', line 2, column 9 to column 16:
+Syntax error in 'profile-bad6.stan', line 2, column 9 to column 16, parsing error:
    -------------------------------------------------
      1:  functions {
      2:      real profile(int i) {

--- a/test/integration/bad/profiling/stanc.expected
+++ b/test/integration/bad/profiling/stanc.expected
@@ -51,7 +51,7 @@ Syntax error in 'profile-bad5.stan', line 2, column 9 to column 16, parsing erro
      3:  }
    -------------------------------------------------
 
-Identifier 'profile' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'profile'.
   $ ../../../../../install/default/bin/stanc profile-bad6.stan
 Syntax error in 'profile-bad6.stan', line 2, column 9 to column 16, parsing error:
    -------------------------------------------------
@@ -62,4 +62,4 @@ Syntax error in 'profile-bad6.stan', line 2, column 9 to column 16, parsing erro
      4:      }
    -------------------------------------------------
 
-Identifier 'profile' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'profile'.

--- a/test/integration/bad/reserved/stanc.expected
+++ b/test/integration/bad/reserved/stanc.expected
@@ -10,7 +10,7 @@ Semantic error in 'auto.stan', line 2, column 7 to column 11:
 
 Identifier 'auto' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc break.stan
-Semantic error in 'break.stan', line 2, column 7 to column 12:
+Syntax error in 'break.stan', line 2, column 7 to column 12, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real break;
@@ -21,7 +21,7 @@ Semantic error in 'break.stan', line 2, column 7 to column 12:
 
 Identifier 'break' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc cholesky_factor_corr.stan
-Semantic error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27:
+Syntax error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real cholesky_factor_corr;
@@ -32,7 +32,7 @@ Semantic error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27:
 
 Identifier 'cholesky_factor_corr' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc cholesky_factor_cov.stan
-Semantic error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26:
+Syntax error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real cholesky_factor_cov;
@@ -43,7 +43,7 @@ Semantic error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26:
 
 Identifier 'cholesky_factor_cov' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc continue.stan
-Semantic error in 'continue.stan', line 2, column 7 to column 15:
+Syntax error in 'continue.stan', line 2, column 7 to column 15, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real continue;
@@ -54,7 +54,7 @@ Semantic error in 'continue.stan', line 2, column 7 to column 15:
 
 Identifier 'continue' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc corr_matrix.stan
-Semantic error in 'corr_matrix.stan', line 2, column 7 to column 18:
+Syntax error in 'corr_matrix.stan', line 2, column 7 to column 18, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real corr_matrix;
@@ -65,7 +65,7 @@ Semantic error in 'corr_matrix.stan', line 2, column 7 to column 18:
 
 Identifier 'corr_matrix' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc cov_matrix.stan
-Semantic error in 'cov_matrix.stan', line 2, column 7 to column 17:
+Syntax error in 'cov_matrix.stan', line 2, column 7 to column 17, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real cov_matrix;
@@ -76,7 +76,7 @@ Semantic error in 'cov_matrix.stan', line 2, column 7 to column 17:
 
 Identifier 'cov_matrix' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc data.stan
-Semantic error in 'data.stan', line 2, column 7 to column 11:
+Syntax error in 'data.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real data;
@@ -87,7 +87,7 @@ Semantic error in 'data.stan', line 2, column 7 to column 11:
 
 Identifier 'data' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc else.stan
-Semantic error in 'else.stan', line 2, column 7 to column 11:
+Syntax error in 'else.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real else;
@@ -131,7 +131,7 @@ Semantic error in 'false.stan', line 2, column 7 to column 12:
 
 Identifier 'false' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc for.stan
-Semantic error in 'for.stan', line 2, column 7 to column 10:
+Syntax error in 'for.stan', line 2, column 7 to column 10, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real for;
@@ -153,7 +153,7 @@ Semantic error in 'generated.stan', line 2, column 7 to column 16:
 
 Identifier 'generated' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc if.stan
-Semantic error in 'if.stan', line 2, column 7 to column 9:
+Syntax error in 'if.stan', line 2, column 7 to column 9, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real if;
@@ -164,7 +164,7 @@ Semantic error in 'if.stan', line 2, column 7 to column 9:
 
 Identifier 'if' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc in.stan
-Semantic error in 'in.stan', line 2, column 7 to column 9:
+Syntax error in 'in.stan', line 2, column 7 to column 9, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real in;
@@ -175,7 +175,7 @@ Semantic error in 'in.stan', line 2, column 7 to column 9:
 
 Identifier 'in' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc int.stan
-Semantic error in 'int.stan', line 2, column 7 to column 10:
+Syntax error in 'int.stan', line 2, column 7 to column 10, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real int;
@@ -186,7 +186,7 @@ Semantic error in 'int.stan', line 2, column 7 to column 10:
 
 Identifier 'int' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc matrix.stan
-Semantic error in 'matrix.stan', line 2, column 7 to column 13:
+Syntax error in 'matrix.stan', line 2, column 7 to column 13, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real matrix;
@@ -197,7 +197,7 @@ Semantic error in 'matrix.stan', line 2, column 7 to column 13:
 
 Identifier 'matrix' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc model.stan
-Semantic error in 'model.stan', line 2, column 7 to column 12:
+Syntax error in 'model.stan', line 2, column 7 to column 12, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real model;
@@ -208,7 +208,7 @@ Semantic error in 'model.stan', line 2, column 7 to column 12:
 
 Identifier 'model' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc ordered.stan
-Semantic error in 'ordered.stan', line 2, column 7 to column 14:
+Syntax error in 'ordered.stan', line 2, column 7 to column 14, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real ordered;
@@ -219,7 +219,7 @@ Semantic error in 'ordered.stan', line 2, column 7 to column 14:
 
 Identifier 'ordered' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc parameters.stan
-Semantic error in 'parameters.stan', line 2, column 7 to column 17:
+Syntax error in 'parameters.stan', line 2, column 7 to column 17, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real parameters;
@@ -230,7 +230,7 @@ Semantic error in 'parameters.stan', line 2, column 7 to column 17:
 
 Identifier 'parameters' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc positive_ordered.stan
-Semantic error in 'positive_ordered.stan', line 2, column 7 to column 23:
+Syntax error in 'positive_ordered.stan', line 2, column 7 to column 23, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real positive_ordered;
@@ -252,7 +252,7 @@ Semantic error in 'quantities.stan', line 2, column 7 to column 17:
 
 Identifier 'quantities' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc real.stan
-Semantic error in 'real.stan', line 2, column 7 to column 11:
+Syntax error in 'real.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real real;
@@ -274,7 +274,7 @@ Semantic error in 'repeat.stan', line 2, column 7 to column 13:
 
 Identifier 'repeat' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc return.stan
-Semantic error in 'return.stan', line 2, column 7 to column 13:
+Syntax error in 'return.stan', line 2, column 7 to column 13, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real return;
@@ -285,7 +285,7 @@ Semantic error in 'return.stan', line 2, column 7 to column 13:
 
 Identifier 'return' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc row_vector.stan
-Semantic error in 'row_vector.stan', line 2, column 7 to column 17:
+Syntax error in 'row_vector.stan', line 2, column 7 to column 17, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real row_vector;
@@ -296,7 +296,7 @@ Semantic error in 'row_vector.stan', line 2, column 7 to column 17:
 
 Identifier 'row_vector' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc simplex.stan
-Semantic error in 'simplex.stan', line 2, column 7 to column 14:
+Syntax error in 'simplex.stan', line 2, column 7 to column 14, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real simplex;
@@ -373,7 +373,7 @@ Semantic error in 'typedef.stan', line 2, column 7 to column 14:
 
 Identifier 'typedef' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc unit_vector.stan
-Semantic error in 'unit_vector.stan', line 2, column 7 to column 18:
+Syntax error in 'unit_vector.stan', line 2, column 7 to column 18, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real unit_vector;
@@ -406,7 +406,7 @@ Semantic error in 'var.stan', line 2, column 7 to column 10:
 
 Identifier 'var' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc vector.stan
-Semantic error in 'vector.stan', line 2, column 7 to column 13:
+Syntax error in 'vector.stan', line 2, column 7 to column 13, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real vector;
@@ -417,7 +417,7 @@ Semantic error in 'vector.stan', line 2, column 7 to column 13:
 
 Identifier 'vector' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc void.stan
-Semantic error in 'void.stan', line 2, column 7 to column 11:
+Syntax error in 'void.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real void;
@@ -428,7 +428,7 @@ Semantic error in 'void.stan', line 2, column 7 to column 11:
 
 Identifier 'void' clashes with reserved keyword.
   $ ../../../../../install/default/bin/stanc while.stan
-Semantic error in 'while.stan', line 2, column 7 to column 12:
+Syntax error in 'while.stan', line 2, column 7 to column 12, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real while;

--- a/test/integration/bad/reserved/stanc.expected
+++ b/test/integration/bad/reserved/stanc.expected
@@ -19,7 +19,7 @@ Syntax error in 'break.stan', line 2, column 7 to column 12, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'break' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'break'.
   $ ../../../../../install/default/bin/stanc cholesky_factor_corr.stan
 Syntax error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27, parsing error:
    -------------------------------------------------
@@ -30,7 +30,7 @@ Syntax error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27, pars
      4:  model {
    -------------------------------------------------
 
-Identifier 'cholesky_factor_corr' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'cholesky_factor_corr'.
   $ ../../../../../install/default/bin/stanc cholesky_factor_cov.stan
 Syntax error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26, parsing error:
    -------------------------------------------------
@@ -41,7 +41,7 @@ Syntax error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26, parsi
      4:  model {
    -------------------------------------------------
 
-Identifier 'cholesky_factor_cov' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'cholesky_factor_cov'.
   $ ../../../../../install/default/bin/stanc continue.stan
 Syntax error in 'continue.stan', line 2, column 7 to column 15, parsing error:
    -------------------------------------------------
@@ -52,7 +52,7 @@ Syntax error in 'continue.stan', line 2, column 7 to column 15, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'continue' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'continue'.
   $ ../../../../../install/default/bin/stanc corr_matrix.stan
 Syntax error in 'corr_matrix.stan', line 2, column 7 to column 18, parsing error:
    -------------------------------------------------
@@ -63,7 +63,7 @@ Syntax error in 'corr_matrix.stan', line 2, column 7 to column 18, parsing error
      4:  model {
    -------------------------------------------------
 
-Identifier 'corr_matrix' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'corr_matrix'.
   $ ../../../../../install/default/bin/stanc cov_matrix.stan
 Syntax error in 'cov_matrix.stan', line 2, column 7 to column 17, parsing error:
    -------------------------------------------------
@@ -74,7 +74,7 @@ Syntax error in 'cov_matrix.stan', line 2, column 7 to column 17, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'cov_matrix' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'cov_matrix'.
   $ ../../../../../install/default/bin/stanc data.stan
 Syntax error in 'data.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
@@ -85,7 +85,7 @@ Syntax error in 'data.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'data' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'data'.
   $ ../../../../../install/default/bin/stanc else.stan
 Syntax error in 'else.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
@@ -96,7 +96,7 @@ Syntax error in 'else.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'else' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'else'.
   $ ../../../../../install/default/bin/stanc export.stan
 Semantic error in 'export.stan', line 2, column 7 to column 13:
    -------------------------------------------------
@@ -140,7 +140,7 @@ Syntax error in 'for.stan', line 2, column 7 to column 10, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'for' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'for'.
   $ ../../../../../install/default/bin/stanc generated.stan
 Semantic error in 'generated.stan', line 2, column 7 to column 16:
    -------------------------------------------------
@@ -162,7 +162,7 @@ Syntax error in 'if.stan', line 2, column 7 to column 9, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'if' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'if'.
   $ ../../../../../install/default/bin/stanc in.stan
 Syntax error in 'in.stan', line 2, column 7 to column 9, parsing error:
    -------------------------------------------------
@@ -173,7 +173,7 @@ Syntax error in 'in.stan', line 2, column 7 to column 9, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'in' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'in'.
   $ ../../../../../install/default/bin/stanc int.stan
 Syntax error in 'int.stan', line 2, column 7 to column 10, parsing error:
    -------------------------------------------------
@@ -184,7 +184,7 @@ Syntax error in 'int.stan', line 2, column 7 to column 10, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'int' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'int'.
   $ ../../../../../install/default/bin/stanc matrix.stan
 Syntax error in 'matrix.stan', line 2, column 7 to column 13, parsing error:
    -------------------------------------------------
@@ -195,7 +195,7 @@ Syntax error in 'matrix.stan', line 2, column 7 to column 13, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'matrix' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'matrix'.
   $ ../../../../../install/default/bin/stanc model.stan
 Syntax error in 'model.stan', line 2, column 7 to column 12, parsing error:
    -------------------------------------------------
@@ -206,7 +206,7 @@ Syntax error in 'model.stan', line 2, column 7 to column 12, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'model' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'model'.
   $ ../../../../../install/default/bin/stanc ordered.stan
 Syntax error in 'ordered.stan', line 2, column 7 to column 14, parsing error:
    -------------------------------------------------
@@ -217,7 +217,7 @@ Syntax error in 'ordered.stan', line 2, column 7 to column 14, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'ordered' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'ordered'.
   $ ../../../../../install/default/bin/stanc parameters.stan
 Syntax error in 'parameters.stan', line 2, column 7 to column 17, parsing error:
    -------------------------------------------------
@@ -228,7 +228,7 @@ Syntax error in 'parameters.stan', line 2, column 7 to column 17, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'parameters' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'parameters'.
   $ ../../../../../install/default/bin/stanc positive_ordered.stan
 Syntax error in 'positive_ordered.stan', line 2, column 7 to column 23, parsing error:
    -------------------------------------------------
@@ -239,7 +239,7 @@ Syntax error in 'positive_ordered.stan', line 2, column 7 to column 23, parsing 
      4:  model {
    -------------------------------------------------
 
-Identifier 'positive_ordered' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'positive_ordered'.
   $ ../../../../../install/default/bin/stanc quantities.stan
 Semantic error in 'quantities.stan', line 2, column 7 to column 17:
    -------------------------------------------------
@@ -261,7 +261,7 @@ Syntax error in 'real.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'real' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'real'.
   $ ../../../../../install/default/bin/stanc repeat.stan
 Semantic error in 'repeat.stan', line 2, column 7 to column 13:
    -------------------------------------------------
@@ -283,7 +283,7 @@ Syntax error in 'return.stan', line 2, column 7 to column 13, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'return' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'return'.
   $ ../../../../../install/default/bin/stanc row_vector.stan
 Syntax error in 'row_vector.stan', line 2, column 7 to column 17, parsing error:
    -------------------------------------------------
@@ -294,7 +294,7 @@ Syntax error in 'row_vector.stan', line 2, column 7 to column 17, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'row_vector' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'row_vector'.
   $ ../../../../../install/default/bin/stanc simplex.stan
 Syntax error in 'simplex.stan', line 2, column 7 to column 14, parsing error:
    -------------------------------------------------
@@ -305,7 +305,7 @@ Syntax error in 'simplex.stan', line 2, column 7 to column 14, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'simplex' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'simplex'.
   $ ../../../../../install/default/bin/stanc static.stan
 Semantic error in 'static.stan', line 2, column 7 to column 13:
    -------------------------------------------------
@@ -382,7 +382,7 @@ Syntax error in 'unit_vector.stan', line 2, column 7 to column 18, parsing error
      4:  model {
    -------------------------------------------------
 
-Identifier 'unit_vector' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'unit_vector'.
   $ ../../../../../install/default/bin/stanc until.stan
 Semantic error in 'until.stan', line 2, column 7 to column 12:
    -------------------------------------------------
@@ -415,7 +415,7 @@ Syntax error in 'vector.stan', line 2, column 7 to column 13, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'vector' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'vector'.
   $ ../../../../../install/default/bin/stanc void.stan
 Syntax error in 'void.stan', line 2, column 7 to column 11, parsing error:
    -------------------------------------------------
@@ -426,7 +426,7 @@ Syntax error in 'void.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'void' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'void'.
   $ ../../../../../install/default/bin/stanc while.stan
 Syntax error in 'while.stan', line 2, column 7 to column 12, parsing error:
    -------------------------------------------------
@@ -437,4 +437,4 @@ Syntax error in 'while.stan', line 2, column 7 to column 12, parsing error:
      4:  model {
    -------------------------------------------------
 
-Identifier 'while' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'while'.

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2344,7 +2344,7 @@ Syntax error in 'string_literal_newline.stan', line 3, column 1, lexing error:
 
 Invalid character found.
   $ ../../../../install/default/bin/stanc target-reserved.stan
-Semantic error in 'target-reserved.stan', line 2, column 7 to column 13:
+Syntax error in 'target-reserved.stan', line 2, column 7 to column 13, parsing error:
    -------------------------------------------------
      1:  data {
      2:    real target;

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2353,7 +2353,7 @@ Syntax error in 'target-reserved.stan', line 2, column 7 to column 13, parsing e
      4:  parameters {
    -------------------------------------------------
 
-Identifier 'target' clashes with reserved keyword.
+Expected a new identifier but found reserved keyword 'target'.
   $ ../../../../install/default/bin/stanc target_pe_bad.stan
 Semantic error in 'target_pe_bad.stan', line 8, column 2 to column 16:
    -------------------------------------------------

--- a/test/integration/bad/tuples/incomplete3.stan
+++ b/test/integration/bad/tuples/incomplete3.stan
@@ -1,1 +1,1 @@
-model { tuple( complex , complex ) while
+model { tuple( complex , complex ) foo,

--- a/test/integration/bad/tuples/stanc.expected
+++ b/test/integration/bad/tuples/stanc.expected
@@ -175,7 +175,7 @@ Expected "," followed by further types and ")" to complete tuple.
   $ ../../../../../install/default/bin/stanc incomplete3.stan
 Syntax error in 'incomplete3.stan', line 2, column 0 to column 0, parsing error:
    -------------------------------------------------
-     1:  model { tuple( complex , complex ) while
+     1:  model { tuple( complex , complex ) foo,
          ^
    -------------------------------------------------
 


### PR DESCRIPTION
See: https://discourse.mc-stan.org/t/ill-formed-phrase-should-be-followed-by-a-statement-variable-declaration-or-expression/32400

This reverts some portions of #771, but rather than using the UNREACHABLE token and updating the messages file, we simply raise the error ourselves directly. 

This unfortunately does make some errors worse, since continuing parsing let us do things like an informative error when a user writes `real foo, int bar;` to try to declare multiple variables of different types on one line. The slightly worse error in that case seems worth it compared to very confusing errors like in the linked thread. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improved errors when using a reserved word as a variable name.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
