### PR TITLE
jenkins: pass appropriate parallel arg to runPerformanceTests.py

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,7 @@ pipeline {
                                     echo "CXXFLAGS+=-march=core2" > cmdstan/make/local
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
                                     cd cmdstan; make clean-all; git show HEAD --stat; cd ..
-                                    CXX="${CXX}" ./compare-compilers.sh "--tests-file all.tests --num-samples=10" "\$(readlink -f ../bin/stanc)"
+                                    CXX="${CXX}" ./compare-compilers.sh "--tests-file all.tests --num-samples=10 -j${env.PARALLEL}" "\$(readlink -f ../bin/stanc)"
                                 """
                             }
 
@@ -514,7 +514,7 @@ pipeline {
                                     echo "CXXFLAGS+=-march=core2" > cmdstan/make/local
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
                                     cd cmdstan; make clean-all; git show HEAD --stat; cd ..
-                                    CXX="${CXX}" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10" "--O1" "\$(readlink -f ../bin/stanc)"
+                                    CXX="${CXX}" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10 -j${env.PARALLEL}" "--O1" "\$(readlink -f ../bin/stanc)"
                                 """
                             }
 


### PR DESCRIPTION
Currently when jenkins runs `compare-compilers.sh` and `compare-optimizer.sh`, they end up running `runPerformanceTest.py` with no `-j` argument, so the resulting builds end up running `-j80` or something (from number of CPUs), while in fact they only have access to 4 cores (as set with `PARALLEL` in jenkins env).  As such the builds are running quite slowly. This should hopefully help.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
