### PR TITLE
Update pedantic mode warning for jacobian usage

### DIFF
--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -391,7 +391,9 @@ let maybe_jacobian_adjustment_warnings (mir : Program.Typed.t) =
       , "Left-hand side of distribution statement (~) may contain a non-linear \
          transform of a parameter or local variable. If it does, you need to \
          include a target += statement with the log absolute determinant of \
-         the Jacobian of the transform." ))
+         the Jacobian of the transform. You could also consider defining a \
+         transformed parameter and using jacobian += in the transformed \
+         parameters block." ))
     locations
 
 let multi_tildes_message (vname : string) : string =

--- a/test/integration/cli-args/warn-pedantic/stanc.expected
+++ b/test/integration/cli-args/warn-pedantic/stanc.expected
@@ -466,61 +466,71 @@ Warning in 'jacobian_warning1.stan', line 7, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
 Warning in 'jacobian_warning1.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
 Warning: The parameter y has 2 priors.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning2.stan
 Warning in 'jacobian_warning2.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning3.stan
 Warning in 'jacobian_warning3.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning4.stan
 Warning in 'jacobian_warning4.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning5.stan
 Warning in 'jacobian_warning5.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning6.stan
 Warning in 'jacobian_warning6.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning7.stan
 Warning in 'jacobian_warning7.stan', line 6, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
 Warning in 'jacobian_warning7.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
 Warning: The parameter y has 2 priors.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  jacobian_warning_user.stan
 Warning in 'jacobian_warning_user.stan', line 5, column 2: Left-hand side of
     distribution statement (~) may contain a non-linear transform of a
     parameter or local variable. If it does, you need to include a target +=
     statement with the log absolute determinant of the Jacobian of the
-    transform.
+    transform. You could also consider defining a transformed parameter and
+    using jacobian += in the transformed parameters block.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  lp_fun.stan
 Warning: The parameter y has 2 priors.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  missing-prior-false-alarm.stan


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Updated pedantic mode warning for jacobian usage to mention `jacobian +=`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
