### PR TITLE
Stop directly exposing hashmaps from Stan_math_signatures

### DIFF
--- a/src/analysis_and_optimization/Memory_patterns.ml
+++ b/src/analysis_and_optimization/Memory_patterns.ml
@@ -94,7 +94,7 @@ let query_stan_math_mem_pattern_support (name : string)
       let name =
         string_operator_to_stan_math_fns (Utils.stdlib_distribution_name name)
       in
-      let namematches = Hashtbl.find_multi stan_math_signatures name in
+      let namematches = lookup_stan_math_function name in
       let filteredmatches =
         List.filter
           ~f:(fun x ->

--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -26,7 +26,7 @@ type t = info list String.Map.t
 
 let stan_math_environment =
   let functions =
-    Hashtbl.to_alist Stan_math_signatures.stan_math_signatures
+    Stan_math_signatures.get_stan_math_signatures_alist ()
     |> List.map ~f:(fun (key, values) ->
            ( key
            , List.map values ~f:(fun (rt, args, mem) ->

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -198,9 +198,7 @@ let match_to_rt_option = function
   | _ -> None
 
 let stan_math_return_type name arg_tys =
-  match
-    Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures name
-  with
+  match Stan_math_signatures.lookup_stan_math_variadic_function name with
   | Some {return_type; _} -> Some (UnsizedType.ReturnType return_type)
   | None when Stan_math_signatures.is_reduce_sum_fn name ->
       Some (UnsizedType.ReturnType UReal)
@@ -667,8 +665,8 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
 and check_variadic ~is_cond_dist loc cf tenv id tes =
   let Stan_math_signatures.
         {control_args; required_fn_args; required_fn_rt; return_type} =
-    Hashtbl.find_exn Stan_math_signatures.stan_math_variadic_signatures id.name
-  in
+    Stan_math_signatures.lookup_stan_math_variadic_function id.name
+    |> Option.value_exn in
   let matching remaining_es Env.{type_= ftype; _} =
     let arg_types =
       (calculate_autodifftype cf Functions ftype, ftype)

--- a/src/middle/Stan_math_signatures.ml
+++ b/src/middle/Stan_math_signatures.ml
@@ -381,8 +381,14 @@ let is_stan_math_function_name name =
   let name = Utils.stdlib_distribution_name name in
   Hashtbl.mem stan_math_signatures name
 
-let is_stan_math_variadic_function_name name =
-  Hashtbl.mem stan_math_variadic_signatures name
+let lookup_stan_math_function = Hashtbl.find_multi stan_math_signatures
+let get_stan_math_signatures_alist () = Hashtbl.to_alist stan_math_signatures
+
+let is_stan_math_variadic_function_name =
+  Hashtbl.mem stan_math_variadic_signatures
+
+let lookup_stan_math_variadic_function =
+  Hashtbl.find stan_math_variadic_signatures
 
 let operator_to_stan_math_fns op =
   match op with

--- a/src/middle/Stan_math_signatures.mli
+++ b/src/middle/Stan_math_signatures.mli
@@ -3,8 +3,6 @@
     functions for dealing with those signatures.
 *)
 
-open Core
-
 (** Function arguments are represented by their type an autodiff
    type. This is [AutoDiffable] for everything except arguments
    marked with the data keyword *)
@@ -14,11 +12,14 @@ type fun_arg = UnsizedType.autodifftype * UnsizedType.t
     for whether or not those arguments can be Struct of Arrays objects *)
 type signature = UnsizedType.returntype * fun_arg list * Mem_pattern.t
 
-val stan_math_signatures : (string, signature list) Hashtbl.t
-(** Mapping from names to signature(s) of functions *)
-
 val is_stan_math_function_name : string -> bool
-(** Equivalent to [Hashtbl.mem stan_math_signatures s]*)
+(** Check if a string names a Stan Math library function *)
+
+val lookup_stan_math_function : string -> signature list
+(** Look up the signature of a Stan Math library function. If it is not found, this returns [[]] *)
+
+val get_stan_math_signatures_alist : unit -> (string * signature list) list
+(** Get all the signatures in the Stan Math library *)
 
 type variadic_signature =
   { return_type: UnsizedType.t
@@ -26,15 +27,15 @@ type variadic_signature =
   ; required_fn_rt: UnsizedType.t
   ; required_fn_args: fun_arg list }
 
-val stan_math_variadic_signatures : (string, variadic_signature) Hashtbl.t
-(** Mapping from names to description of a variadic function.
+val is_stan_math_variadic_function_name : string -> bool
+(** Test if a string names a built-in variadic function
 
   Note that these function names cannot be overloaded, and usually require
   customized code-gen in the backend.
 *)
 
-val is_stan_math_variadic_function_name : string -> bool
-(** Equivalent to [Hashtbl.mem stan_math_variadic_signatures s]*)
+val lookup_stan_math_variadic_function : string -> variadic_signature option
+(** Look up the signature of a built-in variadic function *)
 
 (** Pretty printers *)
 

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -52,7 +52,7 @@ type variadic = FixedArgs | ReduceSum | VariadicHOF of int
 [@@deriving compare, hash]
 
 let functor_type hof =
-  match Hashtbl.find Stan_math_signatures.stan_math_variadic_signatures hof with
+  match Stan_math_signatures.lookup_stan_math_variadic_function hof with
   | Some {required_fn_args; _} -> VariadicHOF (List.length required_fn_args)
   | None when Stan_math_signatures.is_reduce_sum_fn hof -> ReduceSum
   | None -> FixedArgs
@@ -376,8 +376,8 @@ and lower_functionals fname suffix es mem_pattern =
         | _, _
           when Stan_math_signatures.is_stan_math_variadic_function_name fname ->
             let Stan_math_signatures.{control_args; _} =
-              Hashtbl.find_exn
-                Stan_math_signatures.stan_math_variadic_signatures fname in
+              Stan_math_signatures.lookup_stan_math_variadic_function fname
+              |> Option.value_exn in
             let hd, tl =
               List.split_n converted_es (List.length control_args + 1) in
             (fname, hd @ (msgs :: tl))


### PR DESCRIPTION
This is a small change that tries to encapsulate more. In theory we could even use something other than a hash map now, including something that does computation (which could be one solution to #1373, though I'm not necessarily advocating for it)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
