### PR TITLE
Allow model to be supplied on stdin with '-'

### DIFF
--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -22,21 +22,25 @@ type t =
   | Semantic_error of Semantic_error.t
   | DebugDataError of (Middle.Location_span.t * string)
 
-let get_context_callback ?code Middle.Location.{filename; included_from; _} () =
-  (* By the time we are printing an error, all these files are already resolved. *)
+let get_context ?code Middle.Location.{filename; included_from; _} () =
+  (* If the location is not included from anywhere, it's the orignal code *)
+  let code = if Option.is_none included_from then code else None in
+  (* Otherwise, by the time we are printing an error,
+     all these files are already resolved. *)
   match !Include_files.include_provider with
   | FileSystemPaths _ ->
       (* So we can read directly from the filesystem *)
-      In_channel.read_lines filename
+      Option.map code ~f:String.split_lines
+      |> Option.value_or_thunk ~default:(fun () ->
+             In_channel.read_lines filename)
   | InMemory m ->
-      (* If the location is not included from anywhere, it's the orignal code,
-         otherwise we know we can find it in the map *)
-      (if Option.is_none included_from then code else Map.find m filename)
-      |> Option.value_exn |> String.split_lines
+      (* Or, we know we can find it in the map *)
+      Option.value_or_thunk code ~default:(fun () -> Map.find_exn m filename)
+      |> String.split_lines
 
 let pp_context_with_message ?code ppf (msg, loc) =
   Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string)
-    (Middle.Location.context_to_string (get_context_callback ?code loc) loc)
+    (Middle.Location.context_to_string (get_context ?code loc) loc)
     msg
 
 let pp_semantic_error ?printed_filename ?code ppf err =

--- a/src/frontend/Errors.mli
+++ b/src/frontend/Errors.mli
@@ -26,8 +26,3 @@ val pp : ?printed_filename:string -> ?code:string -> t Fmt.t
   If [code] is supplied, read context from that string. Otherwise,
   it will attempt to open the original file.
  *)
-
-val to_string : t -> string
-(** Format an error [t] as a string. Should only be used in testing!
-  For user facing code, prefer [pp]
-  *)

--- a/src/frontend/Pretty_print_prog.ml
+++ b/src/frontend/Pretty_print_prog.ml
@@ -54,7 +54,8 @@ let check_correctness ?(bare_functions = false) prog pretty =
     match res with
     | Ok prog -> prog
     | Error e ->
-        let error = Errors.to_string e in
+        let error =
+          Fmt.str "%a" (Errors.pp ?printed_filename:None ~code:pretty) e in
         Common.ICE.internal_compiler_error
           [%message
             "Pretty-printed program failed to parse" error

--- a/src/stanc/CLI.ml
+++ b/src/stanc/CLI.ml
@@ -7,11 +7,16 @@ module Arguments = struct
 
   let model_file =
     let doc =
-      "The Stan model file to compile. This should be a .stan file or \
-       .stanfunctions file (the latter automatically sets \
-       $(b,--standalone-functions))." in
+      "The Stan model file to compile. This should be a file ending in \
+       $(b,.stan) or $(b,.stanfunctions) (which automatically sets \
+       $(b,--standalone-functions)), or '-' to read from standard input." in
     Arg.(
-      value & pos 0 (some non_dir_file) None & info [] ~docv:"MODEL_FILE" ~doc)
+      let dash_or_file =
+        let else_parse = conv_parser non_dir_file in
+        let pp = conv_printer non_dir_file in
+        let parse s = if String.equal s "-" then Ok s else else_parse s in
+        conv (parse, pp) in
+      value & pos 0 (some dash_or_file) None & info [] ~docv:"MODEL_FILE" ~doc)
 end
 
 module Options = struct

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -22,9 +22,9 @@ Show help
   
   ARGUMENTS
          MODEL_FILE
-             The Stan model file to compile. This should be a .stan file or
-             .stanfunctions file (the latter automatically sets
-             --standalone-functions).
+             The Stan model file to compile. This should be a file ending in
+             .stan or .stanfunctions (which automatically sets
+             --standalone-functions), or '-' to read from standard input.
   
   OPTIONS
          -? [=FMT] (default=auto)
@@ -255,3 +255,23 @@ Error when unreadable file is passed
   Error: file 'unreadable.stan' not found or cannot be opened
   [1]
   $ rm unreadable.stan
+
+
+Can read from stdin
+  $ echo 'parameters {real y;}' | stanc - --auto-format
+  parameters {
+    real y;
+  }
+  
+
+
+Can filename is set to stdin when reading from stdin
+  $ echo 'parameters {real y}' | stanc -
+  Syntax error in 'stdin', line 1, column 18 to column 19, parsing error:
+     -------------------------------------------------
+       1:  parameters {real y}
+                             ^
+     -------------------------------------------------
+  
+  ";" expected after variable declaration.
+  [1]

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -200,6 +200,7 @@ Show help
   
 
 
+
 Qmark alias
   $ stanc -? plain | head
   NAME
@@ -265,7 +266,8 @@ Can read from stdin
   
 
 
-Can filename is set to stdin when reading from stdin
+
+Filename is set to stdin when reading from stdin
   $ echo 'parameters {real y}' | stanc -
   Syntax error in 'stdin', line 1, column 18 to column 19, parsing error:
      -------------------------------------------------

--- a/test/unit/In_memory_include_tests.ml
+++ b/test/unit/In_memory_include_tests.ml
@@ -4,7 +4,7 @@ open Frontend
 let print_ast_or_error code =
   let () =
     match Test_utils.untyped_ast_of_string code with
-    | Result.Error e -> print_endline @@ Errors.to_string e
+    | Result.Error e -> print_endline @@ Test_utils.error_to_string e
     | Result.Ok ast -> print_s [%sexp (ast : Ast.untyped_program)] in
   (* reset *) Include_files.include_provider := FileSystemPaths []
 

--- a/test/unit/In_memory_include_tests.ml
+++ b/test/unit/In_memory_include_tests.ml
@@ -4,7 +4,7 @@ open Frontend
 let print_ast_or_error code =
   let () =
     match Test_utils.untyped_ast_of_string code with
-    | Result.Error e -> print_endline @@ Test_utils.error_to_string e
+    | Result.Error e -> print_endline @@ Test_utils.error_to_string ~code e
     | Result.Ok ast -> print_s [%sexp (ast : Ast.untyped_program)] in
   (* reset *) Include_files.include_provider := FileSystemPaths []
 
@@ -22,6 +22,14 @@ let%expect_test "no includes" =
   [%expect
     {|
     Syntax error in 'string', line 2, column 0, include error:
+       -------------------------------------------------
+         1:
+         2:  #include <foo.stan>
+             ^
+         3:  data {
+         4:      int a;
+       -------------------------------------------------
+
     Could not find include file 'foo.stan'.
     stanc was given information about the following files:
     None |}]
@@ -33,6 +41,14 @@ let%expect_test "wrong include" =
   [%expect
     {|
     Syntax error in 'string', line 2, column 0, include error:
+       -------------------------------------------------
+         1:
+         2:  #include <foo.stan>
+             ^
+         3:  data {
+         4:      int a;
+       -------------------------------------------------
+
     Could not find include file 'foo.stan'.
     stanc was given information about the following files:
     bar.stan |}]

--- a/test/unit/Parse_tests.ml
+++ b/test/unit/Parse_tests.ml
@@ -4,7 +4,7 @@ open Frontend
 let print_ast_of_string s =
   let ast =
     Test_utils.untyped_ast_of_string s
-    |> Result.map_error ~f:Errors.to_string
+    |> Result.map_error ~f:Test_utils.error_to_string
     |> Result.ok_or_failwith in
   print_s [%sexp (ast : Ast.untyped_program)]
 

--- a/test/unit/Parse_tests.ml
+++ b/test/unit/Parse_tests.ml
@@ -1,10 +1,10 @@
 open Core
 open Frontend
 
-let print_ast_of_string s =
+let print_ast_of_string code =
   let ast =
-    Test_utils.untyped_ast_of_string s
-    |> Result.map_error ~f:Test_utils.error_to_string
+    Test_utils.untyped_ast_of_string code
+    |> Result.map_error ~f:(Test_utils.error_to_string ~code)
     |> Result.ok_or_failwith in
   print_s [%sexp (ast : Ast.untyped_program)]
 

--- a/test/unit/Test_utils.ml
+++ b/test/unit/Test_utils.ml
@@ -6,12 +6,14 @@ let untyped_ast_of_string s =
   Fmt.epr "%a" (Fmt.list ~sep:Fmt.nop Warnings.pp) warnings;
   res
 
+let error_to_string = Fmt.str "%a" (Errors.pp ?printed_filename:None ?code:None)
+
 let typed_ast_of_string_exn s =
   Result.(
     untyped_ast_of_string s >>= fun ast ->
     Typechecker.check_program ast
     |> map_error ~f:(fun e -> Errors.Semantic_error e))
-  |> Result.map_error ~f:Errors.to_string
+  |> Result.map_error ~f:error_to_string
   |> Result.ok_or_failwith |> fst
 
 let mir_of_string s = typed_ast_of_string_exn s |> Ast_to_Mir.trans_prog ""

--- a/test/unit/Test_utils.ml
+++ b/test/unit/Test_utils.ml
@@ -6,14 +6,15 @@ let untyped_ast_of_string s =
   Fmt.epr "%a" (Fmt.list ~sep:Fmt.nop Warnings.pp) warnings;
   res
 
-let error_to_string = Fmt.str "%a" (Errors.pp ?printed_filename:None ?code:None)
+let error_to_string ~code =
+  Fmt.str "%a" (Errors.pp ?printed_filename:None ?code:(Some code))
 
-let typed_ast_of_string_exn s =
+let typed_ast_of_string_exn code =
   Result.(
-    untyped_ast_of_string s >>= fun ast ->
+    untyped_ast_of_string code >>= fun ast ->
     Typechecker.check_program ast
     |> map_error ~f:(fun e -> Errors.Semantic_error e))
-  |> Result.map_error ~f:error_to_string
+  |> Result.map_error ~f:(error_to_string ~code)
   |> Result.ok_or_failwith |> fst
 
 let mir_of_string s = typed_ast_of_string_exn s |> Ast_to_Mir.trans_prog ""


### PR DESCRIPTION
This is a small change that allows some better 'scriptability' of the compiler, e.g.

```
 $ cat test/integration/good/for_early_return.stan | stanc - --auto-format
functions {
  real ends() {
    for (i in 1 : 10) {
      return 1;
    }
  }
}
transformed parameters {
  real a = ends();
}
```

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: https://github.com/stan-dev/docs/pull/845
    
## Release notes

The compiler now accepts `-` as a model argument, in which case it reads from standard input

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
