### PR TITLE
Build 'universal' binaries on MacOS

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -182,4 +182,6 @@ jobs:
         run: chmod +x ${{ matrix.name }}-stanc
 
       - name: Run tests
-        run: ./${{ matrix.name }}-stanc --help
+        run: |
+          mv ${{ matrix.name }}-stanc stanc.exe
+          ./stanc.exe --help

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -13,43 +13,48 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            sdk: ""
+            profile: static
             name: ubuntu
           - os: macos-13
-            name: macos
+            sdk: "10.11"
+            profile: release
+            name: macos-x86_64
+          - os: macos-latest
+            sdk: "11.0"
+            profile: release
+            name: macos-arm64
 
     runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.name }} stanc
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Download older SDK
-        if: matrix.name == 'macos'
+        if: matrix.sdk != ''
         run: |
-          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.11.sdk.tar.xz
-          tar -xvf MacOSX10.11.sdk.tar.xz
-          sudo mv MacOSX10.11.sdk /Library/Developer/CommandLineTools/SDKs
+          wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX${{matrix.sdk}}.sdk.tar.xz
+          tar -xvf MacOSX${{matrix.sdk}}.sdk.tar.xz
+          sudo mv MacOSX${{matrix.sdk}}.sdk /Library/Developer/CommandLineTools/SDKs
 
-          echo "MACOSX_DEPLOYMENT_TARGET=10.11" >> $GITHUB_ENV
-          echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX10.11.sdk/" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=${{matrix.sdk}}" >> $GITHUB_ENV
+          echo "SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX${{matrix.sdk}}.sdk/" >> $GITHUB_ENV
 
       - name: Use OCaml ${{ env.OCAML_VERSION }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ env.OCAML_VERSION }}
+          dune-cache: ${{ matrix.name != 'macos-x86_64' }}
 
-      - if: matrix.name == 'macos'
+      - if: matrix.name == 'macos-x86_64'
         run: opam pin -y dune 3.6.0 --no-action
 
       - run: bash -x scripts/install_build_deps.sh
 
-      - name: Build macos
-        if: matrix.name == 'macos'
-        run: opam exec -- dune subst; opam exec -- dune build
-
-      - name: Build ubuntu
-        if: matrix.name == 'ubuntu'
-        run: opam exec -- dune subst; opam exec -- dune build --profile static
+      - name: Build ${{ matrix.name }}
+        run: opam exec -- dune subst; opam exec -- dune build --profile ${{ matrix.profile }}
 
       - run: mv _build/default/src/stanc/stanc.exe ${{ matrix.name }}-stanc
 
@@ -59,8 +64,32 @@ jobs:
           name: ${{ matrix.name }}-stanc
           path: ${{ matrix.name }}-stanc
 
-  build-cross:
+  build-universal:
+    needs: build
+    runs-on: macos-latest
+    name: Build MacOS universal stanc
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Run lipo
+        run: |
+          ls
+          lipo -create -output macos-stanc macos-*-stanc
+          lipo -archs macos-stanc
+
+      - name: Upload macos-stanc
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-stanc
+          path: macos-stanc
+
+  xbuild-windows:
     runs-on: ubuntu-latest
+    name: Build Windows stanc (cross-compiler)
 
     steps:
       - name: Checkout code
@@ -70,13 +99,14 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y gcc-mingw-w64-x86-64
 
       - name: Use OCaml ${{ env.OCAML_VERSION }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           cache-prefix: v1-windows
+          dune-cache: true
           ocaml-compiler: ocaml-windows64.${{ env.OCAML_VERSION }}
           opam-repositories: |
-              windows: http://github.com/ocaml-cross/opam-cross-windows.git
-              default: https://github.com/ocaml/opam-repository.git
+            windows: http://github.com/ocaml-cross/opam-cross-windows.git
+            default: https://github.com/ocaml/opam-repository.git
 
       - run: bash -x scripts/install_build_deps_windows.sh
 
@@ -93,6 +123,22 @@ jobs:
           name: windows-stanc
           path: windows-stanc
 
+  build-js:
+    runs-on: ubuntu-latest
+    name: Build stanc.js
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Use OCaml ${{ env.OCAML_VERSION }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ env.OCAML_VERSION }}
+          dune-cache: true
+          cache-prefix: v1-js
+
+      - run: bash -x scripts/install_build_deps.sh
       - run: bash -x scripts/install_js_deps.sh
 
       - run: opam exec -- dune build --profile release src/stancjs
@@ -104,3 +150,36 @@ jobs:
         with:
           name: stanc.js
           path: stanc.js
+
+  test-builds:
+    needs: [build, build-universal, xbuild-windows]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: ubuntu
+          - os: macos-latest
+            name: macos
+          - os: macos-13
+            name: macos
+          - os: windows-latest
+            name: windows
+
+    runs-on: ${{ matrix.os }}
+
+    name: Test built stanc on ${{ matrix.os }}
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.name }}-stanc
+
+      - name: Update permissions
+        if: matrix.name != 'windows'
+        run: chmod +x ${{ matrix.name }}-stanc
+
+      - name: Run tests
+        run: ./${{ matrix.name }}-stanc --help

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -668,9 +668,9 @@ pipeline {
                                         runShell("""
                                             export PATH=/Users/jenkins/brew/bin:\$PATH
                                             eval \$(opam env --switch=stanc-4.14.1 --set-switch)
-                                            dune subst
                                             opam update || true
                                             bash -x scripts/install_build_deps.sh
+                                            dune subst
                                             dune build @install --root=.
                                         """)
                                     }
@@ -690,9 +690,9 @@ pipeline {
                                         runShell("""
                                             export PATH=/Users/jenkins/brew/bin:\$PATH
                                             eval \$(opam env --switch=stanc-4.14.1 --set-switch)
-                                            dune subst
                                             opam update || true
                                             bash -x scripts/install_build_deps.sh
+                                            dune subst
                                             dune build @install --root=.
                                         """)
                                     }

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,3 +1,4 @@
 #!/bin/bash
-cd `git rev-parse --show-toplevel`
+cd "$(git rev-parse --show-toplevel)" || exit
 dune runtest src test/unit && make format
+curl -X POST -F "jenkinsfile=<Jenkinsfile" "https://jenkins.flatironinstitute.org/pipeline-model-converter/validate" 2>/dev/null | tee /dev/tty | grep "Jenkinsfile successfully validated." -q


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

The MacOS binaries we distribute are now 'universal' (fat) binaries, and therefore will not require Rosetta to run.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
