### PR TITLE
Bump JSOO to 5.9.1 following quickjs fixes

### DIFF
--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -22,7 +22,7 @@ These are automatically installed through the [scripts/install_ocaml.sh] and
 
 For the JavaScript interface to stanc3 we also use the following, installed
 via [scripts/install_js_deps.sh]
-- js_of_ocaml 5.4.0
+- js_of_ocaml 5.9.1
 
 The [stancjs] executable can be built with
 

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -41,7 +41,7 @@ RUN bash -x install_build_deps.sh
 COPY ./scripts/install_dev_deps.sh ./
 RUN bash -x install_dev_deps.sh
 
-# Install Javascript dev environment (js_of_ocaml 5.4.0)
+# Install Javascript dev environment (js_of_ocaml 5.9.1)
 COPY ./scripts/install_js_deps.sh ./
 RUN bash -x install_js_deps.sh
 

--- a/scripts/install_js_deps.sh
+++ b/scripts/install_js_deps.sh
@@ -3,11 +3,7 @@
 # exit when any command fails
 set -e
 
-# JSOO versions higher than this break QuickJS (labelled break statements)
-# Please check compatibility before any updates!
-# https://github.com/stan-dev/stanc3/issues/1425
-# https://github.com/bellard/quickjs/issues/275
-opam pin -y js_of_ocaml 5.4.0
+opam pin -y js_of_ocaml 5.9.1
 
 echo "You should also install node in order to run the tests."
 echo "Tests are run with dune build @runjstest"


### PR DESCRIPTION
Ref. 
https://github.com/stan-dev/stanc3/issues/1425
https://github.com/quickjs-ng/quickjs/issues/741
https://github.com/andrjohns/QuickJSR/issues/76

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Bumped JS-of-Ocaml version to 5.9.1

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
