### PR TITLE
Update formatting of Cram tests

### DIFF
--- a/test/integration/cli-args/debug-generation.t/run.t
+++ b/test/integration/cli-args/debug-generation.t/run.t
@@ -7,12 +7,14 @@ Provide partial data file
 
 Output file works
 
-  $ stanc --debug-generate-data debug.stan --o output.json && ls *.json && rm output.json
+  $ stanc --debug-generate-data debug.stan --o output.json
+  $ ls *.json
   bad.json
   incomplete_data.json
   output.json
   partial-div0.json
   partial_data.json
+  $ rm output.json
 
 Don't provide any data
   $ stanc --debug-generate-inits debug.stan
@@ -42,11 +44,14 @@ Provide an invalid JSON file
   [1]
 
 Provide an unreadable JSON file
-  $ touch unreadable.json && chmod -r unreadable.json && stanc --debug-generate-inits debug.stan --debug-data-file unreadable.json
+  $ touch unreadable.json
+  $ chmod -r unreadable.json
+  $ stanc --debug-generate-inits debug.stan --debug-data-file unreadable.json
   %%NAME%%: File 'unreadable.json' not found or cannot be opened.
   Usage: %%NAME%% [OPTION]… [MODEL_FILE]
   Try '%%NAME%% --help' for more information.
   [124]
+  $ rm unreadable.json
 
 Bad data block, cannot be partially evaluated
   $ stanc --debug-generate-data div0.stan --debug-data-file partial-div0.json

--- a/test/integration/cli-args/output-files.t/run.t
+++ b/test/integration/cli-args/output-files.t/run.t
@@ -1,17 +1,23 @@
 Default is filename.hpp
-  $ stanc basic.stan && ls && rm basic.hpp
+  $ stanc basic.stan
+  $ ls
   basic.hpp
   basic.stan
+  $ rm basic.hpp
 
 Output file is respected
-  $ stanc --o=foo.cpp basic.stan && ls && rm foo.cpp
+  $ stanc --o=foo.cpp basic.stan
+  $ ls
   basic.stan
   foo.cpp
+  $ rm foo.cpp
 
 Output file for formatting prevents cpp generation
-  $ stanc --auto-format --o=basic_fmt.stan basic.stan && ls && cat basic_fmt.stan && rm basic_fmt.stan
+  $ stanc --auto-format --o=basic_fmt.stan basic.stan
+  $ ls
   basic.stan
   basic_fmt.stan
+  $ cat basic_fmt.stan
   data {
     int<lower=0> N;
     array[N] int<lower=0, upper=1> y;
@@ -23,12 +29,18 @@ Output file for formatting prevents cpp generation
     theta ~ beta(1, 1); // uniform prior on interval 0,1
     y ~ bernoulli(theta);
   }
+  $ rm basic_fmt.stan
 
 Output file isn't present in C++ args array
-  $ stanc --O -fno-soa --o=foo.cpp basic.stan && grep "stancflags" foo.cpp && rm foo.cpp
+  $ stanc --O -fno-soa --o=foo.cpp basic.stan
+  $ grep "stancflags" foo.cpp
                "stancflags = --O1 -fno-soa"};
+  $ rm foo.cpp
 
 Error on un-writable output file
-  $ touch basic.hpp && chmod -w basic.hpp && stanc --o=basic.hpp basic.stan
+  $ touch basic.hpp
+  $ chmod -w basic.hpp
+  $ stanc --o=basic.hpp basic.stan
   Error writing to file 'basic.hpp': basic.hpp: Permission denied
   [1]
+  $ rm -f basic.hpp

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -200,8 +200,6 @@ Show help
   
 
 
-
-
 Qmark alias
   $ stanc -? plain | head
   NAME
@@ -234,11 +232,13 @@ Error when multiple files passed
   [124]
 
 Error when a folder is passed
-  $ mkdir foo.d && stanc foo.d
+  $ mkdir foo.d
+  $ stanc foo.d
   %%NAME%%: MODEL_FILE argument: 'foo.d' is a directory
   Usage: %%NAME%% [OPTION]… [MODEL_FILE]
   Try '%%NAME%% --help' for more information.
   [124]
+  $ rm -r foo.d
 
 Error when nonsense argument is passed
   $ stanc -fno-generated-quantities
@@ -249,6 +249,9 @@ Error when nonsense argument is passed
   [124]
 
 Error when unreadable file is passed
-  $ touch unreadable.stan && chmod -r unreadable.stan && stanc unreadable.stan
+  $ touch unreadable.stan
+  $ chmod -r unreadable.stan
+  $ stanc unreadable.stan
   Error: file 'unreadable.stan' not found or cannot be opened
   [1]
+  $ rm unreadable.stan


### PR DESCRIPTION
This makes the tests a bit easier to read and has some nice benefits like preserving error codes rather than them being swallowed by pipes. 

#### Submission Checklist

- x ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
