### PR TITLE
Fix cross-windows build in Github Actions

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install cross-compiler
-        run: sudo apt-get update; sudo apt-get install -y gcc-mingw-w64-x86-64
+        run: sudo apt-get update; sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-mingw-w64-i686
 
       - name: Use OCaml ${{ env.OCAML_VERSION }}
         uses: ocaml/setup-ocaml@v3


### PR DESCRIPTION
Required due to underlying changes to the runner-images. See https://github.com/stan-dev/stanc3/actions/runs/16502365070 for a passing example

## Release notes



## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
