### PR TITLE
Also update wording of manual parser errors in parser.mly

### DIFF
--- a/src/frontend/parser.messages
+++ b/src/frontend/parser.messages
@@ -1117,7 +1117,7 @@ program: DATABLOCK WHILE
 Ill-formed block. Expected "{" followed by a list of top-level variable declarations after "data".
 
 program: FUNCTIONBLOCK LBRACE VOID WHILE LPAREN RPAREN SEMICOLON EOF
-## Concrete syntax: functions { void while ( ) ;
+## Concrete syntax: functions { void while ( ) ; <EOF>
 program: FUNCTIONBLOCK LBRACE VOID IDENTIFIER LPAREN RPAREN SEMICOLON WHILE
 ##
 ## Concrete syntax: functions { void foo ( ) ; while

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -195,7 +195,7 @@ Syntax error in 'bad_decl1.stan', line 2, column 10 to column 13, parsing error:
      3:  }
    -------------------------------------------------
 
-Found a type ('int') where an identifier was expected.
+Ill-formed identifier. Found a type ("int") where an identifier was expected.
 All variables declared in a comma-separated list must be of the same type.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_decl2.stan
@@ -232,7 +232,7 @@ Syntax error in 'bad_decl4.stan', line 2, column 10 to column 16, parsing error:
      3:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'reject'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "reject".
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_function.stan
 Semantic error in 'bad_function.stan', line 3, column 3 to column 7:

--- a/test/integration/bad/new/stanc.expected
+++ b/test/integration/bad/new/stanc.expected
@@ -258,7 +258,7 @@ Syntax error in 'fundef-bad6.stan', line 1, column 37 to column 42, parsing erro
                                               ^
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'while'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "while".
 [exit 1]
   $ ../../../../../install/default/bin/stanc fundef-bad7.stan
 Syntax error in 'fundef-bad7.stan', line 1, column 21 to column 26, parsing error:
@@ -276,7 +276,7 @@ Syntax error in 'fundef-bad8.stan', line 1, column 17 to column 22, parsing erro
                           ^
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'while'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "while".
 [exit 1]
   $ ../../../../../install/default/bin/stanc fundef-bad9.stan
 Syntax error in 'fundef-bad9.stan', line 1, column 23 to column 27, parsing error:

--- a/test/integration/bad/profiling/stanc.expected
+++ b/test/integration/bad/profiling/stanc.expected
@@ -55,7 +55,7 @@ Syntax error in 'profile-bad5.stan', line 2, column 9 to column 16, parsing erro
      3:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'profile'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "profile".
 [exit 1]
   $ ../../../../../install/default/bin/stanc profile-bad6.stan
 Syntax error in 'profile-bad6.stan', line 2, column 9 to column 16, parsing error:
@@ -67,5 +67,5 @@ Syntax error in 'profile-bad6.stan', line 2, column 9 to column 16, parsing erro
      4:      }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'profile'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "profile".
 [exit 1]

--- a/test/integration/bad/removed_features/stanc.expected
+++ b/test/integration/bad/removed_features/stanc.expected
@@ -60,7 +60,7 @@ Syntax error in 'decl.stan', line 2, column 7 to column 12, parsing error:
      4:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'array'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "array".
 [exit 1]
   $ ../../../../../install/default/bin/stanc declarations.stan
 Syntax error in 'declarations.stan', line 3, column 18 to column 19, parsing error:
@@ -73,7 +73,7 @@ Syntax error in 'declarations.stan', line 3, column 18 to column 19, parsing err
      5:    array[1] int a3;
    -------------------------------------------------
 
-";" expected after variable declaration.
+Ill-formed declaration. ";" expected after variable declaration.
 It looks like you are trying to use the old array syntax.
 Please use the new syntax:
 array[1] int<lower=0> a1;
@@ -141,7 +141,7 @@ Syntax error in 'identifiers.stan', line 2, column 6 to column 11, parsing error
      4:    int multiplier;
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'upper'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "upper".
 [exit 1]
   $ ../../../../../install/default/bin/stanc if_else.stan
 Semantic error in 'if_else.stan', line 9, column 26 to column 54:
@@ -244,7 +244,7 @@ Syntax error in 'removed_deprecated_syntax.stan', line 10, column 9 to column 10
     12:  }
    -------------------------------------------------
 
-";" expected after variable declaration.
+Ill-formed declaration. ";" expected after variable declaration.
 It looks like you are trying to use the old array syntax.
 Please use the new syntax:
 array[7] real c;
@@ -259,7 +259,7 @@ Syntax error in 'unreserved-array-keyword.stan', line 2, column 24 to column 29,
      4:  
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'array'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "array".
 [exit 1]
   $ ../../../../../install/default/bin/stanc unsized-old-array.stan
 Syntax error in 'unsized-old-array.stan', line 2, column 17 to column 20, parsing error:
@@ -271,8 +271,21 @@ Syntax error in 'unsized-old-array.stan', line 2, column 17 to column 20, parsin
      4:    }
    -------------------------------------------------
 
-An identifier is expected after the type as a function argument name.
-It looks like you are trying to use the old array syntax.
-Please use the new syntax: 
+Ill-formed type. It looks like you are trying to use the old array syntax.
+Please use the new syntax:
 array[,] real
+[exit 1]
+  $ ../../../../../install/default/bin/stanc unsized-old-array2.stan
+Syntax error in 'unsized-old-array2.stan', line 2, column 6 to column 8, parsing error:
+   -------------------------------------------------
+     1:  functions{
+     2:    real[] foo(real v){
+               ^
+     3:      return sum(v);
+     4:    }
+   -------------------------------------------------
+
+Ill-formed type. It looks like you are trying to use the old array syntax.
+Please use the new syntax:
+array[] real
 [exit 1]

--- a/test/integration/bad/removed_features/unsized-old-array2.stan
+++ b/test/integration/bad/removed_features/unsized-old-array2.stan
@@ -1,0 +1,5 @@
+functions{
+  real[] foo(real v){
+    return sum(v);
+  }
+}

--- a/test/integration/bad/reserved/stanc.expected
+++ b/test/integration/bad/reserved/stanc.expected
@@ -20,7 +20,7 @@ Syntax error in 'break.stan', line 2, column 7 to column 12, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'break'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "break".
 [exit 1]
   $ ../../../../../install/default/bin/stanc cholesky_factor_corr.stan
 Syntax error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27, parsing error:
@@ -32,7 +32,7 @@ Syntax error in 'cholesky_factor_corr.stan', line 2, column 7 to column 27, pars
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'cholesky_factor_corr'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "cholesky_factor_corr".
 [exit 1]
   $ ../../../../../install/default/bin/stanc cholesky_factor_cov.stan
 Syntax error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26, parsing error:
@@ -44,7 +44,7 @@ Syntax error in 'cholesky_factor_cov.stan', line 2, column 7 to column 26, parsi
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'cholesky_factor_cov'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "cholesky_factor_cov".
 [exit 1]
   $ ../../../../../install/default/bin/stanc column_stochastic_matrix.stan
 Syntax error in 'column_stochastic_matrix.stan', line 2, column 7 to column 31, parsing error:
@@ -55,7 +55,7 @@ Syntax error in 'column_stochastic_matrix.stan', line 2, column 7 to column 31, 
      3:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'column_stochastic_matrix'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "column_stochastic_matrix".
 [exit 1]
   $ ../../../../../install/default/bin/stanc continue.stan
 Syntax error in 'continue.stan', line 2, column 7 to column 15, parsing error:
@@ -67,7 +67,7 @@ Syntax error in 'continue.stan', line 2, column 7 to column 15, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'continue'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "continue".
 [exit 1]
   $ ../../../../../install/default/bin/stanc corr_matrix.stan
 Syntax error in 'corr_matrix.stan', line 2, column 7 to column 18, parsing error:
@@ -79,7 +79,7 @@ Syntax error in 'corr_matrix.stan', line 2, column 7 to column 18, parsing error
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'corr_matrix'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "corr_matrix".
 [exit 1]
   $ ../../../../../install/default/bin/stanc cov_matrix.stan
 Syntax error in 'cov_matrix.stan', line 2, column 7 to column 17, parsing error:
@@ -91,7 +91,7 @@ Syntax error in 'cov_matrix.stan', line 2, column 7 to column 17, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'cov_matrix'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "cov_matrix".
 [exit 1]
   $ ../../../../../install/default/bin/stanc data.stan
 Syntax error in 'data.stan', line 2, column 7 to column 11, parsing error:
@@ -103,7 +103,7 @@ Syntax error in 'data.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'data'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "data".
 [exit 1]
   $ ../../../../../install/default/bin/stanc else.stan
 Syntax error in 'else.stan', line 2, column 7 to column 11, parsing error:
@@ -115,7 +115,7 @@ Syntax error in 'else.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'else'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "else".
 [exit 1]
   $ ../../../../../install/default/bin/stanc export.stan
 Semantic error in 'export.stan', line 2, column 7 to column 13:
@@ -163,7 +163,7 @@ Syntax error in 'for.stan', line 2, column 7 to column 10, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'for'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "for".
 [exit 1]
   $ ../../../../../install/default/bin/stanc generated.stan
 Semantic error in 'generated.stan', line 2, column 7 to column 16:
@@ -187,7 +187,7 @@ Syntax error in 'if.stan', line 2, column 7 to column 9, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'if'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "if".
 [exit 1]
   $ ../../../../../install/default/bin/stanc in.stan
 Syntax error in 'in.stan', line 2, column 7 to column 9, parsing error:
@@ -199,7 +199,7 @@ Syntax error in 'in.stan', line 2, column 7 to column 9, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'in'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "in".
 [exit 1]
   $ ../../../../../install/default/bin/stanc int.stan
 Syntax error in 'int.stan', line 2, column 7 to column 10, parsing error:
@@ -211,7 +211,7 @@ Syntax error in 'int.stan', line 2, column 7 to column 10, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'int'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "int".
 [exit 1]
   $ ../../../../../install/default/bin/stanc matrix.stan
 Syntax error in 'matrix.stan', line 2, column 7 to column 13, parsing error:
@@ -223,7 +223,7 @@ Syntax error in 'matrix.stan', line 2, column 7 to column 13, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'matrix'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "matrix".
 [exit 1]
   $ ../../../../../install/default/bin/stanc model.stan
 Syntax error in 'model.stan', line 2, column 7 to column 12, parsing error:
@@ -235,7 +235,7 @@ Syntax error in 'model.stan', line 2, column 7 to column 12, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'model'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "model".
 [exit 1]
   $ ../../../../../install/default/bin/stanc ordered.stan
 Syntax error in 'ordered.stan', line 2, column 7 to column 14, parsing error:
@@ -247,7 +247,7 @@ Syntax error in 'ordered.stan', line 2, column 7 to column 14, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'ordered'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "ordered".
 [exit 1]
   $ ../../../../../install/default/bin/stanc parameters.stan
 Syntax error in 'parameters.stan', line 2, column 7 to column 17, parsing error:
@@ -259,7 +259,7 @@ Syntax error in 'parameters.stan', line 2, column 7 to column 17, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'parameters'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "parameters".
 [exit 1]
   $ ../../../../../install/default/bin/stanc positive_ordered.stan
 Syntax error in 'positive_ordered.stan', line 2, column 7 to column 23, parsing error:
@@ -271,7 +271,7 @@ Syntax error in 'positive_ordered.stan', line 2, column 7 to column 23, parsing 
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'positive_ordered'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "positive_ordered".
 [exit 1]
   $ ../../../../../install/default/bin/stanc quantities.stan
 Semantic error in 'quantities.stan', line 2, column 7 to column 17:
@@ -295,7 +295,7 @@ Syntax error in 'real.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'real'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "real".
 [exit 1]
   $ ../../../../../install/default/bin/stanc repeat.stan
 Semantic error in 'repeat.stan', line 2, column 7 to column 13:
@@ -319,7 +319,7 @@ Syntax error in 'return.stan', line 2, column 7 to column 13, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'return'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "return".
 [exit 1]
   $ ../../../../../install/default/bin/stanc row_stochastic_matrix.stan
 Syntax error in 'row_stochastic_matrix.stan', line 2, column 6 to column 27, parsing error:
@@ -330,7 +330,7 @@ Syntax error in 'row_stochastic_matrix.stan', line 2, column 6 to column 27, par
      3:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'row_stochastic_matrix'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "row_stochastic_matrix".
 [exit 1]
   $ ../../../../../install/default/bin/stanc row_vector.stan
 Syntax error in 'row_vector.stan', line 2, column 7 to column 17, parsing error:
@@ -342,7 +342,7 @@ Syntax error in 'row_vector.stan', line 2, column 7 to column 17, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'row_vector'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "row_vector".
 [exit 1]
   $ ../../../../../install/default/bin/stanc simplex.stan
 Syntax error in 'simplex.stan', line 2, column 7 to column 14, parsing error:
@@ -354,7 +354,7 @@ Syntax error in 'simplex.stan', line 2, column 7 to column 14, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'simplex'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "simplex".
 [exit 1]
   $ ../../../../../install/default/bin/stanc static.stan
 Semantic error in 'static.stan', line 2, column 7 to column 13:
@@ -389,7 +389,7 @@ Syntax error in 'sum_to_zero_matrix.stan', line 2, column 7 to column 25, parsin
      3:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'sum_to_zero_matrix'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "sum_to_zero_matrix".
 [exit 1]
   $ ../../../../../install/default/bin/stanc sum_to_zero_vector.stan
 Syntax error in 'sum_to_zero_vector.stan', line 2, column 7 to column 25, parsing error:
@@ -400,7 +400,7 @@ Syntax error in 'sum_to_zero_vector.stan', line 2, column 7 to column 25, parsin
      3:  }
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'sum_to_zero_vector'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "sum_to_zero_vector".
 [exit 1]
   $ ../../../../../install/default/bin/stanc then.stan
 Semantic error in 'then.stan', line 2, column 7 to column 11:
@@ -460,7 +460,7 @@ Syntax error in 'unit_vector.stan', line 2, column 7 to column 18, parsing error
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'unit_vector'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "unit_vector".
 [exit 1]
   $ ../../../../../install/default/bin/stanc until.stan
 Semantic error in 'until.stan', line 2, column 7 to column 12:
@@ -496,7 +496,7 @@ Syntax error in 'vector.stan', line 2, column 7 to column 13, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'vector'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "vector".
 [exit 1]
   $ ../../../../../install/default/bin/stanc void.stan
 Syntax error in 'void.stan', line 2, column 7 to column 11, parsing error:
@@ -508,7 +508,7 @@ Syntax error in 'void.stan', line 2, column 7 to column 11, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'void'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "void".
 [exit 1]
   $ ../../../../../install/default/bin/stanc while.stan
 Syntax error in 'while.stan', line 2, column 7 to column 12, parsing error:
@@ -520,5 +520,5 @@ Syntax error in 'while.stan', line 2, column 7 to column 12, parsing error:
      4:  model {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'while'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "while".
 [exit 1]

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -107,7 +107,7 @@ Syntax error in 'assign_invalid_lhs1.stan', line 2, column 2 to column 12, parsi
      3:  }
    -------------------------------------------------
 
-Expected an assignable value but found a general expression.
+Ill-formed assignment. Expected an assignable value but found a general expression.
 [exit 1]
   $ ../../../../install/default/bin/stanc assign_invalid_lhs2.stan
 Syntax error in 'assign_invalid_lhs2.stan', line 2, column 3 to column 21, parsing error:
@@ -118,7 +118,7 @@ Syntax error in 'assign_invalid_lhs2.stan', line 2, column 3 to column 21, parsi
      3:  }
    -------------------------------------------------
 
-Expected an assignable value but found a general expression.
+Ill-formed assignment. Expected an assignable value but found a general expression.
 [exit 1]
   $ ../../../../install/default/bin/stanc assign_real_to_int.stan
 Semantic error in 'assign_real_to_int.stan', line 11, column 2 to column 3:
@@ -2869,7 +2869,7 @@ Syntax error in 'target-reserved.stan', line 2, column 7 to column 13, parsing e
      4:  parameters {
    -------------------------------------------------
 
-Expected a new identifier but found reserved keyword 'target'.
+Ill-formed identifier. Expected a new identifier but found reserved keyword "target".
 [exit 1]
   $ ../../../../install/default/bin/stanc target_pe_bad.stan
 Semantic error in 'target_pe_bad.stan', line 8, column 2 to column 16:

--- a/test/integration/bad/tuples/stanc.expected
+++ b/test/integration/bad/tuples/stanc.expected
@@ -151,7 +151,7 @@ Syntax error in 'bad_unpack_lhs.stan', line 4, column 2 to column 15, parsing er
      5:  }
    -------------------------------------------------
 
-Expected an assignable value but found a general expression.
+Ill-formed assignment. Expected an assignable value but found a general expression.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_unpack_overlap1.stan
 Semantic error in 'bad_unpack_overlap1.stan', line 9, column 2 to column 30:
@@ -334,7 +334,7 @@ Syntax error in 'fuzz-tuple-idx1.stan', line 1, column 36 to column 58, parsing 
                                              ^
    -------------------------------------------------
 
-Failed to parse integer from string '.40000000000000000000' in tuple index. 
+Ill-formed index. Failed to parse integer from string ".40000000000000000000" in tuple index. 
 The index is likely too large.
 [exit 1]
   $ ../../../../../install/default/bin/stanc fuzz-tuple-idx2.stan
@@ -344,7 +344,7 @@ Syntax error in 'fuzz-tuple-idx2.stan', line 1, column 61 to column 83, parsing 
                                                                       ^
    -------------------------------------------------
 
-Failed to parse integer from string '.10000000000000000000' in tuple index. 
+Ill-formed index. Failed to parse integer from string ".10000000000000000000" in tuple index. 
 The index is likely too large.
 [exit 1]
   $ ../../../../../install/default/bin/stanc fuzz-tuple-idx3.stan
@@ -354,7 +354,7 @@ Syntax error in 'fuzz-tuple-idx3.stan', line 1, column 45 to column 66, parsing 
                                                       ^
    -------------------------------------------------
 
-Failed to parse integer from string '.6000000000000000000' in tuple index. 
+Ill-formed index. Failed to parse integer from string ".6000000000000000000" in tuple index. 
 The index is likely too large.
 [exit 1]
   $ ../../../../../install/default/bin/stanc incomplete1.stan

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -386,7 +386,7 @@ Syntax error in 'string', line 3, column 8 to column 10, parsing error:
      5:  model {
    -------------------------------------------------
 
-";" expected after variable declaration.
+Ill-formed declaration. ";" expected after variable declaration.
 It looks like you are trying to use the old array syntax.
 Please use the new syntax:
 array[10] real y;
@@ -401,7 +401,7 @@ Syntax error in 'string', line 3, column 8 to column 10, parsing error:
      5:  model {
    -------------------------------------------------
 
-";" expected after variable declaration.
+Ill-formed declaration. ";" expected after variable declaration.
 It looks like you are trying to use the old array syntax.
 Please use the new syntax:
 array[10] real y;


### PR DESCRIPTION
Same as #1549, but for the few errors we manually raise in parser.mly (knew I was forgetting _something_)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improved the wording of syntax error messages.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
