### PR TITLE
 Stancjs: Check input JS types before conversion 

### DIFF
--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -20,7 +20,9 @@
     "--disable"
     "staticeval"
     "--disable"
-    "share"))))
+    "share"
+    "--enable"
+    "with-js-error"))))
 
 (alias
  (name default)

--- a/test/stancjs/bad_inputs.js
+++ b/test/stancjs/bad_inputs.js
@@ -1,0 +1,23 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+let basic_model = `
+parameters {
+	real y;
+}
+model {
+    y ~ std_normal();
+}
+`
+
+let bad_code_type = stanc.stanc("basic", basic_model.split('\n'), []);
+utils.print_error(bad_code_type)
+
+let bad_name_type = stanc.stanc(1234.5, basic_model, []);
+utils.print_error(bad_name_type)
+
+let bad_flags_type = stanc.stanc("basic", basic_model, 1234.5);
+utils.print_error(bad_flags_type)
+
+let bad_flag_type = stanc.stanc("basic", basic_model, ["foo", 1234.5]);
+utils.print_error(bad_flag_type)

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -34,6 +34,38 @@ model {
   y ~ std_normal();
 }
 
+$ node bad_inputs.js
+Internal compiler error:
+TypeError: s.charCodeAt is not a function
+
+
+This should never happen. Please file a bug at https://github.com/stan-dev/stanc3/issues/new
+and include this message and the model that caused this issue.
+
+Internal compiler error:
+TypeError: s.charCodeAt is not a function
+
+
+This should never happen. Please file a bug at https://github.com/stan-dev/stanc3/issues/new
+and include this message and the model that caused this issue.
+
+/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:6418
+     throw err;
+     ^
+
+RangeError: Invalid array length
+    at caml_js_to_array (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:3458:29)
+    at to_ocaml_str_array (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:270436:48)
+    at caml_call1 (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:34910:15)
+    at map (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:34932:53)
+    at caml_call2 (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:269708:15)
+    at stan2cpp_wrapped (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:270444:46)
+    at caml_call_gen (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:2091:15)
+    at Function.stanc (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:6969:13)
+    at Object.<anonymous> (/home/brian/Dev/ml/stanc3/_build/default/test/stancjs/bad_inputs.js:19:28)
+    at Module._compile (node:internal/modules/cjs/loader:1275:14)
+
+Node.js v19.9.0
 $ node basic.js
 Semantic error in 'string', line 6, column 4 to column 5:
    -------------------------------------------------

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -35,37 +35,14 @@ model {
 }
 
 $ node bad_inputs.js
-Internal compiler error:
-TypeError: s.charCodeAt is not a function
-
-
-This should never happen. Please file a bug at https://github.com/stan-dev/stanc3/issues/new
-and include this message and the model that caused this issue.
-
-Internal compiler error:
-TypeError: s.charCodeAt is not a function
-
-
-This should never happen. Please file a bug at https://github.com/stan-dev/stanc3/issues/new
-and include this message and the model that caused this issue.
-
-/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:6418
-     throw err;
-     ^
-
-RangeError: Invalid array length
-    at caml_js_to_array (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:3458:29)
-    at to_ocaml_str_array (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:270436:48)
-    at caml_call1 (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:34910:15)
-    at map (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:34932:53)
-    at caml_call2 (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:269708:15)
-    at stan2cpp_wrapped (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:270444:46)
-    at caml_call_gen (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:2091:15)
-    at Function.stanc (/home/brian/Dev/ml/stanc3/_build/default/src/stancjs/stancjs.bc.js:6969:13)
-    at Object.<anonymous> (/home/brian/Dev/ml/stanc3/_build/default/test/stancjs/bad_inputs.js:19:28)
-    at Module._compile (node:internal/modules/cjs/loader:1275:14)
-
-Node.js v19.9.0
+Failed to convert stanc.js argument 'code'!
+It had type 'object' instead of 'string'.
+Failed to convert stanc.js argument 'name'!
+It had type 'number' instead of 'string'.
+Failed to convert stanc.js argument 'flags'!
+It had type 'number' instead of 'array' or 'object'.
+Failed to convert stanc.js argument 'flags[1]'!
+It had type 'number' instead of 'string'.
 $ node basic.js
 Semantic error in 'string', line 6, column 4 to column 5:
    -------------------------------------------------


### PR DESCRIPTION
Closes #1446 by improving the error message. Note that the actual bad behavior is in RStan, c.f. https://github.com/stan-dev/rstan/issues/1145

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

stanc.js will now properly complain if it is supplied with bad javascript types for its arguments.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
