### PR TITLE
Add opam archive for older Dune version

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -49,7 +49,10 @@ jobs:
           dune-cache: ${{ matrix.name != 'macos-x86_64' }}
 
       - if: matrix.name == 'macos-x86_64'
-        run: opam pin -y dune 3.6.0 --no-action
+        run: |
+          opam repository add archive git+https://github.com/ocaml/opam-repository-archive
+          opam update
+          opam pin -y dune 3.6.0 --no-action
 
       - run: bash -x scripts/install_build_deps.sh
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -648,6 +648,7 @@ pipeline {
                                             export PATH=/Users/jenkins/brew/bin:$PATH
                                             bash -x scripts/install_ocaml.sh "$MACOS_SWITCH"
                                             eval $(opam env --switch="$MACOS_SWITCH" --set-switch)
+                                            opam repository add archive git+https://github.com/ocaml/opam-repository-archive
                                             opam switch list
                                             opam update -y || true
                                             opam pin -y dune 3.6.0 --no-action

--- a/Jenkinsfile-test-binaries
+++ b/Jenkinsfile-test-binaries
@@ -102,6 +102,7 @@ pipeline {
                                             export PATH=/Users/jenkins/brew/bin:$PATH
                                             bash -x scripts/install_ocaml.sh "$MACOS_SWITCH"
                                             eval $(opam env --switch="$MACOS_SWITCH" --set-switch)
+                                            opam repository add archive git+https://github.com/ocaml/opam-repository-archive
                                             opam switch list
                                             opam update -y || true
                                             opam pin -y dune 3.6.0 --no-action


### PR DESCRIPTION
Older dunes are no longer available on the normal opam repository, c.f. https://github.com/ocaml/opam-repository/issues/28065

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
