### PR TITLE
Fix some scalar functions being mislabeled as SoA

### DIFF
--- a/src/stan_math_signatures/Generate.ml
+++ b/src/stan_math_signatures/Generate.ml
@@ -344,7 +344,7 @@ let math_sigs =
   ; ([UnaryVectorized SameAsArg], "minus", [DDeepComplexVectorized], SoA)
   ; ([basic_vectorized], "Phi", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "Phi_approx", [DDeepVectorized], SoA)
-  ; ([basic_vectorized], "round", [DDeepVectorized], SoA)
+  ; ([basic_vectorized], "round", [DDeepVectorized], AoS)
   ; ([basic_vectorized], "sin", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "sinh", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "sqrt", [DDeepVectorized], SoA)
@@ -353,12 +353,12 @@ let math_sigs =
   ; ([basic_vectorized], "std_normal_qf", [DDeepVectorized], SoA)
     (* std_normal_qf is an alias for inv_Phi *)
   ; ([basic_vectorized], "std_normal_log_qf", [DDeepVectorized], SoA)
-  ; ([basic_vectorized], "step", [DReal], SoA)
+  ; ([basic_vectorized], "step", [DReal], AoS)
   ; ([basic_vectorized], "tan", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "tanh", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "tgamma", [DDeepVectorized], SoA)
-  ; ([basic_vectorized], "trunc", [DDeepVectorized], SoA)
-  ; ([basic_vectorized], "trigamma", [DDeepVectorized], SoA) ]
+  ; ([basic_vectorized], "trunc", [DDeepVectorized], AoS)
+  ; ([basic_vectorized], "trigamma", [DDeepVectorized], AoS) ]
 
 let all_declarative_sigs = distributions @ math_sigs
 

--- a/src/stan_math_signatures/Generate.ml
+++ b/src/stan_math_signatures/Generate.ml
@@ -270,7 +270,7 @@ let distributions =
   ; (full_lpdf, "rayleigh", [DVReal; DVReal], SoA)
   ; (full_lpdf, "scaled_inv_chi_square", [DVReal; DVReal; DVReal], SoA)
   ; (full_lpdf, "skew_normal", [DVReal; DVReal; DVReal; DVReal], SoA)
-  ; (full_lpdf, "skew_double_exponential", [DVReal; DVReal; DVReal; DVReal], SoA)
+  ; (full_lpdf, "skew_double_exponential", [DVReal; DVReal; DVReal; DVReal], AoS)
   ; (full_lpdf, "student_t", [DVReal; DVReal; DVReal; DVReal], SoA)
   ; (full_lpdf, "std_normal", [DVReal], SoA)
   ; (full_lpdf, "uniform", [DVReal; DVReal; DVReal], SoA)

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -14908,7 +14908,7 @@ static constexpr std::array<const char*, 8> locations_array__ =
   " (in 'initialize-SoA.stan', line 6, column 2 to column 25)",
   " (in 'initialize-SoA.stan', line 9, column 2 to column 19)",
   " (in 'initialize-SoA.stan', line 11, column 4 to column 30)",
-  " (in 'initialize-SoA.stan', line 10, column 17 to line 12, column 3)",
+  " (in 'initialize-SoA.stan', line 10, column 19 to line 12, column 3)",
   " (in 'initialize-SoA.stan', line 10, column 2 to line 12, column 3)"};
 class initialize_SoA_model final : public model_base_crtp<initialize_SoA_model> {
  private:

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -16194,7 +16194,7 @@ static constexpr std::array<const char*, 8> locations_array__ =
   " (in 'initialize-SoA.stan', line 6, column 2 to column 25)",
   " (in 'initialize-SoA.stan', line 9, column 2 to column 19)",
   " (in 'initialize-SoA.stan', line 11, column 4 to column 30)",
-  " (in 'initialize-SoA.stan', line 10, column 17 to line 12, column 3)",
+  " (in 'initialize-SoA.stan', line 10, column 19 to line 12, column 3)",
   " (in 'initialize-SoA.stan', line 10, column 2 to line 12, column 3)"};
 class initialize_SoA_model final : public model_base_crtp<initialize_SoA_model> {
  private:

--- a/test/integration/good/compiler-optimizations/initialize-SoA.stan
+++ b/test/integration/good/compiler-optimizations/initialize-SoA.stan
@@ -7,7 +7,7 @@ transformed parameters {
 }
 model {
   x ~ std_normal();
-  for (i in 1:3) {
+  for (i in 1 : 3) {
     arr_vec[i] ~ std_normal();
   }
 }


### PR DESCRIPTION
See https://github.com/stan-dev/math/pull/3221#issuecomment-3191808781

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fixed a few functions being labeled as supporting the struct-of-arrays matrix type when they in fact did not. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
