### PR TITLE
Rollback JSOO version for QuickJS compatibility

### DIFF
--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -21,7 +21,7 @@ These are automatically installed through the [scripts/install_ocaml.sh] and
 
 For the JavaScript interface to stanc3 we also use the following, installed
 via [scripts/install_js_deps.sh]
-- js_of_ocaml 5.5.2
+- js_of_ocaml 5.4.0
 
 The [stancjs] executable can be built with
 

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -40,7 +40,7 @@ RUN opam update; bash -x install_build_deps.sh
 COPY ./scripts/install_dev_deps.sh ./
 RUN opam update; bash -x install_dev_deps.sh
 
-# Install Javascript dev environment (js_of_ocaml 5.5.2)
+# Install Javascript dev environment (js_of_ocaml 5.4.0)
 COPY ./scripts/install_js_deps.sh ./
 RUN opam update; bash -x install_js_deps.sh
 

--- a/scripts/install_js_deps.sh
+++ b/scripts/install_js_deps.sh
@@ -5,6 +5,8 @@ set -e
 
 # JSOO versions higher than this break QuickJS (labelled break statements)
 # Please check compatibility before any updates!
+# https://github.com/stan-dev/stanc3/issues/1425
+# https://github.com/bellard/quickjs/issues/275
 opam pin -y js_of_ocaml 5.4.0
 
 echo "You should also install node in order to run the tests."

--- a/scripts/install_js_deps.sh
+++ b/scripts/install_js_deps.sh
@@ -3,7 +3,9 @@
 # exit when any command fails
 set -e
 
-opam pin -y js_of_ocaml 5.5.2
+# JSOO versions higher than this break QuickJS (labelled break statements)
+# Please check compatibility before any updates!
+opam pin -y js_of_ocaml 5.4.0
 
 echo "You should also install node in order to run the tests."
 echo "Tests are run with dune build @runjstest"


### PR DESCRIPTION
#### Submission Checklist

Closes #1425

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Rollback js_of_ocaml to 5.4.0 for compatibility with QuickJS

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
