### PR TITLE
Remove usages of re, clean up libraries fields in dune

### DIFF
--- a/src/analysis_and_optimization/Dataflow_types.ml
+++ b/src/analysis_and_optimization/Dataflow_types.ml
@@ -9,19 +9,19 @@ open Middle
    A label is a unique identifier for a node in the dataflow/dependency graph, and
    often corresponds to one node in the Mir.
 *)
-type label = int [@@deriving sexp, hash, compare]
+type label = int [@@deriving sexp]
 
 (**
    Representation of an expression that can be assigned to. This should also be able to
    represent indexed variables, but we don't support that yet.
 *)
-type vexpr = VVar of string [@@deriving sexp, hash, compare]
+type vexpr = VVar of string [@@deriving sexp]
 
 (**
    A 'reaching definition' (or reaching_defn or RD) statement (v, l) says that the variable
    v could have been affected at the label l.
 *)
-type reaching_defn = vexpr * label [@@deriving sexp, hash, compare]
+type reaching_defn = vexpr * label [@@deriving sexp]
 
 (**
    Description of where a node in the dependency graph came from, where MirNode is the
@@ -31,7 +31,6 @@ type source_loc =
   | MirNode of Location_span.t
   | StartOfBlock
   | TargetTerm of {term: Expr.Typed.t; assignment_label: label}
-[@@deriving sexp]
 
 (**
    Information to be collected about each node
@@ -54,7 +53,6 @@ type 'rd_info node_info =
   ; rhs_set: vexpr Set.Poly.t
   ; controlflow: label Set.Poly.t
   ; loc: source_loc }
-[@@deriving sexp]
 
 (**
    A node_info, where the reaching definition information takes the form of an update
@@ -70,7 +68,6 @@ type node_info_update =
 *)
 type node_info_fixedpoint =
   (reaching_defn Set.Poly.t * reaching_defn Set.Poly.t) node_info
-[@@deriving sexp]
 
 (**
    The state that will be maintained throughout the traversal of the Mir
@@ -112,7 +109,6 @@ type dataflow_graph =
   { node_info_map: (int, node_info_fixedpoint) Map.Poly.t
   ; possible_exits: label Set.Poly.t
   ; probabilistic_nodes: label Set.Poly.t }
-[@@deriving sexp]
 
 (**
    Represents the dataflow graphs for each interesting block in the program MIR.
@@ -121,4 +117,3 @@ type dataflow_graph =
 *)
 type prog_df_graphs =
   {tdatab: dataflow_graph; modelb: dataflow_graph; gqb: dataflow_graph}
-[@@deriving sexp]

--- a/src/analysis_and_optimization/Factor_graph.ml
+++ b/src/analysis_and_optimization/Factor_graph.ml
@@ -11,12 +11,12 @@ type factor =
   | TargetTerm of Expr.Typed.t
   | Reject
   | LPFunction of (string * Expr.Typed.t list)
-[@@deriving sexp, hash, compare]
+[@@deriving sexp]
 
 type factor_graph =
   { factor_map: (factor * label, vexpr Set.Poly.t) Map.Poly.t
   ; var_map: (vexpr, (factor * label) Set.Poly.t) Map.Poly.t }
-[@@deriving sexp, compare]
+[@@deriving sexp]
 
 let extract_factors_statement stmt =
   match stmt with

--- a/src/analysis_and_optimization/dune
+++ b/src/analysis_and_optimization/dune
@@ -1,7 +1,7 @@
 (library
  (name analysis_and_optimization)
  (public_name stanc.analysis)
- (libraries core str fmt common middle frontend)
+ (libraries core middle yojson frontend)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)

--- a/src/common/dune
+++ b/src/common/dune
@@ -1,7 +1,7 @@
 (library
  (name common)
  (public_name stanc.common)
- (libraries core str fmt)
+ (libraries core fmt)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -1,7 +1,13 @@
 (library
  (name driver)
  (public_name stanc.driver)
- (libraries frontend middle stan_math_backend analysis_and_optimization)
+ (libraries
+  core
+  fmt
+  frontend
+  middle
+  stan_math_backend
+  analysis_and_optimization)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -752,8 +752,8 @@ let rec trans_sizedtype_decl declc tr name st =
         let e = trans_expr s in
         let decl_name =
           name
-          |> Str.global_replace (Str.regexp "\\[\\]") "_brack"
-          |> Str.global_replace (Str.regexp "\\.") "_dot" in
+          |> String.substr_replace_all ~pattern:"[]" ~with_:"_brack"
+          |> String.substr_replace_all ~pattern:"." ~with_:"_dot" in
         let decl_id = Fmt.str "%s_%ddim__" decl_name n in
         let decl =
           { Stmt.Fixed.pattern=

--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -11,10 +11,8 @@ type originblock =
   | TParam
   | Model
   | GQuant
-[@@deriving sexp]
 
 type varinfo = {origin: originblock; global: bool; readonly: bool}
-[@@deriving sexp]
 
 type info =
   { type_: UnsizedType.t
@@ -23,7 +21,6 @@ type info =
       | `UserDeclared of Location_span.t
       | `StanMath
       | `UserDefined ] }
-[@@deriving sexp]
 
 type t = info list String.Map.t
 

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -75,7 +75,6 @@ and details =
 and function_mismatch =
   | ArgError of int * type_mismatch
   | ArgNumMismatch of int * int
-[@@deriving sexp]
 
 type signature_error =
   (UnsizedType.returntype * (UnsizedType.autodifftype * UnsizedType.t) list)

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1081,9 +1081,9 @@ let overlapping_lvalues lvals =
     | LIndexed (l, _), _ -> compare_no_indexing l lv2
     | _, LIndexed (l, _) -> compare_no_indexing lv1 l
     | LVariable id1, LVariable id2 -> String.compare id1.name id2.name
-    | LTupleProjection (lv1, idx1), LTupleProjection (lv2, idx2)
-      when idx1 = idx2 ->
-        compare_no_indexing lv1 lv2
+    | LTupleProjection (lv1, idx1), LTupleProjection (lv2, idx2) ->
+        let idx_comp = Int.compare idx1 idx2 in
+        if idx_comp = 0 then compare_no_indexing lv1 lv2 else idx_comp
     | _, _ ->
         (* remaining cases are not equal, we don't care *)
         Ast.compare_untyped_lval lv1 lv2 in

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,7 +1,7 @@
 (library
  (name frontend)
  (public_name stanc.frontend)
- (libraries core re menhirLib fmt middle common yojson)
+ (libraries core menhirLib yojson fmt middle)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)

--- a/src/middle/dune
+++ b/src/middle/dune
@@ -1,7 +1,7 @@
 (library
  (name middle)
  (public_name stanc.middle)
- (libraries core str fmt common re)
+ (libraries core fmt common)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)

--- a/src/stan_math_backend/Cpp_Json.ml
+++ b/src/stan_math_backend/Cpp_Json.ml
@@ -1,6 +1,5 @@
 open Core
 open Middle
-module Str = Re.Str
 
 let rec sizedtype_to_json (st : Expr.Typed.t SizedType.t) : Yojson.Basic.t =
   let emit_cpp_expr e =
@@ -66,10 +65,10 @@ let%expect_test "outvar to json pretty" =
   unslash the ones near a plus*)
 let replace_cpp_expr s =
   s
-  |> Str.global_replace (Str.regexp {|"|}) {|\"|}
-  |> Str.global_replace (Str.regexp {|\\"\+|}) {|" +|}
-  |> Str.global_replace (Str.regexp {|\+\\"|}) {|+ "|}
-  |> Str.global_replace (Str.regexp {|\\n|}) {||}
+  |> String.substr_replace_all ~pattern:{|"|} ~with_:{|\"|}
+  |> String.substr_replace_all ~pattern:{|\"+|} ~with_:{|" +|}
+  |> String.substr_replace_all ~pattern:{|+\"|} ~with_:{|+ "|}
+  |> String.substr_replace_all ~pattern:"\\n" ~with_:""
 
 let wrap_in_quotes s = "\"" ^ s ^ "\""
 

--- a/src/stan_math_backend/Mangle.ml
+++ b/src/stan_math_backend/Mangle.ml
@@ -13,18 +13,9 @@
 *)
 
 open Core
-open Core.Poly
 
 let kwrds_prefix = "_stan_"
-let prefix_len = String.length kwrds_prefix
-
-let remove_prefix s =
-  if
-    String.length s >= prefix_len + 1
-    && Str.first_chars s prefix_len = kwrds_prefix
-  then Str.string_after s prefix_len
-  else s
-
+let remove_prefix s = String.chop_prefix_if_exists ~prefix:kwrds_prefix s
 let prepend_kwrd x = kwrds_prefix ^ x
 
 let cpp_kwrds =

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -221,7 +221,7 @@ let meta_from_sizedtype st =
   ; adlevel= UnsizedType.fill_adtype_for_type DataOnly type_ }
 
 let munge_tuple_name name =
-  Str.global_replace (Str.regexp_string ".") "_dot_" name
+  String.substr_replace_all ~pattern:"." ~with_:"_dot_" name
 
 let make_tuple_temp name = munge_tuple_name name ^ "_temp__"
 

--- a/src/stan_math_backend/dune
+++ b/src/stan_math_backend/dune
@@ -1,7 +1,7 @@
 (library
  (name stan_math_backend)
  (public_name stanc.stan_math_backend)
- (libraries core re fmt middle yojson)
+ (libraries core fmt yojson middle)
  (instrumentation
   (backend bisect_ppx))
  (private_modules

--- a/src/stanc/dune
+++ b/src/stanc/dune
@@ -3,7 +3,7 @@
  (modes
   (byte c)
   (best exe))
- (libraries driver cmdliner)
+ (libraries core fmt cmdliner driver)
  (instrumentation
   (backend bisect_ppx))
  (modules Stanc CLI)

--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -1,6 +1,6 @@
 (executable
  (name stancjs)
- (libraries js_of_ocaml driver)
+ (libraries core fmt js_of_ocaml driver)
  (preprocess
   (pps ppx_jane))
  (modes js))

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -21,10 +21,9 @@ let%expect_test "backtrace indirect test" =
   ( ICE.with_exn_message (fun () -> failwith "oops!")
   |> Result.error |> Option.value_exn
   |> fun s ->
-    try
-      let _ = String.substr_index_exn ~pattern:"Called from Common" s ~pos:0 in
+    if String.is_substring ~substring:"Called from Common" s then
       print_endline "Backtrace found in message"
-    with _ -> print_endline "FAILED TO FIND BACKTRACE" );
+    else print_endline "FAILED TO FIND BACKTRACE" );
   [%expect {| Backtrace found in message |}]
 
 let%expect_test "ICE triggered" =

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -22,7 +22,7 @@ let%expect_test "backtrace indirect test" =
   |> Result.error |> Option.value_exn
   |> fun s ->
     try
-      let _ = Str.search_forward (Str.regexp "^Called from Common") s 0 in
+      let _ = String.substr_index_exn ~pattern:"Called from Common" s ~pos:0 in
       print_endline "Backtrace found in message"
     with _ -> print_endline "FAILED TO FIND BACKTRACE" );
   [%expect {| Backtrace found in message |}]

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,6 +1,12 @@
 (library
  (name unit_tests)
- (libraries core frontend stan_math_backend middle analysis_and_optimization)
+ (libraries
+  core
+  fmt
+  frontend
+  stan_math_backend
+  middle
+  analysis_and_optimization)
  (inline_tests)
  (preprocess
   (pps ppx_jane ppx_deriving.map ppx_deriving.fold)))


### PR DESCRIPTION
This started with me testing building the compiler under OCaml 5.3.0. After installing the most recent version of our dependencies, the build was still failing, because `re` wasn't installed. It turns out, it's no longer in the Jane Street dependency tree in the next version (0.17.x)

I then realized we were not documenting this dependency anywhere, and it's also completely unnecessary based on its usages. So I pulled it out, and then updated the dune files to not request linking it. It turns out that the `str` library we were listing was also just requesting a link to our own alias of `module Str = Re.Str`, which was... messy, to say the least!

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Removed usages of the `re` library

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
