### PR TITLE
Add transformation information to --info

### DIFF
--- a/test/integration/cli-args/info/info.expected
+++ b/test/integration/cli-args/info/info.expected
@@ -1,21 +1,21 @@
   $ ../../../../../install/default/bin/stanc --include-paths=.,includes --info  info.stan
 {
   "inputs": {
-    "a": { "type": "int", "dimensions": 0 },
-    "b": { "type": "real", "dimensions": 0 },
-    "c": { "type": "real", "dimensions": 1 },
-    "d1": { "type": "real", "dimensions": 1 },
-    "d2": { "type": "real", "dimensions": 1 },
-    "e": { "type": "real", "dimensions": 2 },
-    "f": { "type": "int", "dimensions": 1 },
-    "g": { "type": "real", "dimensions": 1 },
-    "h": { "type": "real", "dimensions": 2 },
-    "i": { "type": "real", "dimensions": 3 },
-    "j": { "type": "int", "dimensions": 3 },
-    "cplx": { "type": "complex", "dimensions": 1 },
-    "cplx_vec": { "type": "complex", "dimensions": 1 },
-    "cplx_row": { "type": "complex", "dimensions": 1 },
-    "cplx_mat": { "type": "complex", "dimensions": 2 },
+    "a": { "type": "int", "dimensions": 0, "constraint": "none" },
+    "b": { "type": "real", "dimensions": 0, "constraint": "none" },
+    "c": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "d1": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "d2": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "e": { "type": "real", "dimensions": 2, "constraint": "none" },
+    "f": { "type": "int", "dimensions": 1, "constraint": "none" },
+    "g": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "h": { "type": "real", "dimensions": 2, "constraint": "none" },
+    "i": { "type": "real", "dimensions": 3, "constraint": "none" },
+    "j": { "type": "int", "dimensions": 3, "constraint": "none" },
+    "cplx": { "type": "complex", "dimensions": 1, "constraint": "none" },
+    "cplx_vec": { "type": "complex", "dimensions": 1, "constraint": "none" },
+    "cplx_row": { "type": "complex", "dimensions": 1, "constraint": "none" },
+    "cplx_mat": { "type": "complex", "dimensions": 2, "constraint": "none" },
     "tuples": {
       "type": [
         { "type": "int", "dimensions": 0 },
@@ -28,22 +28,65 @@
           "dimensions": 0
         }
       ],
-      "dimensions": 1
+      "dimensions": 1,
+      "constraint": [
+        { "constraint": "none" },
+        { "constraint": "none" },
+        {
+          "constraint": [
+            { "constraint": "none" }, { "constraint": "none" }
+          ]
+        }
+      ]
     }
   },
   "parameters": {
-    "l": { "type": "real", "dimensions": 1 },
-    "m": { "type": "real", "dimensions": 1 },
-    "n": { "type": "real", "dimensions": 1 },
-    "o": { "type": "real", "dimensions": 1 },
-    "p": { "type": "real", "dimensions": 2 },
-    "q": { "type": "real", "dimensions": 2 },
-    "r": { "type": "real", "dimensions": 2 },
-    "s": { "type": "real", "dimensions": 2 },
-    "y": { "type": "real", "dimensions": 0 }
+    "low": {
+      "type": "real",
+      "dimensions": 0,
+      "constraint": { "lower": "0" }
+    },
+    "l": { "type": "real", "dimensions": 1, "constraint": "simplex" },
+    "m": { "type": "real", "dimensions": 1, "constraint": "unit_vector" },
+    "n": { "type": "real", "dimensions": 1, "constraint": "ordered" },
+    "o": {
+      "type": "real",
+      "dimensions": 1,
+      "constraint": "positive_ordered"
+    },
+    "p": { "type": "real", "dimensions": 2, "constraint": "covariance" },
+    "q": { "type": "real", "dimensions": 2, "constraint": "correlation" },
+    "r": { "type": "real", "dimensions": 2, "constraint": "cholesky_cov" },
+    "s": { "type": "real", "dimensions": 2, "constraint": "cholesky_corr" },
+    "y": { "type": "real", "dimensions": 0, "constraint": "none" },
+    "parameter_transforms": {
+      "type": [
+        { "type": "real", "dimensions": 0 },
+        {
+          "type": [
+            { "type": "real", "dimensions": 1 },
+            { "type": "real", "dimensions": 2 }
+          ],
+          "dimensions": 0
+        }
+      ],
+      "dimensions": 0,
+      "constraint": [
+        { "constraint": { "lower": "y" } },
+        {
+          "constraint": [
+            { "constraint": "simplex" }, { "constraint": "covariance" }
+          ]
+        }
+      ]
+    }
   },
-  "transformed parameters": { "t": { "type": "real", "dimensions": 2 } },
-  "generated quantities": { "u": { "type": "real", "dimensions": 0 } },
+  "transformed parameters": {
+    "t": { "type": "real", "dimensions": 2, "constraint": "none" }
+  },
+  "generated quantities": {
+    "u": { "type": "real", "dimensions": 0, "constraint": "none" }
+  },
   "functions": [
     "fatal_error", "log", "print", "reduce_sum", "reject", "sin", "square"
   ],

--- a/test/integration/cli-args/info/info.stan
+++ b/test/integration/cli-args/info/info.stan
@@ -37,6 +37,7 @@ transformed data {
 }
 
 parameters {
+  real <lower=0> low;
   simplex[10] l;
   unit_vector[11] m;
   ordered[12] n;
@@ -46,6 +47,8 @@ parameters {
   cholesky_factor_cov[16] r;
   cholesky_factor_corr[17] s;
   real y;
+
+  tuple(real<lower=y>, tuple(simplex[18], cov_matrix[19])) parameter_transforms;
 }
 
 transformed parameters {

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -255,7 +255,7 @@ data {
 }
 
 {
-  "inputs": { "a": { "type": "int", "dimensions": 0 } },
+  "inputs": { "a": { "type": "int", "dimensions": 0, "constraint": "none" } },
   "parameters": {},
   "transformed parameters": {},
   "generated quantities": {},
@@ -283,27 +283,31 @@ File include/a.stan recursively included itself.
 $ node info.js
 {
   "inputs": {
-    "a": { "type": "int", "dimensions": 0 },
-    "b": { "type": "real", "dimensions": 0 },
-    "c": { "type": "real", "dimensions": 1 },
-    "d": { "type": "real", "dimensions": 1 },
-    "e": { "type": "real", "dimensions": 2 },
-    "f": { "type": "int", "dimensions": 1 },
-    "g": { "type": "real", "dimensions": 1 },
-    "h": { "type": "real", "dimensions": 2 },
-    "i": { "type": "real", "dimensions": 3 },
-    "j": { "type": "int", "dimensions": 3 }
+    "a": { "type": "int", "dimensions": 0, "constraint": "none" },
+    "b": { "type": "real", "dimensions": 0, "constraint": "none" },
+    "c": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "d": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "e": { "type": "real", "dimensions": 2, "constraint": "none" },
+    "f": { "type": "int", "dimensions": 1, "constraint": "none" },
+    "g": { "type": "real", "dimensions": 1, "constraint": "none" },
+    "h": { "type": "real", "dimensions": 2, "constraint": "none" },
+    "i": { "type": "real", "dimensions": 3, "constraint": "none" },
+    "j": { "type": "int", "dimensions": 3, "constraint": "none" }
   },
   "parameters": {
-    "l": { "type": "real", "dimensions": 1 },
-    "m": { "type": "real", "dimensions": 1 },
-    "n": { "type": "real", "dimensions": 1 },
-    "o": { "type": "real", "dimensions": 1 },
-    "p": { "type": "real", "dimensions": 2 },
-    "q": { "type": "real", "dimensions": 2 },
-    "r": { "type": "real", "dimensions": 2 },
-    "s": { "type": "real", "dimensions": 2 },
-    "y": { "type": "real", "dimensions": 0 }
+    "l": { "type": "real", "dimensions": 1, "constraint": "simplex" },
+    "m": { "type": "real", "dimensions": 1, "constraint": "unit_vector" },
+    "n": { "type": "real", "dimensions": 1, "constraint": "ordered" },
+    "o": {
+      "type": "real",
+      "dimensions": 1,
+      "constraint": "positive_ordered"
+    },
+    "p": { "type": "real", "dimensions": 2, "constraint": "covariance" },
+    "q": { "type": "real", "dimensions": 2, "constraint": "correlation" },
+    "r": { "type": "real", "dimensions": 2, "constraint": "cholesky_cov" },
+    "s": { "type": "real", "dimensions": 2, "constraint": "cholesky_corr" },
+    "y": { "type": "real", "dimensions": 0, "constraint": "none" }
   },
   "transformed parameters": {},
   "generated quantities": {},


### PR DESCRIPTION
Closes #1461.

Bikeshedding: Should this new field be called `constraint`, `transform`, or something else?

#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

The `--info` flag will now also give information about the transformations of each variable

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
