### PR TITLE
Update rstan's stanc.js on nightly release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,10 @@ pipeline {
                     when {
                         beforeAgent true
                         expression {
-                            !skipRemainingStages
+                            anyOf {
+                                !skipRebuildingBinaries
+                                !skipRemainingStages
+                            }
                         }
                     }
                     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1067,6 +1067,20 @@ pipeline {
                             gh release delete ${tagName()} --cleanup-tag -y || true
                             gh release create ${tagName()} --latest --target master --notes "\$(git log --pretty=format:'nightly: %h %s' -n 1)" ./bin/*
                         """)
+
+                        // Update stanc.js in StanHeaders
+                        withCredentials([usernamePassword(credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+                            sh """#!/bin/bash
+                                set -e
+
+                                git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/rstan.git
+                                rm rstan/StanHeaders/inst/stanc.js
+                                cp ./bin/stanc.js rstan/StanHeaders/inst/stanc.js
+                                git -C rstan/StanHeaders add inst/stanc.js
+                                git -C rstan/StanHeaders commit -m "Update stanc.js to ${tagName()}"
+                                git -C rstan/StanHeaders push
+                            """
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1077,11 +1077,15 @@ pipeline {
                                 set -e
 
                                 git clone https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/rstan.git
+                                git config user.email "mc.stanislaw@gmail.com"
+                                git config user.name "Stan Jenkins"
+                                git config auth.token ${GITHUB_TOKEN}
+
                                 rm rstan/StanHeaders/inst/stanc.js
                                 cp ./bin/stanc.js rstan/StanHeaders/inst/stanc.js
-                                git -C rstan/StanHeaders add inst/stanc.js
-                                git -C rstan/StanHeaders commit -m "Update stanc.js to ${tagName()}"
-                                git -C rstan/StanHeaders push
+                                git -C rstan add StanHeaders/inst/stanc.js
+                                git -C rstan commit -m "Update stanc.js to ${tagName()}"
+                                git -C rstan push https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/stan-dev/rstan.git develop
                             """
                         }
                     }


### PR DESCRIPTION
This PR adds a step to the Jenkinsfile stage for nightly releases to also update `rstan`'s bundled `stanc.js`.

@serban-nicusor-toptal would you be able to check whether I've specified the credentials/config correctly? Thanks!

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Update `develop` rstan on nightly release of new `stanc.js`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
