### PR TITLE
Emit new link for lkj_cov deprecation

### DIFF
--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -38,7 +38,7 @@ let is_redundant_forwarddecl fundefs funname arguments =
 let lkj_cov_message =
   "lkj_cov is deprecated and will be removed in Stan 3.0. Use lkj_corr with an \
    independent lognormal distribution on the scales, see: \
-   https://mc-stan.org/docs/reference-manual/lkj_cov-distribution.html"
+   https://mc-stan.org/docs/reference-manual/deprecations.html#lkj_cov-distribution"
 
 let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
     ({expr; emeta} : (typed_expr_meta, fun_kind) expr_with) :

--- a/test/integration/good/warning/pretty.expected
+++ b/test/integration/good/warning/pretty.expected
@@ -473,7 +473,7 @@ model {
 Warning in 'lkj_cov_deprecation1.stan', line 8, column 10: lkj_cov is
     deprecated and will be removed in Stan 3.0. Use lkj_corr with an
     independent lognormal distribution on the scales, see:
-    https://mc-stan.org/docs/reference-manual/lkj_cov-distribution.html
+    https://mc-stan.org/docs/reference-manual/deprecations.html#lkj_cov-distribution
   $ ../../../../../install/default/bin/stanc --auto-format lkj_cov_deprecation2.stan
 parameters {
   cov_matrix[3] Sigma;
@@ -488,7 +488,7 @@ model {
 Warning in 'lkj_cov_deprecation2.stan', line 8, column 12: lkj_cov is
     deprecated and will be removed in Stan 3.0. Use lkj_corr with an
     independent lognormal distribution on the scales, see:
-    https://mc-stan.org/docs/reference-manual/lkj_cov-distribution.html
+    https://mc-stan.org/docs/reference-manual/deprecations.html#lkj_cov-distribution
   $ ../../../../../install/default/bin/stanc --auto-format matrix_pow_warning.stan
 data {
   int<lower=0> N;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Replaced the link show when the deprecated `lkj_cov` distribution is used with the new link (see https://github.com/stan-dev/docs/pull/694).

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
