### PR TITLE
JS Build: Don't try to load node modules

### DIFF
--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -9,7 +9,7 @@
  (release
   (js_of_ocaml
    (flags
-    (:standard "--opt" "3"))))
+    (:standard "--opt" "3" "--target-env" "browser"))))
  (dev
   (js_of_ocaml
    (flags
@@ -21,7 +21,9 @@
     "--disable"
     "share"
     "--enable"
-    "with-js-error"))))
+    "with-js-error"
+    "--target-env"
+    "browser"))))
 
 (alias
  (name default)


### PR DESCRIPTION
Because stanc.js doesn't do any filesystem loading or other features, we can make it slightly more compatible by passing `--target=browser`. This only changes what the code tries to import, not how downstream users can use it (e.g., it will still work with node)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

stanc3js will no longer try to load node modules at startup

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
