### PR TITLE
[CI] Switch to gh binary for releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1024,7 +1024,7 @@ pipeline {
 
                         runShell("""
                             gh release delete ${tagName()} --cleanup-tag -y || true
-                            gh release create ${tagName()} --latest --target master --notes "$(git log --pretty=format:'nightly: %h %s' -n 1)" ./bin/*
+                            gh release create ${tagName()} --latest --target master --notes "\$(git log --pretty=format:'nightly: %h %s' -n 1)" ./bin/*
                         """)
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1023,9 +1023,7 @@ pipeline {
                         unstash 'js-exe'
 
                         runShell("""
-                            wget https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz
-                            tar -zxvpf ghr_v0.12.1_linux_amd64.tar.gz && rm bin/ghr_v0.12.1_linux_amd64.tar.gz || true
-                            ./ghr_v0.12.1_linux_amd64/ghr -r stanc3 -u stan-dev -recreate ${tagName()} bin/
+                            gh release create ${tagName()} --latest --target master --generate-notes ./bin/*
                         """)
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1023,7 +1023,8 @@ pipeline {
                         unstash 'js-exe'
 
                         runShell("""
-                            gh release create ${tagName()} --latest --target master --generate-notes ./bin/*
+                            gh release delete ${tagName()} --cleanup-tag -y || true
+                            gh release create ${tagName()} --latest --target master --notes "$(git log --pretty=format:'nightly: %h %s' -n 1)" ./bin/*
                         """)
                     }
                 }

--- a/scripts/docker/publish/Dockerfile
+++ b/scripts/docker/publish/Dockerfile
@@ -12,6 +12,12 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     rsync git build-essential m4 unzip pkg-config libpcre3-dev \
     python3 python3-pip nodejs sudo
 
+RUN sudo mkdir -p -m 755 /etc/apt/keyrings && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& sudo apt update \
+&& sudo apt install gh -y
+
 RUN addgroup -gid ${PGID} jenkins
 RUN adduser --disabled-password --gecos '' --ingroup jenkins --uid ${PUID} jenkins
 RUN usermod -a -G sudo jenkins


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Requested in #1418, this will replace the `ghr` binary with the official `gh` binary from Github.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
