### PR TITLE
Allow `#include` statements to function in stanc.js

### DIFF
--- a/src/frontend/Filesystem_includes.ml
+++ b/src/frontend/Filesystem_includes.ml
@@ -1,0 +1,29 @@
+(** filesystem-based way of opening new lexbufs for #include directive *)
+
+open Core
+
+(** list of allowed directories to look in for the path *)
+let lookup_paths : string list ref = ref []
+
+let find_include fname =
+  let open Lexing in
+  let rec loop paths =
+    match paths with
+    | [] ->
+        let message =
+          let pp_list ppf l =
+            match l with
+            | [] -> Fmt.string ppf "None"
+            | _ -> Fmt.(list ~sep:comma string) ppf l in
+          Fmt.str
+            "Could not find include file '%s' in specified include paths.@\n\
+             @[Current include paths: %a@]" fname pp_list !lookup_paths in
+        raise
+          (Errors.SyntaxError
+             (Include (message, Preprocessor.current_location_t ())))
+    | path :: rest_of_paths -> (
+        try
+          let full_path = path ^ "/" ^ fname in
+          (In_channel.create full_path |> from_channel, full_path)
+        with _ -> loop rest_of_paths) in
+  loop !lookup_paths

--- a/src/frontend/In_memory_includes.ml
+++ b/src/frontend/In_memory_includes.ml
@@ -1,0 +1,27 @@
+(** in-memory way of opening new lexbufs for #include directive *)
+
+open Core
+
+(** helper to map "./foo.stan" to "foo.stan" *)
+let no_leading_dotslash = String.chop_prefix_if_exists ~prefix:"./"
+
+(** map from filenames to Stan code *)
+let map : string String.Map.t ref = ref String.Map.empty
+
+let find_include fname =
+  let fname = no_leading_dotslash fname in
+  match Map.find !map fname with
+  | None ->
+      let message =
+        let pp_list ppf l =
+          let keys = Map.keys l in
+          if List.is_empty keys then Fmt.string ppf "None"
+          else Fmt.(list ~sep:comma string) ppf keys in
+        Fmt.str
+          "Could not find include file '%s'.@ stanc was given information \
+           about the following files:@ %a"
+          fname pp_list !map in
+      raise
+        (Errors.SyntaxError
+           (Include (message, Preprocessor.current_location_t ())))
+  | Some s -> (Lexing.from_string s, fname)

--- a/src/frontend/Includes_intf.ml
+++ b/src/frontend/Includes_intf.ml
@@ -1,0 +1,15 @@
+(** Functor declarations for preprocessing *)
+
+module type LEXBUF_LOCATOR = sig
+  val find_include : string -> Lexing.lexbuf * string
+  (** Injectable code for finding an included file. In the
+    binary stanc, this will access the filesystem, while in
+    stancjs it is a look up in a map object.
+  *)
+end
+
+module type PREPROCESSOR_LOADER = sig
+  val try_get_new_lexbuf : string -> Lexing.lexbuf
+  (** Search include paths for filename and try to create a new lexing buffer
+        with that filename, record that included from specified position *)
+end

--- a/src/frontend/Parse.mli
+++ b/src/frontend/Parse.mli
@@ -2,6 +2,7 @@
     API *)
 
 open Core
+open Includes_intf
 
 val parse_file :
      (Lexing.position -> Ast.untyped_program Parser.MenhirInterpreter.checkpoint)
@@ -10,7 +11,17 @@ val parse_file :
 (** A helper function to take a parser, a filename and produce an AST. Under the
     hood, it takes care of Menhir's custom syntax error messages. *)
 
-val parse_string :
+val parse_in_memory :
      (Lexing.position -> Ast.untyped_program Parser.MenhirInterpreter.checkpoint)
   -> string
   -> (Ast.untyped_program, Errors.t) result * Warnings.t list
+(** Parse from code stored in the string argument and handle #includes
+through the [In_memory_includes] module *)
+
+val parse_string :
+     (module LEXBUF_LOCATOR)
+  -> (   Lexing.position
+      -> Ast.untyped_program Parser.MenhirInterpreter.checkpoint)
+  -> string
+  -> (Ast.untyped_program, Errors.t) result * Warnings.t list
+(** Parse from code stored in the string, generic over how #includes are found *)

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -9,8 +9,12 @@ let comments = Queue.create ()
 let add_comment = Queue.enqueue comments
 let get_comments () = Queue.to_list comments
 let include_stack = Stack.create ()
-let include_paths : string list ref = ref []
 let included_files : string list ref = ref []
+
+(* TODO consider if this is worth making a Functor *)
+let find_include : (string -> lexbuf * string) ref =
+  ref (fun _ -> failwith "Preprocessor not initialized!")
+
 let size () = Stack.length include_stack
 
 let locations_map : (string * Middle.Location.t option) String.Table.t =
@@ -62,6 +66,9 @@ let current_buffer () =
   let buf = Stack.top_exn include_stack in
   buf
 
+let current_location_t () =
+  location_of_position (lexeme_start_p (current_buffer ()))
+
 let pop_buffer () = Stack.pop_exn include_stack
 
 let update_start_positions pos =
@@ -82,31 +89,6 @@ let restore_prior_lexbuf () =
   lexbuf.lex_start_p <- old_pos;
   old_lexbuf
 
-let try_open_in all_paths fname =
-  let rec loop paths =
-    match paths with
-    | [] ->
-        let message =
-          let pp_list ppf l =
-            match l with
-            | [] -> Fmt.string ppf "None"
-            | _ -> Fmt.(list ~sep:comma string) ppf l in
-          Fmt.str
-            "Could not find include file '%s' in specified include paths.@\n\
-             @[Current include paths: %a@]" fname pp_list all_paths in
-        raise
-          (Errors.SyntaxError
-             (Include
-                ( message
-                , location_of_position
-                    (lexeme_start_p (Stack.top_exn include_stack)) )))
-    | path :: rest_of_paths -> (
-        try
-          let full_path = path ^ "/" ^ fname in
-          (In_channel.create full_path, full_path)
-        with _ -> loop rest_of_paths) in
-  loop all_paths
-
 let maybe_remove_quotes str =
   let open String in
   if is_prefix str ~prefix:"\"" && is_suffix str ~suffix:"\"" then
@@ -115,9 +97,8 @@ let maybe_remove_quotes str =
 
 let try_get_new_lexbuf fname =
   let lexbuf = Stack.top_exn include_stack in
-  let chan, file = try_open_in !include_paths (maybe_remove_quotes fname) in
+  let new_lexbuf, file = !find_include (maybe_remove_quotes fname) in
   lexer_logger ("opened " ^ file);
-  let new_lexbuf = from_channel chan in
   new_lexbuf.lex_start_p <-
     new_file_start_position file
     @@ Some (location_of_position lexbuf.lex_start_p);

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -1,6 +1,6 @@
-(** Preprocessor for handling include directives *)
+open Includes_intf
 
-open Core
+(** Preprocessor for handling include directives *)
 
 val location_of_position : Lexing.position -> Middle.Location.t
 
@@ -21,8 +21,8 @@ val init : Lexing.lexbuf -> string -> unit
 
 val update_start_positions : Lexing.position -> unit
 (** Update the lex_start_p the lexing buffers on the stack.
-    This solves an issue where a parser which started with one lexbuf
-    but is finishing with another can have the wrong information
+  This solves an issue where a parser which started with one lexbuf
+  but is finishing with another can have the wrong information
 *)
 
 val pop_buffer : unit -> Lexing.lexbuf
@@ -30,15 +30,19 @@ val pop_buffer : unit -> Lexing.lexbuf
 
 val add_comment : Ast.comment_type -> unit
 val get_comments : unit -> Ast.comment_type list
-val find_include : (string -> Lexing.lexbuf * string) ref
 
 val included_files : string list ref
 (** List of files that have been included *)
 
 val restore_prior_lexbuf : unit -> Lexing.lexbuf
 (** Restore to a previous lexing buffer (assumes that one exists) and
-    updates positions accordingly. *)
+  updates positions accordingly. *)
 
-val try_get_new_lexbuf : string -> Lexing.lexbuf
-(** Search include paths for filename and try to create a new lexing buffer
-    with that filename, record that included from specified position *)
+(** The part of the preprocessor that loads #include-d files is
+  made generic here to support cases where we have filesystem access
+  and cases where we do not.
+
+  See [In_memory_includes] and [Filesystem_includes] for
+  implementations of the [LEXBUF_LOCATOR] module.
+  *)
+module Make (Locator : LEXBUF_LOCATOR) : PREPROCESSOR_LOADER

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -10,6 +10,9 @@ val location_span_of_positions :
 val current_buffer : unit -> Lexing.lexbuf
 (** Buffer at the top of the include stack *)
 
+val current_location_t : unit -> Middle.Location.t
+(** Location of the current buffer *)
+
 val size : unit -> int
 (** Size of the include stack *)
 
@@ -27,9 +30,7 @@ val pop_buffer : unit -> Lexing.lexbuf
 
 val add_comment : Ast.comment_type -> unit
 val get_comments : unit -> Ast.comment_type list
-
-val include_paths : string list ref
-(** List of paths to search for including files *)
+val find_include : (string -> Lexing.lexbuf * string) ref
 
 val included_files : string list ref
 (** List of files that have been included *)

--- a/src/frontend/Pretty_print_prog.ml
+++ b/src/frontend/Pretty_print_prog.ml
@@ -45,12 +45,18 @@ let pp_program ~bare_functions ~line_length ~inline_includes ~strip_comments ppf
         ; ("generated quantities", bgq) ] in
     pp_block_list ppf blocks
 
-let check_correctness ?(bare_functions = false) prog pretty =
+let sanity_check_pretty_printed_program
+    (module Locator : Includes_intf.LEXBUF_LOCATOR) ?(bare_functions = false)
+    typed_prog pretty =
+  let prog = untyped_program_of_typed_program typed_prog in
   let result_ast =
     let res, (_ : Warnings.t list) =
       if bare_functions then
-        Parse.parse_string Parser.Incremental.functions_only pretty
-      else Parse.parse_string Parser.Incremental.program pretty in
+        Parse.parse_string
+          (module Locator)
+          Parser.Incremental.functions_only pretty
+      else Parse.parse_string (module Locator) Parser.Incremental.program pretty
+    in
     match res with
     | Ok prog -> prog
     | Error e ->
@@ -69,12 +75,9 @@ let check_correctness ?(bare_functions = false) prog pretty =
 
 let pretty_print_program ?(bare_functions = false) ?(line_length = 78)
     ?(inline_includes = false) ?(strip_comments = false) p =
-  let result =
-    str "%a"
-      (pp_program ~bare_functions ~line_length ~inline_includes ~strip_comments)
-      p in
-  check_correctness ~bare_functions p result;
-  result
+  str "%a"
+    (pp_program ~bare_functions ~line_length ~inline_includes ~strip_comments)
+    p
 
 let pretty_print_typed_program ?(bare_functions = false) ?(line_length = 78)
     ?(inline_includes = false) ?(strip_comments = false) p =

--- a/src/frontend/Pretty_print_prog.mli
+++ b/src/frontend/Pretty_print_prog.mli
@@ -16,3 +16,10 @@ val pretty_print_typed_program :
   -> ?strip_comments:bool
   -> Ast.typed_program
   -> string
+
+val sanity_check_pretty_printed_program :
+     (module Includes_intf.LEXBUF_LOCATOR)
+  -> ?bare_functions:bool
+  -> Ast.typed_program
+  -> string
+  -> unit

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -237,7 +237,7 @@ let remove_dotstan s =
 (** filesystem-based way of opening new lexbufs for #include directive
   defined here because a separate function is used in stanc.js
 *)
-let try_open_in fname =
+let find_included_file fname =
   let open Lexing in
   let rec loop paths =
     match paths with
@@ -262,7 +262,7 @@ let try_open_in fname =
 
 let get_ast_or_exit ?printed_filename ?(print_warnings = true)
     ?(bare_functions = false) filename =
-  Preprocessor.find_include := try_open_in;
+  Preprocessor.find_include := find_included_file;
   let res, warnings =
     if bare_functions then
       Parse.parse_file Parser.Incremental.functions_only filename

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -9,7 +9,7 @@ let version = "%%NAME%% %%VERSION%%"
 
 type stanc_error = ProgramError of Errors.t
 
-let make_include_finder includes path =
+let find_included_file ~includes path =
   match Map.find includes path with
   | None ->
       let message =
@@ -40,7 +40,7 @@ let stan2cpp model_name model_string is_flag_set flag_val includes :
   With_return.with_return (fun r ->
       if is_flag_set "version" then
         r.return (Result.Ok (Fmt.str "%s" version), [], []);
-      Preprocessor.find_include := make_include_finder includes;
+      Preprocessor.find_include := find_included_file ~includes;
       let ast, parser_warnings =
         if is_flag_set "functions-only" then
           Parse.parse_string Parser.Incremental.functions_only model_string

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -200,7 +200,7 @@ let () =
     | BadJsInput s -> Some s
     | _ -> None)
 
-let typecheck e typ = Js.equals (Js.typeof e) (Js.string typ)
+let typecheck e typ = String.equal (Js.to_string (Js.typeof e)) typ
 
 (** Converts from a [{ [s:string]:string }] JS object type
 to an OCaml map, with error messages on bad input. *)

--- a/test/integration/good/code-gen/standalone_functions/dune
+++ b/test/integration/good/code-gen/standalone_functions/dune
@@ -16,3 +16,22 @@
  (alias runtest)
  (action
   (diff cpp.expected cpp.output)))
+
+(rule
+ (targets stanc.output)
+ (deps
+  (package stanc)
+  (:stanfiles
+   (glob_files *.stan*)))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run
+    %{bin:run_bin_on_args}
+    "%{bin:stanc} --standalone-functions --allow-undefined --auto-format"
+    %{stanfiles}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff stanc.expected stanc.output)))

--- a/test/integration/good/code-gen/standalone_functions/stanc.expected
+++ b/test/integration/good/code-gen/standalone_functions/stanc.expected
@@ -1,0 +1,124 @@
+  $ ../../../../../../install/default/bin/stanc --standalone-functions --allow-undefined --auto-format basic.stan
+functions {
+  real my_log1p_exp(real x) {
+    return log1p_exp(x);
+  }
+  
+  real array_fun(array[] real a) {
+    return sum(a);
+  }
+  
+  real int_array_fun(array[] int a) {
+    return sum(a);
+  }
+  
+  vector my_vector_mul_by_5(vector x) {
+    vector[num_elements(x)] result = x * 5.0;
+    return result;
+  }
+  
+  int int_only_multiplication(int a, int b) {
+    return a * b;
+  }
+  
+  real test_lgamma(real x) {
+    return lgamma(x);
+  }
+  
+  // test special functions
+  void test_lp(real a) {
+    a ~ normal(0, 1);
+  }
+  
+  real test_rng(real a) {
+    return normal_rng(a, 1);
+  }
+  
+  real test_lpdf(real a, real b) {
+    return normal_lpdf(a | b, 1);
+  }
+  
+  complex_matrix test_complex(complex_matrix a) {
+    return a + a;
+  }
+  
+  array[,,] complex array_fun(array[,,] complex a) {
+    return a;
+  }
+}
+
+  $ ../../../../../../install/default/bin/stanc --standalone-functions --allow-undefined --auto-format basic.stanfunctions
+real my_log1p_exp(real x) {
+  return log1p_exp(x);
+}
+
+real array_fun(array[] real a) {
+  return sum(a);
+}
+
+real int_array_fun(array[] int a) {
+  return sum(a);
+}
+
+vector my_vector_mul_by_5(vector x) {
+  vector[num_elements(x)] result = x * 5.0;
+  return result;
+}
+
+int int_only_multiplication(int a, int b) {
+  return a * b;
+}
+
+real test_lgamma(real x) {
+  return lgamma(x);
+}
+
+// test special functions
+void test_lp(real a) {
+  a ~ normal(0, 1);
+}
+
+real test_rng(real a) {
+  return normal_rng(a, 1);
+}
+
+real test_lpdf(real a, real b) {
+  return normal_lpdf(a | b, 1);
+}
+  $ ../../../../../../install/default/bin/stanc --standalone-functions --allow-undefined --auto-format integrate.stan
+functions {
+  vector integrand(vector x) {
+    return exp(-square(x));
+  }
+  
+  array[] real integrand_ode(real r, array[] real f, array[] real theta,
+                             array[] real x_r, array[] int x_i) {
+    array[1] real df_dx;
+    real x = logit(r);
+    df_dx[1] = exp(-square(x)) * 1 / (r * (1 - r));
+    return (df_dx);
+  }
+  
+  real ode_integrate() {
+    array[0] int x_i;
+    // ok:
+    //return(integrate_ode_rk45(integrand_ode, rep_array(0.0, 1),
+    //1E-5, rep_array(1.0-1E-5, 1), rep_array(0.0, 0), rep_array(0.0,
+    //0), x_i)[1,1]);
+    // not ok
+    return (integrate_ode_bdf(integrand_ode, rep_array(0.0, 1), 1E-5,
+                              rep_array(1.0 - 1E-5, 1), rep_array(0.0, 0),
+                              rep_array(0.0, 0), x_i)[1, 1]);
+  }
+}
+data {
+  
+}
+model {
+  
+}
+
+Warning in 'integrate.stan', line 21, column 12: integrate_ode_bdf is
+    deprecated and will be removed in Stan 3.0. Use ode_bdf instead. 
+    The new interface is slightly different, see:
+    https://mc-stan.org/users/documentation/case-studies/convert_odes.html

--- a/test/stancjs/functions-only.js
+++ b/test/stancjs/functions-only.js
@@ -48,7 +48,9 @@ let basic = stanc.stanc("functions_only", functions_only, ["functions-only"]);
 utils.print_error(basic)
 
 let basic_fmt = stanc.stanc("functions_only", functions_only, ["functions-only", "auto-format"]);
+utils.print_error(basic_fmt)
 utils.print_result(basic_fmt)
 
 let basic_canon = stanc.stanc("functions_only", functions_only, ["functions-only", "print-canonical"]);
+utils.print_error(basic_canon)
 utils.print_result(basic_canon)

--- a/test/stancjs/includes.js
+++ b/test/stancjs/includes.js
@@ -8,9 +8,12 @@ data {
 }
 `
 
-var bar_includes = {"bar.stan":"// nothing here"};
 
 // will fail
+var include_test_missing = stanc.stanc("include-testtest", include_model, []);
+utils.print_error(include_test_missing)
+
+var bar_includes = {"bar.stan":"// nothing here"};
 var include_test_missing = stanc.stanc("include-testtest", include_model, [], bar_includes);
 utils.print_error(include_test_missing)
 

--- a/test/stancjs/includes.js
+++ b/test/stancjs/includes.js
@@ -8,18 +8,40 @@ data {
 }
 `
 
-// will fail
-var include_test_fails = stanc.stanc("include-testtest", include_model, [], {"bar.stan":"// nothing here"});
-utils.print_error(include_test_fails)
+var bar_includes = {"bar.stan":"// nothing here"};
 
-var includes = {
-    "foo.stan" : `
+// will fail
+var include_test_missing = stanc.stanc("include-testtest", include_model, [], bar_includes);
+utils.print_error(include_test_missing)
+
+
+var include_test_bad = stanc.stanc("empty", "model {}", [], {"foo.stan": {"internal":"that wasn't a string!"}});
+utils.print_error(include_test_bad)
+utils.print_warnings(include_test_bad)
+
+var include_test_bad = stanc.stanc("empty", "model {}", [], {"foo.stan": "1", "./foo.stan": "2"});
+utils.print_error(include_test_bad)
+utils.print_warnings(include_test_bad)
+
+var include_test_bad = stanc.stanc("empty", "model {}", [], 1234);
+utils.print_error(include_test_bad)
+utils.print_warnings(include_test_bad)
+
+// good
+var foo_code = `
 functions {
     int foo(real a) {
         return 1;
     }
-}`};
+}`;
 
-var include_test = stanc.stanc("include-testtest", include_model, ["auto-format", "canonicalize=includes"], includes);
-utils.print_error(include_test)
-utils.print_result(include_test)
+var includes_rel_test = stanc.stanc("include-testtest", include_model, [], {"./foo.stan":foo_code});
+utils.print_error(includes_rel_test)
+
+var include_format_test = stanc.stanc("include-testtest", include_model, ["auto-format", "canonicalize=includes"], {"foo.stan":foo_code});
+utils.print_error(include_format_test)
+utils.print_result(include_format_test)
+
+var include_info_test = stanc.stanc("include-testtest", include_model, ["info"], {...bar_includes, "foo.stan":foo_code});
+utils.print_error(include_info_test)
+utils.print_result(include_info_test)

--- a/test/stancjs/includes.js
+++ b/test/stancjs/includes.js
@@ -14,19 +14,6 @@ var bar_includes = {"bar.stan":"// nothing here"};
 var include_test_missing = stanc.stanc("include-testtest", include_model, [], bar_includes);
 utils.print_error(include_test_missing)
 
-
-var include_test_bad = stanc.stanc("empty", "model {}", [], {"foo.stan": {"internal":"that wasn't a string!"}});
-utils.print_error(include_test_bad)
-utils.print_warnings(include_test_bad)
-
-var include_test_bad = stanc.stanc("empty", "model {}", [], {"foo.stan": "1", "./foo.stan": "2"});
-utils.print_error(include_test_bad)
-utils.print_warnings(include_test_bad)
-
-var include_test_bad = stanc.stanc("empty", "model {}", [], 1234);
-utils.print_error(include_test_bad)
-utils.print_warnings(include_test_bad)
-
 // good
 var foo_code = `
 functions {
@@ -45,3 +32,25 @@ utils.print_result(include_format_test)
 var include_info_test = stanc.stanc("include-testtest", include_model, ["info"], {...bar_includes, "foo.stan":foo_code});
 utils.print_error(include_info_test)
 utils.print_result(include_info_test)
+
+
+// warnings
+var include_test_bad = stanc.stanc("empty", "model {}", [], {"foo.stan": {"internal":"that wasn't a string!"}});
+utils.print_error(include_test_bad)
+utils.print_warnings(include_test_bad)
+
+var include_test_bad = stanc.stanc("empty", "model {}", [], {"foo.stan": "1", "./foo.stan": "2"});
+utils.print_error(include_test_bad)
+utils.print_warnings(include_test_bad)
+
+var include_test_bad = stanc.stanc("empty", "model {}", [], 1234);
+utils.print_error(include_test_bad)
+utils.print_warnings(include_test_bad)
+
+// other errors: recursive includes
+var recursive_a = `#include <include/a.stan>`
+var recursive_b = `#include <include/b.stan>`
+
+var recursive_test = stanc.stanc("recursive", recursive_a, [], {"include/a.stan":recursive_b, "include/b.stan":recursive_a});
+utils.print_error(recursive_test)
+utils.print_warnings(recursive_test)

--- a/test/stancjs/includes.js
+++ b/test/stancjs/includes.js
@@ -8,6 +8,10 @@ data {
 }
 `
 
+// will fail
+var include_test_fails = stanc.stanc("include-testtest", include_model, [], {"bar.stan":"// nothing here"});
+utils.print_error(include_test_fails)
+
 var includes = {
     "foo.stan" : `
 functions {
@@ -16,6 +20,6 @@ functions {
     }
 }`};
 
-var include_test = stanc.stanc("include-testtest", include_model, [], includes);
+var include_test = stanc.stanc("include-testtest", include_model, ["auto-format", "canonicalize=includes"], includes);
 utils.print_error(include_test)
-
+utils.print_result(include_test)

--- a/test/stancjs/includes.js
+++ b/test/stancjs/includes.js
@@ -1,0 +1,21 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+var include_model = `
+#include <foo.stan>
+data {
+    int a;
+}
+`
+
+var includes = {
+    "foo.stan" : `
+functions {
+    int foo(real a) {
+        return 1;
+    }
+}`};
+
+var include_test = stanc.stanc("include-testtest", include_model, [], includes);
+utils.print_error(include_test)
+

--- a/test/stancjs/pedantic.js
+++ b/test/stancjs/pedantic.js
@@ -11,26 +11,21 @@ model {
 }
 `
 var pedantic_test = stanc.stanc("pedantic", pedantic_model, ["warn-pedantic"]);
-if (pedantic_test.warnings) {
-    console.log(JSON.stringify(pedantic_test.warnings))
-}
+utils.print_warnings(pedantic_test)
+
 
 var pedantic_test = stanc.stanc("pedantic", pedantic_model);
-if (pedantic_test.warnings) {
-    console.log(JSON.stringify(pedantic_test.warnings))
-}
+utils.print_warnings(pedantic_test)
+
 var warn_uninit_model = `
-transformed data { 
+transformed data {
     real tt;
     tt = tt + 2;
 }
 `
 var warn_uninit_test = stanc.stanc("uninit", warn_uninit_model, ["warn-uninitialized"]);
-if (warn_uninit_test.warnings) {
-    console.log(JSON.stringify(warn_uninit_test.warnings))
-}
+utils.print_warnings(warn_uninit_test)
+
 
 var warn_uninit_test = stanc.stanc("uninit", warn_uninit_model);
-if (warn_uninit_test.warnings) {
-    console.log(JSON.stringify(warn_uninit_test.warnings))
-}
+utils.print_warnings(warn_uninit_test)

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -205,6 +205,28 @@ Syntax error in 'string', line 8, column 0 to column 5, parsing error:
 
 Expected "generated quantities {" or end of file after end of model block.
 
+$ node includes.js
+Syntax error in 'string', line 2, column 0, include error:
+   -------------------------------------------------
+     1:  
+     2:  #include <foo.stan>
+         ^
+     3:  data {
+     4:      int a;
+   -------------------------------------------------
+
+Could not find include file 'foo.stan'. Currently available files are:
+bar.stan
+
+functions {
+  int foo(real a) {
+    return 1;
+  }
+}
+data {
+  int a;
+}
+
 $ node info.js
 {
   "inputs": {

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -215,7 +215,8 @@ Syntax error in 'string', line 2, column 0, include error:
      4:      int a;
    -------------------------------------------------
 
-Could not find include file 'foo.stan'. Currently available files are:
+Could not find include file 'foo.stan'.
+stanc was given information about the following files:
 bar.stan
 
 functions {

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -217,6 +217,19 @@ Syntax error in 'string', line 2, column 0, include error:
 
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
+None
+
+Syntax error in 'string', line 2, column 0, include error:
+   -------------------------------------------------
+     1:  
+     2:  #include <foo.stan>
+         ^
+     3:  data {
+     4:      int a;
+   -------------------------------------------------
+
+Could not find include file 'foo.stan'.
+stanc was given information about the following files:
 bar.stan
 
 functions {

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -219,6 +219,13 @@ Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 bar.stan
 
+Warning: stanc.js failed to parse included file mapping!
+Failed to read property 'foo.stan' of included files map!
+It had type 'object' instead of 'string'.
+Warning: stanc.js failed to parse included file mapping!
+Duplicate string in included files map: 'foo.stan'
+Warning: stanc.js failed to parse included file mapping!
+Included files map was provided but was not of type 'object'
 functions {
   int foo(real a) {
     return 1;
@@ -228,6 +235,15 @@ data {
   int a;
 }
 
+{
+  "inputs": { "a": { "type": "int", "dimensions": 0 } },
+  "parameters": {},
+  "transformed parameters": {},
+  "generated quantities": {},
+  "functions": [],
+  "distributions": [],
+  "included_files": [ "foo.stan" ]
+}
 $ node info.js
 {
   "inputs": {
@@ -276,10 +292,13 @@ Function 'foo' is declared without specifying a definition.
 
 "stancflags = --use-opencl --allow-undefined"
 $ node pedantic.js
-["Warning in 'string', line 7, column 17: Argument 10000 suggests there may be\n    parameters that are not unit scale; consider rescaling with a multiplier\n    (see manual section 22.12).","Warning: The parameter k was declared but was not used in the density\n    calculation."]
-[]
-["Warning in 'string', line 4, column 9: The variable tt may not have been\n    assigned a value before its use."]
-[]
+Warning in 'string', line 7, column 17: Argument 10000 suggests there may be
+    parameters that are not unit scale; consider rescaling with a multiplier
+    (see manual section 22.12).
+Warning: The parameter k was declared but was not used in the density
+    calculation.
+Warning in 'string', line 4, column 9: The variable tt may not have been
+    assigned a value before its use.
 $ node removed.js
 Syntax error in 'string', line 3, column 8 to column 10, parsing error:
    -------------------------------------------------
@@ -319,5 +338,10 @@ $ node version.js
 %%NAME%% %%VERSION%%
 %%NAME%% %%VERSION%%
 $ node warnings.js
-[]
-["Warning in 'string', line 10, column 11: Found int division:\n      x / w\n    Values will be rounded towards zero. If rounding is not desired you can\n    write\n    the division as\n      x * 1.0 / w\n    If rounding is intended please use the integer division operator %/%."]
+Warning in 'string', line 10, column 11: Found int division:
+      x / w
+    Values will be rounded towards zero. If rounding is not desired you can
+    write
+    the division as
+      x * 1.0 / w
+    If rounding is intended please use the integer division operator %/%.

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -219,13 +219,6 @@ Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 bar.stan
 
-Warning: stanc.js failed to parse included file mapping!
-Failed to read property 'foo.stan' of included files map!
-It had type 'object' instead of 'string'.
-Warning: stanc.js failed to parse included file mapping!
-Duplicate string in included files map: 'foo.stan'
-Warning: stanc.js failed to parse included file mapping!
-Included files map was provided but was not of type 'object'
 functions {
   int foo(real a) {
     return 1;
@@ -244,6 +237,24 @@ data {
   "distributions": [],
   "included_files": [ "foo.stan" ]
 }
+Warning: stanc.js failed to parse included file mapping!
+Failed to read property 'foo.stan' of included files map!
+It had type 'object' instead of 'string'.
+Warning: stanc.js failed to parse included file mapping!
+Duplicate string in included files map: 'foo.stan'
+Warning: stanc.js failed to parse included file mapping!
+Included files map was provided but was not of type 'object'
+Syntax error in 'include/a.stan', line 1, column 0, included from
+'include/b.stan', line 1, column 0, included from
+'include/a.stan', line 1, column 0, included from
+'string', line 1, column 0, include error:
+   -------------------------------------------------
+     1:  #include <include/a.stan>
+         ^
+   -------------------------------------------------
+
+File include/b.stan recursively included itself.
+
 $ node info.js
 {
   "inputs": {

--- a/test/stancjs/utils/utils.js
+++ b/test/stancjs/utils/utils.js
@@ -11,3 +11,12 @@ module.exports.print_error = function(m) {
 module.exports.print_result = function(m) {
     console.log(m.result)
 };
+
+
+module.exports.print_warnings = function(m){
+    if (m.warnings){
+        for (w of m.warnings){
+            console.log(w)
+        }
+    }
+}

--- a/test/stancjs/warnings.js
+++ b/test/stancjs/warnings.js
@@ -11,7 +11,7 @@ model {
 }
 `
 var deprecated_test = stanc.stanc("deprecated", deprecated_model);
-console.log(JSON.stringify(deprecated_test.warnings))
+utils.print_warnings(deprecated_test)
 
 var test_no_stderr_model = `
 transformed data {
@@ -45,7 +45,7 @@ generated quantities {
 }
 `
 var typechecker_test = stanc.stanc("deprecated", tc_warn);
-console.log(JSON.stringify(typechecker_test.warnings))
+utils.print_warnings(typechecker_test)
 
 var tc_no_warn = `
 parameters {

--- a/test/unit/Test_utils.ml
+++ b/test/unit/Test_utils.ml
@@ -2,7 +2,7 @@ open Frontend
 open Core
 
 let untyped_ast_of_string s =
-  let res, warnings = Parse.parse_string Parser.Incremental.program s in
+  let res, warnings = Parse.parse_in_memory Parser.Incremental.program s in
   Fmt.epr "%a" (Fmt.list ~sep:Fmt.nop Warnings.pp) warnings;
   res
 


### PR DESCRIPTION
Closes #1430 

This PR can be viewed as several parts:

1. Some boilerplate-y code in stancjs.ml to read a `{ [s: string] : string }` JS object into a ocaml `string String.Map.t`
2. Extracting the logic in the Preprocessor that looks up new included files into a module type that is passed in from the outside
3. Doing the same in the Lexer

An earlier version of this didn't use functors and just had `Preprocessor` store a function pointer that was set by stancjs.ml/stanc.ml, but I had both aesthetic and performance concerns with that approach. These functors are ultimately pretty lightweight

This is currently lightly tested in stanc.js but I intend to add more.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

`stanc.js` can now accept models which contain `#include` statements. A fourth argument is available on the javascript `stanc` function which must be either `undefined` or a object mapping included file names to Stan source code as strings. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
