### PR TITLE
Block uses of laplace functions in 2.37

### DIFF
--- a/src/stan_math_signatures/Stan_math_signatures.ml
+++ b/src/stan_math_signatures/Stan_math_signatures.ml
@@ -170,7 +170,13 @@ let embedded_laplace_functions =
   |> String.Set.of_list
 
 let is_embedded_laplace_fn name =
-  Set.mem embedded_laplace_functions (Utils.stdlib_distribution_name name)
+  (* TEMPORARY: remove after 2.37 release *)
+  (not
+     (let version = "%%VERSION%%" in
+      String.equal "v2.37.0" version
+      || String.equal "v2.37.0-rc"
+           (String.sub ~pos:0 ~len:(String.length version - 1) version)))
+  && Set.mem embedded_laplace_functions (Utils.stdlib_distribution_name name)
 
 let laplace_helper_lik_args =
   [ ( "bernoulli_logit"


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Block the usage of laplace functions for the 2.37 release versions. They are still available when using a development version. See [discussion](https://github.com/stan-dev/cmdstan/issues/1324#issuecomment-3179950922)

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
