### PR TITLE
Move theta0 to tolerance arguments

### DIFF
--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -14,7 +14,6 @@ val invalid_matrix_types : Location_span.t -> UnsizedType.t -> t
 val int_expected : Location_span.t -> string -> UnsizedType.t -> t
 val int_or_real_expected : Location_span.t -> string -> UnsizedType.t -> t
 val tuple_expected : Location_span.t -> string -> UnsizedType.t -> t
-val vector_expected : Location_span.t -> string -> UnsizedType.t -> t
 val int_intarray_or_range_expected : Location_span.t -> UnsizedType.t -> t
 val int_or_real_container_expected : Location_span.t -> UnsizedType.t -> t
 

--- a/src/stan_math_signatures/Stan_math_signatures.ml
+++ b/src/stan_math_signatures/Stan_math_signatures.ml
@@ -201,7 +201,8 @@ let laplace_helper_param_types name =
 
 let laplace_tolerance_argument_types =
   UnsizedType.
-    [ (DataOnly, UReal) (* tolerance *); (DataOnly, UInt) (* max_num_steps *)
+    [ (AutoDiffable, UVector) (* theta_0 *); (DataOnly, UReal) (* tolerance *)
+    ; (DataOnly, UInt) (* max_num_steps *)
     ; (DataOnly, UInt) (* hessian_block_size *); (DataOnly, UInt) (* solver *)
     ; (DataOnly, UInt) (* max_steps_line_search *) ]
 

--- a/test/integration/bad/embedded_laplace/autodiff_incompatibility1.stan
+++ b/test/integration/bad/embedded_laplace/autodiff_incompatibility1.stan
@@ -45,7 +45,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -55,6 +54,5 @@ parameters {
 model {
 
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/autodiff_incompatibility2.stan
+++ b/test/integration/bad/embedded_laplace/autodiff_incompatibility2.stan
@@ -48,7 +48,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -58,6 +57,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                        theta_0,
                         K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/autodiff_incompatibility3.stan
+++ b/test/integration/bad/embedded_laplace/autodiff_incompatibility3.stan
@@ -40,7 +40,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -50,6 +49,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                        theta_0,
                         K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/autodiff_incompatibility4.stan
+++ b/test/integration/bad/embedded_laplace/autodiff_incompatibility4.stan
@@ -39,7 +39,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -49,6 +48,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                        theta_0,
                         K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/autodiff_incompatibility5.stan
+++ b/test/integration/bad/embedded_laplace/autodiff_incompatibility5.stan
@@ -43,7 +43,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -53,6 +52,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                        theta_0,
                         K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_callback1.stan
+++ b/test/integration/bad/embedded_laplace/bad_callback1.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -35,6 +34,5 @@ parameters {
 }
 model {
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_callback2.stan
+++ b/test/integration/bad/embedded_laplace/bad_callback2.stan
@@ -27,7 +27,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 
 }
 parameters {
@@ -37,6 +36,5 @@ parameters {
 }
 model {
   target += laplace_marginal(ll_function_jacobian, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_callback3.stan
+++ b/test/integration/bad/embedded_laplace/bad_callback3.stan
@@ -17,7 +17,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -27,6 +26,5 @@ parameters {
 model {
   real ll_function;
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_callback4.stan
+++ b/test/integration/bad/embedded_laplace/bad_callback4.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -36,6 +35,5 @@ parameters {
 model {
 
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_callback5.stan
+++ b/test/integration/bad/embedded_laplace/bad_callback5.stan
@@ -27,7 +27,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -36,6 +35,5 @@ parameters {
 }
 model {
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward1.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward1.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -36,6 +35,5 @@ parameters {
 model {
 
   target += laplace_marginal(ll_function, {2.0},
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward2.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward2.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -36,6 +35,5 @@ parameters {
 model {
 
   target += laplace_marginal(ll_function, (eta, y, log_ye),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward3.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward3.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -35,6 +34,5 @@ parameters {
 }
 model {
   target += laplace_marginal(ll_function, (eta, y),
-                                  theta_0,
                                   K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward4.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward4.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -35,6 +34,5 @@ parameters {
 }
 model {
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
                                   K_function, (x, alpha, rho, rho, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward5.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward5.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -36,6 +35,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
                     K_function, (x, n_obs, alpha, {rho}));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward6.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward6.stan
@@ -38,7 +38,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -48,6 +47,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (1,1, log_ye, y),
-                    theta_0,
                     K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_forward9.stan
+++ b/test/integration/bad/embedded_laplace/bad_forward9.stan
@@ -26,7 +26,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -35,6 +34,5 @@ parameters {
 }
 model {
   target += laplace_marginal(ll_function, (eta, log_ye, y),
-                    theta_0,
                     K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/bad/embedded_laplace/bad_theta0.stan
+++ b/test/integration/bad/embedded_laplace/bad_theta0.stan
@@ -27,6 +27,10 @@ data {
 transformed data {
   vector[n_obs] log_ye = log(ye);
   array[n_obs] real theta_0 = rep_array(0.0, n_obs); // initial guess
+
+  // control parameters for Laplace approximation
+  real tolerance = 1e-6;
+  int max_num_steps = 100, hessian_block_size = 1, solver = 1, max_steps_line_search = 0;
 }
 parameters {
   real<lower=0> alpha;
@@ -34,7 +38,7 @@ parameters {
   real<lower=0> eta;
 }
 model {
-  target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0,
-                                  K_function, (x, n_obs, alpha, rho));
+  target += laplace_marginal_tol(ll_function, (eta, log_ye, y),
+                                  K_function, (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
+              hessian_block_size, solver, max_steps_line_search);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol1.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol1.stan
@@ -37,6 +37,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol2.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol2.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,2,3,4,5);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4,5);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol3.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol3.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,2,3,4);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol4.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol4.stan
@@ -42,8 +42,7 @@ parameters {
 }
 model {
   target += laplace_marginal_tol(ll_function, (eta, log_ye, y),
-                                theta_0,
-                                K_function, (x, n_obs, alpha, rho),
+                                K_function, (x, n_obs, alpha, rho), theta_0,
                                 eta, max_num_steps, hessian_block_size,
                                 solver, max_steps_line_search);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol5.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol5.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,2,3,4,5.5);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4,5.5);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol6.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol6.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,2,3,4,5,6);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4,5,6);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol7.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol7.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,2,3,4.0,5);
+                     K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4.0,5);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol8.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol8.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,2,3i,4,5);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3i,4,5);
 }

--- a/test/integration/bad/embedded_laplace/bad_tol9.stan
+++ b/test/integration/bad/embedded_laplace/bad_tol9.stan
@@ -36,6 +36,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-                    theta_0,
-                    K_function, (x, n_obs, alpha, rho), 1,{2},3,4,5);
+                    K_function, (x, n_obs, alpha, rho), theta_0, 1,{2},3,4,5);
 }

--- a/test/integration/bad/embedded_laplace/missing_args4.stan
+++ b/test/integration/bad/embedded_laplace/missing_args4.stan
@@ -19,7 +19,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -27,8 +26,7 @@ parameters {
   real<lower=0> eta;
 }
 model {
-  target += laplace_marginal(ll_function, (eta, log_ye, y),
-                                  theta_0);
+  target += laplace_marginal(ll_function, (eta, log_ye, y));
 
 }
 

--- a/test/integration/bad/embedded_laplace/missing_args6.stan
+++ b/test/integration/bad/embedded_laplace/missing_args6.stan
@@ -37,8 +37,7 @@ parameters {
 
 generated quantities {
 
-vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-      theta_0);
+vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y));
 
 
 

--- a/test/integration/bad/embedded_laplace/missing_args7.stan
+++ b/test/integration/bad/embedded_laplace/missing_args7.stan
@@ -15,7 +15,7 @@ parameters {
 
 generated quantities {
 
-  vector[n_obs] theta = laplace_latent_neg_binomial_2_log_rng(y, {1}, [1.0]',
-                      theta_0);
+  vector[n_obs] theta = laplace_latent_neg_binomial_2_log_rng(y, {1}, [1.0]'
+                      );
 
 }

--- a/test/integration/bad/embedded_laplace/missing_args9.stan
+++ b/test/integration/bad/embedded_laplace/missing_args9.stan
@@ -38,6 +38,6 @@ parameters {
 generated quantities {
 
   vector[n_obs] theta = laplace_latent_tol_neg_binomial_2_log_rng(y, {1}, [1.0]',
-                      theta_0,  K_function, (x, n_obs, alpha, rho));
+                        K_function, (x, n_obs, alpha, rho));
 
 }

--- a/test/integration/bad/embedded_laplace/stanc.expected
+++ b/test/integration/bad/embedded_laplace/stanc.expected
@@ -1,12 +1,12 @@
   $ ../../../../../install/default/bin/stanc autodiff_incompatibility1.stan
-Semantic error in 'autodiff_incompatibility1.stan', line 57, column 29 to column 40:
+Semantic error in 'autodiff_incompatibility1.stan', line 56, column 29 to column 40:
    -------------------------------------------------
-    55:  model {
-    56:  
-    57:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    54:  model {
+    55:  
+    56:    target += laplace_marginal(ll_function, (eta, log_ye, y),
                                       ^
-    58:                                    theta_0,
-    59:                                    K_function, (x, n_obs, alpha, rho));
+    57:                                    K_function, (x, n_obs, alpha, rho));
+    58:  }
    -------------------------------------------------
 
 The function 'algebra_solver', called by this likelihood function,
@@ -14,14 +14,14 @@ does not currently support higher-order derivatives, and
 cannot be used in an embedded Laplace approximation.
 [exit 1]
   $ ../../../../../install/default/bin/stanc autodiff_incompatibility2.stan
-Semantic error in 'autodiff_incompatibility2.stan', line 60, column 43 to column 54:
+Semantic error in 'autodiff_incompatibility2.stan', line 59, column 43 to column 54:
    -------------------------------------------------
-    58:  
-    59:  generated quantities {
-    60:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
+    57:  
+    58:  generated quantities {
+    59:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
                                                     ^
-    61:                          theta_0,
-    62:                          K_function, (x, n_obs, alpha, rho));
+    60:                          K_function, (x, n_obs, alpha, rho));
+    61:  }
    -------------------------------------------------
 
 The function 'ode_rk45', called by this likelihood function,
@@ -29,14 +29,14 @@ does not currently support higher-order derivatives, and
 cannot be used in an embedded Laplace approximation.
 [exit 1]
   $ ../../../../../install/default/bin/stanc autodiff_incompatibility3.stan
-Semantic error in 'autodiff_incompatibility3.stan', line 52, column 43 to column 54:
+Semantic error in 'autodiff_incompatibility3.stan', line 51, column 43 to column 54:
    -------------------------------------------------
-    50:  
-    51:  generated quantities {
-    52:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
+    49:  
+    50:  generated quantities {
+    51:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
                                                     ^
-    53:                          theta_0,
-    54:                          K_function, (x, n_obs, alpha, rho));
+    52:                          K_function, (x, n_obs, alpha, rho));
+    53:  }
    -------------------------------------------------
 
 The function 'reduce_sum', called by this likelihood function,
@@ -44,14 +44,14 @@ does not currently support higher-order derivatives, and
 cannot be used in an embedded Laplace approximation.
 [exit 1]
   $ ../../../../../install/default/bin/stanc autodiff_incompatibility4.stan
-Semantic error in 'autodiff_incompatibility4.stan', line 51, column 43 to column 54:
+Semantic error in 'autodiff_incompatibility4.stan', line 50, column 43 to column 54:
    -------------------------------------------------
-    49:  
-    50:  generated quantities {
-    51:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
+    48:  
+    49:  generated quantities {
+    50:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
                                                     ^
-    52:                          theta_0,
-    53:                          K_function, (x, n_obs, alpha, rho));
+    51:                          K_function, (x, n_obs, alpha, rho));
+    52:  }
    -------------------------------------------------
 
 The function 'reduce_sum', called by this likelihood function,
@@ -59,14 +59,14 @@ does not currently support higher-order derivatives, and
 cannot be used in an embedded Laplace approximation.
 [exit 1]
   $ ../../../../../install/default/bin/stanc autodiff_incompatibility5.stan
-Semantic error in 'autodiff_incompatibility5.stan', line 55, column 43 to column 54:
+Semantic error in 'autodiff_incompatibility5.stan', line 54, column 43 to column 54:
    -------------------------------------------------
-    53:  
-    54:  generated quantities {
-    55:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
+    52:  
+    53:  generated quantities {
+    54:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
                                                     ^
-    56:                          theta_0,
-    57:                          K_function, (x, n_obs, alpha, rho));
+    55:                          K_function, (x, n_obs, alpha, rho));
+    56:  }
    -------------------------------------------------
 
 The function 'algebra_solver', called by this likelihood function,
@@ -74,55 +74,55 @@ does not currently support higher-order derivatives, and
 cannot be used in an embedded Laplace approximation.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_callback1.stan
-Semantic error in 'bad_callback1.stan', line 37, column 29 to column 40:
+Semantic error in 'bad_callback1.stan', line 36, column 29 to column 40:
    -------------------------------------------------
-    35:  }
-    36:  model {
-    37:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    34:  }
+    35:  model {
+    36:    target += laplace_marginal(ll_function, (eta, log_ye, y),
                                       ^
-    38:                                    theta_0,
-    39:                                    K_function, (x, n_obs, alpha, rho));
+    37:                                    K_function, (x, n_obs, alpha, rho));
+    38:  }
    -------------------------------------------------
 
 Function 'll_function' does not have a valid signature for use in 'laplace_marginal':
 Expected function returning real but got function returning void.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_callback2.stan
-Semantic error in 'bad_callback2.stan', line 39, column 29 to column 49:
+Semantic error in 'bad_callback2.stan', line 38, column 29 to column 49:
    -------------------------------------------------
-    37:  }
-    38:  model {
-    39:    target += laplace_marginal(ll_function_jacobian, (eta, log_ye, y),
+    36:  }
+    37:  model {
+    38:    target += laplace_marginal(ll_function_jacobian, (eta, log_ye, y),
                                       ^
-    40:                                    theta_0,
-    41:                                    K_function, (x, n_obs, alpha, rho));
+    39:                                    K_function, (x, n_obs, alpha, rho));
+    40:  }
    -------------------------------------------------
 
 Function 'll_function_jacobian' does not have a valid signature for use in 'laplace_marginal':
 Expected a pure function but got a _jacobian function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_callback3.stan
-Semantic error in 'bad_callback3.stan', line 29, column 29 to column 40:
+Semantic error in 'bad_callback3.stan', line 28, column 29 to column 40:
    -------------------------------------------------
-    27:  model {
-    28:    real ll_function;
-    29:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    26:  model {
+    27:    real ll_function;
+    28:    target += laplace_marginal(ll_function, (eta, log_ye, y),
                                       ^
-    30:                                    theta_0,
-    31:                                    K_function, (x, n_obs, alpha, rho));
+    29:                                    K_function, (x, n_obs, alpha, rho));
+    30:  }
    -------------------------------------------------
 
 A returning function was expected but a non-function value 'll_function' was supplied.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_callback4.stan
-Semantic error in 'bad_callback4.stan', line 38, column 29 to column 40:
+Semantic error in 'bad_callback4.stan', line 37, column 29 to column 40:
    -------------------------------------------------
-    36:  model {
-    37:  
-    38:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    35:  model {
+    36:  
+    37:    target += laplace_marginal(ll_function, (eta, log_ye, y),
                                       ^
-    39:                                    theta_0,
-    40:                                    K_function, (x, n_obs, alpha, rho));
+    38:                                    K_function, (x, n_obs, alpha, rho));
+    39:  }
    -------------------------------------------------
 
 Function 'll_function' does not have a valid signature for use in 'laplace_marginal':
@@ -131,42 +131,42 @@ depend on parameters; same goes for function inputs unless they are marked
 with the keyword 'data'.)
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_callback5.stan
-Semantic error in 'bad_callback5.stan', line 38, column 29 to column 40:
+Semantic error in 'bad_callback5.stan', line 37, column 29 to column 40:
    -------------------------------------------------
-    36:  }
-    37:  model {
-    38:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    35:  }
+    36:  model {
+    37:    target += laplace_marginal(ll_function, (eta, log_ye, y),
                                       ^
-    39:                                    theta_0,
-    40:                                    K_function, (x, n_obs, alpha, rho));
+    38:                                    K_function, (x, n_obs, alpha, rho));
+    39:  }
    -------------------------------------------------
 
 Function 'll_function' does not have a valid signature for use in 'laplace_marginal':
 The first argument must be vector but got complex_vector.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward1.stan
-Semantic error in 'bad_forward1.stan', line 38, column 42 to column 47:
+Semantic error in 'bad_forward1.stan', line 37, column 42 to column 47:
    -------------------------------------------------
-    36:  model {
-    37:  
-    38:    target += laplace_marginal(ll_function, {2.0},
+    35:  model {
+    36:  
+    37:    target += laplace_marginal(ll_function, {2.0},
                                                    ^
-    39:                                    theta_0,
-    40:                                    K_function, (x, n_obs, alpha, rho));
+    38:                                    K_function, (x, n_obs, alpha, rho));
+    39:  }
    -------------------------------------------------
 
 Forwarded arguments to 'll_function' in call to 'laplace_marginal' must be a tuple.
 Instead found type array[] real.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward2.stan
-Semantic error in 'bad_forward2.stan', line 38, column 42 to column 58:
+Semantic error in 'bad_forward2.stan', line 37, column 42 to column 58:
    -------------------------------------------------
-    36:  model {
-    37:  
-    38:    target += laplace_marginal(ll_function, (eta, y, log_ye),
+    35:  model {
+    36:  
+    37:    target += laplace_marginal(ll_function, (eta, y, log_ye),
                                                    ^
-    39:                                    theta_0,
-    40:                                    K_function, (x, n_obs, alpha, rho));
+    38:                                    K_function, (x, n_obs, alpha, rho));
+    39:  }
    -------------------------------------------------
 
 Cannot call 'll_function' with arguments forwarded from call to
@@ -175,14 +175,14 @@ The second argument (excluding the latent gaussian vector argument) must be
 vector but got array[] int.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward3.stan
-Semantic error in 'bad_forward3.stan', line 37, column 42 to column 50:
+Semantic error in 'bad_forward3.stan', line 36, column 42 to column 50:
    -------------------------------------------------
-    35:  }
-    36:  model {
-    37:    target += laplace_marginal(ll_function, (eta, y),
+    34:  }
+    35:  model {
+    36:    target += laplace_marginal(ll_function, (eta, y),
                                                    ^
-    38:                                    theta_0,
-    39:                                    K_function, (x, n_obs, alpha, rho));
+    37:                                    K_function, (x, n_obs, alpha, rho));
+    38:  }
    -------------------------------------------------
 
 Cannot call 'll_function' with arguments forwarded from call to
@@ -191,13 +191,13 @@ Expected 3 arguments (excluding the latent gaussian vector argument)
 but got 2 arguments.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward4.stan
-Semantic error in 'bad_forward4.stan', line 39, column 46 to column 71:
+Semantic error in 'bad_forward4.stan', line 37, column 46 to column 71:
    -------------------------------------------------
-    37:    target += laplace_marginal(ll_function, (eta, log_ye, y),
-    38:                                    theta_0,
-    39:                                    K_function, (x, alpha, rho, rho, rho));
+    35:  model {
+    36:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    37:                                    K_function, (x, alpha, rho, rho, rho));
                                                        ^
-    40:  }
+    38:  }
    -------------------------------------------------
 
 Cannot call 'K_function' with arguments forwarded from call to
@@ -205,13 +205,13 @@ Cannot call 'K_function' with arguments forwarded from call to
 Expected 4 arguments but got 5 arguments.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward5.stan
-Semantic error in 'bad_forward5.stan', line 40, column 32 to column 56:
+Semantic error in 'bad_forward5.stan', line 38, column 32 to column 56:
    -------------------------------------------------
-    38:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, {rho}));
+    36:  generated quantities {
+    37:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
+    38:                      K_function, (x, n_obs, alpha, {rho}));
                                          ^
-    41:  }
+    39:  }
    -------------------------------------------------
 
 Cannot call 'K_function' with arguments forwarded from call to
@@ -219,14 +219,14 @@ Cannot call 'K_function' with arguments forwarded from call to
 The fourth argument must be real but got array[] real.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward6.stan
-Semantic error in 'bad_forward6.stan', line 50, column 43 to column 54:
+Semantic error in 'bad_forward6.stan', line 49, column 43 to column 54:
    -------------------------------------------------
-    48:  
-    49:  generated quantities {
-    50:    vector[n_obs] theta = laplace_latent_rng(ll_function, (1,1, log_ye, y),
+    47:  
+    48:  generated quantities {
+    49:    vector[n_obs] theta = laplace_latent_rng(ll_function, (1,1, log_ye, y),
                                                     ^
-    51:                      theta_0,
-    52:                      K_function, (x, n_obs, alpha, rho));
+    50:                      K_function, (x, n_obs, alpha, rho));
+    51:  }
    -------------------------------------------------
 
 No unique minimum promotion found for function 'll_function'.
@@ -268,13 +268,13 @@ Expected the arguments to start with:
 (array[] int, array[] int, vector)
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_forward9.stan
-Semantic error in 'bad_forward9.stan', line 39, column 32 to column 54:
+Semantic error in 'bad_forward9.stan', line 37, column 32 to column 54:
    -------------------------------------------------
-    37:    target += laplace_marginal(ll_function, (eta, log_ye, y),
-    38:                      theta_0,
-    39:                      K_function, (x, n_obs, alpha, rho));
+    35:  model {
+    36:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    37:                      K_function, (x, n_obs, alpha, rho));
                                          ^
-    40:  }
+    38:  }
    -------------------------------------------------
 
 Cannot call 'K_function' with arguments forwarded from call to
@@ -296,137 +296,138 @@ Semantic error in 'bad_overload.stan', line 2, column 7 to column 51:
 Identifier 'laplace_marginal_tol_neg_binomial_2_log_lpmf' clashes with a non-overloadable Stan Math library function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_theta0.stan
-Semantic error in 'bad_theta0.stan', line 38, column 34 to column 41:
+Semantic error in 'bad_theta0.stan', line 42, column 79 to column 88:
    -------------------------------------------------
-    36:  model {
-    37:    target += laplace_marginal(ll_function, (eta, log_ye, y),
-    38:                                    theta_0,
-                                           ^
-    39:                                    K_function, (x, n_obs, alpha, rho));
-    40:  }
+    40:  model {
+    41:    target += laplace_marginal_tol(ll_function, (eta, log_ye, y),
+    42:                                    K_function, (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
+                                                                                        ^
+    43:                hessian_block_size, solver, max_steps_line_search);
+    44:  }
    -------------------------------------------------
 
-Initial guess argument to 'laplace_marginal' must be a vector.
-Instead found type array[] real.
+The first control parameter (initial guess) to 'laplace_marginal_tol' must be
+vector but got array[] real.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol1.stan
-Semantic error in 'bad_tol1.stan', line 41, column 56 to column 57:
+Semantic error in 'bad_tol1.stan', line 40, column 56 to column 63:
    -------------------------------------------------
+    38:  generated quantities {
     39:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-    40:                      theta_0,
-    41:                      K_function, (x, n_obs, alpha, rho), 1);
+    40:                      K_function, (x, n_obs, alpha, rho), theta_0, 1);
                                                                  ^
-    42:  }
+    41:  }
    -------------------------------------------------
 
-Recieved 1 extra argument at the end of the call to 'laplace_latent_rng'.
+Recieved 2 extra arguments at the end of the call to 'laplace_latent_rng'.
 Did you mean to call the _tol version?
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol2.stan
-Semantic error in 'bad_tol2.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol2.stan', line 39, column 56 to column 63:
    -------------------------------------------------
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,2,3,4,5);
+    39:                      K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4,5);
                                                                  ^
-    41:  }
+    40:  }
    -------------------------------------------------
 
-Recieved 5 extra arguments at the end of the call to 'laplace_latent_rng'.
+Recieved 6 extra arguments at the end of the call to 'laplace_latent_rng'.
 Did you mean to call the _tol version?
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol3.stan
-Semantic error in 'bad_tol3.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol3.stan', line 39, column 56 to column 63:
    -------------------------------------------------
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,2,3,4);
+    39:                      K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4);
                                                                  ^
-    41:  }
+    40:  }
    -------------------------------------------------
 
-Recieved 4 control arguments at the end of the call to 'laplace_latent_tol_rng'.
-Expected 5 arguments for the control parameters instead.
+Recieved 5 control arguments at the end of the call to 'laplace_latent_tol_rng'.
+Expected 6 arguments for the control parameters instead.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol4.stan
-Semantic error in 'bad_tol4.stan', line 47, column 32 to column 35:
+Semantic error in 'bad_tol4.stan', line 46, column 37 to column 50:
    -------------------------------------------------
-    45:                                  theta_0,
-    46:                                  K_function, (x, n_obs, alpha, rho),
-    47:                                  eta, max_num_steps, hessian_block_size,
-                                         ^
-    48:                                  solver, max_steps_line_search);
-    49:  }
+    44:    target += laplace_marginal_tol(ll_function, (eta, log_ye, y),
+    45:                                  K_function, (x, n_obs, alpha, rho), theta_0,
+    46:                                  eta, max_num_steps, hessian_block_size,
+                                              ^
+    47:                                  solver, max_steps_line_search);
+    48:  }
    -------------------------------------------------
 
 The control parameters to 'laplace_marginal_tol' must all be data-only,
-but the first control parameter (tolerance) here is not. (Local variables are
-assumed to depend on parameters; same goes for function inputs unless they
-are marked with the keyword 'data'.)
+but the second control parameter (tolerance) here is not. (Local variables
+are assumed to depend on parameters; same goes for function inputs unless
+they are marked with the keyword 'data'.)
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol5.stan
-Semantic error in 'bad_tol5.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol5.stan', line 38, column 24 to line 39, column 77:
    -------------------------------------------------
+    36:  
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,2,3,4,5.5);
-                                                                 ^
-    41:  }
+                                 ^
+    39:                      K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4,5.5);
+    40:  }
    -------------------------------------------------
 
-The fifth control parameter (max_steps_line_search) to 'laplace_latent_tol_rng'
+The sixth control parameter (max_steps_line_search) to 'laplace_latent_tol_rng'
 must be int but got real.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol6.stan
-Semantic error in 'bad_tol6.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol6.stan', line 39, column 56 to column 63:
    -------------------------------------------------
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,2,3,4,5,6);
+    39:                      K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4,5,6);
                                                                  ^
-    41:  }
+    40:  }
    -------------------------------------------------
 
-Recieved 6 control arguments at the end of the call to 'laplace_latent_tol_rng'.
-Expected 5 arguments for the control parameters instead.
+Recieved 7 control arguments at the end of the call to 'laplace_latent_tol_rng'.
+Expected 6 arguments for the control parameters instead.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol7.stan
-Semantic error in 'bad_tol7.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol7.stan', line 39, column 76 to column 77:
    -------------------------------------------------
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,2,3,4.0,5);
-                                                                 ^
-    41:  }
+    39:                       K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3,4.0,5);
+                                                                                     ^
+    40:  }
    -------------------------------------------------
 
-The fourth control parameter (solver) to 'laplace_latent_tol_rng' must be
+The fifth control parameter (solver) to 'laplace_latent_tol_rng' must be
 int but got real.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol8.stan
-Semantic error in 'bad_tol8.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol8.stan', line 39, column 72 to column 73:
    -------------------------------------------------
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,2,3i,4,5);
-                                                                 ^
-    41:  }
+    39:                      K_function, (x, n_obs, alpha, rho), theta_0, 1,2,3i,4,5);
+                                                                                 ^
+    40:  }
    -------------------------------------------------
 
-The third control parameter (hessian_block_size) to 'laplace_latent_tol_rng'
+The fourth control parameter (hessian_block_size) to 'laplace_latent_tol_rng'
 must be int but got complex.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_tol9.stan
-Semantic error in 'bad_tol9.stan', line 40, column 56 to column 57:
+Semantic error in 'bad_tol9.stan', line 39, column 71 to column 72:
    -------------------------------------------------
+    37:  generated quantities {
     38:    vector[n_obs] theta = laplace_latent_tol_rng(ll_function, (eta, log_ye, y),
-    39:                      theta_0,
-    40:                      K_function, (x, n_obs, alpha, rho), 1,{2},3,4,5);
-                                                                 ^
-    41:  }
+    39:                      K_function, (x, n_obs, alpha, rho), theta_0, 1,{2},3,4,5);
+                                                                                ^
+    40:  }
    -------------------------------------------------
 
-The second control parameter (max_num_steps) to 'laplace_latent_tol_rng'
+The third control parameter (max_num_steps) to 'laplace_latent_tol_rng'
 must be int but got array[] int.
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args1.stan
@@ -459,8 +460,8 @@ Semantic error in 'missing_args2.stan', line 2, column 12 to column 34:
 Ill-typed arguments supplied to function 'laplace_marginal_tol'.
 The valid signature of this function is
 laplace_marginal_tol((vector, T_l...) => real, tuple(T_l...), vector,
-  (T_k...) => matrix, tuple(T_k...), data real, data int, data int, data int,
-  data int)
+  (T_k...) => matrix, tuple(T_k...), vector, data real, data int, data int,
+  data int, data int)
 However, we recieved the types:
 ()
 We were unable to start more in-depth checking. Please ensure you are passing
@@ -482,14 +483,14 @@ Expected the arguments to start with:
 (array[] int, array[] int, vector)
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args4.stan
-Semantic error in 'missing_args4.stan', line 30, column 12 to line 31, column 42:
+Semantic error in 'missing_args4.stan', line 29, column 12 to column 59:
    -------------------------------------------------
-    28:  }
-    29:  model {
-    30:    target += laplace_marginal(ll_function, (eta, log_ye, y),
+    27:  }
+    28:  model {
+    29:    target += laplace_marginal(ll_function, (eta, log_ye, y));
                      ^
-    31:                                    theta_0);
-    32:  
+    30:  
+    31:  }
    -------------------------------------------------
 
 Ill-typed arguments supplied to function 'laplace_marginal'.
@@ -498,9 +499,9 @@ laplace_marginal((vector, T_l...) => real, tuple(T_l...), vector,
   (T_k...) => matrix, tuple(T_k...))
 However, we recieved the types:
 ((vector, real, vector, array[] int) => real,
-  tuple(real, vector, array[] int), data vector)
+  tuple(real, vector, array[] int))
 Typechecking failed after checking the first 2 arguments. Please ensure you
-are passing enough arguments and that the 4th is a function.
+are passing enough arguments and that the 3rd is a function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args5.stan
 Semantic error in 'missing_args5.stan', line 3, column 20 to column 40:
@@ -522,13 +523,13 @@ We were unable to start more in-depth checking. Please ensure you are passing
 enough arguments and that the first argument is a function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args6.stan
-Semantic error in 'missing_args6.stan', line 40, column 22 to line 41, column 14:
+Semantic error in 'missing_args6.stan', line 40, column 22 to column 71:
    -------------------------------------------------
     38:  generated quantities {
     39:  
-    40:  vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
+    40:  vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y));
                                ^
-    41:        theta_0);
+    41:  
     42:  
    -------------------------------------------------
 
@@ -538,18 +539,18 @@ laplace_latent_rng((vector, T_l...) => real, tuple(T_l...), vector,
   (T_k...) => matrix, tuple(T_k...))
 However, we recieved the types:
 (data (vector, real, vector, array[] int) => real,
-  tuple(real, vector, array[] int), data vector)
+  tuple(real, vector, array[] int))
 Typechecking failed after checking the first 2 arguments. Please ensure you
-are passing enough arguments and that the 4th is a function.
+are passing enough arguments and that the 3rd is a function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args7.stan
-Semantic error in 'missing_args7.stan', line 18, column 24 to line 19, column 30:
+Semantic error in 'missing_args7.stan', line 18, column 24 to line 19, column 23:
    -------------------------------------------------
     16:  generated quantities {
     17:  
-    18:    vector[n_obs] theta = laplace_latent_neg_binomial_2_log_rng(y, {1}, [1.0]',
+    18:    vector[n_obs] theta = laplace_latent_neg_binomial_2_log_rng(y, {1}, [1.0]'
                                  ^
-    19:                        theta_0);
+    19:                        );
     20:  
    -------------------------------------------------
 
@@ -558,9 +559,9 @@ The valid signature of this function is
 laplace_latent_neg_binomial_2_log_rng(array[] int, array[] int, vector,
   vector, (T_k...) => matrix, tuple(T_k...))
 However, we recieved the types:
-(data array[] int, data array[] int, data vector, data vector)
+(data array[] int, data array[] int, data vector)
 Typechecking failed after checking the first 3 arguments. Please ensure you
-are passing enough arguments and that the 5th is a function.
+are passing enough arguments and that the 4th is a function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args8.stan
 Semantic error in 'missing_args8.stan', line 2, column 12 to column 59:
@@ -574,24 +575,24 @@ Semantic error in 'missing_args8.stan', line 2, column 12 to column 59:
 Ill-typed arguments supplied to function 'laplace_marginal_tol_poisson_log_lpmf'.
 The valid signature of this function is
 laplace_marginal_tol_poisson_log_lpmf(array[] int, array[] int, vector,
-  (T_k...) => matrix, tuple(T_k...), data real, data int, data int, data int,
-  data int)
+  (T_k...) => matrix, tuple(T_k...), vector, data real, data int, data int,
+  data int, data int)
 However, we recieved the types:
 (data array[] int, data array[] int)
 Typechecking failed after checking the first 2 arguments. Please ensure you
-are passing enough arguments and that the 4th is a function.
+are passing enough arguments and that the 3rd is a function.
 [exit 1]
   $ ../../../../../install/default/bin/stanc missing_args9.stan
-Semantic error in 'missing_args9.stan', line 40, column 24 to line 41, column 67:
+Semantic error in 'missing_args9.stan', line 40, column 24 to line 41, column 59:
    -------------------------------------------------
     38:  generated quantities {
     39:  
     40:    vector[n_obs] theta = laplace_latent_tol_neg_binomial_2_log_rng(y, {1}, [1.0]',
                                  ^
-    41:                        theta_0,  K_function, (x, n_obs, alpha, rho));
+    41:                          K_function, (x, n_obs, alpha, rho));
     42:  
    -------------------------------------------------
 
 Recieved 0 control arguments at the end of the call to 'laplace_latent_tol_neg_binomial_2_log_rng'.
-Expected 5 arguments for the control parameters instead.
+Expected 6 arguments for the control parameters instead.
 [exit 1]

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -6883,7 +6883,7 @@ static constexpr std::array<const char*, 44> locations_array__ =
   " (in 'laplace_bernoulli_logit.stan', line 31, column 2 to column 22)",
   " (in 'laplace_bernoulli_logit.stan', line 32, column 2 to column 20)",
   " (in 'laplace_bernoulli_logit.stan', line 33, column 2 to column 20)",
-  " (in 'laplace_bernoulli_logit.stan', line 62, column 2 to line 63, column 62)",
+  " (in 'laplace_bernoulli_logit.stan', line 62, column 2 to line 63, column 64)",
   " (in 'laplace_bernoulli_logit.stan', line 65, column 2 to line 68, column 50)",
   " (in 'laplace_bernoulli_logit.stan', line 36, column 2 to column 55)",
   " (in 'laplace_bernoulli_logit.stan', line 37, column 2 to column 61)",
@@ -7231,50 +7231,50 @@ class laplace_bernoulli_logit_model final : public model_base_crtp<laplace_berno
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
-                         false>(y, y, theta_0, K_function_functor__(),
+                         false>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_bernoulli_logit_lpmf<
-                         false>(y, y, theta_0, K_function_functor__(),
+                         false>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -7331,50 +7331,50 @@ class laplace_bernoulli_logit_model final : public model_base_crtp<laplace_berno
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
-                         false>(y, y, theta_0, K_function_functor__(),
+                         false>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_bernoulli_logit_lpmf<
-                         false>(y, y, theta_0, K_function_functor__(),
+                         false>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_bernoulli_logit_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -7447,7 +7447,7 @@ class laplace_bernoulli_logit_model final : public model_base_crtp<laplace_berno
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 4;
       stan::model::assign(theta,
-        stan::math::laplace_latent_bernoulli_logit_rng(y, y, theta_0,
+        stan::math::laplace_latent_bernoulli_logit_rng(y, y,
           K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
@@ -7457,12 +7457,12 @@ class laplace_bernoulli_logit_model final : public model_base_crtp<laplace_berno
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 5;
       stan::model::assign(theta2,
-        stan::math::laplace_latent_tol_bernoulli_logit_rng(y, y, theta_0,
+        stan::math::laplace_latent_tol_bernoulli_logit_rng(y, y,
           K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
-            double, double>(x, n_obs, alpha, rho), tolerance, max_num_steps,
-          hessian_block_size, solver, max_steps_line_search, base_rng__,
-          pstream__), "assigning variable theta2");
+            double, double>(x, n_obs, alpha, rho), theta_0, tolerance,
+          max_num_steps, hessian_block_size, solver, max_steps_line_search,
+          base_rng__, pstream__), "assigning variable theta2");
       out__.write(theta);
       out__.write(theta2);
     } catch (const std::exception& e) {
@@ -8150,7 +8150,7 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
         lp_accum__.add(stan::math::laplace_marginal(ll_function_functor__(),
                          std::tuple<local_scalar_t__,
                            Eigen::Matrix<double,-1,1>,
-                           const std::vector<int>&>(eta, log_ye, y), theta_0,
+                           const std::vector<int>&>(eta, log_ye, y),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -8161,12 +8161,12 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
                          ll_function_functor__(),
                          std::tuple<local_scalar_t__,
                            Eigen::Matrix<double,-1,1>,
-                           const std::vector<int>&>(eta, log_ye, y), theta_0,
+                           const std::vector<int>&>(eta, log_ye, y),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -8225,7 +8225,7 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
         lp_accum__.add(stan::math::laplace_marginal(ll_function_functor__(),
                          std::tuple<local_scalar_t__,
                            Eigen::Matrix<double,-1,1>,
-                           const std::vector<int>&>(eta, log_ye, y), theta_0,
+                           const std::vector<int>&>(eta, log_ye, y),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -8236,12 +8236,12 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
                          ll_function_functor__(),
                          std::tuple<local_scalar_t__,
                            Eigen::Matrix<double,-1,1>,
-                           const std::vector<int>&>(eta, log_ye, y), theta_0,
+                           const std::vector<int>&>(eta, log_ye, y),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -8316,8 +8316,7 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
       stan::model::assign(theta,
         stan::math::laplace_latent_rng(ll_function_functor__(),
           std::tuple<double, Eigen::Matrix<double,-1,1>,
-            const std::vector<int>&>(eta, log_ye, y), theta_0,
-          K_function_functor__(),
+            const std::vector<int>&>(eta, log_ye, y), K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
         "assigning variable theta");
@@ -8328,12 +8327,11 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
       stan::model::assign(theta2,
         stan::math::laplace_latent_tol_rng(ll_function_functor__(),
           std::tuple<double, Eigen::Matrix<double,-1,1>,
-            const std::vector<int>&>(eta, log_ye, y), theta_0,
-          K_function_functor__(),
+            const std::vector<int>&>(eta, log_ye, y), K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
-            double, double>(x, n_obs, alpha, rho), tolerance, max_num_steps,
-          hessian_block_size, solver, max_steps_line_search, base_rng__,
-          pstream__), "assigning variable theta2");
+            double, double>(x, n_obs, alpha, rho), theta_0, tolerance,
+          max_num_steps, hessian_block_size, solver, max_steps_line_search,
+          base_rng__, pstream__), "assigning variable theta2");
       out__.write(theta);
       out__.write(theta2);
     } catch (const std::exception& e) {
@@ -8594,7 +8592,7 @@ static constexpr std::array<const char*, 46> locations_array__ =
   " (in 'laplace_neg_binomial_2_log.stan', line 33, column 2 to column 22)",
   " (in 'laplace_neg_binomial_2_log.stan', line 34, column 2 to column 20)",
   " (in 'laplace_neg_binomial_2_log.stan', line 35, column 2 to column 20)",
-  " (in 'laplace_neg_binomial_2_log.stan', line 66, column 2 to line 67, column 71)",
+  " (in 'laplace_neg_binomial_2_log.stan', line 66, column 2 to line 67, column 62)",
   " (in 'laplace_neg_binomial_2_log.stan', line 69, column 2 to line 72, column 78)",
   " (in 'laplace_neg_binomial_2_log.stan', line 38, column 2 to column 55)",
   " (in 'laplace_neg_binomial_2_log.stan', line 39, column 2 to column 61)",
@@ -8957,56 +8955,50 @@ class laplace_neg_binomial_2_log_model final : public model_base_crtp<laplace_ne
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_neg_binomial_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -9063,56 +9055,50 @@ class laplace_neg_binomial_2_log_model final : public model_base_crtp<laplace_ne
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_neg_binomial_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -9186,7 +9172,7 @@ class laplace_neg_binomial_2_log_model final : public model_base_crtp<laplace_ne
       current_statement__ = 4;
       stan::model::assign(theta,
         stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, log_ye,
-          theta_0, K_function_functor__(),
+          K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
         "assigning variable theta");
@@ -9196,11 +9182,11 @@ class laplace_neg_binomial_2_log_model final : public model_base_crtp<laplace_ne
       current_statement__ = 5;
       stan::model::assign(theta2,
         stan::math::laplace_latent_tol_neg_binomial_2_log_rng(y, y, log_ye,
-          theta_0, K_function_functor__(),
+          K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
-            double, double>(x, n_obs, alpha, rho), tolerance, max_num_steps,
-          hessian_block_size, solver, max_steps_line_search, base_rng__,
-          pstream__), "assigning variable theta2");
+            double, double>(x, n_obs, alpha, rho), theta_0, tolerance,
+          max_num_steps, hessian_block_size, solver, max_steps_line_search,
+          base_rng__, pstream__), "assigning variable theta2");
       out__.write(theta);
       out__.write(theta2);
     } catch (const std::exception& e) {
@@ -9456,16 +9442,16 @@ namespace laplace_nested_tuple_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 44> locations_array__ =
+static constexpr std::array<const char*, 42> locations_array__ =
   {" (found before start of program)",
-  " (in 'laplace_nested_tuple.stan', line 36, column 2 to column 22)",
-  " (in 'laplace_nested_tuple.stan', line 37, column 2 to column 20)",
-  " (in 'laplace_nested_tuple.stan', line 50, column 2 to line 51, column 77)",
-  " (in 'laplace_nested_tuple.stan', line 53, column 2 to line 55, column 56)",
-  " (in 'laplace_nested_tuple.stan', line 57, column 2 to line 59, column 74)",
-  " (in 'laplace_nested_tuple.stan', line 40, column 2 to line 41, column 36)",
-  " (in 'laplace_nested_tuple.stan', line 43, column 2 to line 44, column 37)",
-  " (in 'laplace_nested_tuple.stan', line 46, column 2 to line 47, column 55)",
+  " (in 'laplace_nested_tuple.stan', line 35, column 2 to column 22)",
+  " (in 'laplace_nested_tuple.stan', line 36, column 2 to column 20)",
+  " (in 'laplace_nested_tuple.stan', line 49, column 2 to line 50, column 68)",
+  " (in 'laplace_nested_tuple.stan', line 52, column 2 to line 54, column 56)",
+  " (in 'laplace_nested_tuple.stan', line 56, column 2 to line 58, column 74)",
+  " (in 'laplace_nested_tuple.stan', line 39, column 2 to line 40, column 36)",
+  " (in 'laplace_nested_tuple.stan', line 42, column 2 to line 43, column 37)",
+  " (in 'laplace_nested_tuple.stan', line 45, column 2 to line 46, column 55)",
   " (in 'laplace_nested_tuple.stan', line 26, column 2 to column 12)",
   " (in 'laplace_nested_tuple.stan', line 27, column 2 to column 20)",
   " (in 'laplace_nested_tuple.stan', line 28, column 8 to column 13)",
@@ -9475,11 +9461,9 @@ static constexpr std::array<const char*, 44> locations_array__ =
   " (in 'laplace_nested_tuple.stan', line 30, column 8 to column 13)",
   " (in 'laplace_nested_tuple.stan', line 30, column 22 to column 35)",
   " (in 'laplace_nested_tuple.stan', line 30, column 2 to column 39)",
-  " (in 'laplace_nested_tuple.stan', line 33, column 9 to column 14)",
-  " (in 'laplace_nested_tuple.stan', line 33, column 2 to column 49)",
-  " (in 'laplace_nested_tuple.stan', line 50, column 9 to column 14)",
-  " (in 'laplace_nested_tuple.stan', line 53, column 9 to column 14)",
-  " (in 'laplace_nested_tuple.stan', line 57, column 9 to column 14)",
+  " (in 'laplace_nested_tuple.stan', line 49, column 9 to column 14)",
+  " (in 'laplace_nested_tuple.stan', line 52, column 9 to column 14)",
+  " (in 'laplace_nested_tuple.stan', line 56, column 9 to column 14)",
   " (in 'laplace_nested_tuple.stan', line 3, column 11 to column 14)",
   " (in 'laplace_nested_tuple.stan', line 3, column 16 to column 19)",
   " (in 'laplace_nested_tuple.stan', line 3, column 4 to column 58)",
@@ -9651,26 +9635,26 @@ scalar_tuple(const T0__& x,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 23;
+    current_statement__ = 21;
     stan::math::validate_non_negative_index("K", "p.1", std::get<0>(p));
-    current_statement__ = 24;
+    current_statement__ = 22;
     stan::math::validate_non_negative_index("K", "p.1", std::get<0>(p));
     Eigen::Matrix<local_scalar_t__,-1,-1> K =
       Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(std::get<0>(p),
         std::get<0>(p), DUMMY_VAR__);
-    current_statement__ = 25;
+    current_statement__ = 23;
     stan::model::assign(K,
       stan::math::gp_exp_quad_cov(x, std::get<0>(std::get<1>(p)),
         std::get<1>(std::get<1>(p))), "assigning variable K");
-    current_statement__ = 27;
+    current_statement__ = 25;
     for (int i = 1; i <= std::get<0>(p); ++i) {
-      current_statement__ = 26;
+      current_statement__ = 24;
       stan::model::assign(K,
         (stan::model::rvalue(K, "K", stan::model::index_uni(i),
            stan::model::index_uni(i)) + 1e-8), "assigning variable K",
         stan::model::index_uni(i), stan::model::index_uni(i));
     }
-    current_statement__ = 28;
+    current_statement__ = 26;
     return K;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9708,26 +9692,26 @@ arr_vec_tuple(const std::tuple<T0__0__, T0__1__>& x, const T1__& n_obs,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 30;
+    current_statement__ = 28;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
-    current_statement__ = 31;
+    current_statement__ = 29;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
     Eigen::Matrix<local_scalar_t__,-1,-1> K =
       Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_obs, n_obs,
         DUMMY_VAR__);
-    current_statement__ = 32;
+    current_statement__ = 30;
     stan::model::assign(K,
       stan::math::gp_exp_quad_cov(std::get<0>(x), alpha, rho),
       "assigning variable K");
-    current_statement__ = 34;
+    current_statement__ = 32;
     for (int i = 1; i <= n_obs; ++i) {
-      current_statement__ = 33;
+      current_statement__ = 31;
       stan::model::assign(K,
         (stan::model::rvalue(K, "K", stan::model::index_uni(i),
            stan::model::index_uni(i)) + 1e-8), "assigning variable K",
         stan::model::index_uni(i), stan::model::index_uni(i));
     }
-    current_statement__ = 35;
+    current_statement__ = 33;
     return K;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9764,26 +9748,26 @@ arr_and_vec_tuple(const std::tuple<T0__0__, T0__1__>& x, const T1__& n_obs,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 37;
+    current_statement__ = 35;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
-    current_statement__ = 38;
+    current_statement__ = 36;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
     Eigen::Matrix<local_scalar_t__,-1,-1> K =
       Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_obs, n_obs,
         DUMMY_VAR__);
-    current_statement__ = 39;
+    current_statement__ = 37;
     stan::model::assign(K,
       stan::math::gp_exp_quad_cov(std::get<0>(x), alpha, rho),
       "assigning variable K");
-    current_statement__ = 41;
+    current_statement__ = 39;
     for (int i = 1; i <= n_obs; ++i) {
-      current_statement__ = 40;
+      current_statement__ = 38;
       stan::model::assign(K,
         (stan::model::rvalue(K, "K", stan::model::index_uni(i),
            stan::model::index_uni(i)) + 1e-8), "assigning variable K",
         stan::model::index_uni(i), stan::model::index_uni(i));
     }
-    current_statement__ = 42;
+    current_statement__ = 40;
     return K;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9796,9 +9780,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
   std::vector<int> y;
   Eigen::Matrix<double,-1,1> ye_data__;
   std::vector<Eigen::Matrix<double,-1,1>> x;
-  Eigen::Matrix<double,-1,1> theta_0_data__;
   Eigen::Map<Eigen::Matrix<double,-1,1>> ye{nullptr, 0};
-  Eigen::Map<Eigen::Matrix<double,-1,1>> theta_0{nullptr, 0};
  public:
   ~laplace_nested_tuple_model() {}
   laplace_nested_tuple_model(stan::io::var_context& context__, unsigned int
@@ -9888,20 +9870,10 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
         }
       }
       current_statement__ = 18;
-      stan::math::validate_non_negative_index("theta_0", "n_obs", n_obs);
-      current_statement__ = 19;
-      theta_0_data__ = Eigen::Matrix<double,-1,1>::Constant(n_obs,
-                         std::numeric_limits<double>::quiet_NaN());
-      new (&theta_0)
-        Eigen::Map<Eigen::Matrix<double,-1,1>>(theta_0_data__.data(), n_obs);
-      current_statement__ = 19;
-      stan::model::assign(theta_0, stan::math::rep_vector(0.0, n_obs),
-        "assigning variable theta_0");
-      current_statement__ = 20;
       stan::math::validate_non_negative_index("theta", "n_obs", n_obs);
-      current_statement__ = 21;
+      current_statement__ = 19;
       stan::math::validate_non_negative_index("theta2", "n_obs", n_obs);
-      current_statement__ = 22;
+      current_statement__ = 20;
       stan::math::validate_non_negative_index("theta3", "n_obs", n_obs);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9950,8 +9922,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
       {
         current_statement__ = 6;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, ye, theta_0,
-                         scalar_tuple_functor__(),
+                         propto__>(y, y, ye, scalar_tuple_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            std::tuple<int,
@@ -9962,8 +9933,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
                                rho))), pstream__));
         current_statement__ = 7;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, ye, theta_0,
-                         arr_vec_tuple_functor__(),
+                         propto__>(y, y, ye, arr_vec_tuple_functor__(),
                          std::tuple<
                            std::tuple<
                              std::vector<Eigen::Matrix<double,-1,1>>,
@@ -9979,8 +9949,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
                            n_obs, alpha, rho), pstream__));
         current_statement__ = 8;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, ye, theta_0,
-                         arr_and_vec_tuple_functor__(),
+                         propto__>(y, y, ye, arr_and_vec_tuple_functor__(),
                          std::tuple<
                            std::tuple<
                              std::vector<Eigen::Matrix<double,-1,1>>,
@@ -10035,8 +10004,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
       {
         current_statement__ = 6;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, ye, theta_0,
-                         scalar_tuple_functor__(),
+                         propto__>(y, y, ye, scalar_tuple_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            std::tuple<int,
@@ -10047,8 +10015,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
                                rho))), pstream__));
         current_statement__ = 7;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, ye, theta_0,
-                         arr_vec_tuple_functor__(),
+                         propto__>(y, y, ye, arr_vec_tuple_functor__(),
                          std::tuple<
                            std::tuple<
                              std::vector<Eigen::Matrix<double,-1,1>>,
@@ -10064,8 +10031,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
                            n_obs, alpha, rho), pstream__));
         current_statement__ = 8;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
-                         propto__>(y, y, ye, theta_0,
-                         arr_and_vec_tuple_functor__(),
+                         propto__>(y, y, ye, arr_and_vec_tuple_functor__(),
                          std::tuple<
                            std::tuple<
                              std::vector<Eigen::Matrix<double,-1,1>>,
@@ -10143,7 +10109,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 3;
       stan::model::assign(theta,
-        stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, ye, theta_0,
+        stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, ye,
           scalar_tuple_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&,
             std::tuple<int, std::tuple<double, double>>>(x,
@@ -10155,7 +10121,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 4;
       stan::model::assign(theta2,
-        stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, ye, theta_0,
+        stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, ye,
           arr_vec_tuple_functor__(),
           std::tuple<
             std::tuple<std::vector<Eigen::Matrix<double,-1,1>>,
@@ -10172,7 +10138,7 @@ class laplace_nested_tuple_model final : public model_base_crtp<laplace_nested_t
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 5;
       stan::model::assign(theta3,
-        stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, ye, theta_0,
+        stan::math::laplace_latent_neg_binomial_2_log_rng(y, y, ye,
           arr_and_vec_tuple_functor__(),
           std::tuple<
             std::tuple<std::vector<Eigen::Matrix<double,-1,1>>,
@@ -10435,20 +10401,20 @@ namespace laplace_nested_tuple2_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 51> locations_array__ =
+static constexpr std::array<const char*, 49> locations_array__ =
   {" (found before start of program)",
-  " (in 'laplace_nested_tuple2.stan', line 47, column 2 to column 22)",
-  " (in 'laplace_nested_tuple2.stan', line 48, column 2 to column 20)",
-  " (in 'laplace_nested_tuple2.stan', line 49, column 2 to column 20)",
-  " (in 'laplace_nested_tuple2.stan', line 66, column 2 to line 68, column 50)",
-  " (in 'laplace_nested_tuple2.stan', line 70, column 2 to line 72, column 51)",
-  " (in 'laplace_nested_tuple2.stan', line 74, column 2 to line 76, column 51)",
-  " (in 'laplace_nested_tuple2.stan', line 52, column 2 to column 55)",
-  " (in 'laplace_nested_tuple2.stan', line 53, column 2 to column 61)",
-  " (in 'laplace_nested_tuple2.stan', line 54, column 2 to column 21)",
-  " (in 'laplace_nested_tuple2.stan', line 56, column 2 to line 57, column 65)",
-  " (in 'laplace_nested_tuple2.stan', line 59, column 2 to line 60, column 65)",
-  " (in 'laplace_nested_tuple2.stan', line 62, column 2 to line 63, column 65)",
+  " (in 'laplace_nested_tuple2.stan', line 45, column 2 to column 22)",
+  " (in 'laplace_nested_tuple2.stan', line 46, column 2 to column 20)",
+  " (in 'laplace_nested_tuple2.stan', line 47, column 2 to column 20)",
+  " (in 'laplace_nested_tuple2.stan', line 64, column 2 to line 66, column 50)",
+  " (in 'laplace_nested_tuple2.stan', line 68, column 2 to line 70, column 51)",
+  " (in 'laplace_nested_tuple2.stan', line 72, column 2 to line 74, column 51)",
+  " (in 'laplace_nested_tuple2.stan', line 50, column 2 to column 55)",
+  " (in 'laplace_nested_tuple2.stan', line 51, column 2 to column 61)",
+  " (in 'laplace_nested_tuple2.stan', line 52, column 2 to column 21)",
+  " (in 'laplace_nested_tuple2.stan', line 54, column 2 to line 55, column 65)",
+  " (in 'laplace_nested_tuple2.stan', line 57, column 2 to line 58, column 65)",
+  " (in 'laplace_nested_tuple2.stan', line 60, column 2 to line 61, column 65)",
   " (in 'laplace_nested_tuple2.stan', line 24, column 2 to column 12)",
   " (in 'laplace_nested_tuple2.stan', line 25, column 2 to column 20)",
   " (in 'laplace_nested_tuple2.stan', line 26, column 8 to column 13)",
@@ -10464,16 +10430,14 @@ static constexpr std::array<const char*, 51> locations_array__ =
   " (in 'laplace_nested_tuple2.stan', line 32, column 2 to column 25)",
   " (in 'laplace_nested_tuple2.stan', line 35, column 9 to column 14)",
   " (in 'laplace_nested_tuple2.stan', line 35, column 2 to column 33)",
-  " (in 'laplace_nested_tuple2.stan', line 37, column 9 to column 14)",
-  " (in 'laplace_nested_tuple2.stan', line 37, column 2 to column 49)",
-  " (in 'laplace_nested_tuple2.stan', line 40, column 2 to column 24)",
-  " (in 'laplace_nested_tuple2.stan', line 41, column 2 to column 26)",
-  " (in 'laplace_nested_tuple2.stan', line 42, column 2 to column 29)",
-  " (in 'laplace_nested_tuple2.stan', line 43, column 2 to column 17)",
-  " (in 'laplace_nested_tuple2.stan', line 44, column 2 to column 32)",
-  " (in 'laplace_nested_tuple2.stan', line 66, column 9 to column 14)",
-  " (in 'laplace_nested_tuple2.stan', line 70, column 9 to column 14)",
-  " (in 'laplace_nested_tuple2.stan', line 74, column 9 to column 14)",
+  " (in 'laplace_nested_tuple2.stan', line 38, column 2 to column 24)",
+  " (in 'laplace_nested_tuple2.stan', line 39, column 2 to column 26)",
+  " (in 'laplace_nested_tuple2.stan', line 40, column 2 to column 29)",
+  " (in 'laplace_nested_tuple2.stan', line 41, column 2 to column 17)",
+  " (in 'laplace_nested_tuple2.stan', line 42, column 2 to column 32)",
+  " (in 'laplace_nested_tuple2.stan', line 64, column 9 to column 14)",
+  " (in 'laplace_nested_tuple2.stan', line 68, column 9 to column 14)",
+  " (in 'laplace_nested_tuple2.stan', line 72, column 9 to column 14)",
   " (in 'laplace_nested_tuple2.stan', line 4, column 4 to column 63)",
   " (in 'laplace_nested_tuple2.stan', line 3, column 35 to line 5, column 3)",
   " (in 'laplace_nested_tuple2.stan', line 8, column 4 to column 60)",
@@ -10668,7 +10632,7 @@ scalar_tuple(const T0__& theta_arg__, const std::tuple<T1__0__, T1__1__>&
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 38;
+    current_statement__ = 36;
     return stan::math::neg_binomial_2_lpmf<false>(y,
              stan::math::exp(stan::math::add(log_ye, theta)),
              std::get<0>(eta));
@@ -10704,7 +10668,7 @@ arr_vec_tuple(const T0__& theta_arg__, const T1__& eta,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 40;
+    current_statement__ = 38;
     return stan::math::neg_binomial_2_lpmf<false>(std::get<1>(p),
              stan::math::exp(stan::math::add(std::get<0>(p), theta)), eta);
   } catch (const std::exception& e) {
@@ -10744,7 +10708,7 @@ nested(const T0__& theta_arg__,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 42;
+    current_statement__ = 40;
     return stan::math::neg_binomial_2_lpmf<false>(std::get<1>(p),
              stan::math::exp(
                stan::math::add(std::get<1>(std::get<0>(p)), theta)),
@@ -10780,25 +10744,25 @@ K_function(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 44;
+    current_statement__ = 42;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
-    current_statement__ = 45;
+    current_statement__ = 43;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
     Eigen::Matrix<local_scalar_t__,-1,-1> K =
       Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_obs, n_obs,
         DUMMY_VAR__);
-    current_statement__ = 46;
+    current_statement__ = 44;
     stan::model::assign(K, stan::math::gp_exp_quad_cov(x, alpha, rho),
       "assigning variable K");
-    current_statement__ = 48;
+    current_statement__ = 46;
     for (int i = 1; i <= n_obs; ++i) {
-      current_statement__ = 47;
+      current_statement__ = 45;
       stan::model::assign(K,
         (stan::model::rvalue(K, "K", stan::model::index_uni(i),
            stan::model::index_uni(i)) + 1e-8), "assigning variable K",
         stan::model::index_uni(i), stan::model::index_uni(i));
     }
-    current_statement__ = 49;
+    current_statement__ = 47;
     return K;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10816,7 +10780,6 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
   double alpha_location_prior;
   double alpha_scale_prior;
   Eigen::Matrix<double,-1,1> log_ye_data__;
-  Eigen::Matrix<double,-1,1> theta_0_data__;
   double tolerance;
   int max_num_steps;
   int hessian_block_size;
@@ -10824,7 +10787,6 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
   int max_steps_line_search;
   Eigen::Map<Eigen::Matrix<double,-1,1>> ye{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> log_ye{nullptr, 0};
-  Eigen::Map<Eigen::Matrix<double,-1,1>> theta_0{nullptr, 0};
  public:
   ~laplace_nested_tuple2_model() {}
   laplace_nested_tuple2_model(stan::io::var_context& context__, unsigned int
@@ -10949,40 +10911,30 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
       stan::model::assign(log_ye, stan::math::log(ye),
         "assigning variable log_ye");
       current_statement__ = 28;
-      stan::math::validate_non_negative_index("theta_0", "n_obs", n_obs);
-      current_statement__ = 29;
-      theta_0_data__ = Eigen::Matrix<double,-1,1>::Constant(n_obs,
-                         std::numeric_limits<double>::quiet_NaN());
-      new (&theta_0)
-        Eigen::Map<Eigen::Matrix<double,-1,1>>(theta_0_data__.data(), n_obs);
-      current_statement__ = 29;
-      stan::model::assign(theta_0, stan::math::rep_vector(0.0, n_obs),
-        "assigning variable theta_0");
-      current_statement__ = 30;
       tolerance = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 30;
+      current_statement__ = 28;
       tolerance = 1e-6;
-      current_statement__ = 31;
+      current_statement__ = 29;
       max_num_steps = std::numeric_limits<int>::min();
-      current_statement__ = 31;
+      current_statement__ = 29;
       max_num_steps = 100;
-      current_statement__ = 32;
+      current_statement__ = 30;
       hessian_block_size = std::numeric_limits<int>::min();
-      current_statement__ = 32;
+      current_statement__ = 30;
       hessian_block_size = 1;
-      current_statement__ = 33;
+      current_statement__ = 31;
       solver = std::numeric_limits<int>::min();
-      current_statement__ = 33;
+      current_statement__ = 31;
       solver = 1;
-      current_statement__ = 34;
+      current_statement__ = 32;
       max_steps_line_search = std::numeric_limits<int>::min();
-      current_statement__ = 34;
+      current_statement__ = 32;
       max_steps_line_search = 0;
-      current_statement__ = 35;
+      current_statement__ = 33;
       stan::math::validate_non_negative_index("theta", "n_obs", n_obs);
-      current_statement__ = 36;
+      current_statement__ = 34;
       stan::math::validate_non_negative_index("theta2", "n_obs", n_obs);
-      current_statement__ = 37;
+      current_statement__ = 35;
       stan::math::validate_non_negative_index("theta3", "n_obs", n_obs);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11050,7 +11002,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                                                       local_scalar_t__,
                                                       local_scalar_t__>(eta,
                                                       eta), log_ye, y),
-                         theta_0, K_function_functor__(),
+                         K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
@@ -11062,7 +11014,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                            std::tuple<Eigen::Matrix<double,-1,1>,
                              std::vector<int>>>(eta,
                            std::tuple<Eigen::Matrix<double,-1,1>,
-                             const std::vector<int>&>(log_ye, y)), theta_0,
+                             const std::vector<int>&>(log_ye, y)),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -11081,7 +11033,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                                                const std::vector<int>&>(
                                                std::tuple<local_scalar_t__,
                                                  Eigen::Matrix<double,-1,1>>(eta,
-                                                 log_ye), y), eta), theta_0,
+                                                 log_ye), y), eta),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -11148,7 +11100,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                                                       local_scalar_t__,
                                                       local_scalar_t__>(eta,
                                                       eta), log_ye, y),
-                         theta_0, K_function_functor__(),
+                         K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
@@ -11160,7 +11112,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                            std::tuple<Eigen::Matrix<double,-1,1>,
                              std::vector<int>>>(eta,
                            std::tuple<Eigen::Matrix<double,-1,1>,
-                             const std::vector<int>&>(log_ye, y)), theta_0,
+                             const std::vector<int>&>(log_ye, y)),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -11179,7 +11131,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                                                const std::vector<int>&>(
                                                std::tuple<local_scalar_t__,
                                                  Eigen::Matrix<double,-1,1>>(eta,
-                                                 log_ye), y), eta), theta_0,
+                                                 log_ye), y), eta),
                          K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -11258,7 +11210,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
         stan::math::laplace_latent_rng(scalar_tuple_functor__(),
           std::tuple<std::tuple<double, double>, Eigen::Matrix<double,-1,1>,
             const std::vector<int>&>(std::tuple<double, double>(eta, eta),
-            log_ye, y), theta_0, K_function_functor__(),
+            log_ye, y), K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
         "assigning variable theta");
@@ -11271,7 +11223,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
           std::tuple<double,
             std::tuple<Eigen::Matrix<double,-1,1>, std::vector<int>>>(eta,
             std::tuple<Eigen::Matrix<double,-1,1>, const std::vector<int>&>(log_ye,
-              y)), theta_0, K_function_functor__(),
+              y)), K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
         "assigning variable theta2");
@@ -11288,7 +11240,7 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
                       std::tuple<double, Eigen::Matrix<double,-1,1>>,
                       const std::vector<int>&>(std::tuple<double,
                                                  Eigen::Matrix<double,-1,1>>(eta,
-                                                 log_ye), y), eta), theta_0,
+                                                 log_ye), y), eta),
           K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
@@ -11558,16 +11510,16 @@ namespace laplace_nested_tuple3_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 41> locations_array__ =
+static constexpr std::array<const char*, 39> locations_array__ =
   {" (found before start of program)",
-  " (in 'laplace_nested_tuple3.stan', line 42, column 2 to column 22)",
-  " (in 'laplace_nested_tuple3.stan', line 43, column 2 to column 20)",
-  " (in 'laplace_nested_tuple3.stan', line 44, column 2 to column 20)",
-  " (in 'laplace_nested_tuple3.stan', line 56, column 2 to line 58, column 71)",
-  " (in 'laplace_nested_tuple3.stan', line 47, column 2 to column 55)",
-  " (in 'laplace_nested_tuple3.stan', line 48, column 2 to column 61)",
-  " (in 'laplace_nested_tuple3.stan', line 49, column 2 to column 21)",
-  " (in 'laplace_nested_tuple3.stan', line 51, column 2 to line 53, column 61)",
+  " (in 'laplace_nested_tuple3.stan', line 40, column 2 to column 22)",
+  " (in 'laplace_nested_tuple3.stan', line 41, column 2 to column 20)",
+  " (in 'laplace_nested_tuple3.stan', line 42, column 2 to column 20)",
+  " (in 'laplace_nested_tuple3.stan', line 54, column 2 to line 56, column 71)",
+  " (in 'laplace_nested_tuple3.stan', line 45, column 2 to column 55)",
+  " (in 'laplace_nested_tuple3.stan', line 46, column 2 to column 61)",
+  " (in 'laplace_nested_tuple3.stan', line 47, column 2 to column 21)",
+  " (in 'laplace_nested_tuple3.stan', line 49, column 2 to line 51, column 61)",
   " (in 'laplace_nested_tuple3.stan', line 19, column 2 to column 12)",
   " (in 'laplace_nested_tuple3.stan', line 20, column 2 to column 20)",
   " (in 'laplace_nested_tuple3.stan', line 21, column 8 to column 13)",
@@ -11583,14 +11535,12 @@ static constexpr std::array<const char*, 41> locations_array__ =
   " (in 'laplace_nested_tuple3.stan', line 27, column 2 to column 25)",
   " (in 'laplace_nested_tuple3.stan', line 30, column 9 to column 14)",
   " (in 'laplace_nested_tuple3.stan', line 30, column 2 to column 33)",
-  " (in 'laplace_nested_tuple3.stan', line 32, column 9 to column 14)",
-  " (in 'laplace_nested_tuple3.stan', line 32, column 2 to column 49)",
-  " (in 'laplace_nested_tuple3.stan', line 35, column 2 to column 24)",
-  " (in 'laplace_nested_tuple3.stan', line 36, column 2 to column 26)",
-  " (in 'laplace_nested_tuple3.stan', line 37, column 2 to column 29)",
-  " (in 'laplace_nested_tuple3.stan', line 38, column 2 to column 17)",
-  " (in 'laplace_nested_tuple3.stan', line 39, column 2 to column 32)",
-  " (in 'laplace_nested_tuple3.stan', line 56, column 9 to column 14)",
+  " (in 'laplace_nested_tuple3.stan', line 33, column 2 to column 24)",
+  " (in 'laplace_nested_tuple3.stan', line 34, column 2 to column 26)",
+  " (in 'laplace_nested_tuple3.stan', line 35, column 2 to column 29)",
+  " (in 'laplace_nested_tuple3.stan', line 36, column 2 to column 17)",
+  " (in 'laplace_nested_tuple3.stan', line 37, column 2 to column 32)",
+  " (in 'laplace_nested_tuple3.stan', line 54, column 9 to column 14)",
   " (in 'laplace_nested_tuple3.stan', line 5, column 4 to line 6, column 26)",
   " (in 'laplace_nested_tuple3.stan', line 4, column 30 to line 7, column 3)",
   " (in 'laplace_nested_tuple3.stan', line 11, column 11 to column 22)",
@@ -11723,7 +11673,7 @@ ll_nested(const T0__& theta_arg__,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 32;
+    current_statement__ = 30;
     return stan::math::neg_binomial_2_lpmf<false>(
              std::get<1>(
                stan::model::rvalue(p, "p", stan::model::index_uni(1))),
@@ -11776,13 +11726,13 @@ K_function(const std::vector<
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 34;
+    current_statement__ = 32;
     stan::math::validate_non_negative_index("K", "p[1].2[1].1",
       std::get<0>(
         stan::model::rvalue(
           std::get<1>(stan::model::rvalue(p, "p", stan::model::index_uni(1))),
           "p[1].2", stan::model::index_uni(1))));
-    current_statement__ = 35;
+    current_statement__ = 33;
     stan::math::validate_non_negative_index("K", "p[1].2[1].1",
       std::get<0>(
         stan::model::rvalue(
@@ -11804,7 +11754,7 @@ K_function(const std::vector<
             std::get<1>(
               stan::model::rvalue(p, "p", stan::model::index_uni(1))),
             "p[1].2", stan::model::index_uni(1))), DUMMY_VAR__);
-    current_statement__ = 36;
+    current_statement__ = 34;
     stan::model::assign(K,
       stan::math::gp_exp_quad_cov(
         std::get<0>(stan::model::rvalue(p, "p", stan::model::index_uni(1))),
@@ -11814,20 +11764,20 @@ K_function(const std::vector<
               stan::model::rvalue(p, "p", stan::model::index_uni(1))),
             "p[1].2", stan::model::index_uni(1))), rho),
       "assigning variable K");
-    current_statement__ = 38;
+    current_statement__ = 36;
     for (int i = 1; i <=
          std::get<0>(
            stan::model::rvalue(
              std::get<1>(
                stan::model::rvalue(p, "p", stan::model::index_uni(1))),
              "p[1].2", stan::model::index_uni(1))); ++i) {
-      current_statement__ = 37;
+      current_statement__ = 35;
       stan::model::assign(K,
         (stan::model::rvalue(K, "K", stan::model::index_uni(i),
            stan::model::index_uni(i)) + 1e-8), "assigning variable K",
         stan::model::index_uni(i), stan::model::index_uni(i));
     }
-    current_statement__ = 39;
+    current_statement__ = 37;
     return K;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -11845,7 +11795,6 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
   double alpha_location_prior;
   double alpha_scale_prior;
   Eigen::Matrix<double,-1,1> log_ye_data__;
-  Eigen::Matrix<double,-1,1> theta_0_data__;
   double tolerance;
   int max_num_steps;
   int hessian_block_size;
@@ -11853,7 +11802,6 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
   int max_steps_line_search;
   Eigen::Map<Eigen::Matrix<double,-1,1>> ye{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> log_ye{nullptr, 0};
-  Eigen::Map<Eigen::Matrix<double,-1,1>> theta_0{nullptr, 0};
  public:
   ~laplace_nested_tuple3_model() {}
   laplace_nested_tuple3_model(stan::io::var_context& context__, unsigned int
@@ -11978,36 +11926,26 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
       stan::model::assign(log_ye, stan::math::log(ye),
         "assigning variable log_ye");
       current_statement__ = 24;
-      stan::math::validate_non_negative_index("theta_0", "n_obs", n_obs);
-      current_statement__ = 25;
-      theta_0_data__ = Eigen::Matrix<double,-1,1>::Constant(n_obs,
-                         std::numeric_limits<double>::quiet_NaN());
-      new (&theta_0)
-        Eigen::Map<Eigen::Matrix<double,-1,1>>(theta_0_data__.data(), n_obs);
-      current_statement__ = 25;
-      stan::model::assign(theta_0, stan::math::rep_vector(0.0, n_obs),
-        "assigning variable theta_0");
-      current_statement__ = 26;
       tolerance = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 26;
+      current_statement__ = 24;
       tolerance = 1e-6;
-      current_statement__ = 27;
+      current_statement__ = 25;
       max_num_steps = std::numeric_limits<int>::min();
-      current_statement__ = 27;
+      current_statement__ = 25;
       max_num_steps = 100;
-      current_statement__ = 28;
+      current_statement__ = 26;
       hessian_block_size = std::numeric_limits<int>::min();
-      current_statement__ = 28;
+      current_statement__ = 26;
       hessian_block_size = 1;
-      current_statement__ = 29;
+      current_statement__ = 27;
       solver = std::numeric_limits<int>::min();
-      current_statement__ = 29;
+      current_statement__ = 27;
       solver = 1;
-      current_statement__ = 30;
+      current_statement__ = 28;
       max_steps_line_search = std::numeric_limits<int>::min();
-      current_statement__ = 30;
+      current_statement__ = 28;
       max_steps_line_search = 0;
-      current_statement__ = 31;
+      current_statement__ = 29;
       stan::math::validate_non_negative_index("theta3", "n_obs", n_obs);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12098,7 +12036,7 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
                                                                     Eigen::Matrix<double,-1,1>>(eta,
                                                                     log_ye)},
                                                                     y)}, eta),
-                         theta_0, K_function_functor__(),
+                         K_function_functor__(),
                          std::tuple<
                            std::vector<
                              std::tuple<
@@ -12208,7 +12146,7 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
                                                                     Eigen::Matrix<double,-1,1>>(eta,
                                                                     log_ye)},
                                                                     y)}, eta),
-                         theta_0, K_function_functor__(),
+                         K_function_functor__(),
                          std::tuple<
                            std::vector<
                              std::tuple<
@@ -12325,7 +12263,7 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
                                                std::tuple<double,
                                                  Eigen::Matrix<double,-1,1>>(eta,
                                                  log_ye)}, y)}, eta),
-          theta_0, K_function_functor__(),
+          K_function_functor__(),
           std::tuple<
             std::vector<
               std::tuple<std::vector<Eigen::Matrix<double,-1,1>>,
@@ -12592,15 +12530,15 @@ namespace laplace_overload_weird_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 39> locations_array__ =
+static constexpr std::array<const char*, 37> locations_array__ =
   {" (found before start of program)",
-  " (in 'laplace_overload_weird.stan', line 42, column 2 to column 22)",
-  " (in 'laplace_overload_weird.stan', line 43, column 2 to column 20)",
-  " (in 'laplace_overload_weird.stan', line 44, column 2 to column 20)",
-  " (in 'laplace_overload_weird.stan', line 47, column 2 to column 55)",
-  " (in 'laplace_overload_weird.stan', line 48, column 2 to column 61)",
-  " (in 'laplace_overload_weird.stan', line 49, column 2 to column 21)",
-  " (in 'laplace_overload_weird.stan', line 51, column 2 to line 52, column 61)",
+  " (in 'laplace_overload_weird.stan', line 40, column 2 to column 22)",
+  " (in 'laplace_overload_weird.stan', line 41, column 2 to column 20)",
+  " (in 'laplace_overload_weird.stan', line 42, column 2 to column 20)",
+  " (in 'laplace_overload_weird.stan', line 45, column 2 to column 55)",
+  " (in 'laplace_overload_weird.stan', line 46, column 2 to column 61)",
+  " (in 'laplace_overload_weird.stan', line 47, column 2 to column 21)",
+  " (in 'laplace_overload_weird.stan', line 49, column 2 to line 50, column 61)",
   " (in 'laplace_overload_weird.stan', line 19, column 2 to column 12)",
   " (in 'laplace_overload_weird.stan', line 20, column 2 to column 20)",
   " (in 'laplace_overload_weird.stan', line 21, column 8 to column 13)",
@@ -12616,13 +12554,11 @@ static constexpr std::array<const char*, 39> locations_array__ =
   " (in 'laplace_overload_weird.stan', line 27, column 2 to column 25)",
   " (in 'laplace_overload_weird.stan', line 30, column 9 to column 14)",
   " (in 'laplace_overload_weird.stan', line 30, column 2 to column 33)",
-  " (in 'laplace_overload_weird.stan', line 32, column 9 to column 14)",
-  " (in 'laplace_overload_weird.stan', line 32, column 2 to column 49)",
-  " (in 'laplace_overload_weird.stan', line 35, column 2 to column 24)",
-  " (in 'laplace_overload_weird.stan', line 36, column 2 to column 26)",
-  " (in 'laplace_overload_weird.stan', line 37, column 2 to column 29)",
-  " (in 'laplace_overload_weird.stan', line 38, column 2 to column 17)",
-  " (in 'laplace_overload_weird.stan', line 39, column 2 to column 32)",
+  " (in 'laplace_overload_weird.stan', line 33, column 2 to column 24)",
+  " (in 'laplace_overload_weird.stan', line 34, column 2 to column 26)",
+  " (in 'laplace_overload_weird.stan', line 35, column 2 to column 29)",
+  " (in 'laplace_overload_weird.stan', line 36, column 2 to column 17)",
+  " (in 'laplace_overload_weird.stan', line 37, column 2 to column 32)",
   " (in 'laplace_overload_weird.stan', line 7, column 4 to column 61)",
   " (in 'laplace_overload_weird.stan', line 5, column 34 to line 8, column 3)",
   " (in 'laplace_overload_weird.stan', line 12, column 11 to column 16)",
@@ -12720,7 +12656,7 @@ my_fun(const T0__& theta_arg__, const T1__& eta, const T2__& log_ye_arg__,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 30;
+    current_statement__ = 28;
     return stan::math::neg_binomial_2_lpmf<false>(y,
              stan::math::exp(stan::math::add(log_ye, theta)), eta);
   } catch (const std::exception& e) {
@@ -12754,25 +12690,25 @@ my_fun(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__& rho,
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 32;
+    current_statement__ = 30;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
-    current_statement__ = 33;
+    current_statement__ = 31;
     stan::math::validate_non_negative_index("K", "n_obs", n_obs);
     Eigen::Matrix<local_scalar_t__,-1,-1> K =
       Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(n_obs, n_obs,
         DUMMY_VAR__);
-    current_statement__ = 34;
+    current_statement__ = 32;
     stan::model::assign(K, stan::math::gp_exp_quad_cov(x, alpha, rho),
       "assigning variable K");
-    current_statement__ = 36;
+    current_statement__ = 34;
     for (int i = 1; i <= n_obs; ++i) {
-      current_statement__ = 35;
+      current_statement__ = 33;
       stan::model::assign(K,
         (stan::model::rvalue(K, "K", stan::model::index_uni(i),
            stan::model::index_uni(i)) + 1e-8), "assigning variable K",
         stan::model::index_uni(i), stan::model::index_uni(i));
     }
-    current_statement__ = 37;
+    current_statement__ = 35;
     return K;
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12790,7 +12726,6 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
   double alpha_location_prior;
   double alpha_scale_prior;
   Eigen::Matrix<double,-1,1> log_ye_data__;
-  Eigen::Matrix<double,-1,1> theta_0_data__;
   double tolerance;
   int max_num_steps;
   int hessian_block_size;
@@ -12798,7 +12733,6 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
   int max_steps_line_search;
   Eigen::Map<Eigen::Matrix<double,-1,1>> ye{nullptr, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> log_ye{nullptr, 0};
-  Eigen::Map<Eigen::Matrix<double,-1,1>> theta_0{nullptr, 0};
  public:
   ~laplace_overload_weird_model() {}
   laplace_overload_weird_model(stan::io::var_context& context__, unsigned int
@@ -12923,34 +12857,24 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
       stan::model::assign(log_ye, stan::math::log(ye),
         "assigning variable log_ye");
       current_statement__ = 23;
-      stan::math::validate_non_negative_index("theta_0", "n_obs", n_obs);
-      current_statement__ = 24;
-      theta_0_data__ = Eigen::Matrix<double,-1,1>::Constant(n_obs,
-                         std::numeric_limits<double>::quiet_NaN());
-      new (&theta_0)
-        Eigen::Map<Eigen::Matrix<double,-1,1>>(theta_0_data__.data(), n_obs);
-      current_statement__ = 24;
-      stan::model::assign(theta_0, stan::math::rep_vector(0.0, n_obs),
-        "assigning variable theta_0");
-      current_statement__ = 25;
       tolerance = std::numeric_limits<double>::quiet_NaN();
-      current_statement__ = 25;
+      current_statement__ = 23;
       tolerance = 1e-6;
-      current_statement__ = 26;
+      current_statement__ = 24;
       max_num_steps = std::numeric_limits<int>::min();
-      current_statement__ = 26;
+      current_statement__ = 24;
       max_num_steps = 100;
-      current_statement__ = 27;
+      current_statement__ = 25;
       hessian_block_size = std::numeric_limits<int>::min();
-      current_statement__ = 27;
+      current_statement__ = 25;
       hessian_block_size = 1;
-      current_statement__ = 28;
+      current_statement__ = 26;
       solver = std::numeric_limits<int>::min();
-      current_statement__ = 28;
+      current_statement__ = 26;
       solver = 1;
-      current_statement__ = 29;
+      current_statement__ = 27;
       max_steps_line_search = std::numeric_limits<int>::min();
-      current_statement__ = 29;
+      current_statement__ = 27;
       max_steps_line_search = 0;
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13013,7 +12937,7 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
         lp_accum__.add(stan::math::laplace_marginal(my_fun_functor__(),
                          std::tuple<local_scalar_t__,
                            Eigen::Matrix<double,-1,1>,
-                           const std::vector<int>&>(eta, log_ye, y), theta_0,
+                           const std::vector<int>&>(eta, log_ye, y),
                          my_fun_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -13075,7 +12999,7 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
         lp_accum__.add(stan::math::laplace_marginal(my_fun_functor__(),
                          std::tuple<local_scalar_t__,
                            Eigen::Matrix<double,-1,1>,
-                           const std::vector<int>&>(eta, log_ye, y), theta_0,
+                           const std::vector<int>&>(eta, log_ye, y),
                          my_fun_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
@@ -13374,7 +13298,7 @@ static constexpr std::array<const char*, 46> locations_array__ =
   " (in 'laplace_poission_2_log.stan', line 33, column 2 to column 22)",
   " (in 'laplace_poission_2_log.stan', line 34, column 2 to column 20)",
   " (in 'laplace_poission_2_log.stan', line 35, column 2 to column 20)",
-  " (in 'laplace_poission_2_log.stan', line 64, column 2 to line 65, column 71)",
+  " (in 'laplace_poission_2_log.stan', line 64, column 2 to line 65, column 62)",
   " (in 'laplace_poission_2_log.stan', line 67, column 2 to line 70, column 58)",
   " (in 'laplace_poission_2_log.stan', line 38, column 2 to column 55)",
   " (in 'laplace_poission_2_log.stan', line 39, column 2 to column 61)",
@@ -13736,56 +13660,50 @@ class laplace_poission_2_log_model final : public model_base_crtp<laplace_poissi
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_poisson_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -13842,56 +13760,50 @@ class laplace_poission_2_log_model final : public model_base_crtp<laplace_poissi
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_poisson_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_2_log_lpmf<
-                         false>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         false>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_2_log_lpmf<
-                         propto__>(y, y, log_ye, theta_0,
-                         K_function_functor__(),
+                         propto__>(y, y, log_ye, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -13964,7 +13876,7 @@ class laplace_poission_2_log_model final : public model_base_crtp<laplace_poissi
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 4;
       stan::model::assign(theta,
-        stan::math::laplace_latent_poisson_2_log_rng(y, y, log_ye, theta_0,
+        stan::math::laplace_latent_poisson_2_log_rng(y, y, log_ye,
           K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
@@ -13975,11 +13887,11 @@ class laplace_poission_2_log_model final : public model_base_crtp<laplace_poissi
       current_statement__ = 5;
       stan::model::assign(theta2,
         stan::math::laplace_latent_tol_poisson_2_log_rng(y, y, log_ye,
-          theta_0, K_function_functor__(),
+          K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
-            double, double>(x, n_obs, alpha, rho), tolerance, max_num_steps,
-          hessian_block_size, solver, max_steps_line_search, base_rng__,
-          pstream__), "assigning variable theta2");
+            double, double>(x, n_obs, alpha, rho), theta_0, tolerance,
+          max_num_steps, hessian_block_size, solver, max_steps_line_search,
+          base_rng__, pstream__), "assigning variable theta2");
       out__.write(theta);
       out__.write(theta2);
     } catch (const std::exception& e) {
@@ -14235,18 +14147,18 @@ namespace laplace_poisson_model_namespace {
 using stan::model::model_base_crtp;
 using namespace stan::math;
 stan::math::profile_map profiles__;
-static constexpr std::array<const char*, 27> locations_array__ =
+static constexpr std::array<const char*, 29> locations_array__ =
   {" (found before start of program)",
-  " (in 'laplace_poisson.stan', line 19, column 2 to column 13)",
-  " (in 'laplace_poisson.stan', line 20, column 2 to column 17)",
-  " (in 'laplace_poisson.stan', line 21, column 2 to column 14)",
-  " (in 'laplace_poisson.stan', line 22, column 2 to column 23)",
-  " (in 'laplace_poisson.stan', line 35, column 0 to column 129)",
-  " (in 'laplace_poisson.stan', line 26, column 2 to column 23)",
-  " (in 'laplace_poisson.stan', line 27, column 2 to column 22)",
-  " (in 'laplace_poisson.stan', line 28, column 2 to column 24)",
-  " (in 'laplace_poisson.stan', line 29, column 2 to column 24)",
-  " (in 'laplace_poisson.stan', line 31, column 2 to column 48)",
+  " (in 'laplace_poisson.stan', line 24, column 2 to column 13)",
+  " (in 'laplace_poisson.stan', line 25, column 2 to column 17)",
+  " (in 'laplace_poisson.stan', line 26, column 2 to column 14)",
+  " (in 'laplace_poisson.stan', line 27, column 2 to column 23)",
+  " (in 'laplace_poisson.stan', line 40, column 0 to line 41, column 65)",
+  " (in 'laplace_poisson.stan', line 31, column 2 to column 23)",
+  " (in 'laplace_poisson.stan', line 32, column 2 to column 22)",
+  " (in 'laplace_poisson.stan', line 33, column 2 to column 24)",
+  " (in 'laplace_poisson.stan', line 34, column 2 to column 24)",
+  " (in 'laplace_poisson.stan', line 36, column 2 to column 48)",
   " (in 'laplace_poisson.stan', line 11, column 2 to column 17)",
   " (in 'laplace_poisson.stan', line 12, column 2 to column 17)",
   " (in 'laplace_poisson.stan', line 13, column 9 to column 10)",
@@ -14257,8 +14169,10 @@ static constexpr std::array<const char*, 27> locations_array__ =
   " (in 'laplace_poisson.stan', line 15, column 9 to column 10)",
   " (in 'laplace_poisson.stan', line 15, column 2 to column 20)",
   " (in 'laplace_poisson.stan', line 16, column 2 to column 27)",
-  " (in 'laplace_poisson.stan', line 20, column 9 to column 10)",
-  " (in 'laplace_poisson.stan', line 21, column 9 to column 10)",
+  " (in 'laplace_poisson.stan', line 20, column 2 to column 24)",
+  " (in 'laplace_poisson.stan', line 21, column 2 to column 89)",
+  " (in 'laplace_poisson.stan', line 25, column 9 to column 10)",
+  " (in 'laplace_poisson.stan', line 26, column 9 to column 10)",
   " (in 'laplace_poisson.stan', line 4, column 4 to column 45)",
   " (in 'laplace_poisson.stan', line 3, column 65 to line 5, column 3)",
   " (in 'laplace_poisson.stan', line 7, column 4 to column 47)",
@@ -14328,7 +14242,7 @@ poisson_re_log_ll(const T0__& theta_arg__, const T1__& y, const T2__&
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 23;
+    current_statement__ = 25;
     return stan::math::poisson_lpmf<false>(y,
              stan::math::exp(stan::math::add(mu, theta)));
   } catch (const std::exception& e) {
@@ -14353,7 +14267,7 @@ cov_fun(const T0__& sigma, const int& N, std::ostream* pstream__) {
   // suppress unused var warning
   (void) DUMMY_VAR__;
   try {
-    current_statement__ = 25;
+    current_statement__ = 27;
     return stan::math::diag_matrix(
              stan::math::rep_vector(stan::math::pow(sigma, 2), N));
   } catch (const std::exception& e) {
@@ -14368,6 +14282,11 @@ class laplace_poisson_model final : public model_base_crtp<laplace_poisson_model
   std::vector<int> y;
   Eigen::Matrix<double,-1,1> offsett_data__;
   double integrate_1d_reltol;
+  double tolerance;
+  int max_num_steps;
+  int hessian_block_size;
+  int solver;
+  int max_steps_line_search;
   Eigen::Map<Eigen::Matrix<double,-1,-1>> X{nullptr, 0, 0};
   Eigen::Map<Eigen::Matrix<double,-1,1>> offsett{nullptr, 0};
  public:
@@ -14469,8 +14388,28 @@ class laplace_poisson_model final : public model_base_crtp<laplace_poisson_model
       current_statement__ = 20;
       integrate_1d_reltol = context__.vals_r("integrate_1d_reltol")[(1 - 1)];
       current_statement__ = 21;
-      stan::math::validate_non_negative_index("beta", "P", P);
+      tolerance = std::numeric_limits<double>::quiet_NaN();
+      current_statement__ = 21;
+      tolerance = 1e-6;
       current_statement__ = 22;
+      max_num_steps = std::numeric_limits<int>::min();
+      current_statement__ = 22;
+      max_num_steps = 100;
+      current_statement__ = 22;
+      hessian_block_size = std::numeric_limits<int>::min();
+      current_statement__ = 22;
+      hessian_block_size = 1;
+      current_statement__ = 22;
+      solver = std::numeric_limits<int>::min();
+      current_statement__ = 22;
+      solver = 1;
+      current_statement__ = 22;
+      max_steps_line_search = std::numeric_limits<int>::min();
+      current_statement__ = 22;
+      max_steps_line_search = 0;
+      current_statement__ = 23;
+      stan::math::validate_non_negative_index("beta", "P", P);
+      current_statement__ = 24;
       stan::math::validate_non_negative_index("z", "N", N);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -14651,14 +14590,17 @@ class laplace_poisson_model final : public model_base_crtp<laplace_poisson_model
       }
       double log_lik_sum = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 5;
-      log_lik_sum = stan::math::laplace_marginal(
+      log_lik_sum = stan::math::laplace_marginal_tol(
                       poisson_re_log_ll_functor__(),
                       std::tuple<const std::vector<int>&,
                         Eigen::Matrix<double,-1,1>>(y,
                         stan::math::add(stan::math::add(offsett, alpha),
                           stan::math::multiply(X, beta))),
-                      stan::math::rep_vector(0.0, N), cov_fun_functor__(),
-                      std::tuple<double, int>(sigmaz, N), pstream__);
+                      cov_fun_functor__(),
+                      std::tuple<double, int>(sigmaz, N),
+                      stan::math::rep_vector(0.0, N), tolerance,
+                      max_num_steps, hessian_block_size, solver,
+                      max_steps_line_search, pstream__);
       out__.write(log_lik_sum);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15303,50 +15245,50 @@ class laplace_poisson_log_model final : public model_base_crtp<laplace_poisson_l
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<false>(
-                         y, y, theta_0, K_function_functor__(),
+                         y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_log_lpmf<
-                         false>(y, y, theta_0, K_function_functor__(),
+                         false>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -15403,50 +15345,50 @@ class laplace_poisson_log_model final : public model_base_crtp<laplace_poisson_l
         lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<false>(
-                         y, y, theta_0, K_function_functor__(),
+                         y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 11;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
                            alpha, rho), pstream__));
         current_statement__ = 12;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 13;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_log_lpmf<
-                         false>(y, y, theta_0, K_function_functor__(),
+                         false>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
         current_statement__ = 14;
         lp_accum__.add(stan::math::laplace_marginal_tol_poisson_log_lpmf<
-                         propto__>(y, y, theta_0, K_function_functor__(),
+                         propto__>(y, y, K_function_functor__(),
                          std::tuple<
                            const std::vector<Eigen::Matrix<double,-1,1>>&,
                            int, local_scalar_t__, local_scalar_t__>(x, n_obs,
-                           alpha, rho), tolerance, max_num_steps,
+                           alpha, rho), theta_0, tolerance, max_num_steps,
                          hessian_block_size, solver, max_steps_line_search,
                          pstream__));
       }
@@ -15519,7 +15461,7 @@ class laplace_poisson_log_model final : public model_base_crtp<laplace_poisson_l
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 4;
       stan::model::assign(theta,
-        stan::math::laplace_latent_poisson_log_rng(y, y, theta_0,
+        stan::math::laplace_latent_poisson_log_rng(y, y,
           K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
             double, double>(x, n_obs, alpha, rho), base_rng__, pstream__),
@@ -15529,12 +15471,12 @@ class laplace_poisson_log_model final : public model_base_crtp<laplace_poisson_l
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 5;
       stan::model::assign(theta2,
-        stan::math::laplace_latent_tol_poisson_log_rng(y, y, theta_0,
+        stan::math::laplace_latent_tol_poisson_log_rng(y, y,
           K_function_functor__(),
           std::tuple<const std::vector<Eigen::Matrix<double,-1,1>>&, int,
-            double, double>(x, n_obs, alpha, rho), tolerance, max_num_steps,
-          hessian_block_size, solver, max_steps_line_search, base_rng__,
-          pstream__), "assigning variable theta2");
+            double, double>(x, n_obs, alpha, rho), theta_0, tolerance,
+          max_num_steps, hessian_block_size, solver, max_steps_line_search,
+          base_rng__, pstream__), "assigning variable theta2");
       out__.write(theta);
       out__.write(theta2);
     } catch (const std::exception& e) {

--- a/test/integration/good/code-gen/laplace_bernoulli_logit.stan
+++ b/test/integration/good/code-gen/laplace_bernoulli_logit.stan
@@ -37,33 +37,33 @@ model {
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
 
-  y ~ laplace_marginal_bernoulli_logit(y, theta_0, K_function,
+  y ~ laplace_marginal_bernoulli_logit(y, K_function,
         (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_bernoulli_logit_lpmf(y | y, theta_0, K_function,
+  target += laplace_marginal_bernoulli_logit_lpmf(y | y, K_function,
               (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_bernoulli_logit_lupmf(y | y, theta_0, K_function,
+  target += laplace_marginal_bernoulli_logit_lupmf(y | y, K_function,
               (x, n_obs, alpha, rho));
 
-  y ~ laplace_marginal_tol_bernoulli_logit(y, theta_0, K_function,
-        (x, n_obs, alpha, rho), tolerance, max_num_steps, hessian_block_size,
+  y ~ laplace_marginal_tol_bernoulli_logit(y, K_function,
+        (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps, hessian_block_size,
         solver, max_steps_line_search);
 
-  target += laplace_marginal_tol_bernoulli_logit_lpmf(y | y, theta_0, K_function,
-              (x, n_obs, alpha, rho), tolerance, max_num_steps,
+  target += laplace_marginal_tol_bernoulli_logit_lpmf(y | y, K_function,
+              (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
               hessian_block_size, solver, max_steps_line_search);
 
-  target += laplace_marginal_tol_bernoulli_logit_lupmf(y | y, theta_0,
-              K_function, (x, n_obs, alpha, rho), tolerance, max_num_steps,
+  target += laplace_marginal_tol_bernoulli_logit_lupmf(y | y,
+              K_function, (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
               hessian_block_size, solver, max_steps_line_search);
 }
 generated quantities {
-  vector[n_obs] theta = laplace_latent_bernoulli_logit_rng(y, y, theta_0,
-                          K_function, (x, n_obs, alpha, rho));
+  vector[n_obs] theta = laplace_latent_bernoulli_logit_rng(y, y,
+                            K_function, (x, n_obs, alpha, rho));
 
-  vector[n_obs] theta2 = laplace_latent_tol_bernoulli_logit_rng(y, y, theta_0,
-                           K_function, (x, n_obs, alpha, rho), tolerance,
+  vector[n_obs] theta2 = laplace_latent_tol_bernoulli_logit_rng(y, y,
+                           K_function, (x, n_obs, alpha, rho), theta_0, tolerance,
                            max_num_steps, hessian_block_size, solver,
                            max_steps_line_search);
 }

--- a/test/integration/good/code-gen/laplace_functionals.stan
+++ b/test/integration/good/code-gen/laplace_functionals.stan
@@ -48,26 +48,26 @@ model {
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
 
-  target += laplace_marginal(ll_function, (eta, log_ye, y), theta_0,
+  target += laplace_marginal(ll_function, (eta, log_ye, y),
                              K_function, (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_tol(ll_function, (eta, log_ye, y), theta_0,
+  target += laplace_marginal_tol(ll_function, (eta, log_ye, y),
                                  K_function, (x, n_obs, alpha, rho),
-                                 tolerance, max_num_steps,
+                                 theta_0, tolerance, max_num_steps,
                                  hessian_block_size, solver,
                                  max_steps_line_search);
 
 }
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                                           theta_0, K_function,
+                                           K_function,
                                            (x, n_obs, alpha, rho));
 
   vector[n_obs] theta2 = laplace_latent_tol_rng(ll_function,
-                                                (eta, log_ye, y), theta_0,
+                                                (eta, log_ye, y),
                                                 K_function,
                                                 (x, n_obs, alpha, rho),
-                                                tolerance, max_num_steps,
+                                                theta_0, tolerance, max_num_steps,
                                                 hessian_block_size, solver,
                                                 max_steps_line_search);
 

--- a/test/integration/good/code-gen/laplace_neg_binomial_2_log.stan
+++ b/test/integration/good/code-gen/laplace_neg_binomial_2_log.stan
@@ -39,35 +39,35 @@ model {
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
 
-  y ~ laplace_marginal_neg_binomial_2_log(y, log_ye, theta_0, K_function,
+  y ~ laplace_marginal_neg_binomial_2_log(y, log_ye,  K_function,
         (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_neg_binomial_2_log_lpmf(y | y, log_ye, theta_0,
+  target += laplace_marginal_neg_binomial_2_log_lpmf(y | y, log_ye,
               K_function, (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_neg_binomial_2_log_lupmf(y | y, log_ye, theta_0,
+  target += laplace_marginal_neg_binomial_2_log_lupmf(y | y, log_ye,
               K_function, (x, n_obs, alpha, rho));
 
-  y ~ laplace_marginal_tol_neg_binomial_2_log(y, log_ye, theta_0, K_function,
-        (x, n_obs, alpha, rho), tolerance, max_num_steps, hessian_block_size,
+  y ~ laplace_marginal_tol_neg_binomial_2_log(y, log_ye, K_function,
+        (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps, hessian_block_size,
         solver, max_steps_line_search);
 
   target += laplace_marginal_tol_neg_binomial_2_log_lpmf(y | y, log_ye,
-              theta_0, K_function, (x, n_obs, alpha, rho), tolerance,
+              K_function, (x, n_obs, alpha, rho), theta_0, tolerance,
               max_num_steps, hessian_block_size, solver,
               max_steps_line_search);
 
   target += laplace_marginal_tol_neg_binomial_2_log_lupmf(y | y, log_ye,
-              theta_0, K_function, (x, n_obs, alpha, rho), tolerance,
+              K_function, (x, n_obs, alpha, rho), theta_0, tolerance,
               max_num_steps, hessian_block_size, solver,
               max_steps_line_search);
 }
 generated quantities {
   vector[n_obs] theta = laplace_latent_neg_binomial_2_log_rng(y, y, log_ye,
-                          theta_0, K_function, (x, n_obs, alpha, rho));
+                          K_function, (x, n_obs, alpha, rho));
 
   vector[n_obs] theta2 = laplace_latent_tol_neg_binomial_2_log_rng(y, y,
-                           log_ye, theta_0, K_function,
-                           (x, n_obs, alpha, rho), tolerance, max_num_steps,
+                           log_ye, K_function,
+                           (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
                            hessian_block_size, solver, max_steps_line_search);
 }

--- a/test/integration/good/code-gen/laplace_nested_tuple.stan
+++ b/test/integration/good/code-gen/laplace_nested_tuple.stan
@@ -30,31 +30,30 @@ data {
   array[n_obs] vector[n_coordinates] x;
 }
 transformed data {
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
   real<lower=0> rho;
 }
 model {
-  y ~ laplace_marginal_neg_binomial_2_log(y, ye, theta_0, scalar_tuple,
+  y ~ laplace_marginal_neg_binomial_2_log(y, ye, scalar_tuple,
         (x, (n_obs, (alpha, rho))));
 
-  y ~ laplace_marginal_neg_binomial_2_log(y, ye, theta_0, arr_vec_tuple,
+  y ~ laplace_marginal_neg_binomial_2_log(y, ye, arr_vec_tuple,
         ((x, x), n_obs, alpha, rho));
 
-  y ~ laplace_marginal_neg_binomial_2_log(y, ye, theta_0, arr_and_vec_tuple,
+  y ~ laplace_marginal_neg_binomial_2_log(y, ye, arr_and_vec_tuple,
         ((x, rep_vector(rho, 10)), n_obs, alpha, rho));
 }
 generated quantities {
   vector[n_obs] theta = laplace_latent_neg_binomial_2_log_rng(y, y, ye,
-                          theta_0, scalar_tuple, (x, (n_obs, (alpha, rho))));
+                          scalar_tuple, (x, (n_obs, (alpha, rho))));
 
   vector[n_obs] theta2 = laplace_latent_neg_binomial_2_log_rng(y, y, ye,
-                           theta_0, arr_vec_tuple,
+                           arr_vec_tuple,
                            ((x, x), n_obs, alpha, rho));
 
   vector[n_obs] theta3 = laplace_latent_neg_binomial_2_log_rng(y, y, ye,
-                           theta_0, arr_and_vec_tuple,
+                           arr_and_vec_tuple,
                            ((x, rep_vector(rho, 10)), n_obs, alpha, rho));
 }

--- a/test/integration/good/code-gen/laplace_nested_tuple2.stan
+++ b/test/integration/good/code-gen/laplace_nested_tuple2.stan
@@ -3,19 +3,19 @@ functions {
                     array[] int y) {
     return neg_binomial_2_lpmf(y | exp(log_ye + theta), eta.1);
   }
-  
+
   real arr_vec_tuple(vector theta, real eta, tuple(vector, array[] int) p) {
     return neg_binomial_2_lpmf(p.2 | exp(p.1 + theta), eta);
   }
-  
+
   real nested(vector theta, tuple(tuple(real, vector), array[] int) p,
               real unused) {
     return neg_binomial_2_lpmf(p.2 | exp(p.1.2 + theta), p.1.1);
   }
-  
+
   matrix K_function(array[] vector x, int n_obs, real alpha, real rho) {
     matrix[n_obs, n_obs] K = gp_exp_quad_cov(x, alpha, rho);
-    for (i in 1 : n_obs) 
+    for (i in 1 : n_obs)
       K[i, i] += 1e-8;
     return K;
   }
@@ -33,9 +33,7 @@ data {
 }
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
-  
+
   // control parameters for Laplace approximation
   real tolerance = 1e-6;
   int max_num_steps = 100;
@@ -52,26 +50,26 @@ model {
   rho ~ inv_gamma(rho_location_prior, rho_scale_prior);
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
-  
-  target += laplace_marginal(scalar_tuple, ((eta, eta), log_ye, y), theta_0,
+
+  target += laplace_marginal(scalar_tuple, ((eta, eta), log_ye, y),
                              K_function, (x, n_obs, alpha, rho));
-  
-  target += laplace_marginal(arr_vec_tuple, (eta, (log_ye, y)), theta_0,
+
+  target += laplace_marginal(arr_vec_tuple, (eta, (log_ye, y)),
                              K_function, (x, n_obs, alpha, rho));
-  
-  target += laplace_marginal(nested, (((eta, log_ye), y), eta), theta_0,
+
+  target += laplace_marginal(nested, (((eta, log_ye), y), eta),
                              K_function, (x, n_obs, alpha, rho));
 }
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(scalar_tuple,
-                          ((eta, eta), log_ye, y), theta_0, K_function,
+                          ((eta, eta), log_ye, y), K_function,
                           (x, n_obs, alpha, rho));
-  
+
   vector[n_obs] theta2 = laplace_latent_rng(arr_vec_tuple,
-                           (eta, (log_ye, y)), theta_0, K_function,
+                           (eta, (log_ye, y)), K_function,
                            (x, n_obs, alpha, rho));
-  
+
   vector[n_obs] theta3 = laplace_latent_rng(nested,
-                           (((eta, log_ye), y), eta), theta_0, K_function,
+                           (((eta, log_ye), y), eta), K_function,
                            (x, n_obs, alpha, rho));
 }

--- a/test/integration/good/code-gen/laplace_nested_tuple3.stan
+++ b/test/integration/good/code-gen/laplace_nested_tuple3.stan
@@ -29,8 +29,6 @@ data {
 transformed data {
   vector[n_obs] log_ye = log(ye);
 
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
-
   // control parameters for Laplace approximation
   real tolerance = 1e-6;
   int max_num_steps = 100;
@@ -49,12 +47,12 @@ model {
   eta ~ normal(0, 1);
 
   target += laplace_marginal(ll_nested, ({({(eta, log_ye)}, y)}, eta),
-                             theta_0, K_function,
+                             K_function,
                              ({(x, {(n_obs, alpha)})}, rho));
 }
 generated quantities {
   vector[n_obs] theta3 = laplace_latent_rng(ll_nested,
-                           ({({(eta, log_ye)}, y)}, eta), theta_0,
+                           ({({(eta, log_ye)}, y)}, eta),
                            K_function, ({(x, {(n_obs, alpha)})}, rho));
 }
 

--- a/test/integration/good/code-gen/laplace_overload_weird.stan
+++ b/test/integration/good/code-gen/laplace_overload_weird.stan
@@ -29,8 +29,6 @@ data {
 transformed data {
   vector[n_obs] log_ye = log(ye);
 
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
-
   // control parameters for Laplace approximation
   real tolerance = 1e-6;
   int max_num_steps = 100;
@@ -48,7 +46,7 @@ model {
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
 
-  target += laplace_marginal(my_fun, (eta, log_ye, y), theta_0,
+  target += laplace_marginal(my_fun, (eta, log_ye, y), 
                              my_fun, (x, n_obs, alpha, rho));
 
 }

--- a/test/integration/good/code-gen/laplace_poission_2_log.stan
+++ b/test/integration/good/code-gen/laplace_poission_2_log.stan
@@ -39,33 +39,33 @@ model {
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
 
-  y ~ laplace_marginal_poisson_2_log(y, log_ye, theta_0, K_function,
+  y ~ laplace_marginal_poisson_2_log(y, log_ye,  K_function,
         (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_poisson_2_log_lpmf(y | y, log_ye, theta_0,
+  target += laplace_marginal_poisson_2_log_lpmf(y | y, log_ye,
               K_function, (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_poisson_2_log_lupmf(y | y, log_ye, theta_0,
+  target += laplace_marginal_poisson_2_log_lupmf(y | y, log_ye,
               K_function, (x, n_obs, alpha, rho));
 
-  y ~ laplace_marginal_tol_poisson_2_log(y, log_ye, theta_0, K_function,
-        (x, n_obs, alpha, rho), tolerance, max_num_steps, hessian_block_size,
+  y ~ laplace_marginal_tol_poisson_2_log(y, log_ye, K_function,
+        (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps, hessian_block_size,
         solver, max_steps_line_search);
 
-  target += laplace_marginal_tol_poisson_2_log_lpmf(y | y, log_ye, theta_0,
-              K_function, (x, n_obs, alpha, rho), tolerance, max_num_steps,
+  target += laplace_marginal_tol_poisson_2_log_lpmf(y | y, log_ye,
+              K_function, (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
               hessian_block_size, solver, max_steps_line_search);
 
-  target += laplace_marginal_tol_poisson_2_log_lupmf(y | y, log_ye, theta_0,
-              K_function, (x, n_obs, alpha, rho), tolerance, max_num_steps,
+  target += laplace_marginal_tol_poisson_2_log_lupmf(y | y, log_ye,
+              K_function, (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
               hessian_block_size, solver, max_steps_line_search);
 }
 generated quantities {
   vector[n_obs] theta = laplace_latent_poisson_2_log_rng(y, y, log_ye,
-                          theta_0, K_function, (x, n_obs, alpha, rho));
+                          K_function, (x, n_obs, alpha, rho));
 
   vector[n_obs] theta2 = laplace_latent_tol_poisson_2_log_rng(y, y, log_ye,
-                           theta_0, K_function, (x, n_obs, alpha, rho),
+                           K_function, (x, n_obs, alpha, rho), theta_0,
                            tolerance, max_num_steps, hessian_block_size,
                            solver, max_steps_line_search);
 }

--- a/test/integration/good/code-gen/laplace_poisson.stan
+++ b/test/integration/good/code-gen/laplace_poisson.stan
@@ -15,6 +15,11 @@ data {
   vector[N] offsett;        // offset (offset variable name is reserved)
   real integrate_1d_reltol;
 }
+transformed data {
+    // control parameters for Laplace approximation
+  real tolerance = 1e-6;
+  int max_num_steps = 100, hessian_block_size = 1, solver = 1, max_steps_line_search = 0;
+}
 parameters {
   real alpha;               // intercept
   vector[P] beta;           // slope
@@ -32,5 +37,6 @@ model {
 }
 generated quantities {
 
-real log_lik_sum =  laplace_marginal(poisson_re_log_ll, (y, offsett + alpha + X*beta), rep_vector(0.0, N), cov_fun, (sigmaz, N));
+real log_lik_sum = laplace_marginal_tol(poisson_re_log_ll, (y, offsett + alpha + X*beta), cov_fun, (sigmaz, N), rep_vector(0.0, N), tolerance, max_num_steps,
+              hessian_block_size, solver, max_steps_line_search);
 }

--- a/test/integration/good/code-gen/laplace_poisson_log.stan
+++ b/test/integration/good/code-gen/laplace_poisson_log.stan
@@ -37,33 +37,33 @@ model {
   alpha ~ inv_gamma(alpha_location_prior, alpha_scale_prior);
   eta ~ normal(0, 1);
 
-  y ~ laplace_marginal_poisson_log(y, theta_0, K_function,
+  y ~ laplace_marginal_poisson_log(y, K_function,
         (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_poisson_log_lpmf(y | y, theta_0, K_function,
+  target += laplace_marginal_poisson_log_lpmf(y | y, K_function,
               (x, n_obs, alpha, rho));
 
-  target += laplace_marginal_poisson_log_lupmf(y | y, theta_0, K_function,
+  target += laplace_marginal_poisson_log_lupmf(y | y, K_function,
               (x, n_obs, alpha, rho));
 
-  y ~ laplace_marginal_tol_poisson_log(y, theta_0, K_function,
-        (x, n_obs, alpha, rho), tolerance, max_num_steps, hessian_block_size,
+  y ~ laplace_marginal_tol_poisson_log(y, K_function,
+        (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps, hessian_block_size,
         solver, max_steps_line_search);
 
-  target += laplace_marginal_tol_poisson_log_lpmf(y | y, theta_0, K_function,
-              (x, n_obs, alpha, rho), tolerance, max_num_steps,
+  target += laplace_marginal_tol_poisson_log_lpmf(y | y,  K_function,
+              (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
               hessian_block_size, solver, max_steps_line_search);
 
-  target += laplace_marginal_tol_poisson_log_lupmf(y | y, theta_0,
-              K_function, (x, n_obs, alpha, rho), tolerance, max_num_steps,
+  target += laplace_marginal_tol_poisson_log_lupmf(y | y,
+              K_function, (x, n_obs, alpha, rho), theta_0, tolerance, max_num_steps,
               hessian_block_size, solver, max_steps_line_search);
 }
 generated quantities {
-  vector[n_obs] theta = laplace_latent_poisson_log_rng(y, y, theta_0,
+  vector[n_obs] theta = laplace_latent_poisson_log_rng(y, y,
                           K_function, (x, n_obs, alpha, rho));
 
-  vector[n_obs] theta2 = laplace_latent_tol_poisson_log_rng(y, y, theta_0,
-                           K_function, (x, n_obs, alpha, rho), tolerance,
+  vector[n_obs] theta2 = laplace_latent_tol_poisson_log_rng(y, y,
+                           K_function, (x, n_obs, alpha, rho), theta_0, tolerance,
                            max_num_steps, hessian_block_size, solver,
                            max_steps_line_search);
 }

--- a/test/integration/good/laplace_deriv_check.stan
+++ b/test/integration/good/laplace_deriv_check.stan
@@ -34,7 +34,6 @@ data {
 
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -44,6 +43,5 @@ parameters {
 
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                        theta_0,
                         K_function, (x, n_obs, alpha, rho));
 }

--- a/test/integration/good/pretty.expected
+++ b/test/integration/good/pretty.expected
@@ -3891,7 +3891,6 @@ data {
 }
 transformed data {
   vector[n_obs] log_ye = log(ye);
-  vector[n_obs] theta_0 = rep_vector(0.0, n_obs); // initial guess
 }
 parameters {
   real<lower=0> alpha;
@@ -3900,7 +3899,7 @@ parameters {
 }
 generated quantities {
   vector[n_obs] theta = laplace_latent_rng(ll_function, (eta, log_ye, y),
-                          theta_0, K_function, (x, n_obs, alpha, rho));
+                          K_function, (x, n_obs, alpha, rho));
 }
 
 [exit 0]


### PR DESCRIPTION
This was discussed in today's language meeting, and again in the Stan the Gathering meeting. @avehtari suggested theta0 be moved to the end of the arguments, and @charlesm93 took it one step further and argued it should actually be treated like a tolerance argument and be removed from the non-`_tol` signatures entirely (assuming the C++ is amenable to this)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    
## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
