### PR TITLE
Update js_of_ocaml to 5.5.2

### DIFF
--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -21,7 +21,7 @@ These are automatically installed through the [scripts/install_ocaml.sh] and
 
 For the JavaScript interface to stanc3 we also use the following, installed
 via [scripts/install_js_deps.sh]
-- js_of_ocaml 4.1.0
+- js_of_ocaml 5.5.2
 
 The [stancjs] executable can be built with
 

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -40,7 +40,7 @@ RUN opam update; bash -x install_build_deps.sh
 COPY ./scripts/install_dev_deps.sh ./
 RUN opam update; bash -x install_dev_deps.sh
 
-# Install Javascript dev environment
+# Install Javascript dev environment (js_of_ocaml 5.5.2)
 COPY ./scripts/install_js_deps.sh ./
 RUN opam update; bash -x install_js_deps.sh
 

--- a/scripts/install_js_deps.sh
+++ b/scripts/install_js_deps.sh
@@ -3,7 +3,7 @@
 # exit when any command fails
 set -e
 
-opam pin -y js_of_ocaml 4.1.0
+opam pin -y js_of_ocaml 5.5.2
 
 echo "You should also install node in order to run the tests."
 echo "Tests are run with dune build @runjstest"

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -246,6 +246,8 @@ let dump_stan_math_distributions () =
   @@ Fmt.str "%a" Stan_math_signatures.pretty_print_all_math_distributions ()
 
 let () =
-  Js.export "dump_stan_math_signatures" dump_stan_math_signatures;
-  Js.export "dump_stan_math_distributions" dump_stan_math_distributions;
-  Js.export "stanc" stan2cpp_wrapped
+  Js.export "dump_stan_math_signatures"
+    (Js.Unsafe.callback dump_stan_math_signatures);
+  Js.export "dump_stan_math_distributions"
+    (Js.Unsafe.callback dump_stan_math_distributions);
+  Js.export "stanc" (Js.Unsafe.callback stan2cpp_wrapped)


### PR DESCRIPTION
The recent release of 5.5 of js_of_ocaml featured some pretty big improvements to the dead code elimination phase which makes the produced file smaller. On my machine, this is a nearly 15% improvement:

```
-r--r--r--  1 brian brian 1873308 Dec  8 10:13 stancjs.4.1.0.bc.js
-r--r--r--  1 brian brian 1608773 Dec  8 10:18 stancjs.5.5.2.bc.js
```

In terms of speed, it seems to be essentially the same, maybe _slightly_ faster, but definitely within the range that the noise on my machine makes benchmarking unable to tell the difference between the two versions.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Updated `js_of_ocaml` to version 5.5.2

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
