### PR TITLE
Statically forbid promotion nodes in the untyped AST

### DIFF
--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -128,7 +128,7 @@ let gen_vector m n t =
   match t with
   | Transformation.Simplex ->
       let l = repeat_th n (fun _ -> Random.float 1.) in
-      let sum = List.fold l ~init:0. ~f:(fun accum elt -> accum +. elt) in
+      let sum = List.fold l ~init:0. ~f:( +. ) in
       let l = List.map l ~f:(fun x -> x /. sum) in
       Expr.Helpers.vector l
   | Ordered ->

--- a/src/analysis_and_optimization/Memory_patterns.ml
+++ b/src/analysis_and_optimization/Memory_patterns.ml
@@ -679,8 +679,7 @@ let collect_mem_pattern_variables stmts =
       when SizedType.has_mem_pattern stype ->
         (decl_id, stype) :: acc
     | _ -> acc in
-  Mir_utils.fold_stmts ~take_expr:(fun acc _ -> acc) ~take_stmt ~init:[] stmts
-  |> List.rev
+  Mir_utils.fold_stmts ~take_expr:Fn.const ~take_stmt ~init:[] stmts |> List.rev
 
 let pp_mem_patterns ppf (Program.{reverse_mode_log_prob; _} : Program.Typed.t) =
   let pp_var ppf (name, stype) =

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -117,8 +117,7 @@ let subst_args_stmt args es =
  * Count the number of returns that happen in a statement
  *)
 let rec count_returns Stmt.{pattern; _} : int =
-  Stmt.Pattern.fold
-    (fun acc _ -> acc)
+  Stmt.Pattern.fold Fn.const
     (fun acc -> function
       | Stmt.{pattern= Return _; _} -> acc + 1
       | stmt -> acc + count_returns stmt)
@@ -1364,4 +1363,4 @@ let optimization_suite ?(settings = all_optimizations) mir =
   let optimizations =
     List.filter_map maybe_optimizations ~f:(fun (fn, flag) ->
         if flag then Some fn else None) in
-  List.fold optimizations ~init:mir ~f:(fun mir opt -> opt mir)
+  List.fold optimizations ~init:mir ~f:Fn.( |> )

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -73,7 +73,7 @@ and trans_expr {Ast.expr; Ast.emeta} =
   | TupleProjection (lhs, i) -> TupleProjection (trans_expr lhs, i) |> ewrap
   | TupleExpr eles ->
       FunApp (CompilerInternal FnMakeTuple, trans_exprs eles) |> ewrap
-  | Promotion (e, ty, ad) -> Promotion (trans_expr e, ty, ad) |> ewrap
+  | Promotion (e, (ty, ad)) -> Promotion (trans_expr e, ty, ad) |> ewrap
 
 and trans_idx = function
   | Ast.All -> All

--- a/src/frontend/Canonicalize.ml
+++ b/src/frontend/Canonicalize.ml
@@ -33,7 +33,7 @@ let rec no_parens {expr; emeta} =
       { expr= BinOp ({e1 with expr= Paren (no_parens e1)}, op2, keep_parens e2)
       ; emeta }
   | TernaryIf _ | BinOp _ | PrefixOp _ | PostfixOp _ ->
-      {expr= map_expression keep_parens Fn.id expr; emeta}
+      {expr= map_expression keep_parens Fn.id Fn.id expr; emeta}
   | Indexed (e, l) ->
       { expr=
           Indexed
@@ -47,11 +47,11 @@ let rec no_parens {expr; emeta} =
   | TupleProjection (e, i) -> {expr= TupleProjection (keep_parens e, i); emeta}
   | ArrayExpr _ | RowVectorExpr _ | FunApp _ | CondDistApp _ | TupleExpr _
    |Promotion _ ->
-      {expr= map_expression no_parens Fn.id expr; emeta}
+      {expr= map_expression no_parens Fn.id Fn.id expr; emeta}
 
 and keep_parens {expr; emeta} =
   match expr with
-  | Promotion (e, ut, ad) -> {expr= Promotion (keep_parens e, ut, ad); emeta}
+  | Promotion (e, (ut, ad)) -> {expr= Promotion (keep_parens e, (ut, ad)); emeta}
   | Paren ({expr= Paren _; _} as e) -> keep_parens e
   | Paren ({expr= BinOp _; _} as e)
    |Paren ({expr= PrefixOp _; _} as e)

--- a/src/frontend/Canonicalize.ml
+++ b/src/frontend/Canonicalize.ml
@@ -33,7 +33,7 @@ let rec no_parens {expr; emeta} =
       { expr= BinOp ({e1 with expr= Paren (no_parens e1)}, op2, keep_parens e2)
       ; emeta }
   | TernaryIf _ | BinOp _ | PrefixOp _ | PostfixOp _ ->
-      {expr= map_expression keep_parens Fn.id Fn.id expr; emeta}
+      {expr= map_expression keep_parens expr; emeta}
   | Indexed (e, l) ->
       { expr=
           Indexed
@@ -47,7 +47,7 @@ let rec no_parens {expr; emeta} =
   | TupleProjection (e, i) -> {expr= TupleProjection (keep_parens e, i); emeta}
   | ArrayExpr _ | RowVectorExpr _ | FunApp _ | CondDistApp _ | TupleExpr _
    |Promotion _ ->
-      {expr= map_expression no_parens Fn.id Fn.id expr; emeta}
+      {expr= map_expression no_parens expr; emeta}
 
 and keep_parens {expr; emeta} =
   match expr with
@@ -60,7 +60,7 @@ and keep_parens {expr; emeta} =
       {expr= Paren (no_parens e); emeta}
   | _ -> no_parens {expr; emeta}
 
-let parens_lval = map_lval_with no_parens Fn.id
+let parens_lval = map_lval_with no_parens
 
 let rec parens_stmt ({stmt; smeta} : typed_statement) : typed_statement =
   let stmt =
@@ -77,7 +77,7 @@ let rec parens_stmt ({stmt; smeta} : typed_statement) : typed_statement =
           ; lower_bound= keep_parens lower_bound
           ; upper_bound= keep_parens upper_bound
           ; loop_body= parens_stmt loop_body }
-    | _ -> map_statement no_parens parens_stmt parens_lval Fn.id stmt in
+    | _ -> map_statement no_parens parens_stmt parens_lval stmt in
   {stmt; smeta}
 
 let rec blocks_stmt ({stmt; smeta} : typed_statement) : typed_statement =
@@ -101,7 +101,7 @@ let rec blocks_stmt ({stmt; smeta} : typed_statement) : typed_statement =
         IfThenElse (e, stmt_to_block s1, Option.map ~f:stmt_to_block s2)
     | For ({loop_body; _} as f) ->
         For {f with loop_body= stmt_to_block loop_body}
-    | _ -> map_statement Fn.id blocks_stmt Fn.id Fn.id stmt in
+    | _ -> map_statement Fn.id blocks_stmt Fn.id stmt in
   {stmt; smeta}
 
 let canonicalize_program program settings : typed_program =

--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -143,14 +143,9 @@ let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
                   [(emeta.loc, lkj_cov_message)]
                 else []) in
       acc @ w @ List.concat_map l ~f:(fun e -> collect_deprecated_expr [] e)
-  | _ ->
-      fold_expression collect_deprecated_expr
-        (fun l _ -> l)
-        (fun x _ -> x)
-        acc expr
+  | _ -> fold_expression collect_deprecated_expr acc expr
 
-let collect_deprecated_lval acc l =
-  fold_lval_with collect_deprecated_expr (fun x _ -> x) acc l
+let collect_deprecated_lval acc l = fold_lval_with collect_deprecated_expr acc l
 
 let rec collect_deprecated_stmt fundefs (acc : (Location_span.t * string) list)
     {stmt; _} : (Location_span.t * string) list =
@@ -175,22 +170,16 @@ let rec collect_deprecated_stmt fundefs (acc : (Location_span.t * string) list)
         :: acc in
       fold_statement collect_deprecated_expr
         (collect_deprecated_stmt fundefs)
-        collect_deprecated_lval
-        (fun l _ -> l)
-        acc body.stmt
+        collect_deprecated_lval acc body.stmt
   | Tilde {distribution; _} when String.equal distribution.name "lkj_cov" ->
       let acc = (distribution.id_loc, lkj_cov_message) :: acc in
       fold_statement collect_deprecated_expr
-        (fun s _ -> s)
-        collect_deprecated_lval
-        (fun l _ -> l)
-        acc stmt
+        (collect_deprecated_stmt fundefs)
+        collect_deprecated_lval acc stmt
   | _ ->
       fold_statement collect_deprecated_expr
         (collect_deprecated_stmt fundefs)
-        collect_deprecated_lval
-        (fun l _ -> l)
-        acc stmt
+        collect_deprecated_lval acc stmt
 
 let collect_warnings (program : typed_program) =
   let fundefs = userdef_functions program in

--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -112,8 +112,7 @@ let set_jacobian_compatibility_mode stmts =
   Fun_kind.jacobian_compat_mode := not (functions_block_contains_jac_pe stmts)
 
 let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
-    ({expr; emeta} : (typed_expr_meta, fun_kind) expr_with) :
-    (Location_span.t * string) list =
+    ({expr; emeta} : Ast.typed_expression) : (Location_span.t * string) list =
   match expr with
   | CondDistApp ((StanLib _ | UserDefined _), {name; _}, l)
    |FunApp ((StanLib _ | UserDefined _), {name; _}, l) ->
@@ -144,7 +143,11 @@ let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
                   [(emeta.loc, lkj_cov_message)]
                 else []) in
       acc @ w @ List.concat_map l ~f:(fun e -> collect_deprecated_expr [] e)
-  | _ -> fold_expression collect_deprecated_expr (fun l _ -> l) acc expr
+  | _ ->
+      fold_expression collect_deprecated_expr
+        (fun l _ -> l)
+        (fun x _ -> x)
+        acc expr
 
 let collect_deprecated_lval acc l =
   fold_lval_with collect_deprecated_expr (fun x _ -> x) acc l

--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -47,10 +47,7 @@ let rec get_function_calls_expr (funs, distrs) expr =
     | FunApp (StanLib _, f, _) -> (Set.add funs f.name, distrs)
     | CondDistApp (StanLib _, f, _) -> (funs, Set.add distrs f.name)
     | _ -> (funs, distrs) in
-  fold_expression get_function_calls_expr
-    (fun acc _ -> acc)
-    (fun acc _ -> acc)
-    acc expr.expr
+  fold_expression get_function_calls_expr acc expr.expr
 
 let rec get_function_calls_stmt ud_dists (funs, distrs) stmt =
   let acc =
@@ -66,8 +63,7 @@ let rec get_function_calls_stmt ud_dists (funs, distrs) stmt =
     | _ -> (funs, distrs) in
   fold_statement get_function_calls_expr
     (get_function_calls_stmt ud_dists)
-    (fun acc _ -> acc)
-    (fun acc _ -> acc)
+    (fold_lval_with get_function_calls_expr)
     acc stmt.stmt
 
 let function_calls_json p =

--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -47,7 +47,10 @@ let rec get_function_calls_expr (funs, distrs) expr =
     | FunApp (StanLib _, f, _) -> (Set.add funs f.name, distrs)
     | CondDistApp (StanLib _, f, _) -> (funs, Set.add distrs f.name)
     | _ -> (funs, distrs) in
-  fold_expression get_function_calls_expr (fun acc _ -> acc) acc expr.expr
+  fold_expression get_function_calls_expr
+    (fun acc _ -> acc)
+    (fun acc _ -> acc)
+    acc expr.expr
 
 let rec get_function_calls_stmt ud_dists (funs, distrs) stmt =
   let acc =

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -287,12 +287,12 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
   | ArrayExpr es -> pf ppf "{@[%a}@]" pp_list_of_expression (es, loc)
   | RowVectorExpr es -> pf ppf "[@[%a]@]" pp_list_of_expression (es, loc)
   | Paren e -> pf ppf "(%a)" pp_expression e
-  | Promotion (e, _, _) -> pp_expression ppf e
   | Indexed (e, l) -> pf ppf "%a[%a]" pp_expression e pp_list_of_indices l
   | TupleProjection (e, i) -> pf ppf "%a.%d" pp_expression e i
   | TupleExpr es ->
       pf ppf "(@[<hv>%a%s@])" pp_list_of_expression (es, loc)
         (if List.length es = 1 then "," else "")
+  | Promotion _ -> .
 
 and pp_list_of_expression ppf es =
   let loc_of (x : untyped_expression) = x.emeta.loc in

--- a/src/frontend/Promotion.ml
+++ b/src/frontend/Promotion.ml
@@ -83,28 +83,28 @@ let promote_inner (exp : Ast.typed_expression) prom =
   match prom with
   | ToVar ->
       Ast.
-        { expr= Ast.Promotion (exp, UReal, AutoDiffable)
+        { expr= Ast.Promotion (exp, (UReal, AutoDiffable))
         ; emeta=
             { emeta with
               type_= UnsizedType.promote_container emeta.type_ UReal
             ; ad_level= AutoDiffable } }
   | ToComplexVar ->
       Ast.
-        { expr= Ast.Promotion (exp, UComplex, AutoDiffable)
+        { expr= Ast.Promotion (exp, (UComplex, AutoDiffable))
         ; emeta=
             { emeta with
               type_= UnsizedType.promote_container emeta.type_ UComplex
             ; ad_level= AutoDiffable } }
   | IntToReal when UnsizedType.is_int_type emeta.type_ ->
       Ast.
-        { expr= Ast.Promotion (exp, UReal, emeta.ad_level)
+        { expr= Ast.Promotion (exp, (UReal, emeta.ad_level))
         ; emeta=
             {emeta with type_= UnsizedType.promote_container emeta.type_ UReal}
         }
   | (IntToComplex | RealToComplex)
     when not (UnsizedType.is_complex_type emeta.type_) ->
       (* these two promotions are separated for cost, but are actually the same promotion *)
-      { expr= Promotion (exp, UComplex, emeta.ad_level)
+      { expr= Promotion (exp, (UComplex, emeta.ad_level))
       ; emeta=
           {emeta with type_= UnsizedType.promote_container emeta.type_ UComplex}
       }
@@ -116,7 +116,7 @@ let promote_inner (exp : Ast.typed_expression) prom =
             promote_unsized_type element emeta.ad_level prom in
           let prom_type = scalarize type_ in
           let type_ = UnsizedType.wind_array_type (type_, size) in
-          { expr= Promotion (exp, prom_type, ad_level)
+          { expr= Promotion (exp, (prom_type, ad_level))
           ; emeta= {emeta with type_; ad_level} }
       | _ ->
           Common.ICE.internal_compiler_error

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -630,7 +630,6 @@ let verify_second_order_derivative_compatibility (ast : typed_program) =
   let rec check_fun (visited : String.Set.t) {name= fn_name; id_loc} =
     if Set.mem visited fn_name then visited
     else
-      let fold_nop v _ = v in
       let rec check_expr seen = function
         | {expr= FunApp (StanLib _, {name; _}, _); _}
           when Stan_math_signatures.lacks_higher_order_autodiff name ->
@@ -643,17 +642,15 @@ let verify_second_order_derivative_compatibility (ast : typed_program) =
             List.fold ~f:check_expr ~init:seen' es
         | {expr= Variable name; emeta= {type_= UFun _; _}} ->
             check_fun seen {name with id_loc}
-        | e -> Ast.fold_expression check_expr fold_nop fold_nop seen e.expr
-      in
-      let check_lval acc l = fold_lval_with check_expr fold_nop acc l in
+        | e -> Ast.fold_expression check_expr seen e.expr in
+      let check_lval acc l = fold_lval_with check_expr acc l in
       let rec check_stmt seen s =
         match s.stmt with
         | NRFunApp (UserDefined _, name, es) ->
             let seen' = check_fun seen {name with id_loc} in
             List.fold ~f:check_expr ~init:seen' es
-        | stmt ->
-            Ast.fold_statement check_expr check_stmt check_lval fold_nop seen
-              stmt in
+        | stmt -> Ast.fold_statement check_expr check_stmt check_lval seen stmt
+      in
       let visited' = Set.add visited fn_name in
       List.fold ~f:check_stmt ~init:visited' (get_function_bodies fn_name) in
   ignore

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -36,7 +36,7 @@ let rec pp pp_e ppf = function
         (d1_expr, d2_expr)
   | SArray (st, expr) ->
       Fmt.pf ppf "array%a"
-        Fmt.(pair ~sep:comma (fun ppf st -> pp pp_e ppf st) pp_e |> brackets)
+        Fmt.(pair ~sep:comma (pp pp_e) pp_e |> brackets)
         (st, expr)
   | STuple subtypes ->
       Fmt.pf ppf "tuple(@[%a@])" Fmt.(list ~sep:comma (pp pp_e)) subtypes

--- a/test/integration/cli-args/debug-flags.t/run.t
+++ b/test/integration/cli-args/debug-flags.t/run.t
@@ -306,13 +306,13 @@ Flags not used elsewhere in the tests
                (Promotion
                 ((expr (IntNumeral 1))
                  (emeta ((loc <opaque>) (ad_level DataOnly) (type_ UInt))))
-                UReal DataOnly))
+                (UReal DataOnly)))
               (emeta ((loc <opaque>) (ad_level DataOnly) (type_ UReal))))
              ((expr
                (Promotion
                 ((expr (IntNumeral 1))
                  (emeta ((loc <opaque>) (ad_level DataOnly) (type_ UInt))))
-                UReal DataOnly))
+                (UReal DataOnly)))
               (emeta ((loc <opaque>) (ad_level DataOnly) (type_ UReal))))))
            (truncation NoTruncate)))
          (smeta ((loc <opaque>) (return_type Incomplete))))


### PR DESCRIPTION
This adds another type parameter to the ast which can be made empty for the untyped ast, allowing us to replace a couple ICEs in the happy path with refutation cases (`.`) that the compiler proves unreachable. 

This has bugged me since adding the Promotion node a while back.
The main annoyance with doing this is that it would add another (broadly useless) argument to `@@deriving` functions like `map_expression` (and `fold_...`). I get around this by re-defining those helper functions towards the bottom of the file without the arguments we don't use, and cleaning up the usage sites. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
