### PR TITLE
Always pull latest version of containers-common and skopeo in Jenkins

### DIFF
--- a/scripts/docker/static/Dockerfile
+++ b/scripts/docker/static/Dockerfile
@@ -16,11 +16,15 @@ LABEL distro_style="apk"
 
 #Install os dependencies
 RUN apk update && apk --no-cache add build-base bzip2 git tar curl ca-certificates openssl m4 bash docker jq git-subtree
+# Upgrade to GNU Grep for -Po to work
+RUN apk add --no-cache --upgrade grep
 
 # Add a recent version of the Skopeo package, which is used for looking up the correct multiarch docker image
 # http://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/containers-common-0.38.11-r0.apk
-RUN curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/containers-common-0.52.0-r0.apk -o cont.apk && \
-    curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/skopeo-1.12.0-r4.apk -o skopeo.apk && \
+RUN CONTAINERS_COMMON_VER=$(curl -s https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/ | grep -Po '(?<=containers-common-)[^apk]+' | head -n 1)apk && \
+    curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/containers-common-${CONTAINERS_COMMON_VER} -o cont.apk && \
+    SKOPEO_VER=$(curl -s https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/ | grep -Po '(?<=skopeo-)[^apk]+' | head -n 1)apk && \
+    curl https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/skopeo-${SKOPEO_VER} -o skopeo.apk && \
     apk add cont.apk && \
     apk add skopeo.apk
 


### PR DESCRIPTION
Always pull latest version of containers-common and skopeo to avoid manually maintaining them.

#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
