### PR TITLE
Fix complex matrix division miscompilation

### DIFF
--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -64,8 +64,18 @@ let functor_suffix_select = function
 let is_scalar e =
   match Expr.Typed.type_of e with UInt | UReal | UComplex -> true | _ -> false
 
-let is_matrix e = Expr.Typed.type_of e = UMatrix
-let is_row_vector e = Expr.Typed.type_of e = URowVector
+(** Used to determine if [operator/] should be
+      mdivide_right() or divide() *)
+let is_matrix e =
+  match Expr.Typed.type_of e with
+  | UMatrix | UComplexMatrix -> true
+  | _ -> false
+
+let is_row_vector e =
+  match Expr.Typed.type_of e with
+  | URowVector | UComplexRowVector -> true
+  | _ -> false
+
 let first es = List.nth_exn es 0
 let second es = List.nth_exn es 1
 let default_multiplier = 1
@@ -241,6 +251,8 @@ and lower_operator_app op es_in =
   | Minus -> lower_binary_op Subtract "stan::math::subtract" es
   | Times -> lower_binary_op Multiply "stan::math::multiply" es
   | Divide | IntDivide ->
+      (* XXX: This conditional is probably a sign that we need to rethink how we store Operators
+         in the MIR *)
       if
         is_matrix (second es)
         && (is_matrix (first es) || is_row_vector (first es))

--- a/test/integration/good/code-gen/complex_numbers/basic_op_param.stan
+++ b/test/integration/good/code-gen/complex_numbers/basic_op_param.stan
@@ -51,6 +51,11 @@ transformed parameters {
   tp_c_matrix = vec * crowvec;
   tp_c_matrix = cvec * rowvec;
 
+  // matrix-matrix division
+  tp_c_matrix = cmat / cmat;
+  tp_c_matrix = cmat / mat;
+  tp_c_matrix = mat / cmat;
+
   complex_vector[N] tp_c_vector = crowvec';
   // matrix-vector products
   tp_c_vector = cmat * cvec;
@@ -114,6 +119,11 @@ transformed parameters {
   tp_c_rowvector = rowvec - crowvec;
   tp_c_rowvector = -crowvec;
   tp_c_rowvector = -rowvec;
+
+  // rowvector-matrix division
+  tp_c_rowvector = crowvec / cmat;
+  tp_c_rowvector = crowvec / mat;
+  tp_c_rowvector = rowvec / cmat;
 
   complex tp_c;
   // rowvector-vector multiply

--- a/test/integration/good/code-gen/complex_numbers/basic_operations.stan
+++ b/test/integration/good/code-gen/complex_numbers/basic_operations.stan
@@ -49,6 +49,11 @@ generated quantities {
   gq_c_matrix = vec * crowvec;
   gq_c_matrix = cvec * rowvec;
 
+  // matrix-matrix division
+  gq_c_matrix = cmat / cmat;
+  gq_c_matrix = cmat / mat;
+  gq_c_matrix = mat / cmat;
+
   complex_vector[N] gq_c_vector = crowvec';
   // matrix-vector products
   gq_c_vector = cmat * cvec;
@@ -112,6 +117,11 @@ generated quantities {
   gq_c_rowvector = rowvec - crowvec;
   gq_c_rowvector = -crowvec;
   gq_c_rowvector = -rowvec;
+
+  // rowvector-matrix division
+  gq_c_rowvector = crowvec / cmat;
+  gq_c_rowvector = crowvec / mat;
+  gq_c_rowvector = rowvec / cmat;
 
   complex gq_c;
   // rowvector-vector multiply

--- a/test/integration/good/code-gen/complex_numbers/basic_ops_mix.stan
+++ b/test/integration/good/code-gen/complex_numbers/basic_ops_mix.stan
@@ -1,32 +1,29 @@
 data {
   int N;
-  complex_matrix[N,N] cmat;
+  complex_matrix[N, N] cmat;
   complex_vector[N] cvec;
   complex_row_vector[N] crowvec;
   complex z;
-
-  matrix[N,N] mat;
+  
+  matrix[N, N] mat;
   vector[N] vec;
   row_vector[N] rowvec;
   real r;
 }
-
 parameters {
-  complex_matrix[N,N] cvmat;
+  complex_matrix[N, N] cvmat;
   complex_vector[N] cvvec;
   complex_row_vector[N] cvrowvec;
   complex zv;
-
-  matrix[N,N] vmat;
+  
+  matrix[N, N] vmat;
   vector[N] vvec;
   row_vector[N] vrowvec;
   real v;
 }
-
-
 transformed parameters {
-  complex_matrix[N,N] tp_c_matrix;
-
+  complex_matrix[N, N] tp_c_matrix;
+  
   // matrix-matrix multiply and elt
   tp_c_matrix = cmat * cvmat;
   tp_c_matrix = cmat * vmat;
@@ -37,7 +34,7 @@ transformed parameters {
   tp_c_matrix = cmat ./ cvmat;
   tp_c_matrix = cmat ./ vmat;
   tp_c_matrix = mat ./ cvmat;
-
+  
   // matrix-scalar multiply
   tp_c_matrix = cmat * zv;
   tp_c_matrix = z * cvmat;
@@ -45,7 +42,7 @@ transformed parameters {
   tp_c_matrix = cmat * v;
   tp_c_matrix = mat * zv;
   tp_c_matrix = z * vmat;
-
+  
   // matrix-matrix addition and subtraction
   tp_c_matrix = cmat + cvmat;
   tp_c_matrix = cmat + vmat;
@@ -53,19 +50,27 @@ transformed parameters {
   tp_c_matrix = cmat - cvmat;
   tp_c_matrix = cmat - vmat;
   tp_c_matrix = mat - cvmat;
-
+  
   // vector-rowvector multiply
   tp_c_matrix = cvec * cvrowvec;
   tp_c_matrix = vec * cvrowvec;
   tp_c_matrix = cvec * vrowvec;
-
+  
+  // matrix-matrix division
+  tp_c_matrix = cvmat / cmat;
+  tp_c_matrix = cvmat / mat;
+  tp_c_matrix = vmat / cmat;
+  tp_c_matrix = cmat / cvmat;
+  tp_c_matrix = cmat / vmat;
+  tp_c_matrix = mat / cvmat;
+  
   complex_vector[N] tp_c_vector = cvrowvec';
   // matrix-vector products
   tp_c_vector = cmat * cvvec;
   tp_c_vector = cvmat * cvec;
   tp_c_vector = mat * cvvec;
   tp_c_vector = cmat * vvec;
-
+  
   // vector-scalar multiplication
   tp_c_vector = z * cvvec;
   tp_c_vector = cvec * zv;
@@ -73,7 +78,7 @@ transformed parameters {
   tp_c_vector = cvec * v;
   tp_c_vector = z * vvec;
   tp_c_vector = vec * zv;
-
+  
   // vector-vector elt mult and div
   tp_c_vector = cvec .* cvvec;
   tp_c_vector = vec .* cvvec;
@@ -81,7 +86,7 @@ transformed parameters {
   tp_c_vector = cvec ./ cvvec;
   tp_c_vector = vec ./ cvvec;
   tp_c_vector = cvec ./ vvec;
-
+  
   // vector-vector addition and subtraction
   tp_c_vector = cvec + cvvec;
   tp_c_vector = vec + cvvec;
@@ -89,13 +94,13 @@ transformed parameters {
   tp_c_vector = cvec - cvvec;
   tp_c_vector = vec - cvvec;
   tp_c_vector = cvec - vvec;
-
+  
   complex_row_vector[N] tp_c_rowvector = cvvec';
   // rowvector-matrix multiplication
   tp_c_rowvector = crowvec * cvmat;
   tp_c_rowvector = rowvec * cvmat;
   tp_c_rowvector = crowvec * vmat;
-
+  
   // rowvector-scalar multiplication
   tp_c_rowvector = z * cvrowvec;
   tp_c_rowvector = crowvec * zv;
@@ -103,7 +108,7 @@ transformed parameters {
   tp_c_rowvector = crowvec * v;
   tp_c_rowvector = z * vrowvec;
   tp_c_rowvector = rowvec * zv;
-
+  
   // rowvector-rowvector elt mult and div
   tp_c_rowvector = crowvec .* cvrowvec;
   tp_c_rowvector = crowvec .* vrowvec;
@@ -111,7 +116,7 @@ transformed parameters {
   tp_c_rowvector = crowvec ./ cvrowvec;
   tp_c_rowvector = crowvec ./ vrowvec;
   tp_c_rowvector = rowvec ./ cvrowvec;
-
+  
   // rowvector-rowvector addition and subtraction
   tp_c_rowvector = crowvec + cvrowvec;
   tp_c_rowvector = crowvec + vrowvec;
@@ -119,78 +124,84 @@ transformed parameters {
   tp_c_rowvector = crowvec - cvrowvec;
   tp_c_rowvector = crowvec - vrowvec;
   tp_c_rowvector = rowvec - cvrowvec;
-
+  
+  // rowvector-matrix division
+  tp_c_rowvector = cvrowvec / cmat;
+  tp_c_rowvector = cvrowvec / mat;
+  tp_c_rowvector = vrowvec / cmat;
+  tp_c_rowvector = crowvec / cvmat;
+  tp_c_rowvector = crowvec / vmat;
+  tp_c_rowvector = rowvec / cvmat;
+  
   complex tp_c;
   // rowvector-vector multiply
   tp_c = crowvec * cvvec;
   tp_c = cvrowvec * cvec;
   tp_c = crowvec * vvec;
   tp_c = rowvec * cvvec;
-
+  
   // broadcasting
   tp_c_matrix = z - cvmat;
   tp_c_matrix = r - cvmat;
   tp_c_matrix = cvmat - r;
   tp_c_matrix = cvmat - z;
-
+  
   tp_c_matrix = z + cvmat;
   tp_c_matrix = r + cvmat;
   tp_c_matrix = cvmat + r;
   tp_c_matrix = cvmat + z;
-
+  
   tp_c_matrix = zv - cmat;
   tp_c_matrix = v - cmat;
   tp_c_matrix = cmat - v;
   tp_c_matrix = cmat - zv;
-
+  
   tp_c_matrix = zv + cmat;
   tp_c_matrix = v + cmat;
   tp_c_matrix = cmat + v;
   tp_c_matrix = cmat + zv;
-
+  
   tp_c_matrix = z ./ cvmat;
   tp_c_matrix = r ./ cvmat;
   tp_c_matrix = cvmat ./ r;
   tp_c_matrix = cvmat ./ z;
-
+  
   tp_c_matrix = zv ./ cmat;
   tp_c_matrix = v ./ cmat;
   tp_c_matrix = cmat ./ v;
   tp_c_matrix = cmat ./ zv;
-
-
+  
   tp_c_matrix = z .* cvmat;
   tp_c_matrix = r .* cvmat;
   tp_c_matrix = cvmat .* r;
   tp_c_matrix = cvmat .* z;
-
+  
   tp_c_matrix = zv .* cmat;
   tp_c_matrix = v .* cmat;
   tp_c_matrix = cmat .* v;
   tp_c_matrix = cmat .* zv;
-
-    tp_c_matrix = z / cvmat;
+  
+  tp_c_matrix = z / cvmat;
   tp_c_matrix = r / cvmat;
   tp_c_matrix = cvmat / r;
   tp_c_matrix = cvmat / z;
-
+  
   tp_c_matrix = zv / cmat;
   tp_c_matrix = v / cmat;
   tp_c_matrix = cmat / v;
   tp_c_matrix = cmat / zv;
-
+  
   tp_c_matrix = z * cvmat;
   tp_c_matrix = r * cvmat;
   tp_c_matrix = cvmat * r;
   tp_c_matrix = cvmat * z;
-
+  
   tp_c_matrix = zv * cmat;
   tp_c_matrix = v * cmat;
   tp_c_matrix = cmat * v;
   tp_c_matrix = cmat * zv;
-
+  
   // transformations
-  array[N,N] complex carray;
+  array[N, N] complex carray;
   carray = to_array_2d(cvmat);
-
 }

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -391,16 +391,16 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_matrix");
       current_statement__ = 40;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::mdivide_right(cmat, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 41;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 42;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
           cmat), "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
@@ -614,16 +614,17 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 89;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(crowvec, cmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 90;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 91;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           cmat), "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
@@ -931,16 +932,16 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_matrix");
       current_statement__ = 40;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::mdivide_right(cmat, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 41;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 42;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
           cmat), "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
@@ -1154,16 +1155,17 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 89;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(crowvec, cmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 90;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 91;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           cmat), "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
@@ -1519,16 +1521,16 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_matrix");
       current_statement__ = 40;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::mdivide_right(cmat, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 41;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 42;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
           cmat), "assigning variable tp_c_matrix");
       current_statement__ = 10;
@@ -1736,16 +1738,17 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 89;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(crowvec, cmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 90;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 91;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           cmat), "assigning variable tp_c_rowvector");
       current_statement__ = 92;
@@ -2998,16 +3001,16 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_matrix");
       current_statement__ = 32;
-      stan::model::assign(gq_c_matrix, stan::math::divide(cmat, cmat),
+      stan::model::assign(gq_c_matrix, stan::math::mdivide_right(cmat, cmat),
         "assigning variable gq_c_matrix");
       current_statement__ = 33;
       stan::model::assign(gq_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable gq_c_matrix");
       current_statement__ = 34;
       stan::model::assign(gq_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(mat), cmat),
         "assigning variable gq_c_matrix");
       Eigen::Matrix<std::complex<double>,-1,1> gq_c_vector =
@@ -3219,16 +3222,17 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       stan::model::assign(gq_c_rowvector, stan::math::minus(rowvec),
         "assigning variable gq_c_rowvector");
       current_statement__ = 81;
-      stan::model::assign(gq_c_rowvector, stan::math::divide(crowvec, cmat),
+      stan::model::assign(gq_c_rowvector,
+        stan::math::mdivide_right(crowvec, cmat),
         "assigning variable gq_c_rowvector");
       current_statement__ = 82;
       stan::model::assign(gq_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable gq_c_rowvector");
       current_statement__ = 83;
       stan::model::assign(gq_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cmat),
         "assigning variable gq_c_rowvector");
       std::complex<double> gq_c =
@@ -4198,29 +4202,31 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_matrix");
       current_statement__ = 38;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, cmat),
+      stan::model::assign(tp_c_matrix,
+        stan::math::mdivide_right(cvmat, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 39;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cvmat,
+        stan::math::mdivide_right(cvmat,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 40;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat),
           cmat), "assigning variable tp_c_matrix");
       current_statement__ = 41;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cvmat),
+      stan::model::assign(tp_c_matrix,
+        stan::math::mdivide_right(cmat, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 42;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 43;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(mat), cvmat),
         "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
@@ -4423,29 +4429,31 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 87;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(cvrowvec, cmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(cvrowvec, cmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 88;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(cvrowvec,
+        stan::math::mdivide_right(cvrowvec,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 89;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec),
           cmat), "assigning variable tp_c_rowvector");
       current_statement__ = 90;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cvmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(crowvec, cvmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 91;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 92;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
         "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
@@ -4823,29 +4831,31 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_matrix");
       current_statement__ = 38;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, cmat),
+      stan::model::assign(tp_c_matrix,
+        stan::math::mdivide_right(cvmat, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 39;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cvmat,
+        stan::math::mdivide_right(cvmat,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 40;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat),
           cmat), "assigning variable tp_c_matrix");
       current_statement__ = 41;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cvmat),
+      stan::model::assign(tp_c_matrix,
+        stan::math::mdivide_right(cmat, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 42;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 43;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(mat), cvmat),
         "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
@@ -5048,29 +5058,31 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 87;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(cvrowvec, cmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(cvrowvec, cmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 88;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(cvrowvec,
+        stan::math::mdivide_right(cvrowvec,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 89;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec),
           cmat), "assigning variable tp_c_rowvector");
       current_statement__ = 90;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cvmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(crowvec, cvmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 91;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 92;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
         "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
@@ -5496,29 +5508,31 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_matrix");
       current_statement__ = 38;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, cmat),
+      stan::model::assign(tp_c_matrix,
+        stan::math::mdivide_right(cvmat, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 39;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cvmat,
+        stan::math::mdivide_right(cvmat,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 40;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat),
           cmat), "assigning variable tp_c_matrix");
       current_statement__ = 41;
-      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cvmat),
+      stan::model::assign(tp_c_matrix,
+        stan::math::mdivide_right(cmat, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 42;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(cmat,
+        stan::math::mdivide_right(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_matrix");
       current_statement__ = 43;
       stan::model::assign(tp_c_matrix,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(mat), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 10;
@@ -5715,29 +5729,31 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 87;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(cvrowvec, cmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(cvrowvec, cmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 88;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(cvrowvec,
+        stan::math::mdivide_right(cvrowvec,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 89;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec),
           cmat), "assigning variable tp_c_rowvector");
       current_statement__ = 90;
-      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cvmat),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::mdivide_right(crowvec, cvmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 91;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(crowvec,
+        stan::math::mdivide_right(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 92;
       stan::model::assign(tp_c_rowvector,
-        stan::math::divide(
+        stan::math::mdivide_right(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
         "assigning variable tp_c_rowvector");
       current_statement__ = 93;

--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -5,7 +5,7 @@ namespace basic_op_param_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 134> locations_array__ =
+static constexpr std::array<const char*, 140> locations_array__ =
   {" (found before start of program)",
   " (in 'basic_op_param.stan', line 5, column 2 to column 27)",
   " (in 'basic_op_param.stan', line 6, column 2 to column 25)",
@@ -16,10 +16,10 @@ static constexpr std::array<const char*, 134> locations_array__ =
   " (in 'basic_op_param.stan', line 12, column 2 to column 23)",
   " (in 'basic_op_param.stan', line 13, column 2 to column 9)",
   " (in 'basic_op_param.stan', line 18, column 2 to column 34)",
-  " (in 'basic_op_param.stan', line 54, column 2 to column 43)",
-  " (in 'basic_op_param.stan', line 86, column 2 to column 47)",
-  " (in 'basic_op_param.stan', line 118, column 2 to column 15)",
-  " (in 'basic_op_param.stan', line 165, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 59, column 2 to column 43)",
+  " (in 'basic_op_param.stan', line 91, column 2 to column 47)",
+  " (in 'basic_op_param.stan', line 128, column 2 to column 15)",
+  " (in 'basic_op_param.stan', line 175, column 2 to column 28)",
   " (in 'basic_op_param.stan', line 21, column 2 to column 28)",
   " (in 'basic_op_param.stan', line 22, column 2 to column 27)",
   " (in 'basic_op_param.stan', line 23, column 2 to column 27)",
@@ -46,85 +46,91 @@ static constexpr std::array<const char*, 134> locations_array__ =
   " (in 'basic_op_param.stan', line 50, column 2 to column 31)",
   " (in 'basic_op_param.stan', line 51, column 2 to column 30)",
   " (in 'basic_op_param.stan', line 52, column 2 to column 30)",
-  " (in 'basic_op_param.stan', line 56, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 55, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 56, column 2 to column 27)",
   " (in 'basic_op_param.stan', line 57, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 58, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 61, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 62, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 63, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 64, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 65, column 2 to column 24)",
-  " (in 'basic_op_param.stan', line 66, column 2 to column 24)",
-  " (in 'basic_op_param.stan', line 69, column 2 to column 29)",
-  " (in 'basic_op_param.stan', line 70, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 71, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 72, column 2 to column 29)",
-  " (in 'basic_op_param.stan', line 73, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 74, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 77, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 78, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 79, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 80, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 81, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 82, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 83, column 2 to column 22)",
-  " (in 'basic_op_param.stan', line 84, column 2 to column 21)",
-  " (in 'basic_op_param.stan', line 88, column 2 to column 34)",
-  " (in 'basic_op_param.stan', line 89, column 2 to column 33)",
-  " (in 'basic_op_param.stan', line 90, column 2 to column 33)",
-  " (in 'basic_op_param.stan', line 93, column 2 to column 31)",
-  " (in 'basic_op_param.stan', line 94, column 2 to column 31)",
-  " (in 'basic_op_param.stan', line 95, column 2 to column 31)",
-  " (in 'basic_op_param.stan', line 96, column 2 to column 31)",
-  " (in 'basic_op_param.stan', line 97, column 2 to column 30)",
-  " (in 'basic_op_param.stan', line 98, column 2 to column 30)",
-  " (in 'basic_op_param.stan', line 101, column 2 to column 38)",
-  " (in 'basic_op_param.stan', line 102, column 2 to column 37)",
-  " (in 'basic_op_param.stan', line 103, column 2 to column 37)",
-  " (in 'basic_op_param.stan', line 104, column 2 to column 38)",
-  " (in 'basic_op_param.stan', line 105, column 2 to column 37)",
-  " (in 'basic_op_param.stan', line 106, column 2 to column 37)",
-  " (in 'basic_op_param.stan', line 109, column 2 to column 37)",
-  " (in 'basic_op_param.stan', line 110, column 2 to column 36)",
-  " (in 'basic_op_param.stan', line 111, column 2 to column 36)",
-  " (in 'basic_op_param.stan', line 112, column 2 to column 37)",
-  " (in 'basic_op_param.stan', line 113, column 2 to column 36)",
-  " (in 'basic_op_param.stan', line 114, column 2 to column 36)",
-  " (in 'basic_op_param.stan', line 115, column 2 to column 28)",
-  " (in 'basic_op_param.stan', line 116, column 2 to column 27)",
-  " (in 'basic_op_param.stan', line 120, column 2 to column 24)",
-  " (in 'basic_op_param.stan', line 121, column 2 to column 23)",
-  " (in 'basic_op_param.stan', line 122, column 2 to column 23)",
-  " (in 'basic_op_param.stan', line 125, column 2 to column 32)",
-  " (in 'basic_op_param.stan', line 127, column 2 to column 32)",
-  " (in 'basic_op_param.stan', line 128, column 2 to column 19)",
-  " (in 'basic_op_param.stan', line 129, column 2 to column 22)",
-  " (in 'basic_op_param.stan', line 130, column 2 to column 19)",
-  " (in 'basic_op_param.stan', line 134, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 135, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 136, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 137, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 139, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 140, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 141, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 142, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 144, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 145, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 146, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 147, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 149, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 150, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 151, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 152, column 2 to column 26)",
-  " (in 'basic_op_param.stan', line 154, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 155, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 156, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 157, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 159, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 160, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 161, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 162, column 2 to column 25)",
-  " (in 'basic_op_param.stan', line 166, column 2 to column 29)",
+  " (in 'basic_op_param.stan', line 61, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 62, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 63, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 66, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 67, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 68, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 69, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 70, column 2 to column 24)",
+  " (in 'basic_op_param.stan', line 71, column 2 to column 24)",
+  " (in 'basic_op_param.stan', line 74, column 2 to column 29)",
+  " (in 'basic_op_param.stan', line 75, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 76, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 77, column 2 to column 29)",
+  " (in 'basic_op_param.stan', line 78, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 79, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 82, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 83, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 84, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 85, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 86, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 87, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 88, column 2 to column 22)",
+  " (in 'basic_op_param.stan', line 89, column 2 to column 21)",
+  " (in 'basic_op_param.stan', line 93, column 2 to column 34)",
+  " (in 'basic_op_param.stan', line 94, column 2 to column 33)",
+  " (in 'basic_op_param.stan', line 95, column 2 to column 33)",
+  " (in 'basic_op_param.stan', line 98, column 2 to column 31)",
+  " (in 'basic_op_param.stan', line 99, column 2 to column 31)",
+  " (in 'basic_op_param.stan', line 100, column 2 to column 31)",
+  " (in 'basic_op_param.stan', line 101, column 2 to column 31)",
+  " (in 'basic_op_param.stan', line 102, column 2 to column 30)",
+  " (in 'basic_op_param.stan', line 103, column 2 to column 30)",
+  " (in 'basic_op_param.stan', line 106, column 2 to column 38)",
+  " (in 'basic_op_param.stan', line 107, column 2 to column 37)",
+  " (in 'basic_op_param.stan', line 108, column 2 to column 37)",
+  " (in 'basic_op_param.stan', line 109, column 2 to column 38)",
+  " (in 'basic_op_param.stan', line 110, column 2 to column 37)",
+  " (in 'basic_op_param.stan', line 111, column 2 to column 37)",
+  " (in 'basic_op_param.stan', line 114, column 2 to column 37)",
+  " (in 'basic_op_param.stan', line 115, column 2 to column 36)",
+  " (in 'basic_op_param.stan', line 116, column 2 to column 36)",
+  " (in 'basic_op_param.stan', line 117, column 2 to column 37)",
+  " (in 'basic_op_param.stan', line 118, column 2 to column 36)",
+  " (in 'basic_op_param.stan', line 119, column 2 to column 36)",
+  " (in 'basic_op_param.stan', line 120, column 2 to column 28)",
+  " (in 'basic_op_param.stan', line 121, column 2 to column 27)",
+  " (in 'basic_op_param.stan', line 124, column 2 to column 34)",
+  " (in 'basic_op_param.stan', line 125, column 2 to column 33)",
+  " (in 'basic_op_param.stan', line 126, column 2 to column 33)",
+  " (in 'basic_op_param.stan', line 130, column 2 to column 24)",
+  " (in 'basic_op_param.stan', line 131, column 2 to column 23)",
+  " (in 'basic_op_param.stan', line 132, column 2 to column 23)",
+  " (in 'basic_op_param.stan', line 135, column 2 to column 32)",
+  " (in 'basic_op_param.stan', line 137, column 2 to column 32)",
+  " (in 'basic_op_param.stan', line 138, column 2 to column 19)",
+  " (in 'basic_op_param.stan', line 139, column 2 to column 22)",
+  " (in 'basic_op_param.stan', line 140, column 2 to column 19)",
+  " (in 'basic_op_param.stan', line 144, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 145, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 146, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 147, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 149, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 150, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 151, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 152, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 154, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 155, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 156, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 157, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 159, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 160, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 161, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 162, column 2 to column 26)",
+  " (in 'basic_op_param.stan', line 164, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 165, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 166, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 167, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 169, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 170, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 171, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 172, column 2 to column 25)",
+  " (in 'basic_op_param.stan', line 176, column 2 to column 29)",
   " (in 'basic_op_param.stan', line 2, column 2 to column 8)",
   " (in 'basic_op_param.stan', line 5, column 17 to column 18)",
   " (in 'basic_op_param.stan', line 5, column 19 to column 20)",
@@ -136,10 +142,10 @@ static constexpr std::array<const char*, 134> locations_array__ =
   " (in 'basic_op_param.stan', line 12, column 13 to column 14)",
   " (in 'basic_op_param.stan', line 18, column 17 to column 18)",
   " (in 'basic_op_param.stan', line 18, column 19 to column 20)",
-  " (in 'basic_op_param.stan', line 54, column 17 to column 18)",
-  " (in 'basic_op_param.stan', line 86, column 21 to column 22)",
-  " (in 'basic_op_param.stan', line 165, column 8 to column 9)",
-  " (in 'basic_op_param.stan', line 165, column 10 to column 11)"};
+  " (in 'basic_op_param.stan', line 59, column 17 to column 18)",
+  " (in 'basic_op_param.stan', line 91, column 21 to column 22)",
+  " (in 'basic_op_param.stan', line 175, column 8 to column 9)",
+  " (in 'basic_op_param.stan', line 175, column 10 to column 11)"};
 class basic_op_param_model final : public model_base_crtp<basic_op_param_model> {
  private:
   int N;
@@ -163,39 +169,39 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
     // suppress unused var warning
     (void) DUMMY_VAR__;
     try {
-      current_statement__ = 119;
+      current_statement__ = 125;
       context__.validate_dims("data initialization", "N", "int",
         std::vector<size_t>{});
       N = std::numeric_limits<int>::min();
-      current_statement__ = 119;
-      N = context__.vals_i("N")[(1 - 1)];
-      current_statement__ = 120;
-      stan::math::validate_non_negative_index("cmat", "N", N);
-      current_statement__ = 121;
-      stan::math::validate_non_negative_index("cmat", "N", N);
-      current_statement__ = 122;
-      stan::math::validate_non_negative_index("cvec", "N", N);
-      current_statement__ = 123;
-      stan::math::validate_non_negative_index("crowvec", "N", N);
-      current_statement__ = 124;
-      stan::math::validate_non_negative_index("mat", "N", N);
       current_statement__ = 125;
-      stan::math::validate_non_negative_index("mat", "N", N);
+      N = context__.vals_i("N")[(1 - 1)];
       current_statement__ = 126;
-      stan::math::validate_non_negative_index("vec", "N", N);
+      stan::math::validate_non_negative_index("cmat", "N", N);
       current_statement__ = 127;
-      stan::math::validate_non_negative_index("rowvec", "N", N);
+      stan::math::validate_non_negative_index("cmat", "N", N);
       current_statement__ = 128;
-      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
+      stan::math::validate_non_negative_index("cvec", "N", N);
       current_statement__ = 129;
-      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
+      stan::math::validate_non_negative_index("crowvec", "N", N);
       current_statement__ = 130;
-      stan::math::validate_non_negative_index("tp_c_vector", "N", N);
+      stan::math::validate_non_negative_index("mat", "N", N);
       current_statement__ = 131;
-      stan::math::validate_non_negative_index("tp_c_rowvector", "N", N);
+      stan::math::validate_non_negative_index("mat", "N", N);
       current_statement__ = 132;
-      stan::math::validate_non_negative_index("carray", "N", N);
+      stan::math::validate_non_negative_index("vec", "N", N);
       current_statement__ = 133;
+      stan::math::validate_non_negative_index("rowvec", "N", N);
+      current_statement__ = 134;
+      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
+      current_statement__ = 135;
+      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
+      current_statement__ = 136;
+      stan::math::validate_non_negative_index("tp_c_vector", "N", N);
+      current_statement__ = 137;
+      stan::math::validate_non_negative_index("tp_c_rowvector", "N", N);
+      current_statement__ = 138;
+      stan::math::validate_non_negative_index("carray", "N", N);
+      current_statement__ = 139;
       stan::math::validate_non_negative_index("carray", "N", N);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -384,107 +390,120 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_matrix");
+      current_statement__ = 40;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 41;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 42;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
+          cmat), "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(crowvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 43;
       stan::model::assign(tp_c_vector, stan::math::multiply(cmat, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 44;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 45;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 46;
       stan::model::assign(tp_c_vector, stan::math::multiply(z, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 44;
-      stan::model::assign(tp_c_vector, stan::math::multiply(cvec, z),
-        "assigning variable tp_c_vector");
-      current_statement__ = 45;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cvec),
-        "assigning variable tp_c_vector");
-      current_statement__ = 46;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(cvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
-        "assigning variable tp_c_vector");
       current_statement__ = 47;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(z,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
+      stan::model::assign(tp_c_vector, stan::math::multiply(cvec, z),
         "assigning variable tp_c_vector");
       current_statement__ = 48;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec), z),
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cvec),
         "assigning variable tp_c_vector");
       current_statement__ = 49;
-      stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvec),
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(cvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_vector");
       current_statement__ = 50;
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(z,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
+        "assigning variable tp_c_vector");
+      current_statement__ = 51;
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec), z),
+        "assigning variable tp_c_vector");
+      current_statement__ = 52;
+      stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvec),
+        "assigning variable tp_c_vector");
+      current_statement__ = 53;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 54;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 55;
       stan::model::assign(tp_c_vector, stan::math::elt_divide(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 56;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 57;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 55;
+      current_statement__ = 58;
       stan::model::assign(tp_c_vector, stan::math::add(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 56;
+      current_statement__ = 59;
       stan::model::assign(tp_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 57;
+      current_statement__ = 60;
       stan::model::assign(tp_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 58;
+      current_statement__ = 61;
       stan::model::assign(tp_c_vector, stan::math::subtract(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 59;
+      current_statement__ = 62;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 60;
+      current_statement__ = 63;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 61;
+      current_statement__ = 64;
       stan::model::assign(tp_c_vector, stan::math::minus(cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 62;
+      current_statement__ = 65;
       stan::model::assign(tp_c_vector, stan::math::minus(vec),
         "assigning variable tp_c_vector");
       Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> tp_c_rowvector =
@@ -493,229 +512,242 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 66;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec, cmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 67;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           cmat), "assigning variable tp_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 68;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 69;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(z, crowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 67;
-      stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, z),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 68;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r),
-          crowvec), "assigning variable tp_c_rowvector");
-      current_statement__ = 69;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
-        "assigning variable tp_c_rowvector");
       current_statement__ = 70;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(z,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
+      stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, z),
         "assigning variable tp_c_rowvector");
       current_statement__ = 71;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
-          z), "assigning variable tp_c_rowvector");
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r),
+          crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 72;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(crowvec, crowvec),
+        stan::math::multiply(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 73;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(crowvec,
+        stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 74;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(
+        stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
-          crowvec), "assigning variable tp_c_rowvector");
+          z), "assigning variable tp_c_rowvector");
       current_statement__ = 75;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec, crowvec),
+        stan::math::elt_multiply(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 76;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec,
+        stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 77;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(
+        stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 78;
-      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, crowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::elt_divide(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 79;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(crowvec,
+        stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 80;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(
+        stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 81;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec, crowvec),
+      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 82;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec,
+        stan::math::add(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 83;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(
+        stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 84;
-      stan::model::assign(tp_c_rowvector, stan::math::minus(crowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 85;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 86;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
+          crowvec), "assigning variable tp_c_rowvector");
+      current_statement__ = 87;
+      stan::model::assign(tp_c_rowvector, stan::math::minus(crowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 88;
       stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
         "assigning variable tp_c_rowvector");
+      current_statement__ = 89;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 90;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 91;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
+          cmat), "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      current_statement__ = 86;
+      current_statement__ = 92;
       tp_c = stan::math::multiply(crowvec, cvec);
-      current_statement__ = 87;
+      current_statement__ = 93;
       tp_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec));
-      current_statement__ = 88;
+      current_statement__ = 94;
       tp_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                  rowvec), cvec);
-      current_statement__ = 89;
+      current_statement__ = 95;
       tp_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 90;
+      current_statement__ = 96;
       tp_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 91;
+      current_statement__ = 97;
       tp_c = stan::math::sum(cvec);
-      current_statement__ = 92;
+      current_statement__ = 98;
       tp_c = stan::math::sum(crowvec);
-      current_statement__ = 93;
+      current_statement__ = 99;
       tp_c = stan::math::sum(cmat);
-      current_statement__ = 94;
+      current_statement__ = 100;
       stan::model::assign(tp_c_matrix, stan::math::subtract(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 95;
+      current_statement__ = 101;
       stan::model::assign(tp_c_matrix,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 96;
+      current_statement__ = 102;
       stan::model::assign(tp_c_matrix,
         stan::math::subtract(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 97;
+      current_statement__ = 103;
       stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 98;
+      current_statement__ = 104;
       stan::model::assign(tp_c_matrix, stan::math::add(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 99;
+      current_statement__ = 105;
       stan::model::assign(tp_c_matrix,
         stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 100;
+      current_statement__ = 106;
       stan::model::assign(tp_c_matrix,
         stan::math::add(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 101;
+      current_statement__ = 107;
       stan::model::assign(tp_c_matrix, stan::math::add(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 102;
+      current_statement__ = 108;
       stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 103;
+      current_statement__ = 109;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 104;
+      current_statement__ = 110;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 105;
+      current_statement__ = 111;
       stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 106;
+      current_statement__ = 112;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 107;
+      current_statement__ = 113;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 108;
+      current_statement__ = 114;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 109;
+      current_statement__ = 115;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 110;
+      current_statement__ = 116;
       stan::model::assign(tp_c_matrix, stan::math::divide(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 111;
+      current_statement__ = 117;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 112;
+      current_statement__ = 118;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 113;
+      current_statement__ = 119;
       stan::model::assign(tp_c_matrix, stan::math::divide(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 114;
+      current_statement__ = 120;
       stan::model::assign(tp_c_matrix, stan::math::multiply(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 115;
+      current_statement__ = 121;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 116;
+      current_statement__ = 122;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 117;
+      current_statement__ = 123;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, z),
         "assigning variable tp_c_matrix");
       std::vector<std::vector<std::complex<local_scalar_t__>>> carray =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(N,
           std::vector<std::complex<local_scalar_t__>>(N,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
-      current_statement__ = 118;
+      current_statement__ = 124;
       stan::model::assign(carray, stan::math::to_array_2d(cmat),
         "assigning variable carray");
     } catch (const std::exception& e) {
@@ -898,107 +930,120 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_matrix");
+      current_statement__ = 40;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 41;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 42;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
+          cmat), "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(crowvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 43;
       stan::model::assign(tp_c_vector, stan::math::multiply(cmat, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 44;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 45;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 46;
       stan::model::assign(tp_c_vector, stan::math::multiply(z, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 44;
-      stan::model::assign(tp_c_vector, stan::math::multiply(cvec, z),
-        "assigning variable tp_c_vector");
-      current_statement__ = 45;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cvec),
-        "assigning variable tp_c_vector");
-      current_statement__ = 46;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(cvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
-        "assigning variable tp_c_vector");
       current_statement__ = 47;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(z,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
+      stan::model::assign(tp_c_vector, stan::math::multiply(cvec, z),
         "assigning variable tp_c_vector");
       current_statement__ = 48;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec), z),
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cvec),
         "assigning variable tp_c_vector");
       current_statement__ = 49;
-      stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvec),
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(cvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_vector");
       current_statement__ = 50;
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(z,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
+        "assigning variable tp_c_vector");
+      current_statement__ = 51;
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec), z),
+        "assigning variable tp_c_vector");
+      current_statement__ = 52;
+      stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvec),
+        "assigning variable tp_c_vector");
+      current_statement__ = 53;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 54;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 55;
       stan::model::assign(tp_c_vector, stan::math::elt_divide(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 56;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 57;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 55;
+      current_statement__ = 58;
       stan::model::assign(tp_c_vector, stan::math::add(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 56;
+      current_statement__ = 59;
       stan::model::assign(tp_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 57;
+      current_statement__ = 60;
       stan::model::assign(tp_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 58;
+      current_statement__ = 61;
       stan::model::assign(tp_c_vector, stan::math::subtract(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 59;
+      current_statement__ = 62;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 60;
+      current_statement__ = 63;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 61;
+      current_statement__ = 64;
       stan::model::assign(tp_c_vector, stan::math::minus(cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 62;
+      current_statement__ = 65;
       stan::model::assign(tp_c_vector, stan::math::minus(vec),
         "assigning variable tp_c_vector");
       Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> tp_c_rowvector =
@@ -1007,229 +1052,242 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 66;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec, cmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 67;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           cmat), "assigning variable tp_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 68;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 69;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(z, crowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 67;
-      stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, z),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 68;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r),
-          crowvec), "assigning variable tp_c_rowvector");
-      current_statement__ = 69;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
-        "assigning variable tp_c_rowvector");
       current_statement__ = 70;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(z,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
+      stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, z),
         "assigning variable tp_c_rowvector");
       current_statement__ = 71;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
-          z), "assigning variable tp_c_rowvector");
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r),
+          crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 72;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(crowvec, crowvec),
+        stan::math::multiply(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 73;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(crowvec,
+        stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 74;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(
+        stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
-          crowvec), "assigning variable tp_c_rowvector");
+          z), "assigning variable tp_c_rowvector");
       current_statement__ = 75;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec, crowvec),
+        stan::math::elt_multiply(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 76;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec,
+        stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 77;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(
+        stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 78;
-      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, crowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::elt_divide(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 79;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(crowvec,
+        stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 80;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(
+        stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 81;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec, crowvec),
+      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 82;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec,
+        stan::math::add(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 83;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(
+        stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 84;
-      stan::model::assign(tp_c_rowvector, stan::math::minus(crowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 85;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 86;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
+          crowvec), "assigning variable tp_c_rowvector");
+      current_statement__ = 87;
+      stan::model::assign(tp_c_rowvector, stan::math::minus(crowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 88;
       stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
         "assigning variable tp_c_rowvector");
+      current_statement__ = 89;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 90;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 91;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
+          cmat), "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      current_statement__ = 86;
+      current_statement__ = 92;
       tp_c = stan::math::multiply(crowvec, cvec);
-      current_statement__ = 87;
+      current_statement__ = 93;
       tp_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec));
-      current_statement__ = 88;
+      current_statement__ = 94;
       tp_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                  rowvec), cvec);
-      current_statement__ = 89;
+      current_statement__ = 95;
       tp_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 90;
+      current_statement__ = 96;
       tp_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 91;
+      current_statement__ = 97;
       tp_c = stan::math::sum(cvec);
-      current_statement__ = 92;
+      current_statement__ = 98;
       tp_c = stan::math::sum(crowvec);
-      current_statement__ = 93;
+      current_statement__ = 99;
       tp_c = stan::math::sum(cmat);
-      current_statement__ = 94;
+      current_statement__ = 100;
       stan::model::assign(tp_c_matrix, stan::math::subtract(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 95;
+      current_statement__ = 101;
       stan::model::assign(tp_c_matrix,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 96;
+      current_statement__ = 102;
       stan::model::assign(tp_c_matrix,
         stan::math::subtract(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 97;
+      current_statement__ = 103;
       stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 98;
+      current_statement__ = 104;
       stan::model::assign(tp_c_matrix, stan::math::add(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 99;
+      current_statement__ = 105;
       stan::model::assign(tp_c_matrix,
         stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 100;
+      current_statement__ = 106;
       stan::model::assign(tp_c_matrix,
         stan::math::add(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 101;
+      current_statement__ = 107;
       stan::model::assign(tp_c_matrix, stan::math::add(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 102;
+      current_statement__ = 108;
       stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 103;
+      current_statement__ = 109;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 104;
+      current_statement__ = 110;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 105;
+      current_statement__ = 111;
       stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 106;
+      current_statement__ = 112;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 107;
+      current_statement__ = 113;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 108;
+      current_statement__ = 114;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 109;
+      current_statement__ = 115;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 110;
+      current_statement__ = 116;
       stan::model::assign(tp_c_matrix, stan::math::divide(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 111;
+      current_statement__ = 117;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 112;
+      current_statement__ = 118;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 113;
+      current_statement__ = 119;
       stan::model::assign(tp_c_matrix, stan::math::divide(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 114;
+      current_statement__ = 120;
       stan::model::assign(tp_c_matrix, stan::math::multiply(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 115;
+      current_statement__ = 121;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 116;
+      current_statement__ = 122;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 117;
+      current_statement__ = 123;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, z),
         "assigning variable tp_c_matrix");
       std::vector<std::vector<std::complex<local_scalar_t__>>> carray =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(N,
           std::vector<std::complex<local_scalar_t__>>(N,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
-      current_statement__ = 118;
+      current_statement__ = 124;
       stan::model::assign(carray, stan::math::to_array_2d(cmat),
         "assigning variable carray");
     } catch (const std::exception& e) {
@@ -1460,326 +1518,352 @@ class basic_op_param_model final : public model_base_crtp<basic_op_param_model> 
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_matrix");
+      current_statement__ = 40;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 41;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 42;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
+          cmat), "assigning variable tp_c_matrix");
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(crowvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 43;
       stan::model::assign(tp_c_vector, stan::math::multiply(cmat, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 44;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 45;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 46;
       stan::model::assign(tp_c_vector, stan::math::multiply(z, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 44;
-      stan::model::assign(tp_c_vector, stan::math::multiply(cvec, z),
-        "assigning variable tp_c_vector");
-      current_statement__ = 45;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cvec),
-        "assigning variable tp_c_vector");
-      current_statement__ = 46;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(cvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
-        "assigning variable tp_c_vector");
       current_statement__ = 47;
-      stan::model::assign(tp_c_vector,
-        stan::math::multiply(z,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
+      stan::model::assign(tp_c_vector, stan::math::multiply(cvec, z),
         "assigning variable tp_c_vector");
       current_statement__ = 48;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec), z),
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cvec),
         "assigning variable tp_c_vector");
       current_statement__ = 49;
-      stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvec),
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(cvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_vector");
       current_statement__ = 50;
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(z,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
+        "assigning variable tp_c_vector");
+      current_statement__ = 51;
+      stan::model::assign(tp_c_vector,
+        stan::math::multiply(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec), z),
+        "assigning variable tp_c_vector");
+      current_statement__ = 52;
+      stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvec),
+        "assigning variable tp_c_vector");
+      current_statement__ = 53;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 54;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 55;
       stan::model::assign(tp_c_vector, stan::math::elt_divide(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 56;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 57;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 55;
+      current_statement__ = 58;
       stan::model::assign(tp_c_vector, stan::math::add(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 56;
+      current_statement__ = 59;
       stan::model::assign(tp_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 57;
+      current_statement__ = 60;
       stan::model::assign(tp_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 58;
+      current_statement__ = 61;
       stan::model::assign(tp_c_vector, stan::math::subtract(cvec, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 59;
+      current_statement__ = 62;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec),
           cvec), "assigning variable tp_c_vector");
-      current_statement__ = 60;
+      current_statement__ = 63;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 61;
+      current_statement__ = 64;
       stan::model::assign(tp_c_vector, stan::math::minus(cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 62;
+      current_statement__ = 65;
       stan::model::assign(tp_c_vector, stan::math::minus(vec),
         "assigning variable tp_c_vector");
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 66;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec, cmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 67;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           cmat), "assigning variable tp_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 68;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 69;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(z, crowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 67;
-      stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, z),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 68;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r),
-          crowvec), "assigning variable tp_c_rowvector");
-      current_statement__ = 69;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
-        "assigning variable tp_c_rowvector");
       current_statement__ = 70;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::multiply(z,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
+      stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, z),
         "assigning variable tp_c_rowvector");
       current_statement__ = 71;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
-          z), "assigning variable tp_c_rowvector");
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r),
+          crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 72;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(crowvec, crowvec),
+        stan::math::multiply(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 73;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(crowvec,
+        stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 74;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(
+        stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
-          crowvec), "assigning variable tp_c_rowvector");
+          z), "assigning variable tp_c_rowvector");
       current_statement__ = 75;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec, crowvec),
+        stan::math::elt_multiply(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 76;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec,
+        stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 77;
       stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(
+        stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 78;
-      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, crowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::elt_divide(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 79;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(crowvec,
+        stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 80;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(
+        stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 81;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec, crowvec),
+      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 82;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec,
+        stan::math::add(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 83;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(
+        stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
           crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 84;
-      stan::model::assign(tp_c_rowvector, stan::math::minus(crowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec, crowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 85;
-      stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 86;
-      tp_c = stan::math::multiply(crowvec, cvec);
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
+          crowvec), "assigning variable tp_c_rowvector");
       current_statement__ = 87;
+      stan::model::assign(tp_c_rowvector, stan::math::minus(crowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 88;
+      stan::model::assign(tp_c_rowvector, stan::math::minus(rowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 89;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 90;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(mat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 91;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(rowvec),
+          cmat), "assigning variable tp_c_rowvector");
+      current_statement__ = 92;
+      tp_c = stan::math::multiply(crowvec, cvec);
+      current_statement__ = 93;
       tp_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(vec));
-      current_statement__ = 88;
+      current_statement__ = 94;
       tp_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                  rowvec), cvec);
-      current_statement__ = 89;
+      current_statement__ = 95;
       tp_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 90;
+      current_statement__ = 96;
       tp_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 91;
+      current_statement__ = 97;
       tp_c = stan::math::sum(cvec);
-      current_statement__ = 92;
+      current_statement__ = 98;
       tp_c = stan::math::sum(crowvec);
-      current_statement__ = 93;
+      current_statement__ = 99;
       tp_c = stan::math::sum(cmat);
-      current_statement__ = 94;
+      current_statement__ = 100;
       stan::model::assign(tp_c_matrix, stan::math::subtract(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 95;
+      current_statement__ = 101;
       stan::model::assign(tp_c_matrix,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 96;
+      current_statement__ = 102;
       stan::model::assign(tp_c_matrix,
         stan::math::subtract(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 97;
+      current_statement__ = 103;
       stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 98;
+      current_statement__ = 104;
       stan::model::assign(tp_c_matrix, stan::math::add(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 99;
+      current_statement__ = 105;
       stan::model::assign(tp_c_matrix,
         stan::math::add(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 100;
+      current_statement__ = 106;
       stan::model::assign(tp_c_matrix,
         stan::math::add(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 101;
+      current_statement__ = 107;
       stan::model::assign(tp_c_matrix, stan::math::add(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 102;
+      current_statement__ = 108;
       stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 103;
+      current_statement__ = 109;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 104;
+      current_statement__ = 110;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 105;
+      current_statement__ = 111;
       stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 106;
+      current_statement__ = 112;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 107;
+      current_statement__ = 113;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 108;
+      current_statement__ = 114;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 109;
+      current_statement__ = 115;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 110;
+      current_statement__ = 116;
       stan::model::assign(tp_c_matrix, stan::math::divide(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 111;
+      current_statement__ = 117;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 112;
+      current_statement__ = 118;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 113;
+      current_statement__ = 119;
       stan::model::assign(tp_c_matrix, stan::math::divide(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 114;
+      current_statement__ = 120;
       stan::model::assign(tp_c_matrix, stan::math::multiply(z, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 115;
+      current_statement__ = 121;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 116;
+      current_statement__ = 122;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(r)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 117;
+      current_statement__ = 123;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 118;
+      current_statement__ = 124;
       stan::model::assign(carray, stan::math::to_array_2d(cmat),
         "assigning variable carray");
       if (emit_transformed_parameters__) {
@@ -2345,13 +2429,13 @@ namespace basic_operations_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 133> locations_array__ =
+static constexpr std::array<const char*, 139> locations_array__ =
   {" (found before start of program)",
   " (in 'basic_operations.stan', line 16, column 2 to column 34)",
-  " (in 'basic_operations.stan', line 52, column 2 to column 43)",
-  " (in 'basic_operations.stan', line 84, column 2 to column 47)",
-  " (in 'basic_operations.stan', line 116, column 2 to column 15)",
-  " (in 'basic_operations.stan', line 163, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 57, column 2 to column 43)",
+  " (in 'basic_operations.stan', line 89, column 2 to column 47)",
+  " (in 'basic_operations.stan', line 126, column 2 to column 15)",
+  " (in 'basic_operations.stan', line 173, column 2 to column 28)",
   " (in 'basic_operations.stan', line 19, column 2 to column 28)",
   " (in 'basic_operations.stan', line 20, column 2 to column 27)",
   " (in 'basic_operations.stan', line 21, column 2 to column 27)",
@@ -2378,84 +2462,90 @@ static constexpr std::array<const char*, 133> locations_array__ =
   " (in 'basic_operations.stan', line 48, column 2 to column 31)",
   " (in 'basic_operations.stan', line 49, column 2 to column 30)",
   " (in 'basic_operations.stan', line 50, column 2 to column 30)",
-  " (in 'basic_operations.stan', line 54, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 53, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 54, column 2 to column 27)",
   " (in 'basic_operations.stan', line 55, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 56, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 59, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 60, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 61, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 62, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 63, column 2 to column 24)",
-  " (in 'basic_operations.stan', line 64, column 2 to column 24)",
-  " (in 'basic_operations.stan', line 67, column 2 to column 29)",
-  " (in 'basic_operations.stan', line 68, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 69, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 70, column 2 to column 29)",
-  " (in 'basic_operations.stan', line 71, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 72, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 75, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 76, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 77, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 78, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 79, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 80, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 81, column 2 to column 22)",
-  " (in 'basic_operations.stan', line 82, column 2 to column 21)",
-  " (in 'basic_operations.stan', line 86, column 2 to column 34)",
-  " (in 'basic_operations.stan', line 87, column 2 to column 33)",
-  " (in 'basic_operations.stan', line 88, column 2 to column 33)",
-  " (in 'basic_operations.stan', line 91, column 2 to column 31)",
-  " (in 'basic_operations.stan', line 92, column 2 to column 31)",
-  " (in 'basic_operations.stan', line 93, column 2 to column 31)",
-  " (in 'basic_operations.stan', line 94, column 2 to column 31)",
-  " (in 'basic_operations.stan', line 95, column 2 to column 30)",
-  " (in 'basic_operations.stan', line 96, column 2 to column 30)",
-  " (in 'basic_operations.stan', line 99, column 2 to column 38)",
-  " (in 'basic_operations.stan', line 100, column 2 to column 37)",
-  " (in 'basic_operations.stan', line 101, column 2 to column 37)",
-  " (in 'basic_operations.stan', line 102, column 2 to column 38)",
-  " (in 'basic_operations.stan', line 103, column 2 to column 37)",
-  " (in 'basic_operations.stan', line 104, column 2 to column 37)",
-  " (in 'basic_operations.stan', line 107, column 2 to column 37)",
-  " (in 'basic_operations.stan', line 108, column 2 to column 36)",
-  " (in 'basic_operations.stan', line 109, column 2 to column 36)",
-  " (in 'basic_operations.stan', line 110, column 2 to column 37)",
-  " (in 'basic_operations.stan', line 111, column 2 to column 36)",
-  " (in 'basic_operations.stan', line 112, column 2 to column 36)",
-  " (in 'basic_operations.stan', line 113, column 2 to column 28)",
-  " (in 'basic_operations.stan', line 114, column 2 to column 27)",
-  " (in 'basic_operations.stan', line 118, column 2 to column 24)",
-  " (in 'basic_operations.stan', line 119, column 2 to column 23)",
-  " (in 'basic_operations.stan', line 120, column 2 to column 23)",
-  " (in 'basic_operations.stan', line 123, column 2 to column 32)",
-  " (in 'basic_operations.stan', line 124, column 2 to column 19)",
-  " (in 'basic_operations.stan', line 125, column 2 to column 22)",
-  " (in 'basic_operations.stan', line 126, column 2 to column 19)",
-  " (in 'basic_operations.stan', line 130, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 131, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 132, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 133, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 135, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 136, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 137, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 138, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 141, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 142, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 143, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 144, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 146, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 147, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 148, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 149, column 2 to column 26)",
-  " (in 'basic_operations.stan', line 152, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 153, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 154, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 155, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 157, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 158, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 159, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 160, column 2 to column 25)",
-  " (in 'basic_operations.stan', line 164, column 2 to column 29)",
+  " (in 'basic_operations.stan', line 59, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 60, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 61, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 64, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 65, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 66, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 67, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 68, column 2 to column 24)",
+  " (in 'basic_operations.stan', line 69, column 2 to column 24)",
+  " (in 'basic_operations.stan', line 72, column 2 to column 29)",
+  " (in 'basic_operations.stan', line 73, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 74, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 75, column 2 to column 29)",
+  " (in 'basic_operations.stan', line 76, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 77, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 80, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 81, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 82, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 83, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 84, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 85, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 86, column 2 to column 22)",
+  " (in 'basic_operations.stan', line 87, column 2 to column 21)",
+  " (in 'basic_operations.stan', line 91, column 2 to column 34)",
+  " (in 'basic_operations.stan', line 92, column 2 to column 33)",
+  " (in 'basic_operations.stan', line 93, column 2 to column 33)",
+  " (in 'basic_operations.stan', line 96, column 2 to column 31)",
+  " (in 'basic_operations.stan', line 97, column 2 to column 31)",
+  " (in 'basic_operations.stan', line 98, column 2 to column 31)",
+  " (in 'basic_operations.stan', line 99, column 2 to column 31)",
+  " (in 'basic_operations.stan', line 100, column 2 to column 30)",
+  " (in 'basic_operations.stan', line 101, column 2 to column 30)",
+  " (in 'basic_operations.stan', line 104, column 2 to column 38)",
+  " (in 'basic_operations.stan', line 105, column 2 to column 37)",
+  " (in 'basic_operations.stan', line 106, column 2 to column 37)",
+  " (in 'basic_operations.stan', line 107, column 2 to column 38)",
+  " (in 'basic_operations.stan', line 108, column 2 to column 37)",
+  " (in 'basic_operations.stan', line 109, column 2 to column 37)",
+  " (in 'basic_operations.stan', line 112, column 2 to column 37)",
+  " (in 'basic_operations.stan', line 113, column 2 to column 36)",
+  " (in 'basic_operations.stan', line 114, column 2 to column 36)",
+  " (in 'basic_operations.stan', line 115, column 2 to column 37)",
+  " (in 'basic_operations.stan', line 116, column 2 to column 36)",
+  " (in 'basic_operations.stan', line 117, column 2 to column 36)",
+  " (in 'basic_operations.stan', line 118, column 2 to column 28)",
+  " (in 'basic_operations.stan', line 119, column 2 to column 27)",
+  " (in 'basic_operations.stan', line 122, column 2 to column 34)",
+  " (in 'basic_operations.stan', line 123, column 2 to column 33)",
+  " (in 'basic_operations.stan', line 124, column 2 to column 33)",
+  " (in 'basic_operations.stan', line 128, column 2 to column 24)",
+  " (in 'basic_operations.stan', line 129, column 2 to column 23)",
+  " (in 'basic_operations.stan', line 130, column 2 to column 23)",
+  " (in 'basic_operations.stan', line 133, column 2 to column 32)",
+  " (in 'basic_operations.stan', line 134, column 2 to column 19)",
+  " (in 'basic_operations.stan', line 135, column 2 to column 22)",
+  " (in 'basic_operations.stan', line 136, column 2 to column 19)",
+  " (in 'basic_operations.stan', line 140, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 141, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 142, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 143, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 145, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 146, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 147, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 148, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 151, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 152, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 153, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 154, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 156, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 157, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 158, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 159, column 2 to column 26)",
+  " (in 'basic_operations.stan', line 162, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 163, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 164, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 165, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 167, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 168, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 169, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 170, column 2 to column 25)",
+  " (in 'basic_operations.stan', line 174, column 2 to column 29)",
   " (in 'basic_operations.stan', line 2, column 2 to column 8)",
   " (in 'basic_operations.stan', line 3, column 17 to column 18)",
   " (in 'basic_operations.stan', line 3, column 19 to column 20)",
@@ -2475,10 +2565,10 @@ static constexpr std::array<const char*, 133> locations_array__ =
   " (in 'basic_operations.stan', line 11, column 2 to column 9)",
   " (in 'basic_operations.stan', line 16, column 17 to column 18)",
   " (in 'basic_operations.stan', line 16, column 19 to column 20)",
-  " (in 'basic_operations.stan', line 52, column 17 to column 18)",
-  " (in 'basic_operations.stan', line 84, column 21 to column 22)",
-  " (in 'basic_operations.stan', line 163, column 8 to column 9)",
-  " (in 'basic_operations.stan', line 163, column 10 to column 11)"};
+  " (in 'basic_operations.stan', line 57, column 17 to column 18)",
+  " (in 'basic_operations.stan', line 89, column 21 to column 22)",
+  " (in 'basic_operations.stan', line 173, column 8 to column 9)",
+  " (in 'basic_operations.stan', line 173, column 10 to column 11)"};
 class basic_operations_model final : public model_base_crtp<basic_operations_model> {
  private:
   int N;
@@ -2518,17 +2608,17 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
-      current_statement__ = 110;
+      current_statement__ = 116;
       context__.validate_dims("data initialization", "N", "int",
         std::vector<size_t>{});
       N = std::numeric_limits<int>::min();
-      current_statement__ = 110;
+      current_statement__ = 116;
       N = context__.vals_i("N")[(1 - 1)];
-      current_statement__ = 111;
+      current_statement__ = 117;
       stan::math::validate_non_negative_index("cmat", "N", N);
-      current_statement__ = 112;
+      current_statement__ = 118;
       stan::math::validate_non_negative_index("cmat", "N", N);
-      current_statement__ = 113;
+      current_statement__ = 119;
       context__.validate_dims("data initialization", "cmat", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
           static_cast<size_t>(2)});
@@ -2541,7 +2631,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         N, N);
       {
         std::vector<std::complex<local_scalar_t__>> cmat_flat__;
-        current_statement__ = 113;
+        current_statement__ = 119;
         cmat_flat__ = context__.vals_c("cmat");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -2553,9 +2643,9 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           }
         }
       }
-      current_statement__ = 114;
+      current_statement__ = 120;
       stan::math::validate_non_negative_index("cvec", "N", N);
-      current_statement__ = 115;
+      current_statement__ = 121;
       context__.validate_dims("data initialization", "cvec", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)});
       cvec_data__ = Eigen::Matrix<std::complex<double>,-1,1>::Constant(N,
@@ -2567,7 +2657,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         N);
       {
         std::vector<std::complex<local_scalar_t__>> cvec_flat__;
-        current_statement__ = 115;
+        current_statement__ = 121;
         cvec_flat__ = context__.vals_c("cvec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -2576,9 +2666,9 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 116;
+      current_statement__ = 122;
       stan::math::validate_non_negative_index("crowvec", "N", N);
-      current_statement__ = 117;
+      current_statement__ = 123;
       context__.validate_dims("data initialization", "crowvec", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)});
       crowvec_data__ = Eigen::Matrix<std::complex<double>,1,-1>::Constant(N,
@@ -2590,7 +2680,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         N);
       {
         std::vector<std::complex<local_scalar_t__>> crowvec_flat__;
-        current_statement__ = 117;
+        current_statement__ = 123;
         crowvec_flat__ = context__.vals_c("crowvec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -2599,18 +2689,18 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 118;
+      current_statement__ = 124;
       context__.validate_dims("data initialization", "z", "double",
         std::vector<size_t>{static_cast<size_t>(2)});
       z = std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
             std::numeric_limits<double>::quiet_NaN());
-      current_statement__ = 118;
+      current_statement__ = 124;
       z = context__.vals_c("z")[(1 - 1)];
-      current_statement__ = 119;
+      current_statement__ = 125;
       stan::math::validate_non_negative_index("mat", "N", N);
-      current_statement__ = 120;
+      current_statement__ = 126;
       stan::math::validate_non_negative_index("mat", "N", N);
-      current_statement__ = 121;
+      current_statement__ = 127;
       context__.validate_dims("data initialization", "mat", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)});
       mat_data__ = Eigen::Matrix<double,-1,-1>::Constant(N, N,
@@ -2619,7 +2709,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         N, N);
       {
         std::vector<local_scalar_t__> mat_flat__;
-        current_statement__ = 121;
+        current_statement__ = 127;
         mat_flat__ = context__.vals_r("mat");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -2631,9 +2721,9 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           }
         }
       }
-      current_statement__ = 122;
+      current_statement__ = 128;
       stan::math::validate_non_negative_index("vec", "N", N);
-      current_statement__ = 123;
+      current_statement__ = 129;
       context__.validate_dims("data initialization", "vec", "double",
         std::vector<size_t>{static_cast<size_t>(N)});
       vec_data__ = Eigen::Matrix<double,-1,1>::Constant(N,
@@ -2641,7 +2731,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       new (&vec) Eigen::Map<Eigen::Matrix<double,-1,1>>(vec_data__.data(), N);
       {
         std::vector<local_scalar_t__> vec_flat__;
-        current_statement__ = 123;
+        current_statement__ = 129;
         vec_flat__ = context__.vals_r("vec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -2650,9 +2740,9 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 124;
+      current_statement__ = 130;
       stan::math::validate_non_negative_index("rowvec", "N", N);
-      current_statement__ = 125;
+      current_statement__ = 131;
       context__.validate_dims("data initialization", "rowvec", "double",
         std::vector<size_t>{static_cast<size_t>(N)});
       rowvec_data__ = Eigen::Matrix<double,1,-1>::Constant(N,
@@ -2661,7 +2751,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         Eigen::Map<Eigen::Matrix<double,1,-1>>(rowvec_data__.data(), N);
       {
         std::vector<local_scalar_t__> rowvec_flat__;
-        current_statement__ = 125;
+        current_statement__ = 131;
         rowvec_flat__ = context__.vals_r("rowvec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -2670,23 +2760,23 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 126;
+      current_statement__ = 132;
       context__.validate_dims("data initialization", "r", "double",
         std::vector<size_t>{});
       r = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 126;
-      r = context__.vals_r("r")[(1 - 1)];
-      current_statement__ = 127;
-      stan::math::validate_non_negative_index("gq_c_matrix", "N", N);
-      current_statement__ = 128;
-      stan::math::validate_non_negative_index("gq_c_matrix", "N", N);
-      current_statement__ = 129;
-      stan::math::validate_non_negative_index("gq_c_vector", "N", N);
-      current_statement__ = 130;
-      stan::math::validate_non_negative_index("gq_c_rowvector", "N", N);
-      current_statement__ = 131;
-      stan::math::validate_non_negative_index("carray", "N", N);
       current_statement__ = 132;
+      r = context__.vals_r("r")[(1 - 1)];
+      current_statement__ = 133;
+      stan::math::validate_non_negative_index("gq_c_matrix", "N", N);
+      current_statement__ = 134;
+      stan::math::validate_non_negative_index("gq_c_matrix", "N", N);
+      current_statement__ = 135;
+      stan::math::validate_non_negative_index("gq_c_vector", "N", N);
+      current_statement__ = 136;
+      stan::math::validate_non_negative_index("gq_c_rowvector", "N", N);
+      current_statement__ = 137;
+      stan::math::validate_non_negative_index("carray", "N", N);
+      current_statement__ = 138;
       stan::math::validate_non_negative_index("carray", "N", N);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2907,6 +2997,19 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_matrix");
+      current_statement__ = 32;
+      stan::model::assign(gq_c_matrix, stan::math::divide(cmat, cmat),
+        "assigning variable gq_c_matrix");
+      current_statement__ = 33;
+      stan::model::assign(gq_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable gq_c_matrix");
+      current_statement__ = 34;
+      stan::model::assign(gq_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(mat), cmat),
+        "assigning variable gq_c_matrix");
       Eigen::Matrix<std::complex<double>,-1,1> gq_c_vector =
         Eigen::Matrix<std::complex<double>,-1,1>::Constant(N,
           std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
@@ -2914,99 +3017,99 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       current_statement__ = 2;
       stan::model::assign(gq_c_vector, stan::math::transpose(crowvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 32;
+      current_statement__ = 35;
       stan::model::assign(gq_c_vector, stan::math::multiply(cmat, cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 33;
+      current_statement__ = 36;
       stan::model::assign(gq_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(mat), cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 34;
+      current_statement__ = 37;
       stan::model::assign(gq_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<double>>(vec)),
         "assigning variable gq_c_vector");
-      current_statement__ = 35;
+      current_statement__ = 38;
       stan::model::assign(gq_c_vector, stan::math::multiply(z, cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 36;
+      current_statement__ = 39;
       stan::model::assign(gq_c_vector, stan::math::multiply(cvec, z),
         "assigning variable gq_c_vector");
-      current_statement__ = 37;
+      current_statement__ = 40;
       stan::model::assign(gq_c_vector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 38;
+      current_statement__ = 41;
       stan::model::assign(gq_c_vector,
         stan::math::multiply(cvec, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_vector");
-      current_statement__ = 39;
+      current_statement__ = 42;
       stan::model::assign(gq_c_vector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<double>>(vec)),
         "assigning variable gq_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 43;
       stan::model::assign(gq_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), z),
         "assigning variable gq_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 44;
       stan::model::assign(gq_c_vector, stan::math::elt_multiply(cvec, cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 45;
       stan::model::assign(gq_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 46;
       stan::model::assign(gq_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<double>>(vec)),
         "assigning variable gq_c_vector");
-      current_statement__ = 44;
+      current_statement__ = 47;
       stan::model::assign(gq_c_vector, stan::math::elt_divide(cvec, cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 45;
+      current_statement__ = 48;
       stan::model::assign(gq_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<double>>(vec), cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 46;
+      current_statement__ = 49;
       stan::model::assign(gq_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<double>>(vec)),
         "assigning variable gq_c_vector");
-      current_statement__ = 47;
+      current_statement__ = 50;
       stan::model::assign(gq_c_vector, stan::math::add(cvec, cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 48;
+      current_statement__ = 51;
       stan::model::assign(gq_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<double>>(vec), cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 49;
+      current_statement__ = 52;
       stan::model::assign(gq_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<double>>(vec)),
         "assigning variable gq_c_vector");
-      current_statement__ = 50;
+      current_statement__ = 53;
       stan::model::assign(gq_c_vector, stan::math::subtract(cvec, cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 54;
       stan::model::assign(gq_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(vec), cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 55;
       stan::model::assign(gq_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<double>>(vec)),
         "assigning variable gq_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 56;
       stan::model::assign(gq_c_vector, stan::math::minus(cvec),
         "assigning variable gq_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 57;
       stan::model::assign(gq_c_vector, stan::math::minus(vec),
         "assigning variable gq_c_vector");
       Eigen::Matrix<std::complex<double>,1,-1> gq_c_rowvector =
@@ -3016,206 +3119,219 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
       current_statement__ = 3;
       stan::model::assign(gq_c_rowvector, stan::math::transpose(cvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 55;
+      current_statement__ = 58;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(crowvec, cmat),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 56;
+      current_statement__ = 59;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cmat),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 57;
+      current_statement__ = 60;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<double>>(mat)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 58;
+      current_statement__ = 61;
       stan::model::assign(gq_c_rowvector, stan::math::multiply(z, crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 59;
+      current_statement__ = 62;
       stan::model::assign(gq_c_rowvector, stan::math::multiply(crowvec, z),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 60;
+      current_statement__ = 63;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(stan::math::to_complex(r, 0), crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 61;
+      current_statement__ = 64;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(crowvec, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 62;
+      current_statement__ = 65;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 66;
       stan::model::assign(gq_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), z),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 67;
       stan::model::assign(gq_c_rowvector,
         stan::math::elt_multiply(crowvec, crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 68;
       stan::model::assign(gq_c_rowvector,
         stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 69;
       stan::model::assign(gq_c_rowvector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 67;
+      current_statement__ = 70;
       stan::model::assign(gq_c_rowvector,
         stan::math::elt_divide(crowvec, crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 68;
+      current_statement__ = 71;
       stan::model::assign(gq_c_rowvector,
         stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 69;
+      current_statement__ = 72;
       stan::model::assign(gq_c_rowvector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<double>>(rowvec), crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 70;
+      current_statement__ = 73;
       stan::model::assign(gq_c_rowvector, stan::math::add(crowvec, crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 71;
+      current_statement__ = 74;
       stan::model::assign(gq_c_rowvector,
         stan::math::add(crowvec,
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 72;
+      current_statement__ = 75;
       stan::model::assign(gq_c_rowvector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<double>>(rowvec), crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 73;
+      current_statement__ = 76;
       stan::model::assign(gq_c_rowvector,
         stan::math::subtract(crowvec, crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 74;
+      current_statement__ = 77;
       stan::model::assign(gq_c_rowvector,
         stan::math::subtract(crowvec,
           stan::math::promote_scalar<std::complex<double>>(rowvec)),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 75;
+      current_statement__ = 78;
       stan::model::assign(gq_c_rowvector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(rowvec), crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 76;
+      current_statement__ = 79;
       stan::model::assign(gq_c_rowvector, stan::math::minus(crowvec),
         "assigning variable gq_c_rowvector");
-      current_statement__ = 77;
+      current_statement__ = 80;
       stan::model::assign(gq_c_rowvector, stan::math::minus(rowvec),
+        "assigning variable gq_c_rowvector");
+      current_statement__ = 81;
+      stan::model::assign(gq_c_rowvector, stan::math::divide(crowvec, cmat),
+        "assigning variable gq_c_rowvector");
+      current_statement__ = 82;
+      stan::model::assign(gq_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable gq_c_rowvector");
+      current_statement__ = 83;
+      stan::model::assign(gq_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cmat),
         "assigning variable gq_c_rowvector");
       std::complex<double> gq_c =
         std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
           std::numeric_limits<double>::quiet_NaN());
-      current_statement__ = 78;
+      current_statement__ = 84;
       gq_c = stan::math::multiply(crowvec, cvec);
-      current_statement__ = 79;
+      current_statement__ = 85;
       gq_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<double>>(vec));
-      current_statement__ = 80;
+      current_statement__ = 86;
       gq_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<double>>(rowvec), cvec);
-      current_statement__ = 81;
+      current_statement__ = 87;
       gq_c = stan::math::sum(stan::math::to_array_1d(cvec));
-      current_statement__ = 82;
+      current_statement__ = 88;
       gq_c = stan::math::sum(cvec);
-      current_statement__ = 83;
+      current_statement__ = 89;
       gq_c = stan::math::sum(crowvec);
-      current_statement__ = 84;
+      current_statement__ = 90;
       gq_c = stan::math::sum(cmat);
-      current_statement__ = 85;
+      current_statement__ = 91;
       stan::model::assign(gq_c_matrix, stan::math::subtract(z, cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 86;
+      current_statement__ = 92;
       stan::model::assign(gq_c_matrix,
         stan::math::subtract(stan::math::to_complex(r, 0), cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 87;
+      current_statement__ = 93;
       stan::model::assign(gq_c_matrix,
         stan::math::subtract(cmat, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_matrix");
-      current_statement__ = 88;
+      current_statement__ = 94;
       stan::model::assign(gq_c_matrix, stan::math::subtract(cmat, z),
         "assigning variable gq_c_matrix");
-      current_statement__ = 89;
+      current_statement__ = 95;
       stan::model::assign(gq_c_matrix, stan::math::add(z, cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 90;
+      current_statement__ = 96;
       stan::model::assign(gq_c_matrix,
         stan::math::add(stan::math::to_complex(r, 0), cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 91;
+      current_statement__ = 97;
       stan::model::assign(gq_c_matrix,
         stan::math::add(cmat, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_matrix");
-      current_statement__ = 92;
+      current_statement__ = 98;
       stan::model::assign(gq_c_matrix, stan::math::add(cmat, z),
         "assigning variable gq_c_matrix");
-      current_statement__ = 93;
+      current_statement__ = 99;
       stan::model::assign(gq_c_matrix, stan::math::elt_divide(z, cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 94;
+      current_statement__ = 100;
       stan::model::assign(gq_c_matrix,
         stan::math::elt_divide(stan::math::to_complex(r, 0), cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 95;
+      current_statement__ = 101;
       stan::model::assign(gq_c_matrix,
         stan::math::elt_divide(cmat, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_matrix");
-      current_statement__ = 96;
+      current_statement__ = 102;
       stan::model::assign(gq_c_matrix, stan::math::elt_divide(cmat, z),
         "assigning variable gq_c_matrix");
-      current_statement__ = 97;
+      current_statement__ = 103;
       stan::model::assign(gq_c_matrix, stan::math::elt_multiply(z, cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 98;
+      current_statement__ = 104;
       stan::model::assign(gq_c_matrix,
         stan::math::elt_multiply(stan::math::to_complex(r, 0), cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 99;
+      current_statement__ = 105;
       stan::model::assign(gq_c_matrix,
         stan::math::elt_multiply(cmat, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_matrix");
-      current_statement__ = 100;
+      current_statement__ = 106;
       stan::model::assign(gq_c_matrix, stan::math::elt_multiply(cmat, z),
         "assigning variable gq_c_matrix");
-      current_statement__ = 101;
+      current_statement__ = 107;
       stan::model::assign(gq_c_matrix, stan::math::divide(z, cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 102;
+      current_statement__ = 108;
       stan::model::assign(gq_c_matrix,
         stan::math::divide(stan::math::to_complex(r, 0), cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 103;
+      current_statement__ = 109;
       stan::model::assign(gq_c_matrix,
         stan::math::divide(cmat, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_matrix");
-      current_statement__ = 104;
+      current_statement__ = 110;
       stan::model::assign(gq_c_matrix, stan::math::divide(cmat, z),
         "assigning variable gq_c_matrix");
-      current_statement__ = 105;
+      current_statement__ = 111;
       stan::model::assign(gq_c_matrix, stan::math::multiply(z, cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 106;
+      current_statement__ = 112;
       stan::model::assign(gq_c_matrix,
         stan::math::multiply(stan::math::to_complex(r, 0), cmat),
         "assigning variable gq_c_matrix");
-      current_statement__ = 107;
+      current_statement__ = 113;
       stan::model::assign(gq_c_matrix,
         stan::math::multiply(cmat, stan::math::to_complex(r, 0)),
         "assigning variable gq_c_matrix");
-      current_statement__ = 108;
+      current_statement__ = 114;
       stan::model::assign(gq_c_matrix, stan::math::multiply(cmat, z),
         "assigning variable gq_c_matrix");
       std::vector<std::vector<std::complex<double>>> carray =
@@ -3223,7 +3339,7 @@ class basic_operations_model final : public model_base_crtp<basic_operations_mod
           std::vector<std::complex<double>>(N,
             std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
               std::numeric_limits<double>::quiet_NaN())));
-      current_statement__ = 109;
+      current_statement__ = 115;
       stan::model::assign(carray, stan::math::to_array_2d(cmat),
         "assigning variable carray");
       out__.write(gq_c_matrix);
@@ -3498,172 +3614,184 @@ namespace basic_ops_mix_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 165> locations_array__ =
+static constexpr std::array<const char*, 177> locations_array__ =
   {" (found before start of program)",
-  " (in 'basic_ops_mix.stan', line 15, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 16, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 17, column 2 to column 33)",
-  " (in 'basic_ops_mix.stan', line 18, column 2 to column 13)",
-  " (in 'basic_ops_mix.stan', line 20, column 2 to column 19)",
-  " (in 'basic_ops_mix.stan', line 21, column 2 to column 17)",
-  " (in 'basic_ops_mix.stan', line 22, column 2 to column 24)",
-  " (in 'basic_ops_mix.stan', line 23, column 2 to column 9)",
-  " (in 'basic_ops_mix.stan', line 28, column 2 to column 34)",
-  " (in 'basic_ops_mix.stan', line 62, column 2 to column 44)",
-  " (in 'basic_ops_mix.stan', line 93, column 2 to column 48)",
-  " (in 'basic_ops_mix.stan', line 123, column 2 to column 15)",
-  " (in 'basic_ops_mix.stan', line 193, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 31, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 32, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 33, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 14, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 15, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 16, column 2 to column 33)",
+  " (in 'basic_ops_mix.stan', line 17, column 2 to column 13)",
+  " (in 'basic_ops_mix.stan', line 19, column 2 to column 20)",
+  " (in 'basic_ops_mix.stan', line 20, column 2 to column 17)",
+  " (in 'basic_ops_mix.stan', line 21, column 2 to column 24)",
+  " (in 'basic_ops_mix.stan', line 22, column 2 to column 9)",
+  " (in 'basic_ops_mix.stan', line 25, column 2 to column 35)",
+  " (in 'basic_ops_mix.stan', line 67, column 2 to column 44)",
+  " (in 'basic_ops_mix.stan', line 98, column 2 to column 48)",
+  " (in 'basic_ops_mix.stan', line 136, column 2 to column 15)",
+  " (in 'basic_ops_mix.stan', line 205, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 28, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 29, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 30, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 31, column 2 to column 30)",
+  " (in 'basic_ops_mix.stan', line 32, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 33, column 2 to column 29)",
   " (in 'basic_ops_mix.stan', line 34, column 2 to column 30)",
   " (in 'basic_ops_mix.stan', line 35, column 2 to column 29)",
   " (in 'basic_ops_mix.stan', line 36, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 37, column 2 to column 30)",
-  " (in 'basic_ops_mix.stan', line 38, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 39, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 42, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 43, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 44, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 45, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 46, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 47, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 39, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 40, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 41, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 42, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 43, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 44, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 47, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 48, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 49, column 2 to column 28)",
   " (in 'basic_ops_mix.stan', line 50, column 2 to column 29)",
   " (in 'basic_ops_mix.stan', line 51, column 2 to column 28)",
   " (in 'basic_ops_mix.stan', line 52, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 53, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 54, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 55, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 58, column 2 to column 32)",
-  " (in 'basic_ops_mix.stan', line 59, column 2 to column 31)",
-  " (in 'basic_ops_mix.stan', line 60, column 2 to column 31)",
-  " (in 'basic_ops_mix.stan', line 64, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 65, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 66, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 67, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 70, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 71, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 72, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 73, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 74, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 75, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 78, column 2 to column 30)",
-  " (in 'basic_ops_mix.stan', line 79, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 80, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 81, column 2 to column 30)",
-  " (in 'basic_ops_mix.stan', line 82, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 83, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 86, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 87, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 88, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 89, column 2 to column 29)",
-  " (in 'basic_ops_mix.stan', line 90, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 91, column 2 to column 28)",
-  " (in 'basic_ops_mix.stan', line 95, column 2 to column 35)",
-  " (in 'basic_ops_mix.stan', line 96, column 2 to column 34)",
-  " (in 'basic_ops_mix.stan', line 97, column 2 to column 34)",
-  " (in 'basic_ops_mix.stan', line 100, column 2 to column 32)",
-  " (in 'basic_ops_mix.stan', line 101, column 2 to column 32)",
-  " (in 'basic_ops_mix.stan', line 102, column 2 to column 32)",
-  " (in 'basic_ops_mix.stan', line 103, column 2 to column 31)",
-  " (in 'basic_ops_mix.stan', line 104, column 2 to column 31)",
-  " (in 'basic_ops_mix.stan', line 105, column 2 to column 31)",
-  " (in 'basic_ops_mix.stan', line 108, column 2 to column 39)",
-  " (in 'basic_ops_mix.stan', line 109, column 2 to column 38)",
-  " (in 'basic_ops_mix.stan', line 110, column 2 to column 38)",
-  " (in 'basic_ops_mix.stan', line 111, column 2 to column 39)",
-  " (in 'basic_ops_mix.stan', line 112, column 2 to column 38)",
-  " (in 'basic_ops_mix.stan', line 113, column 2 to column 38)",
-  " (in 'basic_ops_mix.stan', line 116, column 2 to column 38)",
-  " (in 'basic_ops_mix.stan', line 117, column 2 to column 37)",
-  " (in 'basic_ops_mix.stan', line 118, column 2 to column 37)",
-  " (in 'basic_ops_mix.stan', line 119, column 2 to column 38)",
-  " (in 'basic_ops_mix.stan', line 120, column 2 to column 37)",
-  " (in 'basic_ops_mix.stan', line 121, column 2 to column 37)",
-  " (in 'basic_ops_mix.stan', line 125, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 126, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 127, column 2 to column 24)",
-  " (in 'basic_ops_mix.stan', line 128, column 2 to column 24)",
-  " (in 'basic_ops_mix.stan', line 131, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 132, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 133, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 134, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 136, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 137, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 138, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 139, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 141, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 142, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 143, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 55, column 2 to column 32)",
+  " (in 'basic_ops_mix.stan', line 56, column 2 to column 31)",
+  " (in 'basic_ops_mix.stan', line 57, column 2 to column 31)",
+  " (in 'basic_ops_mix.stan', line 60, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 61, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 62, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 63, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 64, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 65, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 69, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 70, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 71, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 72, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 75, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 76, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 77, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 78, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 79, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 80, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 83, column 2 to column 30)",
+  " (in 'basic_ops_mix.stan', line 84, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 85, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 86, column 2 to column 30)",
+  " (in 'basic_ops_mix.stan', line 87, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 88, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 91, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 92, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 93, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 94, column 2 to column 29)",
+  " (in 'basic_ops_mix.stan', line 95, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 96, column 2 to column 28)",
+  " (in 'basic_ops_mix.stan', line 100, column 2 to column 35)",
+  " (in 'basic_ops_mix.stan', line 101, column 2 to column 34)",
+  " (in 'basic_ops_mix.stan', line 102, column 2 to column 34)",
+  " (in 'basic_ops_mix.stan', line 105, column 2 to column 32)",
+  " (in 'basic_ops_mix.stan', line 106, column 2 to column 32)",
+  " (in 'basic_ops_mix.stan', line 107, column 2 to column 32)",
+  " (in 'basic_ops_mix.stan', line 108, column 2 to column 31)",
+  " (in 'basic_ops_mix.stan', line 109, column 2 to column 31)",
+  " (in 'basic_ops_mix.stan', line 110, column 2 to column 31)",
+  " (in 'basic_ops_mix.stan', line 113, column 2 to column 39)",
+  " (in 'basic_ops_mix.stan', line 114, column 2 to column 38)",
+  " (in 'basic_ops_mix.stan', line 115, column 2 to column 38)",
+  " (in 'basic_ops_mix.stan', line 116, column 2 to column 39)",
+  " (in 'basic_ops_mix.stan', line 117, column 2 to column 38)",
+  " (in 'basic_ops_mix.stan', line 118, column 2 to column 38)",
+  " (in 'basic_ops_mix.stan', line 121, column 2 to column 38)",
+  " (in 'basic_ops_mix.stan', line 122, column 2 to column 37)",
+  " (in 'basic_ops_mix.stan', line 123, column 2 to column 37)",
+  " (in 'basic_ops_mix.stan', line 124, column 2 to column 38)",
+  " (in 'basic_ops_mix.stan', line 125, column 2 to column 37)",
+  " (in 'basic_ops_mix.stan', line 126, column 2 to column 37)",
+  " (in 'basic_ops_mix.stan', line 129, column 2 to column 35)",
+  " (in 'basic_ops_mix.stan', line 130, column 2 to column 34)",
+  " (in 'basic_ops_mix.stan', line 131, column 2 to column 34)",
+  " (in 'basic_ops_mix.stan', line 132, column 2 to column 35)",
+  " (in 'basic_ops_mix.stan', line 133, column 2 to column 34)",
+  " (in 'basic_ops_mix.stan', line 134, column 2 to column 34)",
+  " (in 'basic_ops_mix.stan', line 138, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 139, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 140, column 2 to column 24)",
+  " (in 'basic_ops_mix.stan', line 141, column 2 to column 24)",
   " (in 'basic_ops_mix.stan', line 144, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 145, column 2 to column 26)",
   " (in 'basic_ops_mix.stan', line 146, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 147, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 148, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 147, column 2 to column 26)",
   " (in 'basic_ops_mix.stan', line 149, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 151, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 152, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 153, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 154, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 156, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 150, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 151, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 152, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 154, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 155, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 156, column 2 to column 25)",
   " (in 'basic_ops_mix.stan', line 157, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 158, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 159, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 162, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 163, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 159, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 160, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 161, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 162, column 2 to column 26)",
   " (in 'basic_ops_mix.stan', line 164, column 2 to column 27)",
   " (in 'basic_ops_mix.stan', line 165, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 166, column 2 to column 27)",
   " (in 'basic_ops_mix.stan', line 167, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 168, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 169, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 170, column 2 to column 27)",
-  " (in 'basic_ops_mix.stan', line 172, column 4 to column 28)",
-  " (in 'basic_ops_mix.stan', line 173, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 174, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 175, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 177, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 178, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 179, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 169, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 170, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 171, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 172, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 174, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 175, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 176, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 177, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 179, column 2 to column 27)",
   " (in 'basic_ops_mix.stan', line 180, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 182, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 183, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 181, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 182, column 2 to column 27)",
   " (in 'basic_ops_mix.stan', line 184, column 2 to column 26)",
   " (in 'basic_ops_mix.stan', line 185, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 186, column 2 to column 26)",
   " (in 'basic_ops_mix.stan', line 187, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 188, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 189, column 2 to column 25)",
-  " (in 'basic_ops_mix.stan', line 190, column 2 to column 26)",
-  " (in 'basic_ops_mix.stan', line 194, column 2 to column 30)",
+  " (in 'basic_ops_mix.stan', line 189, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 190, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 191, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 192, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 194, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 195, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 196, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 197, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 199, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 200, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 201, column 2 to column 25)",
+  " (in 'basic_ops_mix.stan', line 202, column 2 to column 26)",
+  " (in 'basic_ops_mix.stan', line 206, column 2 to column 30)",
   " (in 'basic_ops_mix.stan', line 2, column 2 to column 8)",
   " (in 'basic_ops_mix.stan', line 3, column 17 to column 18)",
-  " (in 'basic_ops_mix.stan', line 3, column 19 to column 20)",
-  " (in 'basic_ops_mix.stan', line 3, column 2 to column 27)",
+  " (in 'basic_ops_mix.stan', line 3, column 20 to column 21)",
+  " (in 'basic_ops_mix.stan', line 3, column 2 to column 28)",
   " (in 'basic_ops_mix.stan', line 4, column 17 to column 18)",
   " (in 'basic_ops_mix.stan', line 4, column 2 to column 25)",
   " (in 'basic_ops_mix.stan', line 5, column 21 to column 22)",
   " (in 'basic_ops_mix.stan', line 5, column 2 to column 32)",
   " (in 'basic_ops_mix.stan', line 6, column 2 to column 12)",
   " (in 'basic_ops_mix.stan', line 8, column 9 to column 10)",
-  " (in 'basic_ops_mix.stan', line 8, column 11 to column 12)",
-  " (in 'basic_ops_mix.stan', line 8, column 2 to column 18)",
+  " (in 'basic_ops_mix.stan', line 8, column 12 to column 13)",
+  " (in 'basic_ops_mix.stan', line 8, column 2 to column 19)",
   " (in 'basic_ops_mix.stan', line 9, column 9 to column 10)",
   " (in 'basic_ops_mix.stan', line 9, column 2 to column 16)",
   " (in 'basic_ops_mix.stan', line 10, column 13 to column 14)",
   " (in 'basic_ops_mix.stan', line 10, column 2 to column 23)",
   " (in 'basic_ops_mix.stan', line 11, column 2 to column 9)",
+  " (in 'basic_ops_mix.stan', line 14, column 17 to column 18)",
+  " (in 'basic_ops_mix.stan', line 14, column 20 to column 21)",
   " (in 'basic_ops_mix.stan', line 15, column 17 to column 18)",
-  " (in 'basic_ops_mix.stan', line 15, column 19 to column 20)",
-  " (in 'basic_ops_mix.stan', line 16, column 17 to column 18)",
-  " (in 'basic_ops_mix.stan', line 17, column 21 to column 22)",
+  " (in 'basic_ops_mix.stan', line 16, column 21 to column 22)",
+  " (in 'basic_ops_mix.stan', line 19, column 9 to column 10)",
+  " (in 'basic_ops_mix.stan', line 19, column 12 to column 13)",
   " (in 'basic_ops_mix.stan', line 20, column 9 to column 10)",
-  " (in 'basic_ops_mix.stan', line 20, column 11 to column 12)",
-  " (in 'basic_ops_mix.stan', line 21, column 9 to column 10)",
-  " (in 'basic_ops_mix.stan', line 22, column 13 to column 14)",
-  " (in 'basic_ops_mix.stan', line 28, column 17 to column 18)",
-  " (in 'basic_ops_mix.stan', line 28, column 19 to column 20)",
-  " (in 'basic_ops_mix.stan', line 62, column 17 to column 18)",
-  " (in 'basic_ops_mix.stan', line 93, column 21 to column 22)",
-  " (in 'basic_ops_mix.stan', line 193, column 8 to column 9)",
-  " (in 'basic_ops_mix.stan', line 193, column 10 to column 11)"};
+  " (in 'basic_ops_mix.stan', line 21, column 13 to column 14)",
+  " (in 'basic_ops_mix.stan', line 25, column 17 to column 18)",
+  " (in 'basic_ops_mix.stan', line 25, column 20 to column 21)",
+  " (in 'basic_ops_mix.stan', line 67, column 17 to column 18)",
+  " (in 'basic_ops_mix.stan', line 98, column 21 to column 22)",
+  " (in 'basic_ops_mix.stan', line 205, column 8 to column 9)",
+  " (in 'basic_ops_mix.stan', line 205, column 11 to column 12)"};
 class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
  private:
   int N;
@@ -3703,17 +3831,17 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
     try {
       int pos__ = std::numeric_limits<int>::min();
       pos__ = 1;
-      current_statement__ = 134;
+      current_statement__ = 146;
       context__.validate_dims("data initialization", "N", "int",
         std::vector<size_t>{});
       N = std::numeric_limits<int>::min();
-      current_statement__ = 134;
+      current_statement__ = 146;
       N = context__.vals_i("N")[(1 - 1)];
-      current_statement__ = 135;
+      current_statement__ = 147;
       stan::math::validate_non_negative_index("cmat", "N", N);
-      current_statement__ = 136;
+      current_statement__ = 148;
       stan::math::validate_non_negative_index("cmat", "N", N);
-      current_statement__ = 137;
+      current_statement__ = 149;
       context__.validate_dims("data initialization", "cmat", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N),
           static_cast<size_t>(2)});
@@ -3726,7 +3854,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         N, N);
       {
         std::vector<std::complex<local_scalar_t__>> cmat_flat__;
-        current_statement__ = 137;
+        current_statement__ = 149;
         cmat_flat__ = context__.vals_c("cmat");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -3738,9 +3866,9 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           }
         }
       }
-      current_statement__ = 138;
+      current_statement__ = 150;
       stan::math::validate_non_negative_index("cvec", "N", N);
-      current_statement__ = 139;
+      current_statement__ = 151;
       context__.validate_dims("data initialization", "cvec", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)});
       cvec_data__ = Eigen::Matrix<std::complex<double>,-1,1>::Constant(N,
@@ -3752,7 +3880,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         N);
       {
         std::vector<std::complex<local_scalar_t__>> cvec_flat__;
-        current_statement__ = 139;
+        current_statement__ = 151;
         cvec_flat__ = context__.vals_c("cvec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -3761,9 +3889,9 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 140;
+      current_statement__ = 152;
       stan::math::validate_non_negative_index("crowvec", "N", N);
-      current_statement__ = 141;
+      current_statement__ = 153;
       context__.validate_dims("data initialization", "crowvec", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(2)});
       crowvec_data__ = Eigen::Matrix<std::complex<double>,1,-1>::Constant(N,
@@ -3775,7 +3903,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         N);
       {
         std::vector<std::complex<local_scalar_t__>> crowvec_flat__;
-        current_statement__ = 141;
+        current_statement__ = 153;
         crowvec_flat__ = context__.vals_c("crowvec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -3784,18 +3912,18 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 142;
+      current_statement__ = 154;
       context__.validate_dims("data initialization", "z", "double",
         std::vector<size_t>{static_cast<size_t>(2)});
       z = std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
             std::numeric_limits<double>::quiet_NaN());
-      current_statement__ = 142;
+      current_statement__ = 154;
       z = context__.vals_c("z")[(1 - 1)];
-      current_statement__ = 143;
+      current_statement__ = 155;
       stan::math::validate_non_negative_index("mat", "N", N);
-      current_statement__ = 144;
+      current_statement__ = 156;
       stan::math::validate_non_negative_index("mat", "N", N);
-      current_statement__ = 145;
+      current_statement__ = 157;
       context__.validate_dims("data initialization", "mat", "double",
         std::vector<size_t>{static_cast<size_t>(N), static_cast<size_t>(N)});
       mat_data__ = Eigen::Matrix<double,-1,-1>::Constant(N, N,
@@ -3804,7 +3932,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         N, N);
       {
         std::vector<local_scalar_t__> mat_flat__;
-        current_statement__ = 145;
+        current_statement__ = 157;
         mat_flat__ = context__.vals_r("mat");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -3816,9 +3944,9 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           }
         }
       }
-      current_statement__ = 146;
+      current_statement__ = 158;
       stan::math::validate_non_negative_index("vec", "N", N);
-      current_statement__ = 147;
+      current_statement__ = 159;
       context__.validate_dims("data initialization", "vec", "double",
         std::vector<size_t>{static_cast<size_t>(N)});
       vec_data__ = Eigen::Matrix<double,-1,1>::Constant(N,
@@ -3826,7 +3954,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       new (&vec) Eigen::Map<Eigen::Matrix<double,-1,1>>(vec_data__.data(), N);
       {
         std::vector<local_scalar_t__> vec_flat__;
-        current_statement__ = 147;
+        current_statement__ = 159;
         vec_flat__ = context__.vals_r("vec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -3835,9 +3963,9 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 148;
+      current_statement__ = 160;
       stan::math::validate_non_negative_index("rowvec", "N", N);
-      current_statement__ = 149;
+      current_statement__ = 161;
       context__.validate_dims("data initialization", "rowvec", "double",
         std::vector<size_t>{static_cast<size_t>(N)});
       rowvec_data__ = Eigen::Matrix<double,1,-1>::Constant(N,
@@ -3846,7 +3974,7 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         Eigen::Map<Eigen::Matrix<double,1,-1>>(rowvec_data__.data(), N);
       {
         std::vector<local_scalar_t__> rowvec_flat__;
-        current_statement__ = 149;
+        current_statement__ = 161;
         rowvec_flat__ = context__.vals_r("rowvec");
         pos__ = 1;
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -3855,39 +3983,39 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
           pos__ = (pos__ + 1);
         }
       }
-      current_statement__ = 150;
+      current_statement__ = 162;
       context__.validate_dims("data initialization", "r", "double",
         std::vector<size_t>{});
       r = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 150;
-      r = context__.vals_r("r")[(1 - 1)];
-      current_statement__ = 151;
-      stan::math::validate_non_negative_index("cvmat", "N", N);
-      current_statement__ = 152;
-      stan::math::validate_non_negative_index("cvmat", "N", N);
-      current_statement__ = 153;
-      stan::math::validate_non_negative_index("cvvec", "N", N);
-      current_statement__ = 154;
-      stan::math::validate_non_negative_index("cvrowvec", "N", N);
-      current_statement__ = 155;
-      stan::math::validate_non_negative_index("vmat", "N", N);
-      current_statement__ = 156;
-      stan::math::validate_non_negative_index("vmat", "N", N);
-      current_statement__ = 157;
-      stan::math::validate_non_negative_index("vvec", "N", N);
-      current_statement__ = 158;
-      stan::math::validate_non_negative_index("vrowvec", "N", N);
-      current_statement__ = 159;
-      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
-      current_statement__ = 160;
-      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
-      current_statement__ = 161;
-      stan::math::validate_non_negative_index("tp_c_vector", "N", N);
       current_statement__ = 162;
-      stan::math::validate_non_negative_index("tp_c_rowvector", "N", N);
+      r = context__.vals_r("r")[(1 - 1)];
       current_statement__ = 163;
-      stan::math::validate_non_negative_index("carray", "N", N);
+      stan::math::validate_non_negative_index("cvmat", "N", N);
       current_statement__ = 164;
+      stan::math::validate_non_negative_index("cvmat", "N", N);
+      current_statement__ = 165;
+      stan::math::validate_non_negative_index("cvvec", "N", N);
+      current_statement__ = 166;
+      stan::math::validate_non_negative_index("cvrowvec", "N", N);
+      current_statement__ = 167;
+      stan::math::validate_non_negative_index("vmat", "N", N);
+      current_statement__ = 168;
+      stan::math::validate_non_negative_index("vmat", "N", N);
+      current_statement__ = 169;
+      stan::math::validate_non_negative_index("vvec", "N", N);
+      current_statement__ = 170;
+      stan::math::validate_non_negative_index("vrowvec", "N", N);
+      current_statement__ = 171;
+      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
+      current_statement__ = 172;
+      stan::math::validate_non_negative_index("tp_c_matrix", "N", N);
+      current_statement__ = 173;
+      stan::math::validate_non_negative_index("tp_c_vector", "N", N);
+      current_statement__ = 174;
+      stan::math::validate_non_negative_index("tp_c_rowvector", "N", N);
+      current_statement__ = 175;
+      stan::math::validate_non_negative_index("carray", "N", N);
+      current_statement__ = 176;
       stan::math::validate_non_negative_index("carray", "N", N);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -4069,101 +4197,127 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_matrix");
+      current_statement__ = 38;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 39;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cvmat,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 40;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat),
+          cmat), "assigning variable tp_c_matrix");
+      current_statement__ = 41;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 42;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 43;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(mat), cvmat),
+        "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(cvrowvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 38;
+      current_statement__ = 44;
       stan::model::assign(tp_c_vector, stan::math::multiply(cmat, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 39;
+      current_statement__ = 45;
       stan::model::assign(tp_c_vector, stan::math::multiply(cvmat, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 46;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(mat), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 47;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 48;
       stan::model::assign(tp_c_vector, stan::math::multiply(z, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 49;
       stan::model::assign(tp_c_vector, stan::math::multiply(cvec, zv),
         "assigning variable tp_c_vector");
-      current_statement__ = 44;
+      current_statement__ = 50;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 45;
+      current_statement__ = 51;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_vector");
-      current_statement__ = 46;
+      current_statement__ = 52;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 47;
+      current_statement__ = 53;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), zv),
         "assigning variable tp_c_vector");
-      current_statement__ = 48;
+      current_statement__ = 54;
       stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 49;
+      current_statement__ = 55;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 50;
+      current_statement__ = 56;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 57;
       stan::model::assign(tp_c_vector, stan::math::elt_divide(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 58;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 59;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 60;
       stan::model::assign(tp_c_vector, stan::math::add(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 55;
+      current_statement__ = 61;
       stan::model::assign(tp_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 56;
+      current_statement__ = 62;
       stan::model::assign(tp_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 57;
+      current_statement__ = 63;
       stan::model::assign(tp_c_vector, stan::math::subtract(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 58;
+      current_statement__ = 64;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 59;
+      current_statement__ = 65;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
@@ -4174,299 +4328,325 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 60;
+      current_statement__ = 66;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec, cvmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 61;
+      current_statement__ = 67;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 62;
+      current_statement__ = 68;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 69;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(z, cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 70;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, zv),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 71;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 72;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 67;
+      current_statement__ = 73;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 68;
+      current_statement__ = 74;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), zv),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 69;
+      current_statement__ = 75;
       stan::model::assign(tp_c_rowvector,
         stan::math::elt_multiply(crowvec, cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 70;
+      current_statement__ = 76;
       stan::model::assign(tp_c_rowvector,
         stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 71;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(
-          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 72;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec, cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 73;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 74;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(
-          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 75;
-      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 76;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::add(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
-        "assigning variable tp_c_rowvector");
       current_statement__ = 77;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(
+        stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 78;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec, cvrowvec),
+        stan::math::elt_divide(crowvec, cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 79;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec,
+        stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 80;
       stan::model::assign(tp_c_rowvector,
+        stan::math::elt_divide(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 81;
+      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 82;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::add(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 83;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::add(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 84;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec, cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 85;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 86;
+      stan::model::assign(tp_c_rowvector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
+      current_statement__ = 87;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(cvrowvec, cmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 88;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(cvrowvec,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 89;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec),
+          cmat), "assigning variable tp_c_rowvector");
+      current_statement__ = 90;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cvmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 91;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 92;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
+        "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      current_statement__ = 81;
+      current_statement__ = 93;
       tp_c = stan::math::multiply(crowvec, cvvec);
-      current_statement__ = 82;
+      current_statement__ = 94;
       tp_c = stan::math::multiply(cvrowvec, cvec);
-      current_statement__ = 83;
+      current_statement__ = 95;
       tp_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                  vvec));
-      current_statement__ = 84;
+      current_statement__ = 96;
       tp_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<double>>(rowvec),
                cvvec);
-      current_statement__ = 85;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(z, cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 86;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(stan::math::to_complex(r, 0), cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 87;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(cvmat, stan::math::to_complex(r, 0)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 88;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(cvmat, z),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 89;
-      stan::model::assign(tp_c_matrix, stan::math::add(z, cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 90;
-      stan::model::assign(tp_c_matrix,
-        stan::math::add(stan::math::to_complex(r, 0), cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 91;
-      stan::model::assign(tp_c_matrix,
-        stan::math::add(cvmat, stan::math::to_complex(r, 0)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 92;
-      stan::model::assign(tp_c_matrix, stan::math::add(cvmat, z),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 93;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(zv, cmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 94;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 95;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(cmat,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 96;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, zv),
-        "assigning variable tp_c_matrix");
       current_statement__ = 97;
-      stan::model::assign(tp_c_matrix, stan::math::add(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 98;
       stan::model::assign(tp_c_matrix,
-        stan::math::add(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
+        stan::math::subtract(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 99;
       stan::model::assign(tp_c_matrix,
-        stan::math::add(cmat,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
+        stan::math::subtract(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
       current_statement__ = 100;
-      stan::model::assign(tp_c_matrix, stan::math::add(cmat, zv),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(cvmat, z),
         "assigning variable tp_c_matrix");
       current_statement__ = 101;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cvmat),
+      stan::model::assign(tp_c_matrix, stan::math::add(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 102;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(stan::math::to_complex(r, 0), cvmat),
+        stan::math::add(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 103;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(cvmat, stan::math::to_complex(r, 0)),
+        stan::math::add(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
       current_statement__ = 104;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cvmat, z),
+      stan::model::assign(tp_c_matrix, stan::math::add(cvmat, z),
         "assigning variable tp_c_matrix");
       current_statement__ = 105;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(zv, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 106;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(
+        stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 107;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(cmat,
+        stan::math::subtract(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
       current_statement__ = 108;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, zv),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, zv),
         "assigning variable tp_c_matrix");
       current_statement__ = 109;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cvmat),
+      stan::model::assign(tp_c_matrix, stan::math::add(zv, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 110;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_multiply(stan::math::to_complex(r, 0), cvmat),
+        stan::math::add(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 111;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_multiply(cvmat, stan::math::to_complex(r, 0)),
+        stan::math::add(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
       current_statement__ = 112;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cvmat, z),
+      stan::model::assign(tp_c_matrix, stan::math::add(cmat, zv),
         "assigning variable tp_c_matrix");
       current_statement__ = 113;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 114;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(stan::math::to_complex(r, 0), cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 115;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(cvmat, stan::math::to_complex(r, 0)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 116;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cvmat, z),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 117;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(zv, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 118;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 119;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 120;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, zv),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 121;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 122;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_multiply(stan::math::to_complex(r, 0), cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 123;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_multiply(cvmat, stan::math::to_complex(r, 0)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 124;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cvmat, z),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 125;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(zv, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 126;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 115;
+      current_statement__ = 127;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 116;
+      current_statement__ = 128;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 117;
+      current_statement__ = 129;
       stan::model::assign(tp_c_matrix, stan::math::divide(z, cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 118;
+      current_statement__ = 130;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 119;
+      current_statement__ = 131;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 120;
+      current_statement__ = 132;
       stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 121;
+      current_statement__ = 133;
       stan::model::assign(tp_c_matrix, stan::math::divide(zv, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 122;
+      current_statement__ = 134;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 123;
+      current_statement__ = 135;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 124;
+      current_statement__ = 136;
       stan::model::assign(tp_c_matrix, stan::math::divide(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 125;
+      current_statement__ = 137;
       stan::model::assign(tp_c_matrix, stan::math::multiply(z, cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 126;
+      current_statement__ = 138;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 127;
+      current_statement__ = 139;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 128;
+      current_statement__ = 140;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cvmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 129;
+      current_statement__ = 141;
       stan::model::assign(tp_c_matrix, stan::math::multiply(zv, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 130;
+      current_statement__ = 142;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 131;
+      current_statement__ = 143;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 132;
+      current_statement__ = 144;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, zv),
         "assigning variable tp_c_matrix");
       std::vector<std::vector<std::complex<local_scalar_t__>>> carray =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(N,
           std::vector<std::complex<local_scalar_t__>>(N,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
-      current_statement__ = 133;
+      current_statement__ = 145;
       stan::model::assign(carray, stan::math::to_array_2d(cvmat),
         "assigning variable carray");
     } catch (const std::exception& e) {
@@ -4642,101 +4822,127 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_matrix");
+      current_statement__ = 38;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 39;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cvmat,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 40;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat),
+          cmat), "assigning variable tp_c_matrix");
+      current_statement__ = 41;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 42;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 43;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(mat), cvmat),
+        "assigning variable tp_c_matrix");
       Eigen::Matrix<std::complex<local_scalar_t__>,-1,1> tp_c_vector =
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(N,
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__));
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(cvrowvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 38;
+      current_statement__ = 44;
       stan::model::assign(tp_c_vector, stan::math::multiply(cmat, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 39;
+      current_statement__ = 45;
       stan::model::assign(tp_c_vector, stan::math::multiply(cvmat, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 46;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(mat), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 47;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 48;
       stan::model::assign(tp_c_vector, stan::math::multiply(z, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 49;
       stan::model::assign(tp_c_vector, stan::math::multiply(cvec, zv),
         "assigning variable tp_c_vector");
-      current_statement__ = 44;
+      current_statement__ = 50;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 45;
+      current_statement__ = 51;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_vector");
-      current_statement__ = 46;
+      current_statement__ = 52;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 47;
+      current_statement__ = 53;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), zv),
         "assigning variable tp_c_vector");
-      current_statement__ = 48;
+      current_statement__ = 54;
       stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 49;
+      current_statement__ = 55;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 50;
+      current_statement__ = 56;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 57;
       stan::model::assign(tp_c_vector, stan::math::elt_divide(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 58;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 59;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 60;
       stan::model::assign(tp_c_vector, stan::math::add(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 55;
+      current_statement__ = 61;
       stan::model::assign(tp_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 56;
+      current_statement__ = 62;
       stan::model::assign(tp_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 57;
+      current_statement__ = 63;
       stan::model::assign(tp_c_vector, stan::math::subtract(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 58;
+      current_statement__ = 64;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 59;
+      current_statement__ = 65;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
@@ -4747,299 +4953,325 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 60;
+      current_statement__ = 66;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec, cvmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 61;
+      current_statement__ = 67;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 62;
+      current_statement__ = 68;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 69;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(z, cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 70;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, zv),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 71;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 72;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 67;
+      current_statement__ = 73;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 68;
+      current_statement__ = 74;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), zv),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 69;
+      current_statement__ = 75;
       stan::model::assign(tp_c_rowvector,
         stan::math::elt_multiply(crowvec, cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 70;
+      current_statement__ = 76;
       stan::model::assign(tp_c_rowvector,
         stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 71;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(
-          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 72;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec, cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 73;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 74;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(
-          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 75;
-      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 76;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::add(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
-        "assigning variable tp_c_rowvector");
       current_statement__ = 77;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(
+        stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 78;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec, cvrowvec),
+        stan::math::elt_divide(crowvec, cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 79;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec,
+        stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 80;
       stan::model::assign(tp_c_rowvector,
+        stan::math::elt_divide(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 81;
+      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 82;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::add(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 83;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::add(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 84;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec, cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 85;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 86;
+      stan::model::assign(tp_c_rowvector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
+      current_statement__ = 87;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(cvrowvec, cmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 88;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(cvrowvec,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 89;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec),
+          cmat), "assigning variable tp_c_rowvector");
+      current_statement__ = 90;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cvmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 91;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 92;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
+        "assigning variable tp_c_rowvector");
       std::complex<local_scalar_t__> tp_c =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
-      current_statement__ = 81;
+      current_statement__ = 93;
       tp_c = stan::math::multiply(crowvec, cvvec);
-      current_statement__ = 82;
+      current_statement__ = 94;
       tp_c = stan::math::multiply(cvrowvec, cvec);
-      current_statement__ = 83;
+      current_statement__ = 95;
       tp_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                  vvec));
-      current_statement__ = 84;
+      current_statement__ = 96;
       tp_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<double>>(rowvec),
                cvvec);
-      current_statement__ = 85;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(z, cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 86;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(stan::math::to_complex(r, 0), cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 87;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(cvmat, stan::math::to_complex(r, 0)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 88;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(cvmat, z),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 89;
-      stan::model::assign(tp_c_matrix, stan::math::add(z, cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 90;
-      stan::model::assign(tp_c_matrix,
-        stan::math::add(stan::math::to_complex(r, 0), cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 91;
-      stan::model::assign(tp_c_matrix,
-        stan::math::add(cvmat, stan::math::to_complex(r, 0)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 92;
-      stan::model::assign(tp_c_matrix, stan::math::add(cvmat, z),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 93;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(zv, cmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 94;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 95;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(cmat,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 96;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, zv),
-        "assigning variable tp_c_matrix");
       current_statement__ = 97;
-      stan::model::assign(tp_c_matrix, stan::math::add(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 98;
       stan::model::assign(tp_c_matrix,
-        stan::math::add(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
+        stan::math::subtract(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 99;
       stan::model::assign(tp_c_matrix,
-        stan::math::add(cmat,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
+        stan::math::subtract(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
       current_statement__ = 100;
-      stan::model::assign(tp_c_matrix, stan::math::add(cmat, zv),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(cvmat, z),
         "assigning variable tp_c_matrix");
       current_statement__ = 101;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cvmat),
+      stan::model::assign(tp_c_matrix, stan::math::add(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 102;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(stan::math::to_complex(r, 0), cvmat),
+        stan::math::add(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 103;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(cvmat, stan::math::to_complex(r, 0)),
+        stan::math::add(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
       current_statement__ = 104;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cvmat, z),
+      stan::model::assign(tp_c_matrix, stan::math::add(cvmat, z),
         "assigning variable tp_c_matrix");
       current_statement__ = 105;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(zv, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 106;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(
+        stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 107;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(cmat,
+        stan::math::subtract(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
       current_statement__ = 108;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, zv),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, zv),
         "assigning variable tp_c_matrix");
       current_statement__ = 109;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cvmat),
+      stan::model::assign(tp_c_matrix, stan::math::add(zv, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 110;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_multiply(stan::math::to_complex(r, 0), cvmat),
+        stan::math::add(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 111;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_multiply(cvmat, stan::math::to_complex(r, 0)),
+        stan::math::add(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
       current_statement__ = 112;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cvmat, z),
+      stan::model::assign(tp_c_matrix, stan::math::add(cmat, zv),
         "assigning variable tp_c_matrix");
       current_statement__ = 113;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 114;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(stan::math::to_complex(r, 0), cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 115;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(cvmat, stan::math::to_complex(r, 0)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 116;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cvmat, z),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 117;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(zv, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 118;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 119;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 120;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, zv),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 121;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 122;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_multiply(stan::math::to_complex(r, 0), cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 123;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_multiply(cvmat, stan::math::to_complex(r, 0)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 124;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cvmat, z),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 125;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(zv, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 126;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 115;
+      current_statement__ = 127;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 116;
+      current_statement__ = 128;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 117;
+      current_statement__ = 129;
       stan::model::assign(tp_c_matrix, stan::math::divide(z, cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 118;
+      current_statement__ = 130;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 119;
+      current_statement__ = 131;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 120;
+      current_statement__ = 132;
       stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 121;
+      current_statement__ = 133;
       stan::model::assign(tp_c_matrix, stan::math::divide(zv, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 122;
+      current_statement__ = 134;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 123;
+      current_statement__ = 135;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 124;
+      current_statement__ = 136;
       stan::model::assign(tp_c_matrix, stan::math::divide(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 125;
+      current_statement__ = 137;
       stan::model::assign(tp_c_matrix, stan::math::multiply(z, cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 126;
+      current_statement__ = 138;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 127;
+      current_statement__ = 139;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 128;
+      current_statement__ = 140;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cvmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 129;
+      current_statement__ = 141;
       stan::model::assign(tp_c_matrix, stan::math::multiply(zv, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 130;
+      current_statement__ = 142;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 131;
+      current_statement__ = 143;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 132;
+      current_statement__ = 144;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, zv),
         "assigning variable tp_c_matrix");
       std::vector<std::vector<std::complex<local_scalar_t__>>> carray =
         std::vector<std::vector<std::complex<local_scalar_t__>>>(N,
           std::vector<std::complex<local_scalar_t__>>(N,
             std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
-      current_statement__ = 133;
+      current_statement__ = 145;
       stan::model::assign(carray, stan::math::to_array_2d(cvmat),
         "assigning variable carray");
     } catch (const std::exception& e) {
@@ -5263,98 +5495,124 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_matrix");
+      current_statement__ = 38;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 39;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cvmat,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 40;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat),
+          cmat), "assigning variable tp_c_matrix");
+      current_statement__ = 41;
+      stan::model::assign(tp_c_matrix, stan::math::divide(cmat, cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 42;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 43;
+      stan::model::assign(tp_c_matrix,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(mat), cvmat),
+        "assigning variable tp_c_matrix");
       current_statement__ = 10;
       stan::model::assign(tp_c_vector, stan::math::transpose(cvrowvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 38;
+      current_statement__ = 44;
       stan::model::assign(tp_c_vector, stan::math::multiply(cmat, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 39;
+      current_statement__ = 45;
       stan::model::assign(tp_c_vector, stan::math::multiply(cvmat, cvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 40;
+      current_statement__ = 46;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(mat), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 41;
+      current_statement__ = 47;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 42;
+      current_statement__ = 48;
       stan::model::assign(tp_c_vector, stan::math::multiply(z, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 43;
+      current_statement__ = 49;
       stan::model::assign(tp_c_vector, stan::math::multiply(cvec, zv),
         "assigning variable tp_c_vector");
-      current_statement__ = 44;
+      current_statement__ = 50;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 45;
+      current_statement__ = 51;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_vector");
-      current_statement__ = 46;
+      current_statement__ = 52;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 47;
+      current_statement__ = 53;
       stan::model::assign(tp_c_vector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), zv),
         "assigning variable tp_c_vector");
-      current_statement__ = 48;
+      current_statement__ = 54;
       stan::model::assign(tp_c_vector, stan::math::elt_multiply(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 49;
+      current_statement__ = 55;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 50;
+      current_statement__ = 56;
       stan::model::assign(tp_c_vector,
         stan::math::elt_multiply(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 51;
+      current_statement__ = 57;
       stan::model::assign(tp_c_vector, stan::math::elt_divide(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 52;
+      current_statement__ = 58;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 53;
+      current_statement__ = 59;
       stan::model::assign(tp_c_vector,
         stan::math::elt_divide(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 54;
+      current_statement__ = 60;
       stan::model::assign(tp_c_vector, stan::math::add(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 55;
+      current_statement__ = 61;
       stan::model::assign(tp_c_vector,
         stan::math::add(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 56;
+      current_statement__ = 62;
       stan::model::assign(tp_c_vector,
         stan::math::add(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
         "assigning variable tp_c_vector");
-      current_statement__ = 57;
+      current_statement__ = 63;
       stan::model::assign(tp_c_vector, stan::math::subtract(cvec, cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 58;
+      current_statement__ = 64;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(
           stan::math::promote_scalar<std::complex<double>>(vec), cvvec),
         "assigning variable tp_c_vector");
-      current_statement__ = 59;
+      current_statement__ = 65;
       stan::model::assign(tp_c_vector,
         stan::math::subtract(cvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vvec)),
@@ -5362,293 +5620,319 @@ class basic_ops_mix_model final : public model_base_crtp<basic_ops_mix_model> {
       current_statement__ = 11;
       stan::model::assign(tp_c_rowvector, stan::math::transpose(cvvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 60;
+      current_statement__ = 66;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec, cvmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 61;
+      current_statement__ = 67;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 62;
+      current_statement__ = 68;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 63;
+      current_statement__ = 69;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(z, cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 64;
+      current_statement__ = 70;
       stan::model::assign(tp_c_rowvector, stan::math::multiply(crowvec, zv),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 65;
+      current_statement__ = 71;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(stan::math::to_complex(r, 0), cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 66;
+      current_statement__ = 72;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 67;
+      current_statement__ = 73;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 68;
+      current_statement__ = 74;
       stan::model::assign(tp_c_rowvector,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), zv),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 69;
+      current_statement__ = 75;
       stan::model::assign(tp_c_rowvector,
         stan::math::elt_multiply(crowvec, cvrowvec),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 70;
+      current_statement__ = 76;
       stan::model::assign(tp_c_rowvector,
         stan::math::elt_multiply(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
-      current_statement__ = 71;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_multiply(
-          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 72;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec, cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 73;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 74;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::elt_divide(
-          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 75;
-      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, cvrowvec),
-        "assigning variable tp_c_rowvector");
-      current_statement__ = 76;
-      stan::model::assign(tp_c_rowvector,
-        stan::math::add(crowvec,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
-        "assigning variable tp_c_rowvector");
       current_statement__ = 77;
       stan::model::assign(tp_c_rowvector,
-        stan::math::add(
+        stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 78;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec, cvrowvec),
+        stan::math::elt_divide(crowvec, cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 79;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(crowvec,
+        stan::math::elt_divide(crowvec,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
         "assigning variable tp_c_rowvector");
       current_statement__ = 80;
       stan::model::assign(tp_c_rowvector,
-        stan::math::subtract(
+        stan::math::elt_divide(
           stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
         "assigning variable tp_c_rowvector");
       current_statement__ = 81;
-      tp_c = stan::math::multiply(crowvec, cvvec);
+      stan::model::assign(tp_c_rowvector, stan::math::add(crowvec, cvrowvec),
+        "assigning variable tp_c_rowvector");
       current_statement__ = 82;
-      tp_c = stan::math::multiply(cvrowvec, cvec);
+      stan::model::assign(tp_c_rowvector,
+        stan::math::add(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
+        "assigning variable tp_c_rowvector");
       current_statement__ = 83;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::add(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 84;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec, cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 85;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 86;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::subtract(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvrowvec),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 87;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(cvrowvec, cmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 88;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(cvrowvec,
+          stan::math::promote_scalar<std::complex<double>>(mat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 89;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vrowvec),
+          cmat), "assigning variable tp_c_rowvector");
+      current_statement__ = 90;
+      stan::model::assign(tp_c_rowvector, stan::math::divide(crowvec, cvmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 91;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(crowvec,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(vmat)),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 92;
+      stan::model::assign(tp_c_rowvector,
+        stan::math::divide(
+          stan::math::promote_scalar<std::complex<double>>(rowvec), cvmat),
+        "assigning variable tp_c_rowvector");
+      current_statement__ = 93;
+      tp_c = stan::math::multiply(crowvec, cvvec);
+      current_statement__ = 94;
+      tp_c = stan::math::multiply(cvrowvec, cvec);
+      current_statement__ = 95;
       tp_c = stan::math::multiply(crowvec,
                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                  vvec));
-      current_statement__ = 84;
+      current_statement__ = 96;
       tp_c = stan::math::multiply(
                stan::math::promote_scalar<std::complex<double>>(rowvec),
                cvvec);
-      current_statement__ = 85;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(z, cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 86;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(stan::math::to_complex(r, 0), cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 87;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(cvmat, stan::math::to_complex(r, 0)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 88;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(cvmat, z),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 89;
-      stan::model::assign(tp_c_matrix, stan::math::add(z, cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 90;
-      stan::model::assign(tp_c_matrix,
-        stan::math::add(stan::math::to_complex(r, 0), cvmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 91;
-      stan::model::assign(tp_c_matrix,
-        stan::math::add(cvmat, stan::math::to_complex(r, 0)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 92;
-      stan::model::assign(tp_c_matrix, stan::math::add(cvmat, z),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 93;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(zv, cmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 94;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 95;
-      stan::model::assign(tp_c_matrix,
-        stan::math::subtract(cmat,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
-        "assigning variable tp_c_matrix");
-      current_statement__ = 96;
-      stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, zv),
-        "assigning variable tp_c_matrix");
       current_statement__ = 97;
-      stan::model::assign(tp_c_matrix, stan::math::add(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 98;
       stan::model::assign(tp_c_matrix,
-        stan::math::add(
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
+        stan::math::subtract(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 99;
       stan::model::assign(tp_c_matrix,
-        stan::math::add(cmat,
-          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
+        stan::math::subtract(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
       current_statement__ = 100;
-      stan::model::assign(tp_c_matrix, stan::math::add(cmat, zv),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(cvmat, z),
         "assigning variable tp_c_matrix");
       current_statement__ = 101;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cvmat),
+      stan::model::assign(tp_c_matrix, stan::math::add(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 102;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(stan::math::to_complex(r, 0), cvmat),
+        stan::math::add(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 103;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(cvmat, stan::math::to_complex(r, 0)),
+        stan::math::add(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
       current_statement__ = 104;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cvmat, z),
+      stan::model::assign(tp_c_matrix, stan::math::add(cvmat, z),
         "assigning variable tp_c_matrix");
       current_statement__ = 105;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(zv, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 106;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(
+        stan::math::subtract(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 107;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_divide(cmat,
+        stan::math::subtract(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
       current_statement__ = 108;
-      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, zv),
+      stan::model::assign(tp_c_matrix, stan::math::subtract(cmat, zv),
         "assigning variable tp_c_matrix");
       current_statement__ = 109;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cvmat),
+      stan::model::assign(tp_c_matrix, stan::math::add(zv, cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 110;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_multiply(stan::math::to_complex(r, 0), cvmat),
+        stan::math::add(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 111;
       stan::model::assign(tp_c_matrix,
-        stan::math::elt_multiply(cvmat, stan::math::to_complex(r, 0)),
+        stan::math::add(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
       current_statement__ = 112;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cvmat, z),
+      stan::model::assign(tp_c_matrix, stan::math::add(cmat, zv),
         "assigning variable tp_c_matrix");
       current_statement__ = 113;
-      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(zv, cmat),
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(z, cvmat),
         "assigning variable tp_c_matrix");
       current_statement__ = 114;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(stan::math::to_complex(r, 0), cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 115;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(cvmat, stan::math::to_complex(r, 0)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 116;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cvmat, z),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 117;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(zv, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 118;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 119;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_divide(cmat,
+          stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 120;
+      stan::model::assign(tp_c_matrix, stan::math::elt_divide(cmat, zv),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 121;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(z, cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 122;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_multiply(stan::math::to_complex(r, 0), cvmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 123;
+      stan::model::assign(tp_c_matrix,
+        stan::math::elt_multiply(cvmat, stan::math::to_complex(r, 0)),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 124;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cvmat, z),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 125;
+      stan::model::assign(tp_c_matrix, stan::math::elt_multiply(zv, cmat),
+        "assigning variable tp_c_matrix");
+      current_statement__ = 126;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 115;
+      current_statement__ = 127;
       stan::model::assign(tp_c_matrix,
         stan::math::elt_multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 116;
+      current_statement__ = 128;
       stan::model::assign(tp_c_matrix, stan::math::elt_multiply(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 117;
+      current_statement__ = 129;
       stan::model::assign(tp_c_matrix, stan::math::divide(z, cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 118;
+      current_statement__ = 130;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 119;
+      current_statement__ = 131;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 120;
+      current_statement__ = 132;
       stan::model::assign(tp_c_matrix, stan::math::divide(cvmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 121;
+      current_statement__ = 133;
       stan::model::assign(tp_c_matrix, stan::math::divide(zv, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 122;
+      current_statement__ = 134;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 123;
+      current_statement__ = 135;
       stan::model::assign(tp_c_matrix,
         stan::math::divide(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 124;
+      current_statement__ = 136;
       stan::model::assign(tp_c_matrix, stan::math::divide(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 125;
+      current_statement__ = 137;
       stan::model::assign(tp_c_matrix, stan::math::multiply(z, cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 126;
+      current_statement__ = 138;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(stan::math::to_complex(r, 0), cvmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 127;
+      current_statement__ = 139;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cvmat, stan::math::to_complex(r, 0)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 128;
+      current_statement__ = 140;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cvmat, z),
         "assigning variable tp_c_matrix");
-      current_statement__ = 129;
+      current_statement__ = 141;
       stan::model::assign(tp_c_matrix, stan::math::multiply(zv, cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 130;
+      current_statement__ = 142;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v), cmat),
         "assigning variable tp_c_matrix");
-      current_statement__ = 131;
+      current_statement__ = 143;
       stan::model::assign(tp_c_matrix,
         stan::math::multiply(cmat,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(v)),
         "assigning variable tp_c_matrix");
-      current_statement__ = 132;
+      current_statement__ = 144;
       stan::model::assign(tp_c_matrix, stan::math::multiply(cmat, zv),
         "assigning variable tp_c_matrix");
-      current_statement__ = 133;
+      current_statement__ = 145;
       stan::model::assign(carray, stan::math::to_array_2d(cvmat),
         "assigning variable carray");
       if (emit_transformed_parameters__) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fixed an issue where `operator/` was not generating the correct C++ for complex linear algebra types.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
