### PR TITLE
Update js_of_ocaml to 4.1.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
         stage('Verify changes') {
             agent {
                 docker {
-                    image 'stanorg/stanc3:debianfi'
+                    image 'stanorg/stanc3:debian-js4.1.0'
                     args "--entrypoint=\'\'"
                     label 'linux'
                 }
@@ -148,7 +148,7 @@ pipeline {
             }
             agent {
                 docker {
-                    image 'stanorg/stanc3:debianfi'
+                    image 'stanorg/stanc3:debian-js4.1.0'
                     //Forces image to ignore entrypoint
                     args "--entrypoint=\'\'"
                     label 'linux'
@@ -176,7 +176,7 @@ pipeline {
             }
             agent {
                 docker {
-                    image 'stanorg/stanc3:debianfi'
+                    image 'stanorg/stanc3:debian-js4.1.0'
                     //Forces image to ignore entrypoint
                     args "--entrypoint=\'\'"
                 }
@@ -209,7 +209,7 @@ pipeline {
                 stage("Dune tests") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debianfi'
+                            image 'stanorg/stanc3:debian-js4.1.0'
                             //Forces image to ignore entrypoint
                             args "--entrypoint=\'\'"
                         }
@@ -243,7 +243,7 @@ pipeline {
                 stage("stancjs tests") {
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debianfi'
+                            image 'stanorg/stanc3:debian-js4.1.0'
                             //Forces image to ignore entrypoint
                             args "--entrypoint=\'\'"
                         }
@@ -623,7 +623,7 @@ pipeline {
                     }
                     agent {
                         docker {
-                            image 'stanorg/stanc3:debianfi'
+                            image 'stanorg/stanc3:debian-js4.1.0'
                             //Forces image to ignore entrypoint
                             args "--entrypoint=\'\'"
                             label 'linux'

--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -20,7 +20,7 @@ These are automatically installed through the [scripts/install_ocaml.sh] and
 
 For the JavaScript interface to stanc3 we also use the following, installed
 via [scripts/install_js_deps.sh]
-- js_of_ocaml-ppx 3.11.0
+- js_of_ocaml 4.1.0
 - yojson 1.7.0
 
 The [stancjs] executable can be built with

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -5,9 +5,8 @@ set -e
 
 eval $(opam env)
 
-opam pin -y dune 2.8.4 --no-action
 opam pin -y core_kernel v0.14.2 --no-action
 
-opam install -y dune.2.8.4 core_kernel.v0.14.2 menhir.20210929 ppx_deriving.5.2.1 fmt.0.8.8 yojson.1.7.0
+opam install -y dune core_kernel.v0.14.2 menhir.20210929 ppx_deriving.5.2.1 fmt.0.8.8 yojson.1.7.0
 
 eval $(opam env)

--- a/scripts/install_js_deps.sh
+++ b/scripts/install_js_deps.sh
@@ -3,7 +3,7 @@
 # exit when any command fails
 set -e
 
-opam pin -y js_of_ocaml-ppx 3.11.0
+opam pin -y js_of_ocaml 4.1.0
 
 echo "You should also install node in order to run the tests."
 echo "Tests are run with dune build @runjstest"

--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -7,7 +7,7 @@
   analysis_and_optimization
   stan_math_backend)
  (preprocess
-  (pps js_of_ocaml-ppx ppx_jane))
+  (pps ppx_jane))
  (modes js))
 
 (alias


### PR DESCRIPTION
This bumps us from 3.11 to 4.1, which includes a fix for an inlining issue that can affect performance that @andrjohns found discussions of. Some quick local tests suggested that this is about 10% faster just from updating.

@serban-nicusor-toptal - I think to actually get this going in our CI we need to re-build our docker images, right?

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Updated the OCaml-to-JS compiler used to create stanc.js

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
