### PR TITLE
Improve internal error handling and message

### DIFF
--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -18,7 +18,7 @@ let with_exn_message f =
       else "Backtrace missing." in
     Error
       (Fmt.str
-         "Fatal error:@ @[%a@]@\n\
+         "Internal compiler error:@ @[%a@]@\n\
           %s@\n\
           @\n\
           This should never happen. Please file a bug at \

--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -2,13 +2,24 @@
 
 open Core
 
-(** Equivalent to [raise_s] but prepends a stanc specific
-  message asking users to report a bug *)
-let internal_compiler_error message =
-  let augmented =
-    Sexplib0.Sexp.List
-      [ [%message
-          "Fatal error: this should never happen. Please file a bug on \
-           https://github.com/stan-dev/stanc3/issues/new and include the model \
-           that caused this issue."]; message ] in
-  raise_s augmented
+(** An alias of [Core.raise_s]. This used to do more
+    processing, for now it is preserved just as a nicer
+    marker in the code *)
+let internal_compiler_error = raise_s
+
+(** Catch all exceptions at the top-level and convert them into a ['a, string result]
+    where the string contains the exception and a backtrace if present, followed
+    by a link to our bugtracker. *)
+let with_exn_message f =
+  try Ok (f ())
+  with e ->
+    let bt = Printexc.get_backtrace () in
+    Error
+      (Fmt.str
+         "Fatal error:@ @[%a@]@\n\
+          %s@\n\
+          @\n\
+          This should never happen. Please file a bug on \
+          https://github.com/stan-dev/stanc3/issues/new and include this \
+          message and the model that caused this issue.@\n"
+         Exn.pp e bt)

--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -13,13 +13,15 @@ let internal_compiler_error = raise_s
 let with_exn_message f =
   try Ok (f ())
   with e ->
-    let bt = Printexc.get_backtrace () in
+    let bt =
+      if Printexc.backtrace_status () then Printexc.get_backtrace ()
+      else "Backtrace missing." in
     Error
       (Fmt.str
          "Fatal error:@ @[%a@]@\n\
           %s@\n\
           @\n\
-          This should never happen. Please file a bug on \
-          https://github.com/stan-dev/stanc3/issues/new and include this \
+          This should never happen. Please file a bug at \
+          https://github.com/stan-dev/stanc3/issues/new@ and include this \
           message and the model that caused this issue.@\n"
          Exn.pp e bt)

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -417,4 +417,10 @@ let main () =
   else Typechecker.model_name := mangle !Typechecker.model_name;
   use_file !model_file
 
-let () = main ()
+let () =
+  match Common.ICE.with_exn_message main with
+  | Ok () -> ()
+  | Error internal_error ->
+      Out_channel.output_string stderr internal_error;
+      Out_channel.flush stderr;
+      exit 2

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -1,0 +1,86 @@
+open Core
+open! Frontend
+open Common
+
+let%expect_test "with_exn_message" =
+  Printexc.record_backtrace false;
+  ICE.with_exn_message (fun () -> failwith "oops!")
+  |> Result.error |> Option.value_exn |> print_endline;
+  Printexc.record_backtrace true;
+  [%expect
+    {|
+    Fatal error:
+    (Failure oops!)
+    Backtrace missing.
+
+    This should never happen. Please file a bug at https://github.com/stan-dev/stanc3/issues/new
+    and include this message and the model that caused this issue. |}]
+
+(* expect_tests warn against directly including a backtrace for fragility reasons *)
+let%expect_test "backtrace indirect test" =
+  ( ICE.with_exn_message (fun () -> failwith "oops!")
+  |> Result.error |> Option.value_exn
+  |> fun s ->
+    try
+      let _ = Str.search_forward (Str.regexp "^Called from Common") s 0 in
+      print_endline "Backtrace found in message"
+    with _ -> print_endline "FAILED TO FIND BACKTRACE" );
+  [%expect {| Backtrace found in message |}]
+
+let%expect_test "ICE triggered" =
+  (* Manually construct an untyped AST with a Promotion node.
+     This is impossible in the parser, so leads to an ICE
+     during typechecking *)
+  let ast : Ast.untyped_program =
+    Ast.
+      { functionblock= None
+      ; datablock= None
+      ; transformeddatablock= None
+      ; parametersblock= None
+      ; transformedparametersblock= None
+      ; modelblock= None
+      ; generatedquantitiesblock=
+          Some
+            Ast.
+              { stmts=
+                  [ { stmt=
+                        VarDecl
+                          { decl_type= Middle.SizedType.SReal
+                          ; transformation= Middle.Transformation.Identity
+                          ; is_global= false
+                          ; variables=
+                              [ Ast.
+                                  { identifier=
+                                      Ast.
+                                        { name= "foo"
+                                        ; id_loc= Middle.Location_span.empty }
+                                  ; initial_value=
+                                      Some
+                                        { expr=
+                                            Promotion
+                                              ( { expr= IntNumeral "1"
+                                                ; emeta=
+                                                    { loc=
+                                                        Middle.Location_span
+                                                        .empty } }
+                                              , Middle.UnsizedType.UReal
+                                              , Middle.UnsizedType.DataOnly )
+                                        ; emeta=
+                                            {loc= Middle.Location_span.empty} }
+                                  } ] }
+                    ; smeta= {loc= Middle.Location_span.empty} } ]
+              ; xloc= Middle.Location_span.empty }
+      ; comments= [] } in
+  Printexc.record_backtrace false;
+  ICE.with_exn_message (fun () -> Typechecker.check_program ast)
+  |> Result.error |> Option.value_exn |> print_endline;
+  Printexc.record_backtrace true;
+  [%expect
+    {|
+    Fatal error:
+    ("Promotion in untyped AST"
+     (e ((expr (IntNumeral 1)) (emeta ((loc <opaque>))))))
+    Backtrace missing.
+
+    This should never happen. Please file a bug at https://github.com/stan-dev/stanc3/issues/new
+    and include this message and the model that caused this issue. |}]


### PR DESCRIPTION
This closes #1408. There is no real difference in the end result for the binary executable, but this is a huge improvement for stanc3js since internal errors will be cleanly converted to the error string format rather than percolating as javascript exceptions.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

The compiler should display a cleaner error if it encounters an internal error.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
