### PR TITLE
Include function suffixes when looking for "Did you mean" suggestions

### DIFF
--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -109,5 +109,10 @@ let max_distance = 3
 let nearest_ident env name =
   try
     (* catch any errors in distance and just ignore them, no big deal *)
-    Distance.find_min ~max:max_distance (Map.keys env) name
+    Option.first_some
+      (Distance.find_min ~max:max_distance (Map.keys env) name)
+      (Utils.(distribution_suffices @ cumulative_distribution_suffices_w_rng)
+      |> List.map ~f:(fun suffix -> name ^ suffix)
+      |> List.filter ~f:(Map.mem env)
+      |> List.hd)
   with _ -> None

--- a/test/integration/bad/call_dist_no_suffix.stan
+++ b/test/integration/bad/call_dist_no_suffix.stan
@@ -1,0 +1,6 @@
+parameters {
+  real x;
+}
+model {
+  target += std_normal(x);
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -407,6 +407,18 @@ Semantic error in 'break8.stan', line 12, column 4 to column 10:
    -------------------------------------------------
 
 Break statements may only be used in loops.
+  $ ../../../../install/default/bin/stanc call_dist_no_suffix.stan
+Semantic error in 'call_dist_no_suffix.stan', line 5, column 12 to column 25:
+   -------------------------------------------------
+     3:  }
+     4:  model {
+     5:    target += std_normal(x);
+                     ^
+     6:  }
+   -------------------------------------------------
+
+A returning function was expected but an undeclared identifier 'std_normal' was supplied.
+A similar known identifier is 'std_normal_lpdf'
   $ ../../../../install/default/bin/stanc ccdf-sample.stan
 Semantic error in 'ccdf-sample.stan', line 5, column 2 to column 24:
    -------------------------------------------------


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

Since #1024, unknown identifier related errors give a similar identifier as a suggestion but the algorithm only considered typos involving at most three letters. Another likely error is omitting the distribution suffix from a function name:
https://discourse.mc-stan.org/t/how-to-interpret-a-returning-function-was-expected-but-an-undeclared-identifier-was-supplied/34078

## Release notes

When encountering an unknown identifier that matches a known suffixed function without its suffix, add the known function name to the error message.

## Copyright and Licensing

Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
