### PR TITLE
jenkins: remove old build logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
     options {
         parallelsAlwaysFailFast()
         skipDefaultCheckout()
+        buildDiscarder(logRotator(numToKeepStr: '20', daysToKeepStr: '30'))
     }
     environment {
         CXX = 'clang++-6.0'


### PR DESCRIPTION
Add jenkins configuration to remove old build logs and artifacts after some time to avoid running out of disk space. Feel free to tweak the specific numbers, as long as we don't keep them forever.