### PR TITLE
Fix "build binaries" action on MacOS

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -41,6 +41,9 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           cache-prefix: v3
 
+      - if: matrix.os == 'macos'
+        run: opam pin -y dune.3.9.3 --no-action
+
       - run: bash -x scripts/install_build_deps.sh
 
       - name: Build

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -42,7 +42,7 @@ jobs:
           cache-prefix: v3
 
       - if: matrix.os == 'macos'
-        run: opam pin -y dune.3.9.3 --no-action
+        run: opam pin -y dune 3.9.3 --no-action
 
       - run: bash -x scripts/install_build_deps.sh
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -42,7 +42,7 @@ jobs:
           cache-prefix: v3
 
       - if: matrix.os == 'macos'
-        run: opam pin -y dune 3.9.3 --no-action
+        run: opam pin -y dune 3.6.0 --no-action
 
       - run: bash -x scripts/install_build_deps.sh
 


### PR DESCRIPTION
Reported by @yizhang-yiz - recent versions of dune do not build with the older MacOS SDK we use, so we pin an older version.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
