### PR TITLE
Encapsulate local exception usage

### DIFF
--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -2,16 +2,9 @@
 
 open Core
 
-(** Our type of syntax error information *)
-type syntax_error =
-  | Lexing of Middle.Location.t
-  | UnexpectedEOF of Middle.Location.t
-  | Include of string * Middle.Location.t
-  | Parsing of string * Middle.Location_span.t
-
 type t =
   | FileNotFound of string
-  | Syntax_error of syntax_error
+  | Syntax_error of Syntax_error.t
   | Semantic_error of Semantic_error.t
   | DebugDataError of (Middle.Location_span.t * string)
 
@@ -46,25 +39,13 @@ let pp_semantic_error ?printed_filename ?code ppf err =
     loc_span (pp_context ?code) loc_span.begin_loc Semantic_error.pp err
 
 (** A syntax error message used when handling a SyntaxError *)
-let pp_syntax_error ?printed_filename ?code ppf = function
-  | Parsing (message, loc_span) ->
-      Fmt.pf ppf "Syntax error in %a, parsing error:@,%a@,%s"
-        (Middle.Location_span.pp ?printed_filename)
-        loc_span (pp_context ?code) loc_span.begin_loc message
-  | Lexing loc ->
-      Fmt.pf ppf "Syntax error in %a, lexing error:@,%a@,%s@."
-        (Middle.Location.pp printed_filename)
-        {loc with col_num= loc.col_num - 1}
-        (pp_context ?code) loc "Invalid character found."
-  | UnexpectedEOF loc ->
-      Fmt.pf ppf "Syntax error in %a, lexing error:@,%a@,%s@."
-        (Middle.Location.pp printed_filename)
-        {loc with col_num= loc.col_num - 1}
-        (pp_context ?code) loc "Unexpected end of input"
-  | Include (message, loc) ->
-      Fmt.pf ppf "Syntax error in %a, include error:@,%a@,%s@."
-        (Middle.Location.pp printed_filename)
-        loc (pp_context ?code) loc message
+let pp_syntax_error ?printed_filename ?code ppf err =
+  let loc_span = Syntax_error.location err in
+  let error_type = Syntax_error.kind err in
+  Fmt.pf ppf "Syntax error in %a, %s:@;%a@,%a"
+    (Middle.Location_span.pp ?printed_filename)
+    loc_span error_type (pp_context ?code) loc_span.begin_loc Syntax_error.pp
+    err
 
 let pp ?printed_filename ?code ppf = function
   | FileNotFound f ->
@@ -78,10 +59,3 @@ let pp ?printed_filename ?code ppf = function
         Fmt.pf ppf "@[<v>Error in %a:@ %s@;@]"
           (Middle.Location_span.pp ?printed_filename)
           loc msg
-
-module type ParserExn = sig
-  val include_error : string -> 'a
-  val parse_error : loc:Lexing.position * Lexing.position -> string -> 'a
-  val unexpected_eof : unit -> 'a
-  val unexpected_character : unit -> 'a
-end

--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -12,10 +12,6 @@ type syntax_error =
 (** Exception for Syntax Errors *)
 exception SyntaxError of syntax_error
 
-(** Exception [SemanticError (msg, loc)] indicates a semantic error with message
-    [msg], occurring in location [loc]. *)
-exception SemanticError of Semantic_error.t
-
 type t =
   | FileNotFound of string
   | Syntax_error of syntax_error

--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -9,9 +9,6 @@ type syntax_error =
   | Include of string * Middle.Location.t
   | Parsing of string * Middle.Location_span.t
 
-(** Exception for Syntax Errors *)
-exception SyntaxError of syntax_error
-
 type t =
   | FileNotFound of string
   | Syntax_error of syntax_error
@@ -81,3 +78,10 @@ let pp ?printed_filename ?code ppf = function
         Fmt.pf ppf "@[<v>Error in %a:@ %s@;@]"
           (Middle.Location_span.pp ?printed_filename)
           loc msg
+
+module type ParserExn = sig
+  val include_error : string -> 'a
+  val parse_error : loc:Lexing.position * Lexing.position -> string -> 'a
+  val unexpected_eof : unit -> 'a
+  val unexpected_character : unit -> 'a
+end

--- a/src/frontend/Errors.mli
+++ b/src/frontend/Errors.mli
@@ -1,31 +1,8 @@
 (** Some plumbing for our compiler errors *)
 
-(** Our type of syntax error information *)
-type syntax_error =
-  | Lexing of Middle.Location.t
-  | UnexpectedEOF of Middle.Location.t
-  | Include of string * Middle.Location.t
-  | Parsing of string * Middle.Location_span.t
-
-module type ParserExn = sig
-  (** Signal that a syntax_error has occured dynamically *)
-
-  val include_error : string -> 'a
-  (** Raise an include error with the given message *)
-
-  val parse_error : loc:Lexing.position * Lexing.position -> string -> 'a
-  (** Raise a parser error at the specified location *)
-
-  val unexpected_eof : unit -> 'a
-  (** Raise an unexpected end of file error at the current position *)
-
-  val unexpected_character : unit -> 'a
-  (** Raise an unexpected character error at the current position *)
-end
-
 type t =
   | FileNotFound of string
-  | Syntax_error of syntax_error
+  | Syntax_error of Syntax_error.t
   | Semantic_error of Semantic_error.t
   | DebugDataError of (Middle.Location_span.t * string)
 

--- a/src/frontend/Errors.mli
+++ b/src/frontend/Errors.mli
@@ -7,8 +7,21 @@ type syntax_error =
   | Include of string * Middle.Location.t
   | Parsing of string * Middle.Location_span.t
 
-(** Exception for Syntax Errors *)
-exception SyntaxError of syntax_error
+module type ParserExn = sig
+  (** Signal that a syntax_error has occured dynamically *)
+
+  val include_error : string -> 'a
+  (** Raise an include error with the given message *)
+
+  val parse_error : loc:Lexing.position * Lexing.position -> string -> 'a
+  (** Raise a parser error at the specified location *)
+
+  val unexpected_eof : unit -> 'a
+  (** Raise an unexpected end of file error at the current position *)
+
+  val unexpected_character : unit -> 'a
+  (** Raise an unexpected character error at the current position *)
+end
 
 type t =
   | FileNotFound of string

--- a/src/frontend/Errors.mli
+++ b/src/frontend/Errors.mli
@@ -10,10 +10,6 @@ type syntax_error =
 (** Exception for Syntax Errors *)
 exception SyntaxError of syntax_error
 
-(** Exception [SemanticError (loc, msg)] indicates a semantic error with message
-    [msg], occurring at location [loc]. *)
-exception SemanticError of Semantic_error.t
-
 type t =
   | FileNotFound of string
   | Syntax_error of syntax_error

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -61,7 +61,8 @@ let current_buffer () =
   buf
 
 let current_location () =
-  location_of_position (Lexing.lexeme_start_p (current_buffer ()))
+  let buf = current_buffer () in
+  location_span_of_positions (Lexing.lexeme_start_p buf, Lexing.lexeme_end_p buf)
 
 let pop_buffer () = Stack.pop_exn include_stack
 

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -80,69 +80,68 @@ let restore_prior_lexbuf () =
   lexbuf.lex_start_p <- old_pos;
   old_lexbuf
 
-module Make (ParserExns : Errors.ParserExn) = struct
-  let find_include_fs lookup_paths fname =
-    let rec loop paths =
-      match paths with
-      | [] ->
-          let message =
-            let pp_list ppf l =
-              match l with
-              | [] -> Fmt.string ppf "None"
-              | _ -> Fmt.(list ~sep:comma string) ppf l in
-            Fmt.str
-              "Could not find include file '%s' in specified include paths.@\n\
-               @[Current include paths: %a@]" fname pp_list lookup_paths in
-          ParserExns.include_error message
-      | path :: rest_of_paths -> (
-          try
-            let full_path = path ^ "/" ^ fname in
-            (In_channel.create full_path |> Lexing.from_channel, full_path)
-          with _ -> loop rest_of_paths) in
-    loop lookup_paths
-
-  let find_include_inmemory map fname =
-    match Map.find map fname with
-    | None ->
+let find_include_fs (module ParserExns : Errors.ParserExn) lookup_paths fname =
+  let rec loop paths =
+    match paths with
+    | [] ->
         let message =
           let pp_list ppf l =
-            let keys = Map.keys l in
-            if List.is_empty keys then Fmt.string ppf "None"
-            else Fmt.(list ~sep:comma string) ppf keys in
+            match l with
+            | [] -> Fmt.string ppf "None"
+            | _ -> Fmt.(list ~sep:comma string) ppf l in
           Fmt.str
-            "Could not find include file '%s'.@ stanc was given information \
-             about the following files:@ %a"
-            fname pp_list map in
+            "Could not find include file '%s' in specified include paths.@\n\
+             @[Current include paths: %a@]" fname pp_list lookup_paths in
         ParserExns.include_error message
-    | Some s -> (Lexing.from_string s, fname)
+    | path :: rest_of_paths -> (
+        try
+          let full_path = path ^ "/" ^ fname in
+          (In_channel.create full_path |> Lexing.from_channel, full_path)
+        with _ -> loop rest_of_paths) in
+  loop lookup_paths
 
-  let find_include fname =
-    match !Include_files.include_provider with
-    | FileSystemPaths lookup_paths -> find_include_fs lookup_paths fname
-    | InMemory map -> find_include_inmemory map fname
+let find_include_inmemory (module ParserExns : Errors.ParserExn) map fname =
+  match Map.find map fname with
+  | None ->
+      let message =
+        let pp_list ppf l =
+          let keys = Map.keys l in
+          if List.is_empty keys then Fmt.string ppf "None"
+          else Fmt.(list ~sep:comma string) ppf keys in
+        Fmt.str
+          "Could not find include file '%s'.@ stanc was given information \
+           about the following files:@ %a"
+          fname pp_list map in
+      ParserExns.include_error message
+  | Some s -> (Lexing.from_string s, fname)
 
-  let try_get_new_lexbuf fname =
-    let lexbuf = Stack.top_exn include_stack in
-    let new_lexbuf, file = find_include fname in
-    lexer_logger ("opened " ^ file);
-    new_lexbuf.lex_start_p <-
-      new_file_start_position file
-      @@ Some (location_of_position lexbuf.lex_start_p);
-    new_lexbuf.lex_curr_p <- new_lexbuf.lex_start_p;
-    let dup_exists {Middle.Location.filename; included_from; _} =
-      let is_dup = String.equal filename in
-      let rec go = function
-        | None -> false
-        | Some {Middle.Location.filename; included_from; _} ->
-            if is_dup filename then true else go included_from in
-      go included_from in
-    if dup_exists (location_of_position lexbuf.lex_start_p) then
-      ParserExns.include_error
-        (Printf.sprintf "File %s recursively included itself." fname);
-    Stack.push include_stack new_lexbuf;
-    update_start_positions new_lexbuf.lex_curr_p;
-    included_files := file :: !included_files;
-    new_lexbuf
-end
+let find_include (module ParserExns : Errors.ParserExn) fname =
+  match !Include_files.include_provider with
+  | FileSystemPaths lookup_paths ->
+      find_include_fs (module ParserExns) lookup_paths fname
+  | InMemory map -> find_include_inmemory (module ParserExns) map fname
+
+let try_get_new_lexbuf (module ParserExns : Errors.ParserExn) fname =
+  let lexbuf = Stack.top_exn include_stack in
+  let new_lexbuf, file = find_include (module ParserExns) fname in
+  lexer_logger ("opened " ^ file);
+  new_lexbuf.lex_start_p <-
+    new_file_start_position file
+    @@ Some (location_of_position lexbuf.lex_start_p);
+  new_lexbuf.lex_curr_p <- new_lexbuf.lex_start_p;
+  let dup_exists {Middle.Location.filename; included_from; _} =
+    let is_dup = String.equal filename in
+    let rec go = function
+      | None -> false
+      | Some {Middle.Location.filename; included_from; _} ->
+          if is_dup filename then true else go included_from in
+    go included_from in
+  if dup_exists (location_of_position lexbuf.lex_start_p) then
+    ParserExns.include_error
+      (Printf.sprintf "File %s recursively included itself." fname);
+  Stack.push include_stack new_lexbuf;
+  update_start_positions new_lexbuf.lex_curr_p;
+  included_files := file :: !included_files;
+  new_lexbuf
 
 let included_files () = List.rev !included_files

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -8,7 +8,7 @@ val location_span_of_positions :
 val current_buffer : unit -> Lexing.lexbuf
 (** Buffer at the top of the include stack *)
 
-val current_location : unit -> Middle.Location.t
+val current_location : unit -> Middle.Location_span.t
 (** Current location in the top buffer *)
 
 val size : unit -> int

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -33,6 +33,8 @@ val restore_prior_lexbuf : unit -> Lexing.lexbuf
 (** Restore to a previous lexing buffer (assumes that one exists) and
     updates positions accordingly. *)
 
-val try_get_new_lexbuf : string -> Lexing.lexbuf
-(** Search include paths for filename and try to create a new lexing buffer
+module Make (ParserExns : Errors.ParserExn) : sig
+  val try_get_new_lexbuf : string -> Lexing.lexbuf
+  (** Search include paths for filename and try to create a new lexing buffer
     with that filename, record that included from specified position *)
+end

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -33,8 +33,6 @@ val restore_prior_lexbuf : unit -> Lexing.lexbuf
 (** Restore to a previous lexing buffer (assumes that one exists) and
     updates positions accordingly. *)
 
-module Make (ParserExns : Errors.ParserExn) : sig
-  val try_get_new_lexbuf : string -> Lexing.lexbuf
-  (** Search include paths for filename and try to create a new lexing buffer
+val try_get_new_lexbuf : (module Errors.ParserExn) -> string -> Lexing.lexbuf
+(** Search include paths for filename and try to create a new lexing buffer
     with that filename, record that included from specified position *)
-end

--- a/src/frontend/Preprocessor.mli
+++ b/src/frontend/Preprocessor.mli
@@ -8,6 +8,9 @@ val location_span_of_positions :
 val current_buffer : unit -> Lexing.lexbuf
 (** Buffer at the top of the include stack *)
 
+val current_location : unit -> Middle.Location.t
+(** Current location in the top buffer *)
+
 val size : unit -> int
 (** Size of the include stack *)
 
@@ -33,6 +36,6 @@ val restore_prior_lexbuf : unit -> Lexing.lexbuf
 (** Restore to a previous lexing buffer (assumes that one exists) and
     updates positions accordingly. *)
 
-val try_get_new_lexbuf : (module Errors.ParserExn) -> string -> Lexing.lexbuf
+val try_get_new_lexbuf : string -> Lexing.lexbuf
 (** Search include paths for filename and try to create a new lexing buffer
     with that filename, record that included from specified position *)

--- a/src/frontend/Syntax_error.ml
+++ b/src/frontend/Syntax_error.ml
@@ -22,7 +22,7 @@ let pp ppf = function
   | Parsing (message, _) -> Fmt.string ppf message
   | Lexing _ -> Fmt.pf ppf "Invalid character found.@."
   | UnexpectedEOF _ -> Fmt.pf ppf "Unexpected end of input.@."
-  | Include (message, _) -> Fmt.string ppf message
+  | Include (message, _) -> Fmt.pf ppf "%s@." message
 
 exception ParserException of string * Middle.Location_span.t
 exception UnexpectedEOF of Middle.Location_span.t

--- a/src/frontend/Syntax_error.ml
+++ b/src/frontend/Syntax_error.ml
@@ -1,14 +1,16 @@
 (** Our type of syntax error information *)
 type t =
-  | Lexing of Middle.Location.t
-  | UnexpectedEOF of Middle.Location.t
-  | Include of string * Middle.Location.t
+  | Lexing of Middle.Location_span.t
+  | UnexpectedEOF of Middle.Location_span.t
+  | Include of string * Middle.Location_span.t
   | Parsing of string * Middle.Location_span.t
 
 let location = function
-  | Parsing (_, loc_span) -> loc_span
-  | Lexing loc | UnexpectedEOF loc | Include (_, loc) ->
-      {begin_loc= loc; end_loc= loc}
+  | Parsing (_, loc_span)
+   |Lexing loc_span
+   |UnexpectedEOF loc_span
+   |Include (_, loc_span) ->
+      loc_span
 
 let kind = function
   | Parsing _ -> "parsing error"
@@ -23,9 +25,9 @@ let pp ppf = function
   | Include (message, _) -> Fmt.string ppf message
 
 exception ParserException of string * Middle.Location_span.t
-exception UnexpectedEOF of Middle.Location.t
-exception UnexpectedCharacter of Middle.Location.t
-exception IncludeError of string * Middle.Location.t
+exception UnexpectedEOF of Middle.Location_span.t
+exception UnexpectedCharacter of Middle.Location_span.t
+exception IncludeError of string * Middle.Location_span.t
 
 let unexpected_eof loc = raise (UnexpectedEOF loc)
 let unexpected_character loc = raise (UnexpectedCharacter loc)

--- a/src/frontend/Syntax_error.ml
+++ b/src/frontend/Syntax_error.ml
@@ -1,0 +1,40 @@
+(** Our type of syntax error information *)
+type t =
+  | Lexing of Middle.Location.t
+  | UnexpectedEOF of Middle.Location.t
+  | Include of string * Middle.Location.t
+  | Parsing of string * Middle.Location_span.t
+
+let location = function
+  | Parsing (_, loc_span) -> loc_span
+  | Lexing loc | UnexpectedEOF loc | Include (_, loc) ->
+      {begin_loc= loc; end_loc= loc}
+
+let kind = function
+  | Parsing _ -> "parsing error"
+  | UnexpectedEOF _ | Lexing _ -> "lexing error"
+  | Include _ -> "include error"
+
+(** A syntax error message used when handling a SyntaxError *)
+let pp ppf = function
+  | Parsing (message, _) -> Fmt.string ppf message
+  | Lexing _ -> Fmt.pf ppf "Invalid character found.@."
+  | UnexpectedEOF _ -> Fmt.pf ppf "Unexpected end of input.@."
+  | Include (message, _) -> Fmt.string ppf message
+
+exception ParserException of string * Middle.Location_span.t
+exception UnexpectedEOF of Middle.Location.t
+exception UnexpectedCharacter of Middle.Location.t
+exception IncludeError of string * Middle.Location.t
+
+let unexpected_eof loc = raise (UnexpectedEOF loc)
+let unexpected_character loc = raise (UnexpectedCharacter loc)
+let include_error msg loc = raise (IncludeError (msg, loc))
+let parse_error msg loc = raise (ParserException (msg, loc))
+
+let try_with f =
+  try Ok (f ()) with
+  | ParserException (msg, loc) -> Error (Parsing (msg, loc))
+  | UnexpectedEOF loc -> Error (UnexpectedEOF loc)
+  | UnexpectedCharacter loc -> Error (Lexing loc)
+  | IncludeError (msg, loc) -> Error (Include (msg, loc))

--- a/src/frontend/Syntax_error.mli
+++ b/src/frontend/Syntax_error.mli
@@ -1,0 +1,14 @@
+type t
+
+val location : t -> Middle.Location_span.t
+val kind : t -> string
+val pp : Format.formatter -> t -> unit
+
+(** Exception-based control flow is useful during parsing/lexing.
+    These helpers are used to try to keep all that logic in one place*)
+
+val unexpected_eof : Middle.Location.t -> 'a
+val unexpected_character : Middle.Location.t -> 'a
+val include_error : string -> Middle.Location.t -> 'a
+val parse_error : string -> Middle.Location_span.t -> 'a
+val try_with : (unit -> 'a) -> ('a, t) result

--- a/src/frontend/Syntax_error.mli
+++ b/src/frontend/Syntax_error.mli
@@ -7,8 +7,8 @@ val pp : Format.formatter -> t -> unit
 (** Exception-based control flow is useful during parsing/lexing.
     These helpers are used to try to keep all that logic in one place*)
 
-val unexpected_eof : Middle.Location.t -> 'a
-val unexpected_character : Middle.Location.t -> 'a
-val include_error : string -> Middle.Location.t -> 'a
+val unexpected_eof : Middle.Location_span.t -> 'a
+val unexpected_character : Middle.Location_span.t -> 'a
+val include_error : string -> Middle.Location_span.t -> 'a
 val parse_error : string -> Middle.Location_span.t -> 'a
 val try_with : (unit -> 'a) -> ('a, t) result

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -2,11 +2,11 @@
 
   Functions which begin with "check_" return a typed version of their input
   Functions which begin with "verify_" return unit if a check succeeds, or else
-    throw an SemanticError exception.
+    throw an TypecheckerException exception.
   Other functions which begin with "infer"/"calculate" vary. Usually they return
     a value, but a few do have error conditions.
 
-  All SemanticError exceptions are caught by check_program
+  All TypecheckerException exceptions are caught by check_program
   which turns the ast or exception into a Result.t for external usage
 
   A type environment (Env.t) is used to hold variables and functions, including
@@ -19,10 +19,11 @@ open Middle
 open Ast
 module Env = Environment
 
-exception SemanticError of Semantic_error.t
+(** Internal (private) exception used for errors. *)
+exception TypecheckerException of Semantic_error.t
 
 (* we only allow errors raised by this function *)
-let error e = raise (SemanticError e)
+let error e = raise (TypecheckerException e)
 
 (* warnings are built up in a list *)
 let warnings : Warnings.t list ref = ref []
@@ -2197,5 +2198,5 @@ let check_program_exn ~allow_undefined_functions
 let check_program ?(allow_undefined_functions = false) ast =
   Result.try_with (fun () -> check_program_exn ~allow_undefined_functions ast)
   |> Result.map_error ~f:(function
-       | SemanticError exn -> exn
+       | TypecheckerException exn -> exn
        | exn -> raise exn)

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -2196,7 +2196,5 @@ let check_program_exn ~allow_undefined_functions
   attach_warnings prog
 
 let check_program ?(allow_undefined_functions = false) ast =
-  Result.try_with (fun () -> check_program_exn ~allow_undefined_functions ast)
-  |> Result.map_error ~f:(function
-       | TypecheckerException exn -> exn
-       | exn -> raise exn)
+  try Result.Ok (check_program_exn ~allow_undefined_functions ast)
+  with TypecheckerException err -> Result.Error err

--- a/src/frontend/Typechecker.mli
+++ b/src/frontend/Typechecker.mli
@@ -2,11 +2,11 @@
 
   Functions which begin with "check_" return a typed version of their input
   Functions which begin with "verify_" return unit if a check succeeds, or else
-    throw an {!exception:Frontend.Errors.SemanticError} exception.
+    throw an exception.
   Other functions which begin with "infer"/"calculate" vary. Usually they return
     a value, but a few do have error conditions.
 
-  All [Error.SemanticError] excepetions are caught by check_program
+  All (intentional) exceptions are caught by [check_program]
   which turns the ast or exception into a [Result.t] for external usage
 
   A type environment {!type:Frontend.Environment.t} is used to hold variables

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -6,7 +6,6 @@ module Make (ParserExns: Errors.ParserExn) = struct
   module Stack = Core.Stack
   module Queue = Core.Queue
   module Parser = Parser.Make(ParserExns)
-  open Preprocessor.Make(ParserExns)
   open ParserExns
   open Lexing
   open Debugging
@@ -74,7 +73,7 @@ rule token = parse
     )                         { lexer_logger ("include " ^ fname) ;
                                 add_include fname lexbuf ;
                                 let new_lexbuf =
-                                  try_get_new_lexbuf fname in
+                                  try_get_new_lexbuf (module ParserExns) fname in
                                 token new_lexbuf }
 (* Program blocks *)
   | "functions"               { lexer_logger "functions" ;

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -1,11 +1,12 @@
 (** The parser for Stan. A Menhir file. *)
-
+%parameter<ParserExns: Errors.ParserExn>
 %{
 open Core
 open Middle
 open Ast
 open Debugging
 open Preprocessor
+open ParserExns
 
 (* Takes a sized_basic_type and a list of sizes and repeatedly applies then
    SArray constructor, taking sizes off the list *)
@@ -13,27 +14,20 @@ let reducearray (sbt, l) =
   List.fold_right l ~f:(fun z y -> SizedType.SArray (y, z)) ~init:sbt
 
 let build_id id loc =
-  grammar_logger ("identifier " ^ id) ;
+  grammar_logger ("identifier " ^ id);
   {name= id; id_loc= location_span_of_positions loc}
 
 let reserved (name, loc, _) =
-  raise
-    (Errors.SyntaxError
-       (Errors.Parsing
-          ( "Expected a new identifier but found reserved keyword '" ^ name
-            ^ "'.\n"
-          , location_span_of_positions loc ) ) )
+  parse_error ~loc
+    ("Expected a new identifier but found reserved keyword '" ^ name ^ "'.\n")
 
 let reserved_decl (name, loc, is_type) =
   if is_type then
-    raise
-      (Errors.SyntaxError
-         (Errors.Parsing
-            ( "Found a type ('" ^ name
-              ^ "') where an identifier was expected.\n\
-                 All variables declared in a comma-separated list must be of \
-                 the same type.\n"
-            , location_span_of_positions loc ) ) )
+    parse_error ~loc
+      ("Found a type ('" ^ name
+     ^ "') where an identifier was expected.\n\
+        All variables declared in a comma-separated list must be of the same \
+        type.\n")
   else reserved (name, loc, is_type)
 
 let build_expr expr loc = {expr; emeta= {loc= location_span_of_positions loc}}
@@ -42,12 +36,9 @@ let rec iterate_n f x = function 0 -> x | n -> iterate_n f (f x) (n - 1)
 let parse_tuple_slot ix_str loc =
   match int_of_string_opt (String.drop_prefix ix_str 1) with
   | None ->
-      raise
-        (Errors.SyntaxError
-           (Errors.Parsing
-              ( "Failed to parse integer from string '" ^ ix_str
-                ^ "' in tuple index. \nThe index is likely too large.\n"
-              , location_span_of_positions loc ) ) )
+      parse_error ~loc
+        ("Failed to parse integer from string '" ^ ix_str
+       ^ "' in tuple index. \nThe index is likely too large.\n")
   | Some ix -> ix
 
 (** Given a parsed expression, try to convert it to
@@ -56,11 +47,8 @@ let try_convert_to_lvalue expr loc =
   match Ast.lvalue_of_expr_opt expr with
   | Some l -> l
   | None ->
-    raise
-        (Errors.SyntaxError
-           (Errors.Parsing
-              ( "Expected an assignable value but found a general expression.\n"
-              , location_span_of_positions loc ) ) )
+      parse_error ~loc
+        "Expected an assignable value but found a general expression.\n"
 
 let nest_unsized_array basic_type n =
   iterate_n (fun t -> UnsizedType.UArray t) basic_type n
@@ -307,16 +295,13 @@ unsized_type:
     It can go away at some point if it starts causing conflicts.
   *)
   | bt=basic_type dims=unsized_dims {
-    raise
-    (Errors.SyntaxError
-       (Errors.Parsing
-          (Fmt.str
-              "An identifier is expected after the type as a function argument \
-               name.@ It looks like you are trying to use the old array \
-               syntax.@ Please use the new syntax: @ @[<h>array[%s] %a@]@\n"
-              (String.make (dims-1) ',')
-              UnsizedType.pp bt
-          , location_span_of_positions $loc(dims) )))
+    parse_error ~loc:($loc(dims))
+      (Fmt.str
+         "An identifier is expected after the type as a function argument \
+          name.@ It looks like you are trying to use the old array syntax.@ \
+          Please use the new syntax: @ @[<h>array[%s] %a@]@\n"
+         (String.make (dims - 1) ',')
+         UnsizedType.pp bt)
   }
   | bt=basic_type
     {  grammar_logger "unsized_type";
@@ -394,15 +379,12 @@ decl(type_rule, rhs):
     let (ty, trans) = ty in
     let ty = List.fold_right ~f:(fun e ty -> SizedType.SArray (ty, e)) ~init:ty dims in
     let ty = (ty, trans) in
-    raise
-    (Errors.SyntaxError
-       (Errors.Parsing
-          ( Fmt.str
-              "\";\" expected after variable declaration.@ It looks like you \
-               are trying to use the old array syntax.@ Please use the new \
-               syntax:@ @[<h>%a %s;@]@\n"
-              Pretty_printing.pp_transformed_type ty id.name
-          , location_span_of_positions $loc(dims) )))
+    parse_error ~loc:($loc(dims))
+      (Fmt.str
+         "\";\" expected after variable declaration.@ It looks like you are \
+          trying to use the old array syntax.@ Please use the new syntax:@ \
+          @[<h>%a %s;@]@\n"
+         Pretty_printing.pp_transformed_type ty id.name)
     }
   | ty=higher_type(type_rule)
     (* additional indirection only for better error messaging *)

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -1,12 +1,13 @@
 (** The parser for Stan. A Menhir file. *)
-%parameter<ParserExns: Errors.ParserExn>
 %{
 open Core
 open Middle
 open Ast
 open Debugging
 open Preprocessor
-open ParserExns
+
+let parse_error ~loc msg =
+  Syntax_error.parse_error msg (location_span_of_positions loc)
 
 (* Takes a sized_basic_type and a list of sizes and repeatedly applies then
    SArray constructor, taking sizes off the list *)

--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -8,13 +8,16 @@ let merge left right = {begin_loc= left.begin_loc; end_loc= right.end_loc}
 
 let pp ?printed_filename ppf {begin_loc; end_loc} =
   let end_loc_pp =
-    Fmt.if' (Option.is_none begin_loc.included_from)
+    let same_file = String.equal begin_loc.filename end_loc.filename in
+    let same_line = begin_loc.line_num = end_loc.line_num in
+    let same_column = begin_loc.col_num = end_loc.col_num in
+    Fmt.if'
+      (Option.is_none begin_loc.included_from
+      && not (same_file && same_line && same_column))
       (fun ppf (end_loc : Location.t) ->
         Fmt.pf ppf " to %a"
-          (Location.pp printed_filename
-             ~print_file:
-               (not @@ String.equal begin_loc.filename end_loc.filename)
-             ~print_line:(begin_loc.line_num <> end_loc.line_num))
+          (Location.pp printed_filename ~print_file:(not same_file)
+             ~print_line:(not same_line))
           end_loc) in
   Fmt.pf ppf "%a%a" (Location.pp printed_filename) begin_loc end_loc_pp end_loc
 

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -1,5 +1,5 @@
   $ ../../../../../install/default/bin/stanc bad1.stan
-Syntax error in 'bad1.stan', line 1, column 8 to column 8, parsing error:
+Syntax error in 'bad1.stan', line 1, column 8, parsing error:
    -------------------------------------------------
      1:  model { 
                  ^
@@ -283,7 +283,7 @@ Semantic error in 'bad_lpdf.stan', line 2, column 2 to line 4, column 3:
 Probability density functions require real variates (first argument).
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_data.stan
-Syntax error in 'bad_periods_data.stan', line 2, column 7, lexing error:
+Syntax error in 'bad_periods_data.stan', line 2, column 8, lexing error:
    -------------------------------------------------
      1:  data {
      2:    real x.y;
@@ -295,7 +295,7 @@ Syntax error in 'bad_periods_data.stan', line 2, column 7, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_gqs.stan
-Syntax error in 'bad_periods_gqs.stan', line 8, column 7, lexing error:
+Syntax error in 'bad_periods_gqs.stan', line 8, column 8, lexing error:
    -------------------------------------------------
      6:  }
      7:  generated quantities {
@@ -308,7 +308,7 @@ Syntax error in 'bad_periods_gqs.stan', line 8, column 7, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_local.stan
-Syntax error in 'bad_periods_local.stan', line 5, column 7, lexing error:
+Syntax error in 'bad_periods_local.stan', line 5, column 8, lexing error:
    -------------------------------------------------
      3:  }
      4:  model {
@@ -321,7 +321,7 @@ Syntax error in 'bad_periods_local.stan', line 5, column 7, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_params.stan
-Syntax error in 'bad_periods_params.stan', line 2, column 7, lexing error:
+Syntax error in 'bad_periods_params.stan', line 2, column 8, lexing error:
    -------------------------------------------------
      1:  parameters {
      2:    real x.y;
@@ -333,7 +333,7 @@ Syntax error in 'bad_periods_params.stan', line 2, column 7, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_tdata.stan
-Syntax error in 'bad_periods_tdata.stan', line 2, column 7, lexing error:
+Syntax error in 'bad_periods_tdata.stan', line 2, column 8, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:    real x.y;
@@ -345,7 +345,7 @@ Syntax error in 'bad_periods_tdata.stan', line 2, column 7, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_tparams.stan
-Syntax error in 'bad_periods_tparams.stan', line 2, column 7, lexing error:
+Syntax error in 'bad_periods_tparams.stan', line 2, column 8, lexing error:
    -------------------------------------------------
      1:  transformed parameters {
      2:    real x.;
@@ -479,7 +479,7 @@ Syntax error in 'incomplete4.stan', line 2, column 13 to column 14, parsing erro
 Ill-formed phrase. Found an expression where we expected a statement.
 [exit 1]
   $ ../../../../../install/default/bin/stanc incomplete5.stan
-Syntax error in 'incomplete5.stan', line 3, column 0 to column 0, parsing error:
+Syntax error in 'incomplete5.stan', line 3, column 0, parsing error:
    -------------------------------------------------
      1:  transformed data {
      2:    if (2.0) ;
@@ -535,12 +535,12 @@ Semantic error in 'tparam_tuple_int.stan', line 2, column 2 to column 21:
 (Transformed) Parameters cannot be integers.
 [exit 1]
   $ ../../../../../install/default/bin/stanc unterminated_comment.stan
-Syntax error in 'unterminated_comment.stan', line 4, column -1, lexing error:
+Syntax error in 'unterminated_comment.stan', line 4, column 0, lexing error:
    -------------------------------------------------
      2:  never
      3:  ends
          ^
    -------------------------------------------------
 
-Unexpected end of input
+Unexpected end of input.
 [exit 1]

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -283,7 +283,7 @@ Semantic error in 'bad_lpdf.stan', line 2, column 2 to line 4, column 3:
 Probability density functions require real variates (first argument).
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_data.stan
-Syntax error in 'bad_periods_data.stan', line 2, column 8, lexing error:
+Syntax error in 'bad_periods_data.stan', line 2, column 8 to column 9, lexing error:
    -------------------------------------------------
      1:  data {
      2:    real x.y;
@@ -295,7 +295,7 @@ Syntax error in 'bad_periods_data.stan', line 2, column 8, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_gqs.stan
-Syntax error in 'bad_periods_gqs.stan', line 8, column 8, lexing error:
+Syntax error in 'bad_periods_gqs.stan', line 8, column 8 to column 9, lexing error:
    -------------------------------------------------
      6:  }
      7:  generated quantities {
@@ -308,7 +308,7 @@ Syntax error in 'bad_periods_gqs.stan', line 8, column 8, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_local.stan
-Syntax error in 'bad_periods_local.stan', line 5, column 8, lexing error:
+Syntax error in 'bad_periods_local.stan', line 5, column 8 to column 9, lexing error:
    -------------------------------------------------
      3:  }
      4:  model {
@@ -321,7 +321,7 @@ Syntax error in 'bad_periods_local.stan', line 5, column 8, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_params.stan
-Syntax error in 'bad_periods_params.stan', line 2, column 8, lexing error:
+Syntax error in 'bad_periods_params.stan', line 2, column 8 to column 9, lexing error:
    -------------------------------------------------
      1:  parameters {
      2:    real x.y;
@@ -333,7 +333,7 @@ Syntax error in 'bad_periods_params.stan', line 2, column 8, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_tdata.stan
-Syntax error in 'bad_periods_tdata.stan', line 2, column 8, lexing error:
+Syntax error in 'bad_periods_tdata.stan', line 2, column 8 to column 9, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:    real x.y;
@@ -345,7 +345,7 @@ Syntax error in 'bad_periods_tdata.stan', line 2, column 8, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_periods_tparams.stan
-Syntax error in 'bad_periods_tparams.stan', line 2, column 8, lexing error:
+Syntax error in 'bad_periods_tparams.stan', line 2, column 8 to column 9, lexing error:
    -------------------------------------------------
      1:  transformed parameters {
      2:    real x.;

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -1444,7 +1444,7 @@ Syntax error in 'indices-bad3.stan', line 1, column 22 to column 27, parsing err
 Ill-formed expression. We expect a comma separated list of expressions, followed by "]".
 [exit 1]
   $ ../../../../../install/default/bin/stanc lexing_error.stan
-Syntax error in 'lexing_error.stan', line 1, column 7, lexing error:
+Syntax error in 'lexing_error.stan', line 1, column 7 to column 8, lexing error:
    -------------------------------------------------
      1:  model {½ }
                 ^

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -1295,7 +1295,7 @@ Syntax error in 'ill-formed-statement25.stan', line 1, column 34 to column 38, p
 Ill-formed statement. Expected statement after else.
 [exit 1]
   $ ../../../../../install/default/bin/stanc ill-formed-statement26.stan
-Syntax error in 'ill-formed-statement26.stan', line 2, column 0 to column 0, parsing error:
+Syntax error in 'ill-formed-statement26.stan', line 2, column 0, parsing error:
    -------------------------------------------------
      1:  transformed data { if ( T) ; foo
          ^
@@ -1444,7 +1444,7 @@ Syntax error in 'indices-bad3.stan', line 1, column 22 to column 27, parsing err
 Ill-formed expression. We expect a comma separated list of expressions, followed by "]".
 [exit 1]
   $ ../../../../../install/default/bin/stanc lexing_error.stan
-Syntax error in 'lexing_error.stan', line 1, column 6, lexing error:
+Syntax error in 'lexing_error.stan', line 1, column 7, lexing error:
    -------------------------------------------------
      1:  model {½ }
                 ^

--- a/test/integration/bad/numeric-literal/stanc.expected
+++ b/test/integration/bad/numeric-literal/stanc.expected
@@ -1,5 +1,5 @@
   $ ../../../../../install/default/bin/stanc int-bad1.stan
-Syntax error in 'int-bad1.stan', line 2, column 17, lexing error:
+Syntax error in 'int-bad1.stan', line 2, column 18, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      int n = 10_000_;
@@ -10,7 +10,7 @@ Syntax error in 'int-bad1.stan', line 2, column 17, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc int-bad2.stan
-Syntax error in 'int-bad2.stan', line 2, column 13, lexing error:
+Syntax error in 'int-bad2.stan', line 2, column 14, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      int n = 10__000;
@@ -54,7 +54,7 @@ Semantic error in 'int-bad6.stan', line 2, column 13 to column 23:
 Integer literal cannot be larger than 2_147_483_647.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad1.stan
-Syntax error in 'real-bad1.stan', line 2, column 12, lexing error:
+Syntax error in 'real-bad1.stan', line 2, column 13, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = .e+44;
@@ -65,7 +65,7 @@ Syntax error in 'real-bad1.stan', line 2, column 12, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad2.stan
-Syntax error in 'real-bad2.stan', line 2, column 14, lexing error:
+Syntax error in 'real-bad2.stan', line 2, column 15, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12_.345;
@@ -76,7 +76,7 @@ Syntax error in 'real-bad2.stan', line 2, column 14, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad3.stan
-Syntax error in 'real-bad3.stan', line 2, column 15, lexing error:
+Syntax error in 'real-bad3.stan', line 2, column 16, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12._345;
@@ -87,7 +87,7 @@ Syntax error in 'real-bad3.stan', line 2, column 15, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad4.stan
-Syntax error in 'real-bad4.stan', line 2, column 18, lexing error:
+Syntax error in 'real-bad4.stan', line 2, column 19, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12.345_;
@@ -98,7 +98,7 @@ Syntax error in 'real-bad4.stan', line 2, column 18, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad5.stan
-Syntax error in 'real-bad5.stan', line 2, column 16, lexing error:
+Syntax error in 'real-bad5.stan', line 2, column 17, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12.3_e+10;
@@ -109,7 +109,7 @@ Syntax error in 'real-bad5.stan', line 2, column 16, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad6.stan
-Syntax error in 'real-bad6.stan', line 2, column 20, lexing error:
+Syntax error in 'real-bad6.stan', line 2, column 21, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12.3e+10_;

--- a/test/integration/bad/numeric-literal/stanc.expected
+++ b/test/integration/bad/numeric-literal/stanc.expected
@@ -1,5 +1,5 @@
   $ ../../../../../install/default/bin/stanc int-bad1.stan
-Syntax error in 'int-bad1.stan', line 2, column 18, lexing error:
+Syntax error in 'int-bad1.stan', line 2, column 18 to column 19, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      int n = 10_000_;
@@ -10,7 +10,7 @@ Syntax error in 'int-bad1.stan', line 2, column 18, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc int-bad2.stan
-Syntax error in 'int-bad2.stan', line 2, column 14, lexing error:
+Syntax error in 'int-bad2.stan', line 2, column 14 to column 15, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      int n = 10__000;
@@ -54,7 +54,7 @@ Semantic error in 'int-bad6.stan', line 2, column 13 to column 23:
 Integer literal cannot be larger than 2_147_483_647.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad1.stan
-Syntax error in 'real-bad1.stan', line 2, column 13, lexing error:
+Syntax error in 'real-bad1.stan', line 2, column 13 to column 14, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = .e+44;
@@ -65,7 +65,7 @@ Syntax error in 'real-bad1.stan', line 2, column 13, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad2.stan
-Syntax error in 'real-bad2.stan', line 2, column 15, lexing error:
+Syntax error in 'real-bad2.stan', line 2, column 15 to column 16, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12_.345;
@@ -76,7 +76,7 @@ Syntax error in 'real-bad2.stan', line 2, column 15, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad3.stan
-Syntax error in 'real-bad3.stan', line 2, column 16, lexing error:
+Syntax error in 'real-bad3.stan', line 2, column 16 to column 17, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12._345;
@@ -87,7 +87,7 @@ Syntax error in 'real-bad3.stan', line 2, column 16, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad4.stan
-Syntax error in 'real-bad4.stan', line 2, column 19, lexing error:
+Syntax error in 'real-bad4.stan', line 2, column 19 to column 20, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12.345_;
@@ -98,7 +98,7 @@ Syntax error in 'real-bad4.stan', line 2, column 19, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad5.stan
-Syntax error in 'real-bad5.stan', line 2, column 17, lexing error:
+Syntax error in 'real-bad5.stan', line 2, column 17 to column 18, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12.3_e+10;
@@ -109,7 +109,7 @@ Syntax error in 'real-bad5.stan', line 2, column 17, lexing error:
 Invalid character found.
 [exit 1]
   $ ../../../../../install/default/bin/stanc real-bad6.stan
-Syntax error in 'real-bad6.stan', line 2, column 21, lexing error:
+Syntax error in 'real-bad6.stan', line 2, column 21 to column 22, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:      real x = 12.3e+10_;

--- a/test/integration/bad/removed_features/stanc.expected
+++ b/test/integration/bad/removed_features/stanc.expected
@@ -209,7 +209,7 @@ Semantic error in 'old-log-funs.stan', line 3, column 6 to column 24:
 A returning function was expected but an undeclared identifier 'multiply_log' was supplied.
 [exit 1]
   $ ../../../../../install/default/bin/stanc pound-comment-deprecated.stan
-Syntax error in 'pound-comment-deprecated.stan', line 2, column 2, lexing error:
+Syntax error in 'pound-comment-deprecated.stan', line 2, column 2 to column 3, lexing error:
    -------------------------------------------------
      1:  data {
      2:    # hey, this is the old way to do things, should raise warning

--- a/test/integration/bad/removed_features/stanc.expected
+++ b/test/integration/bad/removed_features/stanc.expected
@@ -209,7 +209,7 @@ Semantic error in 'old-log-funs.stan', line 3, column 6 to column 24:
 A returning function was expected but an undeclared identifier 'multiply_log' was supplied.
 [exit 1]
   $ ../../../../../install/default/bin/stanc pound-comment-deprecated.stan
-Syntax error in 'pound-comment-deprecated.stan', line 2, column 1, lexing error:
+Syntax error in 'pound-comment-deprecated.stan', line 2, column 2, lexing error:
    -------------------------------------------------
      1:  data {
      2:    # hey, this is the old way to do things, should raise warning

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -922,7 +922,7 @@ Semantic error in 'err-double-dims.stan', line 2, column 8 to column 11:
 Array sizes must be of type int. Instead found type real.
 [exit 1]
   $ ../../../../install/default/bin/stanc err-expected-bracket.stan
-Syntax error in 'err-expected-bracket.stan', line 4, column 0 to column 0, parsing error:
+Syntax error in 'err-expected-bracket.stan', line 4, column 0, parsing error:
    -------------------------------------------------
      2:  }
      3:  generated quantities 
@@ -1286,7 +1286,7 @@ Semantic error in 'err_void_rng_check.stan', line 8, column 4 to column 17:
 Random number generators are only allowed in transformed data block, generated quantities block or user-defined functions with names ending in _rng.
 [exit 1]
   $ ../../../../install/default/bin/stanc expect_statement_seq_close_brace.stan
-Syntax error in 'expect_statement_seq_close_brace.stan', line 6, column 0 to column 0, parsing error:
+Syntax error in 'expect_statement_seq_close_brace.stan', line 6, column 0, parsing error:
    -------------------------------------------------
      4:  model {
      5:    y ~ normal(0,1);
@@ -1296,7 +1296,7 @@ Syntax error in 'expect_statement_seq_close_brace.stan', line 6, column 0 to col
 Variable declaration, statement or "}" expected.
 [exit 1]
   $ ../../../../install/default/bin/stanc expect_statement_seq_close_brace_2.stan
-Syntax error in 'expect_statement_seq_close_brace_2.stan', line 17, column 0 to column 0, parsing error:
+Syntax error in 'expect_statement_seq_close_brace_2.stan', line 17, column 0, parsing error:
    -------------------------------------------------
     15:  
     16:  
@@ -1319,7 +1319,7 @@ Syntax error in 'expect_statement_seq_close_brace_3.stan', line 8, column 0 to c
 Ill-formed block. Expected a statement, variable declaration, or just "}".
 [exit 1]
   $ ../../../../install/default/bin/stanc expect_statement_seq_close_brace_4.stan
-Syntax error in 'expect_statement_seq_close_brace_4.stan', line 10, column 0 to column 0, parsing error:
+Syntax error in 'expect_statement_seq_close_brace_4.stan', line 10, column 0, parsing error:
    -------------------------------------------------
      8:    array[2,3] int vs;
      9:  
@@ -2829,7 +2829,7 @@ Semantic error in 'stanc_helper.stan', line 5, column 2 to column 18:
 Ill-typed arguments to '~' statement. No function 'ormal_lpdf' was found when looking for distribution 'ormal'.
 [exit 1]
   $ ../../../../install/default/bin/stanc string_literal_newline.stan
-Syntax error in 'string_literal_newline.stan', line 3, column 1, lexing error:
+Syntax error in 'string_literal_newline.stan', line 3, column 2, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:    print(

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -2829,7 +2829,7 @@ Semantic error in 'stanc_helper.stan', line 5, column 2 to column 18:
 Ill-typed arguments to '~' statement. No function 'ormal_lpdf' was found when looking for distribution 'ormal'.
 [exit 1]
   $ ../../../../install/default/bin/stanc string_literal_newline.stan
-Syntax error in 'string_literal_newline.stan', line 3, column 2, lexing error:
+Syntax error in 'string_literal_newline.stan', line 3, column 2 to column 3, lexing error:
    -------------------------------------------------
      1:  transformed data {
      2:    print(

--- a/test/integration/bad/tuples/stanc.expected
+++ b/test/integration/bad/tuples/stanc.expected
@@ -379,7 +379,7 @@ Invalid type specification, unmatched "(".
 Expected "," followed by further types and ")" to complete tuple.
 [exit 1]
   $ ../../../../../install/default/bin/stanc incomplete3.stan
-Syntax error in 'incomplete3.stan', line 2, column 0 to column 0, parsing error:
+Syntax error in 'incomplete3.stan', line 2, column 0, parsing error:
    -------------------------------------------------
      1:  model { tuple( complex , complex ) foo,
          ^

--- a/test/integration/included/stanc.expected
+++ b/test/integration/included/stanc.expected
@@ -181,7 +181,7 @@ Could not find include file 'I'm not here.stan' in specified include paths.
 Current include paths: ../included
 [exit 1]
   $ ../../../../install/default/bin/stanc --include-paths="../included"  stanc_helper_with_bad_include_lex_error.stan
-Syntax error in '../included/lex-err.stan', line 2, column 8, included from
+Syntax error in '../included/lex-err.stan', line 2, column 9, included from
 '../included/incl_stanc_helper_lex_error.stan', line 2, column 2, included from
 'stanc_helper_with_bad_include_lex_error.stan', line 2, column 0, lexing error:
    -------------------------------------------------

--- a/test/integration/included/stanc.expected
+++ b/test/integration/included/stanc.expected
@@ -231,7 +231,7 @@ Semantic error in 'stanc_helper_with_good_include_err_after_incl.stan', line 9, 
 Identifier 'ww' not in scope. Did you mean 'w'?
 [exit 1]
   $ ../../../../install/default/bin/stanc stanc_helper_with_good_include.stan
-Syntax error in 'stanc_helper_with_good_include.stan', line 2, column 0, include error:
+Syntax error in 'stanc_helper_with_good_include.stan', line 2, column 0 to column 31, include error:
    -------------------------------------------------
      1:  parameters {
      2:  #include incl_stanc_helper.stan

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -231,6 +231,7 @@ Syntax error in 'string', line 2, column 0 to column 19, include error:
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 None
+
 Syntax error in 'string', line 2, column 0 to column 19, include error:
    -------------------------------------------------
      1:  
@@ -243,6 +244,7 @@ Syntax error in 'string', line 2, column 0 to column 19, include error:
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 bar.stan
+
 Syntax error in 'string', line 2, column 0 to column 19, include error:
    -------------------------------------------------
      1:  
@@ -255,6 +257,7 @@ Syntax error in 'string', line 2, column 0 to column 19, include error:
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 ./foo.stan
+
 functions {
   int foo(real a) {
     return 1;
@@ -314,6 +317,7 @@ Syntax error in 'include/b.stan', line 1, column 0, included from
    -------------------------------------------------
 
 File include/a.stan recursively included itself.
+
 $ node info.js
 {
   "inputs": {

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -219,7 +219,7 @@ Syntax error in 'string', line 8, column 0 to column 5, parsing error:
 Expected "generated quantities {" or end of file after end of model block.
 
 $ node includes.js
-Syntax error in 'string', line 2, column 0, include error:
+Syntax error in 'string', line 2, column 0 to column 19, include error:
    -------------------------------------------------
      1:  
      2:  #include <foo.stan>
@@ -231,8 +231,7 @@ Syntax error in 'string', line 2, column 0, include error:
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 None
-
-Syntax error in 'string', line 2, column 0, include error:
+Syntax error in 'string', line 2, column 0 to column 19, include error:
    -------------------------------------------------
      1:  
      2:  #include <foo.stan>
@@ -244,8 +243,7 @@ Syntax error in 'string', line 2, column 0, include error:
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 bar.stan
-
-Syntax error in 'string', line 2, column 0, include error:
+Syntax error in 'string', line 2, column 0 to column 19, include error:
    -------------------------------------------------
      1:  
      2:  #include <foo.stan>
@@ -257,7 +255,6 @@ Syntax error in 'string', line 2, column 0, include error:
 Could not find include file 'foo.stan'.
 stanc was given information about the following files:
 ./foo.stan
-
 functions {
   int foo(real a) {
     return 1;
@@ -317,7 +314,6 @@ Syntax error in 'include/b.stan', line 1, column 0, included from
    -------------------------------------------------
 
 File include/a.stan recursively included itself.
-
 $ node info.js
 {
   "inputs": {

--- a/test/unit/In_memory_include_tests.ml
+++ b/test/unit/In_memory_include_tests.ml
@@ -21,7 +21,7 @@ let%expect_test "no includes" =
   print_ast_or_error include_model;
   [%expect
     {|
-    Syntax error in 'string', line 2, column 0, include error:
+    Syntax error in 'string', line 2, column 0 to column 19, include error:
        -------------------------------------------------
          1:
          2:  #include <foo.stan>
@@ -40,7 +40,7 @@ let%expect_test "wrong include" =
   print_ast_or_error include_model;
   [%expect
     {|
-    Syntax error in 'string', line 2, column 0, include error:
+    Syntax error in 'string', line 2, column 0 to column 19, include error:
        -------------------------------------------------
          1:
          2:  #include <foo.stan>


### PR DESCRIPTION
There are a couple places where we use exceptions for control flow. This PR improves the encapsulation of those usages by making the exception type module-local and private, preventing other modules from throwing these, or even knowing that they are being used.  

This required a little bit of module trickery for the parsing code, but I don't think it's too bad overall.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Replace this text with a short note on what will change if this pull request is merged. This will be included in the release notes.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
