### PR TITLE
use tabs to position error message cursor when appropriate

### DIFF
--- a/src/middle/Location.ml
+++ b/src/middle/Location.ml
@@ -33,7 +33,12 @@ let pp_context_list ppf (lines, {line_num; col_num; _}) =
   let line_2_before = get_line (line_num - 2) in
   let line_before = get_line (line_num - 1) in
   let our_line = get_line line_num in
-  let cursor_line = String.make (col_num + 9) ' ' ^ "^\n" in
+  let offset = 9 + col_num in
+  let copied = Int.min offset (String.length our_line) in
+  let blank_line =
+    String.slice our_line 0 copied
+    |> String.map ~f:(function '\t' -> '\t' | _ -> ' ') in
+  let cursor_line = blank_line ^ String.make (offset - copied) ' ' ^ "^\n" in
   let line_after = get_line (line_num + 1) in
   let line_2_after = get_line (line_num + 2) in
   Fmt.pf ppf

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -251,7 +251,7 @@ Syntax error in 'string', line 3, column 8 to column 10, parsing error:
      1:  
      2:  parameters {
      3:  	real y[10];
-                 ^
+         	       ^
      4:  }
      5:  model {
    -------------------------------------------------
@@ -266,7 +266,7 @@ Syntax error in 'string', line 3, column 8 to column 10, parsing error:
      1:  
      2:  parameters {
      3:  	real y[10];
-                 ^
+         	       ^
      4:  }
      5:  model {
    -------------------------------------------------


### PR DESCRIPTION
On error, stanc prints the problematic source line and a caret that points to the horizontal location of the error but if the source line contains tabs instead of spaces the caret was at the wrong location.
A simple fix is to duplicate the tabs from the source to the line that contains the caret.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Copyright and Licensing
Copyright holder: Niko Huurre

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
