### PR TITLE
Use macos-15-intel for github actions build

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,7 +16,7 @@ jobs:
             sdk: ""
             profile: static
             name: ubuntu
-          - os: macos-13
+          - os: macos-15-intel
             sdk: "10.11"
             profile: release
             name: macos-x86_64


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/13045. The macos-13 image is deprecated and will be removed soon. macos-15-intel will be available until August 2027

Successful run [here](https://github.com/stan-dev/stanc3/actions/runs/18754501430/job/53502778314)