### PR TITLE
Restore previous behavior of model name arguments

### DIFF
--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -49,7 +49,6 @@ let main () =
     | Compile settings -> settings in
   Debugging.lexer_logging := debug_lex;
   Debugging.grammar_logging := debug_parse;
-  Typechecker.model_name := Option.value ~default:"" name;
   Driver.Flags.set_backend_args_list
     (* remove executable itself from list before passing *)
     (Sys.get_argv () |> Array.to_list |> List.tl_exn);
@@ -65,7 +64,9 @@ let main () =
       , Option.first_some flags.filename_in_msg (Some "stdin") )
     else (model_file, `File model_file, flags.filename_in_msg) in
   match
-    Driver.Entry.stan2cpp model_file_name model_source flags
+    Driver.Entry.stan2cpp
+      (Option.value ~default:model_file_name name)
+      model_source flags
       (output_callback output_file printed_filename)
   with
   | Ok cpp_str ->

--- a/test/integration/cli-args/model-name/stanc.t
+++ b/test/integration/cli-args/model-name/stanc.t
@@ -1,0 +1,15 @@
+Test model name mangeling for non-alphanumeric characters
+  $ echo 'parameters {real y;}' >> añd.stan
+Filename
+  $ stanc añd.stan
+  $ grep "namespace a" añd.hpp
+  namespace ax195x177d_model_namespace {
+Name argument
+  $ stanc --name=añd añd.stan
+  $ grep "namespace a" añd.hpp
+  namespace ax195x177d_namespace {
+Name argument with dash
+  $ stanc --name="a-d" añd.stan
+  $ grep "namespace a" añd.hpp
+  namespace a_d_namespace {
+  $ rm añd.hpp añd.stan

--- a/test/stancjs/model_name.js
+++ b/test/stancjs/model_name.js
@@ -1,0 +1,29 @@
+var stanc = require('../../src/stancjs/stancjs.bc.js');
+var utils = require("./utils/utils.js");
+
+
+let basic_model = `
+parameters {
+	real y;
+}
+model {
+    y ~ std_normal();
+}
+`
+
+let basic_name1 = stanc.stanc("basic1", basic_model, []);
+utils.print_error(basic_name1);
+console.assert(basic_name1.result.includes("namespace basic1_namespace"), "Error: namespace not in C++ code");
+
+// test that the state doesn't persist
+
+let basic_name2 = stanc.stanc("basic2", basic_model, []);
+utils.print_error(basic_name2);
+console.assert(basic_name2.result.includes("namespace basic2_namespace"), "Error: namespace not in C++ code");
+
+
+// test that _model is added if the name is file-like
+
+let basic_name3 = stanc.stanc("basic.stan", basic_model, []);
+utils.print_error(basic_name3);
+console.assert(basic_name3.result.includes("namespace basic_model_namespace"), "Error: namespace not in C++ code");

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -352,9 +352,7 @@ $ node info.js
 $ node math_sigs.js
 
 $ node model_name.js
-Assertion failed: Error: namespace not in C++ code
-Assertion failed: Error: namespace not in C++ code
-Assertion failed: Error: namespace not in C++ code
+
 $ node optimization.js
 Semantic error in 'string', line 3, column 8 to column 11:
    -------------------------------------------------

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -351,6 +351,10 @@ $ node info.js
 }
 $ node math_sigs.js
 
+$ node model_name.js
+Assertion failed: Error: namespace not in C++ code
+Assertion failed: Error: namespace not in C++ code
+Assertion failed: Error: namespace not in C++ code
 $ node optimization.js
 Semantic error in 'string', line 3, column 8 to column 11:
    -------------------------------------------------


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fixes #1491 where repeated calls to stanc.js would re-use the same model namespace in the generated C++

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
