### PR TITLE
Mark 'jacobian' as reserved for future use

### DIFF
--- a/src/frontend/Input_warnings.ml
+++ b/src/frontend/Input_warnings.ml
@@ -9,3 +9,9 @@ let empty file =
   add_warning Middle.Location_span.empty
     ("Empty file '" ^ file
    ^ "' detected; this is a valid stan model but likely unintended!")
+
+let future_keyword kwrd version positions =
+  add_warning
+    (Preprocessor.location_span_of_positions positions)
+    ("Variable name '" ^ kwrd ^ "' will be a reserved word starting in Stan "
+   ^ version ^ ". Please rename it!")

--- a/src/frontend/Input_warnings.mli
+++ b/src/frontend/Input_warnings.mli
@@ -14,3 +14,7 @@ val add_warning : Middle.Location_span.t -> string -> unit
 
 val empty : string -> unit
 (** Register that an empty file is being parsed *)
+
+val future_keyword :
+  string -> string -> Lexing.position * Lexing.position -> unit
+(** Warn on a keyword which will be reserved in the future*)

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -144,6 +144,7 @@ rule token = parse
   | "upper"                   { lexer_logger "upper" ; Parser.UPPER }
   | "offset"                  { lexer_logger "offset" ; Parser.OFFSET }
   | "multiplier"              { lexer_logger "multiplier" ; Parser.MULTIPLIER }
+  | "jacobian"                { lexer_logger "jacobian" ; Parser.JACOBIAN }
 (* Operators *)
   | '?'                       { lexer_logger "?" ; add_separator lexbuf ; Parser.QMARK }
   | ':'                       { lexer_logger ":" ; Parser.COLON }
@@ -189,7 +190,7 @@ rule token = parse
                                 Parser.DOTNUMERAL (lexeme lexbuf) }
   | imag_constant as z        { lexer_logger ("imag_constant " ^ z) ;
                                 Parser.IMAGNUMERAL (lexeme lexbuf) }
-  | "target"                  { lexer_logger "target" ; Parser.TARGET } 
+  | "target"                  { lexer_logger "target" ; Parser.TARGET }
   | string_literal as s       { lexer_logger ("string_literal " ^ s) ;
                                 Parser.STRINGLITERAL (lexeme lexbuf) }
   | identifier as id          { lexer_logger ("identifier " ^ id) ;

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -86,6 +86,7 @@ let nest_unsized_array basic_type n =
        CHOLESKYFACTORCORR "cholesky_factor_corr" CHOLESKYFACTORCOV "cholesky_factor_cov"
        CORRMATRIX "corr_matrix" COVMATRIX "cov_matrix" COMPLEXMATRIX "complex_matrix"
 %token LOWER "lower" UPPER "upper" OFFSET "offset" MULTIPLIER "multiplier"
+%token JACOBIAN "jacobian"
 %token <string> INTNUMERAL "24"
 %token <string> REALNUMERAL "3.1415" DOTNUMERAL ".2"
 %token <string> IMAGNUMERAL "1i"
@@ -212,7 +213,15 @@ generated_quantities_block:
 identifier:
   | id=IDENTIFIER { build_id id $loc }
   | TRUNCATE { build_id "T" $loc}
+  | id_and_v = future_keyword
+    {
+      let id, v = id_and_v in
+      Input_warnings.future_keyword id.name v $loc;
+      id
+    }
 
+future_keyword:
+  | JACOBIAN { build_id "jacobian" $loc, "2.38.0" }
 
 decl_identifier:
   | id=identifier { id }

--- a/test/integration/good/warning/deprecated_syntax.stan
+++ b/test/integration/good/warning/deprecated_syntax.stan
@@ -1,5 +1,5 @@
 parameters {
-
+  real jacobian;
 }
 model {
   if (1 < 2 < 3 < 4) {

--- a/test/integration/good/warning/pretty.expected
+++ b/test/integration/good/warning/pretty.expected
@@ -1,6 +1,6 @@
   $ ../../../../../install/default/bin/stanc --auto-format deprecated_syntax.stan
 parameters {
-  
+  real jacobian;
 }
 model {
   if (1 < 2 < 3 < 4) {
@@ -8,6 +8,9 @@ model {
   }
 }
 
+Warning in 'deprecated_syntax.stan', line 2, column 7: Variable name
+    'jacobian' will be a reserved word starting in Stan 2.38.0. Please rename
+    it!
 Warning in 'deprecated_syntax.stan', line 5, column 6: Found 1 < 2 < 3. This
     is interpreted as (1 < 2) < 3. Consider if the intended meaning was 
     1 < 2 && 2 < 3 instead.


### PR DESCRIPTION
See https://github.com/stan-dev/design-docs/pull/52. 

While that design may not be the final one that is approved, I think getting some sort of warning in early is probably useful.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Giving a variable the name `jacobian` is now deprecated. This name is being reserved for future language extensions. 


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
