### PR TITLE
Revert "Selectively initialize SoA types"

### DIFF
--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -16340,10 +16340,7 @@ class initialize_SoA_model final : public model_base_crtp<initialize_SoA_model> 
       arr_vec = in__.template read<
                   std::vector<
                     stan::math::var_value<Eigen::Matrix<double,-1,1>>>>(3, 4);
-      stan::math::var_value<Eigen::Matrix<double,-1,1>> x =
-        stan::math::var_value<Eigen::Matrix<double,-1,1>>(Eigen::Matrix<double,-1,1>::Constant(3,
-                                                            std::numeric_limits<double>::quiet_NaN(
-                                                              )));
+      stan::math::var_value<Eigen::Matrix<double,-1,1>> x;
       current_statement__ = 3;
       stan::model::assign(x,
         stan::model::rvalue(y, "y", stan::model::index_min_max(1, 3)),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Reverted #1323 as https://github.com/stan-dev/math/pull/2978 provides a better solution at a lower level.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
