### PR TITLE
Clean up some pretty-printer usage

### DIFF
--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -22,58 +22,56 @@ type t =
   | Semantic_error of Semantic_error.t
   | DebugDataError of (Middle.Location_span.t * string)
 
-let get_context ?code Middle.Location.{filename; included_from; _} () =
-  (* If the location is not included from anywhere, and we
-     have code provided, use it *)
-  match (included_from, code) with
-  | None, Some code -> String.split_lines code
-  | _ -> (
-      (* Otherwise, by the time we are printing an error,
-         all these files are already resolved. *)
-      match !Include_files.include_provider with
-      | FileSystemPaths _ ->
-          (* So we can read directly from the filesystem *)
-          In_channel.read_lines filename
-      | InMemory m ->
-          (* Or, we know we can find it in the map *)
-          String.split_lines (Map.find_exn m filename))
+let get_context ?code Middle.Location.{filename; included_from; _} =
+  let lines () =
+    (* If the location is not included from anywhere, and we
+       have code provided, use it *)
+    match (included_from, code) with
+    | None, Some code -> String.split_lines code
+    | _ -> (
+        (* Otherwise, by the time we are printing an error,
+           all these files are already resolved. *)
+        match !Include_files.include_provider with
+        | FileSystemPaths _ ->
+            (* So we can read directly from the filesystem *)
+            In_channel.read_lines filename
+        | InMemory m ->
+            (* Or, we know we can find it in the map *)
+            String.split_lines (Map.find_exn m filename)) in
+  Option.try_with lines
 
-let pp_context_with_message ?code ppf (msg, loc) =
-  Fmt.pf ppf "%a@,%s" (Fmt.option Fmt.string)
-    (Middle.Location.context_to_string (get_context ?code loc) loc)
-    msg
+let pp_context ?code ppf loc =
+  let context =
+    get_context ?code loc
+    |> Option.map ~f:(fun lines -> (loc, Array.of_list lines)) in
+  (Fmt.option Middle.Location.pp_context_for) ppf context
 
 let pp_semantic_error ?printed_filename ?code ppf err =
   let loc_span = Semantic_error.location err in
-  Fmt.pf ppf "Semantic error in %s:@;%a"
-    (Middle.Location_span.to_string ?printed_filename loc_span)
-    (pp_context_with_message ?code)
-    (Fmt.str "%a@." Semantic_error.pp err, loc_span.begin_loc)
+  Fmt.pf ppf "Semantic error in %a:@;%a@,%a@."
+    (Middle.Location_span.pp ?printed_filename)
+    loc_span (pp_context ?code) loc_span.begin_loc Semantic_error.pp err
 
 (** A syntax error message used when handling a SyntaxError *)
 let pp_syntax_error ?printed_filename ?code ppf = function
   | Parsing (message, loc_span) ->
-      Fmt.pf ppf "Syntax error in %s, parsing error:@,%a"
-        (Middle.Location_span.to_string ?printed_filename loc_span)
-        (pp_context_with_message ?code)
-        (message, loc_span.begin_loc)
+      Fmt.pf ppf "Syntax error in %a, parsing error:@,%a@,%s"
+        (Middle.Location_span.pp ?printed_filename)
+        loc_span (pp_context ?code) loc_span.begin_loc message
   | Lexing loc ->
-      Fmt.pf ppf "Syntax error in %s, lexing error:@,%a@."
-        (Middle.Location.to_string ?printed_filename
-           {loc with col_num= loc.col_num - 1})
-        (pp_context_with_message ?code)
-        ("Invalid character found.", loc)
+      Fmt.pf ppf "Syntax error in %a, lexing error:@,%a@,%s@."
+        (Middle.Location.pp ?printed_filename ())
+        {loc with col_num= loc.col_num - 1}
+        (pp_context ?code) loc "Invalid character found."
   | UnexpectedEOF loc ->
-      Fmt.pf ppf "Syntax error in %s, lexing error:@,%a@."
-        (Middle.Location.to_string ?printed_filename
-           {loc with col_num= loc.col_num - 1})
-        (pp_context_with_message ?code)
-        ("Unexpected end of input", loc)
+      Fmt.pf ppf "Syntax error in %a, lexing error:@,%a@,%s@."
+        (Middle.Location.pp ?printed_filename ())
+        {loc with col_num= loc.col_num - 1}
+        (pp_context ?code) loc "Unexpected end of input"
   | Include (message, loc) ->
-      Fmt.pf ppf "Syntax error in %s, include error:@,%a@."
-        (Middle.Location.to_string loc ?printed_filename)
-        (pp_context_with_message ?code)
-        (message, loc)
+      Fmt.pf ppf "Syntax error in %a, include error:@,%a@,%s@."
+        (Middle.Location.pp ?printed_filename ())
+        loc (pp_context ?code) loc message
 
 let pp ?printed_filename ?code ppf = function
   | FileNotFound f ->
@@ -81,7 +79,9 @@ let pp ?printed_filename ?code ppf = function
   | Syntax_error e -> pp_syntax_error ?printed_filename ?code ppf e
   | Semantic_error e -> pp_semantic_error ?printed_filename ?code ppf e
   | DebugDataError (loc, msg) ->
-      if Middle.Location_span.(loc = empty) then Fmt.pf ppf "Error: %s" msg
+      if Middle.Location_span.(compare loc empty = 0) then
+        Fmt.pf ppf "Error: %s" msg
       else
-        let loc = Middle.Location_span.to_string ?printed_filename loc in
-        Fmt.pf ppf "@[<v>Error in %s:@ %s@;@]" loc msg
+        Fmt.pf ppf "@[<v>Error in %a:@ %s@;@]"
+          (Middle.Location_span.pp ?printed_filename)
+          loc msg

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -64,11 +64,6 @@ module TypeError = struct
     | TupleIndexNotTuple of UnsizedType.t
     | NotIndexable of UnsizedType.t * int
 
-  let pp_laplace_tols ppf () =
-    Fmt.pf ppf ", %a"
-      Fmt.(list ~sep:comma UnsizedType.pp_fun_arg)
-      Stan_math_signatures.laplace_tolerance_argument_types
-
   let laplace_tolerance_arg_name n =
     match n with
     | 1 -> "first control parameter (tolerance)"
@@ -215,17 +210,20 @@ module TypeError = struct
                Please ensure you are passing enough arguments and that the \
                %dth is a function."
               n (n + 2) in
-        let pp_lik_args ppf () =
+        let pp_lik_args ppf =
           if is_helper then Fmt.(list ~sep:comma UnsizedType.pp_fun_arg) ppf req
           else Fmt.pf ppf "(vector, T_l...) => real,@ tuple(T_l...)" in
+        let pp_laplace_tols ppf =
+          if String.is_substring ~substring:"_tol" name then
+            Fmt.pf ppf ", %a"
+              Fmt.(list ~sep:comma UnsizedType.pp_fun_arg)
+              Stan_math_signatures.laplace_tolerance_argument_types in
         Fmt.pf ppf
           "@[<v>Ill-typed arguments supplied to function '%s'.@ The valid \
-           signature of this function is@ @[<hov 2>%s(%a,@ vector,@ (T_k...) \
-           => matrix,@ tuple(T_k...)%a)@]@ However, we recieved the types:@ \
+           signature of this function is@ @[<hov 2>%s(%t,@ vector,@ (T_k...) \
+           => matrix,@ tuple(T_k...)%t)@]@ However, we recieved the types:@ \
            @[<hov 2>(%a)@]@ @[%a@]@]"
-          name name pp_lik_args ()
-          Fmt.(if' (String.is_substring ~substring:"_tol" name) pp_laplace_tols)
-          ()
+          name name pp_lik_args pp_laplace_tols
           Fmt.(list ~sep:comma UnsizedType.pp_fun_arg)
           supplied Fmt.text info
     | LaplaceCompatibilityIssue banned_function ->
@@ -275,9 +273,7 @@ module TypeError = struct
            function has several:@ @[<v>%a@]@ Consider defining a new signature \
            for the exact types needed or@ re-thinking existing definitions."
           name
-          (Fmt.option
-             ~none:(fun ppf () -> Fmt.pf ppf "This")
-             (fun ppf tys ->
+          (Fmt.option ~none:(Fmt.any "This") (fun ppf tys ->
                Fmt.pf ppf "For args @[(%a)@], this"
                  (Fmt.list ~sep:Fmt.comma UnsizedType.pp)
                  tys))

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -457,14 +457,14 @@ let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
     Fmt.pf ppf "%a@ @[<hov 2>  %a@]"
       (pp_with_where ctx (pp_fundef ctx))
       fun_ty pp_explain err in
-  let pp_omitted ppf () =
+  let pp_omitted ppf =
     if omitted then pf ppf "@,(Additional signatures omitted)" in
   pf ppf
     "@[<v>Ill-typed arguments supplied to function '%s':@ %a@ Available \
-     signatures:@ %a%a@]"
+     signatures:@ %a%t@]"
     name pp_args arg_tys
     (list ~sep:cut pp_signature)
-    sigs pp_omitted ()
+    sigs pp_omitted
 
 let pp_math_lib_assignmentoperator_sigs ppf (lt, op) =
   let signatures =

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -976,7 +976,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
       let binop_type_warnings x y =
         match (x.emeta.type_, y.emeta.type_, op) with
         | UInt, UInt, Divide ->
-            let hint ppf () =
+            let hint ppf =
               match (x.expr, y.expr) with
               | IntNumeral x, _ ->
                   Fmt.pf ppf "%s.0 / %a" x Pretty_printing.pp_typed_expression y
@@ -988,12 +988,12 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
             let s =
               Fmt.str
                 "@[<v>@[<hov 0>Found int division:@]@   @[<hov 2>%a@]@,\
-                 @[<hov>%a@]@   @[<hov 2>%a@]@,\
+                 @[<hov>%a@]@   @[<hov 2>%t@]@,\
                  @[<hov>%a@]@]"
                 Pretty_printing.pp_expression {expr; emeta} Fmt.text
                 "Values will be rounded towards zero. If rounding is not \
                  desired you can write the division as"
-                hint () Fmt.text
+                hint Fmt.text
                 "If rounding is intended please use the integer division \
                  operator %/%." in
             add_warning x.emeta.loc s
@@ -1017,21 +1017,18 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
                 let pp = Operator.pp in
                 add_warning loc
                   (Fmt.str
-                     "Found %a. This is interpreted as %a. Consider if the \
-                      intended meaning was %a instead.@ You can silence this \
+                     "Found %t. This is interpreted as %t. Consider if the \
+                      intended meaning was %t instead.@ You can silence this \
                       warning by adding explicit parenthesis. This can be \
                       automatically changed using the canonicalize flag for \
                       stanc"
-                     (fun ppf () ->
+                     (fun ppf ->
                        Fmt.pf ppf "@[<hov>%a %a %a@]" pp_e le pp op2 pp_e re)
-                     ()
-                     (fun ppf () ->
+                     (fun ppf ->
                        Fmt.pf ppf "@[<hov>(%a) %a %a@]" pp_e le pp op2 pp_e re)
-                     ()
-                     (fun ppf () ->
+                     (fun ppf ->
                        Fmt.pf ppf "@[<hov>%a %a %a && %a %a %a@]" pp_e e1 pp op
-                         pp_e e2 pp_e e2 pp op2 pp_e re)
-                     ())
+                         pp_e e2 pp_e e2 pp op2 pp_e re))
             | _ -> ())
         | _ -> () in
       binop_type_warnings le re;

--- a/src/frontend/Warnings.ml
+++ b/src/frontend/Warnings.ml
@@ -4,10 +4,11 @@ module Location = Middle.Location
 type t = Location_span.t * string
 
 let pp ?printed_filename ppf (span, message) =
-  let loc_str =
-    if span = Location_span.empty then ""
-    else " in " ^ Location.to_string ?printed_filename span.begin_loc in
-  Fmt.pf ppf "@[<hov 4>Warning%s: %a@]" loc_str Fmt.text message
+  let maybe_loc =
+    Fmt.if' (span <> Location_span.empty) (fun ppf loc ->
+        Fmt.pf ppf " in %a" (Location.pp ?printed_filename ()) loc) in
+  Fmt.pf ppf "@[<hov 4>Warning%a: %a@]" maybe_loc span.begin_loc Fmt.text
+    message
 
 let pp_warnings ?printed_filename ppf warnings =
   if List.length warnings > 0 then

--- a/src/middle/Location.ml
+++ b/src/middle/Location.ml
@@ -1,54 +1,33 @@
-(** Storing locations in the original source *)
-
 open Core
 
-(** Source code locations *)
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
 [@@deriving sexp, hash]
 
-let pp_context_list ppf (lines, {line_num; col_num; _}) =
-  let advance l =
-    let front = List.hd !l in
-    match front with
-    | Some _ ->
-        l := List.tl_exn !l;
-        front
-    | None -> None in
-  let input = ref lines in
-  for _ = 1 to line_num - 3 do
-    ignore (advance input : string option)
-  done;
-  let get_line num =
-    if num > 0 then
-      match advance input with
-      | Some input -> Printf.sprintf "%6d:  %s\n" num input
-      | _ -> ""
-    else "" in
-  let line_2_before = get_line (line_num - 2) in
-  let line_before = get_line (line_num - 1) in
-  let our_line = get_line line_num in
-  let offset = 9 + col_num in
-  let copied = Int.min offset (String.length our_line) in
-  let blank_line =
-    String.slice our_line 0 copied
-    |> String.map ~f:(function '\t' -> '\t' | _ -> ' ') in
-  let cursor_line = blank_line ^ String.make (offset - copied) ' ' ^ "^\n" in
-  let line_after = get_line (line_num + 1) in
-  let line_2_after = get_line (line_num + 2) in
-  Fmt.pf ppf
-    "   -------------------------------------------------\n\
-     %s%s%s%s%s%s   -------------------------------------------------\n"
-    line_2_before line_before our_line cursor_line line_after line_2_after
-
-(** Turn the given location into a string holding the code of that location.
-    Code is retrieved by calling context_cb, which may do IO.
-    Exceptions in the callback or in the creation of the string
-    (possible if the context is incorrectly too short for the given location)
-    return [None] *)
-let context_to_string (context_cb : unit -> string list) (loc : t) :
-    string option =
-  Option.try_with (fun () ->
-      Fmt.to_to_string pp_context_list (context_cb (), loc))
+let pp_context_for ppf (({line_num; _} as loc), lines) =
+  let bars = Fmt.fmt "   -------------------------------------------------\n" in
+  let pp_number ppf num = Fmt.pf ppf "%6d:" num in
+  let get_line i =
+    let line = i - 1 in
+    if line < 0 || line >= Array.length lines then None
+    else Some (Array.get lines line) in
+  let pp_line_and_number ppf n =
+    let pp ppf line = Fmt.pf ppf "%a  %s\n" pp_number n line in
+    Fmt.option pp ppf (get_line n) in
+  let cursor_line ppf {line_num; col_num; _} =
+    let blank_line =
+      (* to get visual alignment, we copy any tabs in the line we are pointing at *)
+      let highlighted_line = get_line line_num |> Option.value ~default:"" in
+      String.sub highlighted_line ~pos:0 ~len:col_num
+      |> String.map ~f:(function '\t' -> '\t' | _ -> ' ') in
+    Fmt.pf ppf "         %s^\n" blank_line in
+  bars ppf;
+  pp_line_and_number ppf (line_num - 2);
+  pp_line_and_number ppf (line_num - 1);
+  pp_line_and_number ppf line_num;
+  cursor_line ppf loc;
+  pp_line_and_number ppf (line_num + 1);
+  pp_line_and_number ppf (line_num + 2);
+  bars ppf
 
 let empty = {filename= ""; line_num= 0; col_num= 0; included_from= None}
 
@@ -58,18 +37,20 @@ Format the location for error messaging.
 If printed_filename is passed, it replaces the highest-level name and
 leaves the filenames of included files intact.
 *)
-let rec to_string ?printed_filename ?(print_file = true) ?(print_line = true)
+let rec pp ?printed_filename ?(print_file = true) ?(print_line = true) () ppf
     loc =
-  let open Format in
   let incl, filename =
     match loc.included_from with
     | Some loc2 ->
-        ( sprintf ", included from\n%s" (to_string ?printed_filename loc2)
+        ( (fun ppf ->
+            Fmt.pf ppf ", included from\n%a" (pp ?printed_filename ()) loc2)
         , loc.filename )
-    | None -> ("", Option.value ~default:loc.filename printed_filename) in
-  let file = if print_file then sprintf "'%s', " filename else "" in
-  let line = if print_line then sprintf "line %d, " loc.line_num else "" in
-  sprintf "%s%scolumn %d%s" file line loc.col_num incl
+    | None -> (ignore, Option.value ~default:loc.filename printed_filename)
+  in
+  let file =
+    Fmt.if' print_file (fun ppf s -> Fmt.pf ppf "%a, " (Fmt.fmt "'%s'") s) in
+  let line = Fmt.if' print_line (Fmt.fmt "line %d, ") in
+  Fmt.pf ppf "%a%acolumn %d%t" file filename line loc.line_num loc.col_num incl
 
 let compare loc1 loc2 =
   let rec unfold = function

--- a/src/middle/Location.mli
+++ b/src/middle/Location.mli
@@ -1,0 +1,19 @@
+(** Storing locations in the original source *)
+
+(** Source code locations *)
+type t = {filename: string; line_num: int; col_num: int; included_from: t option}
+[@@deriving sexp, hash]
+
+val compare : t -> t -> int
+val empty : t
+
+val pp :
+     ?printed_filename:string
+  -> ?print_file:bool
+  -> ?print_line:bool
+  -> unit
+  -> t Fmt.t
+
+val pp_context_for : (t * string Array.t) Fmt.t
+(* Prints the text surrounding the provided [t].
+   If the callback fails, this gracefully degrades to printing nothing. *)

--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -1,5 +1,3 @@
-(** Delimited locations in source code *)
-
 open Core
 
 type t = {begin_loc: Location.t; end_loc: Location.t}
@@ -8,33 +6,20 @@ type t = {begin_loc: Location.t; end_loc: Location.t}
 let empty = {begin_loc= Location.empty; end_loc= Location.empty}
 let merge left right = {begin_loc= left.begin_loc; end_loc= right.end_loc}
 
-(** Render a location_span as a string *)
-let to_string ?printed_filename {begin_loc; end_loc} =
-  let end_loc_str =
-    match begin_loc.included_from with
-    | None ->
-        " to "
-        ^ Location.to_string ?printed_filename
-            ~print_file:(not @@ String.equal begin_loc.filename end_loc.filename)
-            ~print_line:(begin_loc.line_num <> end_loc.line_num)
-            end_loc
-    | _ -> "" in
-  Location.to_string ?printed_filename begin_loc ^ end_loc_str
+let pp ?printed_filename ppf {begin_loc; end_loc} =
+  let end_loc_pp =
+    Fmt.if' (Option.is_none begin_loc.included_from)
+      (fun ppf (end_loc : Location.t) ->
+        Fmt.pf ppf " to %a"
+          (Location.pp ?printed_filename
+             ~print_file:
+               (not @@ String.equal begin_loc.filename end_loc.filename)
+             ~print_line:(begin_loc.line_num <> end_loc.line_num)
+             ())
+          end_loc) in
+  Fmt.pf ppf "%a%a"
+    (Location.pp ?printed_filename ())
+    begin_loc end_loc_pp end_loc
 
-module Comparator = Comparator.Make (struct
-  type nonrec t = t
-
-  let compare = compare
-  let sexp_of_t = sexp_of_t
-end)
-
-include Comparator
-
-include Comparable.Make_using_comparator (struct
-  type nonrec t = t
-
-  let sexp_of_t = sexp_of_t
-  let t_of_sexp = t_of_sexp
-
-  include Comparator
-end)
+let to_string ?printed_filename loc_span =
+  Fmt.str "%a" (pp ?printed_filename) loc_span

--- a/src/middle/Location_span.mli
+++ b/src/middle/Location_span.mli
@@ -1,0 +1,11 @@
+(** Delimited locations in source code *)
+
+type t = {begin_loc: Location.t; end_loc: Location.t}
+[@@deriving sexp, hash, compare]
+
+val empty : t
+val merge : t -> t -> t
+val pp : ?printed_filename:string -> t Fmt.t
+
+val to_string : ?printed_filename:string -> t -> string
+(** Render a location_span as a string *)


### PR DESCRIPTION
Draft until after the freeze.

This is the first PR in a series that is the result of me reading more about the Format (and Fmt) module. The three contributions are:

1. Using `%t` to replace existing places where we were using `%a` with a `unit` formatter, which makes some of the code briefer.
2. Replacing the to_string methods in Location and Location_span with pretty-printers
3. Clean up some of the rather tortured logic involved in printing the "context" (code surrounding the location) for errors


None of the current outputs are changed as part of this refactor

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
