### PR TITLE
Allow flags to be passed multiple times 

### DIFF
--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -284,3 +284,4 @@ Flags can be passed multiple times
     real y;
   }
   
+  Warning: Duplicated flag '--auto-format' ignored, consider updating your call to stanc!


### PR DESCRIPTION
This was supported by the old Stdlib.Arg.parse style of CLI, likely by accident. I'm not entirely sure we'd like to duplicate this old behavior, but not doing so could also lead to issues (cf stan-dev/cmdstanr#1111)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Release notes

Command line flags like `--use-opencl` can be passed multiple times once more. This is equivalent to passing them exactly once, and is only provided for backwards compatibility with existing code that may not properly prepare the arguments to the compiler.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
