### PR TITLE
Add tuple-returning special functions

### DIFF
--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -479,6 +479,7 @@ let string_operator_to_stan_math_fns str =
 
 let pretty_print_all_math_sigs ppf () =
   let open Fmt in
+  Format.pp_set_margin ppf 180 ;
   let pp_sig ppf (name, (rt, args, _)) =
     pf ppf "%s(@[<h>%a@]) => %a" name
       (list ~sep:comma UnsizedType.pp)
@@ -1007,6 +1008,16 @@ let () =
   add_unqualified
     ("columns_dot_self", ReturnType UComplexRowVector, [UComplexMatrix], AoS) ;
   add_unqualified
+    ( "complex_schur_decompose"
+    , ReturnType (UTuple [UComplexMatrix; UComplexMatrix])
+    , [UComplexMatrix]
+    , AoS ) ;
+  add_unqualified
+    ( "complex_schur_decompose"
+    , ReturnType (UTuple [UComplexMatrix; UComplexMatrix])
+    , [UMatrix]
+    , AoS ) ;
+  add_unqualified
     ( "complex_schur_decompose_t"
     , ReturnType UComplexMatrix
     , [UComplexMatrix]
@@ -1053,6 +1064,11 @@ let () =
     ( "csr_to_dense_matrix"
     , ReturnType UMatrix
     , [UInt; UInt; UVector; UArray UInt; UArray UInt]
+    , AoS ) ;
+  add_unqualified
+    ( "csr_extract"
+    , ReturnType (UTuple [UVector; UArray UInt; UArray UInt])
+    , [UMatrix]
     , AoS ) ;
   add_unqualified ("csr_extract_w", ReturnType UVector, [UMatrix], AoS) ;
   add_unqualified ("csr_extract_v", ReturnType (UArray UInt), [UMatrix], AoS) ;
@@ -1175,12 +1191,32 @@ let () =
   add_unqualified ("dot_self", ReturnType UComplex, [UComplexVector], AoS) ;
   add_unqualified ("dot_self", ReturnType UComplex, [UComplexRowVector], AoS) ;
   add_nullary "e" ;
+  add_unqualified
+    ( "eigendecompose"
+    , ReturnType (UTuple [UComplexMatrix; UComplexVector])
+    , [UMatrix]
+    , AoS ) ;
+  add_unqualified
+    ( "eigendecompose"
+    , ReturnType (UTuple [UComplexMatrix; UComplexVector])
+    , [UComplexMatrix]
+    , AoS ) ;
   add_unqualified ("eigenvalues", ReturnType UComplexVector, [UMatrix], AoS) ;
   add_unqualified ("eigenvectors", ReturnType UComplexMatrix, [UMatrix], AoS) ;
   add_unqualified
     ("eigenvalues", ReturnType UComplexVector, [UComplexMatrix], AoS) ;
   add_unqualified
     ("eigenvectors", ReturnType UComplexMatrix, [UComplexMatrix], AoS) ;
+  add_unqualified
+    ( "eigendecompose_sym"
+    , ReturnType (UTuple [UMatrix; UVector])
+    , [UMatrix]
+    , AoS ) ;
+  add_unqualified
+    ( "eigendecompose_sym"
+    , ReturnType (UTuple [UComplexMatrix; UComplexVector])
+    , [UComplexMatrix]
+    , AoS ) ;
   add_unqualified ("eigenvalues_sym", ReturnType UVector, [UMatrix], AoS) ;
   add_unqualified
     ("eigenvalues_sym", ReturnType UComplexVector, [UComplexMatrix], AoS) ;
@@ -1191,6 +1227,8 @@ let () =
   add_unqualified ("qr", ReturnType (UTuple [UMatrix; UMatrix]), [UMatrix], AoS) ;
   add_unqualified ("qr_Q", ReturnType UMatrix, [UMatrix], AoS) ;
   add_unqualified ("qr_R", ReturnType UMatrix, [UMatrix], AoS) ;
+  add_unqualified
+    ("qr_thin", ReturnType (UTuple [UMatrix; UMatrix]), [UMatrix], AoS) ;
   add_unqualified ("qr_thin_Q", ReturnType UMatrix, [UMatrix], AoS) ;
   add_unqualified ("qr_thin_R", ReturnType UMatrix, [UMatrix], AoS) ;
   List.iter
@@ -2365,6 +2403,14 @@ let () =
   add_unqualified ("sum", ReturnType UComplex, [UComplexVector], SoA) ;
   add_unqualified ("sum", ReturnType UComplex, [UComplexRowVector], SoA) ;
   add_unqualified ("sum", ReturnType UComplex, [UComplexMatrix], SoA) ;
+  (* TODO (future): SoA inside of tuples, update following signatures *)
+  add_unqualified
+    ("svd", ReturnType (UTuple [UMatrix; UVector; UMatrix]), [UMatrix], AoS) ;
+  add_unqualified
+    ( "svd"
+    , ReturnType (UTuple [UComplexMatrix; UVector; UComplexMatrix])
+    , [UComplexMatrix]
+    , AoS ) ;
   add_unqualified ("svd_U", ReturnType UMatrix, [UMatrix], SoA) ;
   add_unqualified ("svd_U", ReturnType UComplexMatrix, [UComplexMatrix], SoA) ;
   add_unqualified ("svd_V", ReturnType UMatrix, [UMatrix], SoA) ;

--- a/test/integration/good/function-signatures/math/matrix/complex_schur_decompose.stan
+++ b/test/integration/good/function-signatures/math/matrix/complex_schur_decompose.stan
@@ -7,30 +7,39 @@ transformed data {
   complex_matrix[d_int, d_int] transformed_data_cmatrix;
   transformed_data_cmatrix = complex_schur_decompose_t(d_matrix);
   transformed_data_cmatrix = complex_schur_decompose_t(d_cmatrix);
-
+  
   transformed_data_cmatrix = complex_schur_decompose_u(d_matrix);
   transformed_data_cmatrix = complex_schur_decompose_u(d_cmatrix);
-
+  
+  tuple(complex_matrix[d_int, d_int], complex_matrix[d_int, d_int]) transformed_data_cmatrix_tuple;
+  transformed_data_cmatrix_tuple = complex_schur_decompose(d_matrix);
+  transformed_data_cmatrix_tuple = complex_schur_decompose(d_cmatrix);
 }
 parameters {
   real y_p;
-
+  
   matrix[d_int, d_int] p_matrix;
   complex_matrix[d_int, d_int] p_cmatrix;
 }
 transformed parameters {
   complex_matrix[d_int, d_int] transformed_param_cmatrix;
-
+  
   transformed_param_cmatrix = complex_schur_decompose_t(d_matrix);
   transformed_param_cmatrix = complex_schur_decompose_t(p_matrix);
   transformed_param_cmatrix = complex_schur_decompose_t(d_cmatrix);
   transformed_param_cmatrix = complex_schur_decompose_t(p_cmatrix);
-
+  
   transformed_param_cmatrix = complex_schur_decompose_u(d_matrix);
   transformed_param_cmatrix = complex_schur_decompose_u(p_matrix);
   transformed_param_cmatrix = complex_schur_decompose_u(d_cmatrix);
   transformed_param_cmatrix = complex_schur_decompose_u(p_cmatrix);
+  
+  tuple(complex_matrix[d_int, d_int], complex_matrix[d_int, d_int]) transformed_param_cmatrix_tuple;
+  transformed_param_cmatrix_tuple = complex_schur_decompose(d_matrix);
+  transformed_param_cmatrix_tuple = complex_schur_decompose(p_matrix);
+  transformed_param_cmatrix_tuple = complex_schur_decompose(d_cmatrix);
+  transformed_param_cmatrix_tuple = complex_schur_decompose(p_cmatrix);
 }
 model {
-  y_p ~ normal(0,1);
+  y_p ~ normal(0, 1);
 }

--- a/test/integration/good/function-signatures/math/matrix/csr_extract.stan
+++ b/test/integration/good/function-signatures/math/matrix/csr_extract.stan
@@ -1,0 +1,17 @@
+data {
+  matrix[3, 4] a_d;
+}
+transformed data {
+  tuple(vector[3], array[5] int, array[5] int) td_wvu;
+  td_wvu = csr_extract(a_d);
+}
+parameters {
+  real y;
+  matrix[3, 4] a_p;
+}
+model {
+  tuple(vector[3], array[5] int, array[5] int) m_wvu;
+  m_wvu = csr_extract(a_d);
+  m_wvu = csr_extract(a_p);
+  y ~ normal(0, 1);
+}

--- a/test/integration/good/function-signatures/math/matrix/eigendecompose.stan
+++ b/test/integration/good/function-signatures/math/matrix/eigendecompose.stan
@@ -1,0 +1,28 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_cmatrix;
+}
+transformed data {
+  tuple(complex_matrix[d_int, d_int], complex_vector[d_int]) eigendec;
+  
+  eigendec = eigendecompose(d_matrix);
+  eigendec = eigendecompose(d_cmatrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_cmatrix;
+}
+transformed parameters {
+  tuple(complex_matrix[d_int, d_int], complex_vector[d_int]) tp_eigendec;
+  
+  tp_eigendec = eigendecompose(d_matrix);
+  tp_eigendec = eigendecompose(p_matrix);
+  
+  tp_eigendec = eigendecompose(d_cmatrix);
+  tp_eigendec = eigendecompose(p_cmatrix);
+}
+model {
+  y_p ~ normal(0, 1);
+}

--- a/test/integration/good/function-signatures/math/matrix/eigendecompose_sym.stan
+++ b/test/integration/good/function-signatures/math/matrix/eigendecompose_sym.stan
@@ -1,0 +1,32 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_cmatrix;
+}
+transformed data {
+  tuple(matrix[d_int, d_int], vector[d_int]) eigendec;
+  
+  eigendec = eigendecompose_sym(d_matrix);
+  
+  tuple(complex_matrix[d_int, d_int], complex_vector[d_int]) eigendecc;
+  eigendecc = eigendecompose_sym(d_cmatrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_cmatrix;
+}
+transformed parameters {
+  tuple(matrix[d_int, d_int], vector[d_int]) tp_eigendec;
+  
+  tp_eigendec = eigendecompose_sym(d_matrix);
+  tp_eigendec = eigendecompose_sym(p_matrix);
+  
+  tuple(complex_matrix[d_int, d_int], complex_vector[d_int]) tp_eigendecc;
+  
+  tp_eigendecc = eigendecompose_sym(d_cmatrix);
+  tp_eigendecc = eigendecompose_sym(p_cmatrix);
+}
+model {
+  y_p ~ normal(0, 1);
+}

--- a/test/integration/good/function-signatures/math/matrix/qr_thin.stan
+++ b/test/integration/good/function-signatures/math/matrix/qr_thin.stan
@@ -1,0 +1,22 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+}
+transformed data {
+  tuple(matrix[d_int, d_int], matrix[d_int, d_int]) QR_tdata;
+  
+  QR_tdata = qr_thin(d_matrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int, d_int] p_matrix;
+}
+transformed parameters {
+  tuple(matrix[d_int, d_int], matrix[d_int, d_int]) QR_tparam;
+  
+  QR_tparam = qr_thin(d_matrix);
+  QR_tparam = qr_thin(p_matrix);
+}
+model {
+  y_p ~ normal(0, 1);
+}

--- a/test/integration/good/function-signatures/math/matrix/svd.stan
+++ b/test/integration/good/function-signatures/math/matrix/svd.stan
@@ -1,0 +1,34 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_cmatrix;
+}
+transformed data {
+  tuple(matrix[d_int, d_int], vector[d_int], matrix[d_int, d_int]) transformed_data_svd_tuple;
+  
+  transformed_data_svd_tuple = svd(d_matrix);
+  
+  tuple(complex_matrix[d_int, d_int], vector[d_int],
+        complex_matrix[d_int, d_int]) transformed_data_csvd_tuple;
+  transformed_data_csvd_tuple = svd(d_cmatrix);
+}
+parameters {
+  real y_p;
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_cmatrix;
+}
+transformed parameters {
+  tuple(matrix[d_int, d_int], vector[d_int], matrix[d_int, d_int]) transformed_param_svd_tuple;
+  
+  transformed_param_svd_tuple = svd(d_matrix);
+  transformed_param_svd_tuple = svd(p_matrix);
+  
+  tuple(complex_matrix[d_int, d_int], vector[d_int],
+        complex_matrix[d_int, d_int]) transformed_param_csvd_tuple;
+  
+  transformed_param_csvd_tuple = svd(d_cmatrix);
+  transformed_param_csvd_tuple = svd(p_cmatrix);
+}
+model {
+  y_p ~ normal(0, 1);
+}

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -3740,6 +3740,8 @@ Display all Stan math signatures exposed in the language
   columns_dot_self(complex_vector) => complex_row_vector
   columns_dot_self(complex_row_vector) => complex_row_vector
   columns_dot_self(complex_matrix) => complex_row_vector
+  complex_schur_decompose(matrix) => tuple(complex_matrix, complex_matrix)
+  complex_schur_decompose(complex_matrix) => tuple(complex_matrix, complex_matrix)
   complex_schur_decompose_t(matrix) => complex_matrix
   complex_schur_decompose_t(complex_matrix) => complex_matrix
   complex_schur_decompose_u(matrix) => complex_matrix
@@ -3865,6 +3867,7 @@ Display all Stan math signatures exposed in the language
   cov_exp_quad(array[] row_vector, real, real) => matrix
   cov_exp_quad(array[] row_vector, array[] row_vector, real, real) => matrix
   crossprod(matrix) => matrix
+  csr_extract(matrix) => tuple(vector, array[] int, array[] int)
   csr_extract_u(matrix) => array[] int
   csr_extract_v(matrix) => array[] int
   csr_extract_w(matrix) => vector
@@ -4619,6 +4622,10 @@ Display all Stan math signatures exposed in the language
   double_exponential_rng(array[] real, array[] int) => array[] real
   double_exponential_rng(array[] real, array[] real) => array[] real
   e() => real
+  eigendecompose(matrix) => tuple(complex_matrix, complex_vector)
+  eigendecompose(complex_matrix) => tuple(complex_matrix, complex_vector)
+  eigendecompose_sym(matrix) => tuple(matrix, vector)
+  eigendecompose_sym(complex_matrix) => tuple(complex_matrix, complex_vector)
   eigenvalues(matrix) => complex_vector
   eigenvalues(complex_matrix) => complex_vector
   eigenvalues_sym(matrix) => vector
@@ -19580,6 +19587,7 @@ Display all Stan math signatures exposed in the language
   qr(matrix) => tuple(matrix, matrix)
   qr_Q(matrix) => matrix
   qr_R(matrix) => matrix
+  qr_thin(matrix) => tuple(matrix, matrix)
   qr_thin_Q(matrix) => matrix
   qr_thin_R(matrix) => matrix
   quad_form(matrix, vector) => real
@@ -26976,6 +26984,8 @@ Display all Stan math signatures exposed in the language
   sum(complex_row_vector) => complex
   sum(complex_matrix) => complex
   sum(array[] complex) => complex
+  svd(matrix) => tuple(matrix, vector, matrix)
+  svd(complex_matrix) => tuple(complex_matrix, vector, complex_matrix)
   svd_U(matrix) => matrix
   svd_U(complex_matrix) => complex_matrix
   svd_V(matrix) => matrix


### PR DESCRIPTION
Counterpart to https://github.com/stan-dev/math/pull/2931

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: https://github.com/stan-dev/docs/pull/664
    
## Release notes

Exposed new functions `qr_thin`,  `eigendecompose_sym`, `eigendecompose`, `complex_schur_decompose`, `svd`, and `csr_extract`.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
