### PR TITLE
Update reference in pedantic warning about scales

### DIFF
--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -341,7 +341,8 @@ let list_unscaled_constants (distributions_list : dist_info Set.Poly.t) :
 let unscaled_constants_message (name : string) : string =
   Printf.sprintf
     "Argument %s suggests there may be parameters that are not unit scale; \
-     consider rescaling with a multiplier (see manual section 22.12)."
+     consider rescaling with a multiplier, see: \
+     https://mc-stan.org/docs/stan-users-guide/efficiency-tuning.html#standardizing-predictors"
     name
 
 let unscaled_constants_warnings (distributions_list : dist_info Set.Poly.t) =

--- a/test/integration/cli-args/warn-pedantic/stanc.expected
+++ b/test/integration/cli-args/warn-pedantic/stanc.expected
@@ -696,10 +696,12 @@ Warning: The parameter a has 2 priors.
   $ ../../../../../install/default/bin/stanc --warn-pedantic  unscaled.stan
 Warning in 'unscaled.stan', line 10, column 20 to column 25:
     Argument 10000 suggests there may be parameters that are not unit scale;
-    consider rescaling with a multiplier (see manual section 22.12).
+    consider rescaling with a multiplier, see:
+    https://mc-stan.org/docs/stan-users-guide/efficiency-tuning.html#standardizing-predictors
 Warning in 'unscaled.stan', line 10, column 13 to column 18:
     Argument 0.001 suggests there may be parameters that are not unit scale;
-    consider rescaling with a multiplier (see manual section 22.12).
+    consider rescaling with a multiplier, see:
+    https://mc-stan.org/docs/stan-users-guide/efficiency-tuning.html#standardizing-predictors
 [exit 0]
   $ ../../../../../install/default/bin/stanc --warn-pedantic  unused-param.stan
 Warning: The parameter e was declared but was not used in the density

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -370,7 +370,8 @@ Function "foo" is declared without specifying a definition.
 $ node pedantic.js
 Warning in 'string', line 7, column 17 to column 22:
     Argument 10000 suggests there may be parameters that are not unit scale;
-    consider rescaling with a multiplier (see manual section 22.12).
+    consider rescaling with a multiplier, see:
+    https://mc-stan.org/docs/stan-users-guide/efficiency-tuning.html#standardizing-predictors
 Warning: The parameter k was declared but was not used in the density
     calculation.
 Warning in 'string', line 4, column 9 to column 11:


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Fixed a pedantic warning referring to a now-incorrect location in the user's guide.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
