### PR TITLE
codegen: unconditionally generate static casts from int to double for Promotion nodes

### DIFF
--- a/test/integration/good/code-gen/complex_numbers/cpp.expected
+++ b/test/integration/good/code-gen/complex_numbers/cpp.expected
@@ -7543,7 +7543,7 @@ foo1(const T0__& z, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 408;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -7643,7 +7643,7 @@ foo5(const T0__& z, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 416;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -7727,7 +7727,7 @@ foo8(const T0__& z, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 422;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -7938,15 +7938,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 363;
       td_complex = stan::math::to_complex();
       current_statement__ = 364;
-      td_complex = stan::math::to_complex(1);
+      td_complex = stan::math::to_complex(static_cast<double>(1));
       current_statement__ = 365;
       td_complex = stan::math::to_complex(1.2);
       current_statement__ = 366;
-      td_complex = stan::math::to_complex(1, 2);
+      td_complex = stan::math::to_complex(static_cast<double>(1),
+                     static_cast<double>(2));
       current_statement__ = 367;
-      td_complex = stan::math::to_complex(1.1, 2);
+      td_complex = stan::math::to_complex(1.1, static_cast<double>(2));
       current_statement__ = 368;
-      td_complex = stan::math::to_complex(1, 2.2);
+      td_complex = stan::math::to_complex(static_cast<double>(1), 2.2);
       current_statement__ = 369;
       td_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 370;
@@ -7955,10 +7956,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 371;
       stan::model::assign(td_complex_array,
         std::vector<std::complex<double>>{td_complex,
-          stan::math::to_complex(1, 0), stan::math::to_complex(2, 3)},
-        "assigning variable td_complex_array");
+          stan::math::to_complex(1, 0),
+          stan::math::to_complex(static_cast<double>(2),
+            static_cast<double>(3))}, "assigning variable td_complex_array");
       current_statement__ = 372;
-      stan::model::assign(td_complex_array, stan::math::to_complex(5.1, 6),
+      stan::model::assign(td_complex_array,
+        stan::math::to_complex(5.1, static_cast<double>(6)),
         "assigning variable td_complex_array", stan::model::index_uni(1));
       current_statement__ = 373;
       stan::model::assign(td_complex_array_2d, d_complex_array_2d,
@@ -7972,10 +7975,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                                                          stan::math::to_complex(
                                                            3, 0)},
           std::vector<std::complex<double>>{stan::math::to_complex(),
-            stan::math::to_complex(1.1), stan::math::to_complex(1, 2.1)}},
+            stan::math::to_complex(1.1),
+            stan::math::to_complex(static_cast<double>(1), 2.1)}},
         "assigning variable td_complex_array_2d");
       current_statement__ = 375;
-      stan::model::assign(td_complex_array_2d, stan::math::to_complex(1, 2),
+      stan::model::assign(td_complex_array_2d,
+        stan::math::to_complex(static_cast<double>(1), static_cast<double>(2)),
         "assigning variable td_complex_array_2d", stan::model::index_uni(1),
         stan::model::index_uni(1));
       current_statement__ = 376;
@@ -7988,7 +7993,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 378;
       stan::model::assign(td_complex_array_2d,
         std::vector<std::complex<double>>{td_complex,
-          stan::math::to_complex(1, 2), stan::math::to_complex(2.4, 0)},
+          stan::math::to_complex(static_cast<double>(1),
+            static_cast<double>(2)), stan::math::to_complex(2.4, 0)},
         "assigning variable td_complex_array_2d", stan::model::index_uni(1));
       current_statement__ = 383;
       for (int td_j = 1; td_j <= 2; ++td_j) {
@@ -7996,7 +8002,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         for (int td_k = 1; td_k <= 3; ++td_k) {
           current_statement__ = 379;
           stan::model::assign(td_complex_array_2d,
-            stan::math::to_complex(1, 2.2),
+            stan::math::to_complex(static_cast<double>(1), 2.2),
             "assigning variable td_complex_array_2d",
             stan::model::index_uni(td_j), stan::model::index_uni(td_k));
         }
@@ -8163,15 +8169,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 31;
       tp_complex = stan::math::to_complex();
       current_statement__ = 32;
-      tp_complex = stan::math::to_complex(1);
+      tp_complex = stan::math::to_complex(static_cast<double>(1));
       current_statement__ = 33;
       tp_complex = stan::math::to_complex(1.2);
       current_statement__ = 34;
-      tp_complex = stan::math::to_complex(1, 2);
+      tp_complex = stan::math::to_complex(static_cast<double>(1),
+                     static_cast<double>(2));
       current_statement__ = 35;
-      tp_complex = stan::math::to_complex(1.1, 2);
+      tp_complex = stan::math::to_complex(1.1, static_cast<double>(2));
       current_statement__ = 36;
-      tp_complex = stan::math::to_complex(1, 2.2);
+      tp_complex = stan::math::to_complex(static_cast<double>(1), 2.2);
       current_statement__ = 37;
       tp_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 38;
@@ -8185,10 +8192,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::vector<std::complex<local_scalar_t__>>{tp_complex,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(1),
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            stan::math::to_complex(2, 3))},
+            stan::math::to_complex(static_cast<double>(2),
+              static_cast<double>(3)))},
         "assigning variable tp_complex_array");
       current_statement__ = 41;
-      stan::model::assign(tp_complex_array, stan::math::to_complex(5.1, 6),
+      stan::model::assign(tp_complex_array,
+        stan::math::to_complex(5.1, static_cast<double>(6)),
         "assigning variable tp_complex_array", stan::model::index_uni(1));
       current_statement__ = 42;
       stan::model::assign(tp_complex_array_2d, d_complex_array_2d,
@@ -8214,10 +8223,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             stan::math::promote_scalar<std::complex<local_scalar_t__>>(
               stan::math::to_complex(1.1)),
             stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-              stan::math::to_complex(1, 2.1))}},
+              stan::math::to_complex(static_cast<double>(1), 2.1))}},
         "assigning variable tp_complex_array_2d");
       current_statement__ = 45;
-      stan::model::assign(tp_complex_array_2d, stan::math::to_complex(1, 2),
+      stan::model::assign(tp_complex_array_2d,
+        stan::math::to_complex(static_cast<double>(1), static_cast<double>(2)),
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
         stan::model::index_uni(1));
       current_statement__ = 46;
@@ -8231,7 +8241,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::model::assign(tp_complex_array_2d,
         std::vector<std::complex<local_scalar_t__>>{tp_complex,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            stan::math::to_complex(1, 2)),
+            stan::math::to_complex(static_cast<double>(1),
+              static_cast<double>(2))),
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(2.4)},
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1));
       current_statement__ = 53;
@@ -8240,7 +8251,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         for (int tp_k = 1; tp_k <= 3; ++tp_k) {
           current_statement__ = 49;
           stan::model::assign(tp_complex_array_2d,
-            stan::math::to_complex(1, 2.2),
+            stan::math::to_complex(static_cast<double>(1), 2.2),
             "assigning variable tp_complex_array_2d",
             stan::model::index_uni(tp_j), stan::model::index_uni(tp_k));
         }
@@ -8325,7 +8336,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
               std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
         current_statement__ = 344;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::abs(p_complex), 0, 1));
+                         stan::math::abs(p_complex), static_cast<double>(0),
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8412,15 +8424,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 31;
       tp_complex = stan::math::to_complex();
       current_statement__ = 32;
-      tp_complex = stan::math::to_complex(1);
+      tp_complex = stan::math::to_complex(static_cast<double>(1));
       current_statement__ = 33;
       tp_complex = stan::math::to_complex(1.2);
       current_statement__ = 34;
-      tp_complex = stan::math::to_complex(1, 2);
+      tp_complex = stan::math::to_complex(static_cast<double>(1),
+                     static_cast<double>(2));
       current_statement__ = 35;
-      tp_complex = stan::math::to_complex(1.1, 2);
+      tp_complex = stan::math::to_complex(1.1, static_cast<double>(2));
       current_statement__ = 36;
-      tp_complex = stan::math::to_complex(1, 2.2);
+      tp_complex = stan::math::to_complex(static_cast<double>(1), 2.2);
       current_statement__ = 37;
       tp_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 38;
@@ -8434,10 +8447,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::vector<std::complex<local_scalar_t__>>{tp_complex,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(1),
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            stan::math::to_complex(2, 3))},
+            stan::math::to_complex(static_cast<double>(2),
+              static_cast<double>(3)))},
         "assigning variable tp_complex_array");
       current_statement__ = 41;
-      stan::model::assign(tp_complex_array, stan::math::to_complex(5.1, 6),
+      stan::model::assign(tp_complex_array,
+        stan::math::to_complex(5.1, static_cast<double>(6)),
         "assigning variable tp_complex_array", stan::model::index_uni(1));
       current_statement__ = 42;
       stan::model::assign(tp_complex_array_2d, d_complex_array_2d,
@@ -8463,10 +8478,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             stan::math::promote_scalar<std::complex<local_scalar_t__>>(
               stan::math::to_complex(1.1)),
             stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-              stan::math::to_complex(1, 2.1))}},
+              stan::math::to_complex(static_cast<double>(1), 2.1))}},
         "assigning variable tp_complex_array_2d");
       current_statement__ = 45;
-      stan::model::assign(tp_complex_array_2d, stan::math::to_complex(1, 2),
+      stan::model::assign(tp_complex_array_2d,
+        stan::math::to_complex(static_cast<double>(1), static_cast<double>(2)),
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
         stan::model::index_uni(1));
       current_statement__ = 46;
@@ -8480,7 +8496,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::model::assign(tp_complex_array_2d,
         std::vector<std::complex<local_scalar_t__>>{tp_complex,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            stan::math::to_complex(1, 2)),
+            stan::math::to_complex(static_cast<double>(1),
+              static_cast<double>(2))),
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(2.4)},
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1));
       current_statement__ = 53;
@@ -8489,7 +8506,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         for (int tp_k = 1; tp_k <= 3; ++tp_k) {
           current_statement__ = 49;
           stan::model::assign(tp_complex_array_2d,
-            stan::math::to_complex(1, 2.2),
+            stan::math::to_complex(static_cast<double>(1), 2.2),
             "assigning variable tp_complex_array_2d",
             stan::model::index_uni(tp_j), stan::model::index_uni(tp_k));
         }
@@ -8574,7 +8591,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
               std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__)));
         current_statement__ = 344;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::abs(p_complex), 0, 1));
+                         stan::math::abs(p_complex), static_cast<double>(0),
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8691,15 +8709,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 31;
       tp_complex = stan::math::to_complex();
       current_statement__ = 32;
-      tp_complex = stan::math::to_complex(1);
+      tp_complex = stan::math::to_complex(static_cast<double>(1));
       current_statement__ = 33;
       tp_complex = stan::math::to_complex(1.2);
       current_statement__ = 34;
-      tp_complex = stan::math::to_complex(1, 2);
+      tp_complex = stan::math::to_complex(static_cast<double>(1),
+                     static_cast<double>(2));
       current_statement__ = 35;
-      tp_complex = stan::math::to_complex(1.1, 2);
+      tp_complex = stan::math::to_complex(1.1, static_cast<double>(2));
       current_statement__ = 36;
-      tp_complex = stan::math::to_complex(1, 2.2);
+      tp_complex = stan::math::to_complex(static_cast<double>(1), 2.2);
       current_statement__ = 37;
       tp_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 38;
@@ -8713,10 +8732,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::vector<std::complex<local_scalar_t__>>{tp_complex,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(1),
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            stan::math::to_complex(2, 3))},
+            stan::math::to_complex(static_cast<double>(2),
+              static_cast<double>(3)))},
         "assigning variable tp_complex_array");
       current_statement__ = 41;
-      stan::model::assign(tp_complex_array, stan::math::to_complex(5.1, 6),
+      stan::model::assign(tp_complex_array,
+        stan::math::to_complex(5.1, static_cast<double>(6)),
         "assigning variable tp_complex_array", stan::model::index_uni(1));
       current_statement__ = 42;
       stan::model::assign(tp_complex_array_2d, d_complex_array_2d,
@@ -8742,10 +8763,11 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
             stan::math::promote_scalar<std::complex<local_scalar_t__>>(
               stan::math::to_complex(1.1)),
             stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-              stan::math::to_complex(1, 2.1))}},
+              stan::math::to_complex(static_cast<double>(1), 2.1))}},
         "assigning variable tp_complex_array_2d");
       current_statement__ = 45;
-      stan::model::assign(tp_complex_array_2d, stan::math::to_complex(1, 2),
+      stan::model::assign(tp_complex_array_2d,
+        stan::math::to_complex(static_cast<double>(1), static_cast<double>(2)),
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1),
         stan::model::index_uni(1));
       current_statement__ = 46;
@@ -8759,7 +8781,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       stan::model::assign(tp_complex_array_2d,
         std::vector<std::complex<local_scalar_t__>>{tp_complex,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            stan::math::to_complex(1, 2)),
+            stan::math::to_complex(static_cast<double>(1),
+              static_cast<double>(2))),
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(2.4)},
         "assigning variable tp_complex_array_2d", stan::model::index_uni(1));
       current_statement__ = 53;
@@ -8768,7 +8791,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         for (int tp_k = 1; tp_k <= 3; ++tp_k) {
           current_statement__ = 49;
           stan::model::assign(tp_complex_array_2d,
-            stan::math::to_complex(1, 2.2),
+            stan::math::to_complex(static_cast<double>(1), 2.2),
             "assigning variable tp_complex_array_2d",
             stan::model::index_uni(tp_j), stan::model::index_uni(tp_k));
         }
@@ -8902,15 +8925,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 85;
       gq_complex = stan::math::to_complex();
       current_statement__ = 86;
-      gq_complex = stan::math::to_complex(1);
+      gq_complex = stan::math::to_complex(static_cast<double>(1));
       current_statement__ = 87;
       gq_complex = stan::math::to_complex(1.2);
       current_statement__ = 88;
-      gq_complex = stan::math::to_complex(1, 2);
+      gq_complex = stan::math::to_complex(static_cast<double>(1),
+                     static_cast<double>(2));
       current_statement__ = 89;
-      gq_complex = stan::math::to_complex(1.1, 2);
+      gq_complex = stan::math::to_complex(1.1, static_cast<double>(2));
       current_statement__ = 90;
-      gq_complex = stan::math::to_complex(1, 2.2);
+      gq_complex = stan::math::to_complex(static_cast<double>(1), 2.2);
       current_statement__ = 91;
       gq_complex = stan::math::to_complex(1.1, 2.2);
       current_statement__ = 92;
@@ -8922,10 +8946,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 94;
       stan::model::assign(gq_complex_array,
         std::vector<std::complex<double>>{gq_complex,
-          stan::math::to_complex(1, 0), stan::math::to_complex(2, 3)},
-        "assigning variable gq_complex_array");
+          stan::math::to_complex(1, 0),
+          stan::math::to_complex(static_cast<double>(2),
+            static_cast<double>(3))}, "assigning variable gq_complex_array");
       current_statement__ = 95;
-      stan::model::assign(gq_complex_array, stan::math::to_complex(5.1, 6),
+      stan::model::assign(gq_complex_array,
+        stan::math::to_complex(5.1, static_cast<double>(6)),
         "assigning variable gq_complex_array", stan::model::index_uni(1));
       current_statement__ = 96;
       stan::model::assign(gq_complex_array_2d, d_complex_array_2d,
@@ -8942,10 +8968,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
                                                          stan::math::to_complex(
                                                            3, 0)},
           std::vector<std::complex<double>>{stan::math::to_complex(),
-            stan::math::to_complex(1.1), stan::math::to_complex(1, 2.1)}},
+            stan::math::to_complex(1.1),
+            stan::math::to_complex(static_cast<double>(1), 2.1)}},
         "assigning variable gq_complex_array_2d");
       current_statement__ = 99;
-      stan::model::assign(gq_complex_array_2d, stan::math::to_complex(1, 2),
+      stan::model::assign(gq_complex_array_2d,
+        stan::math::to_complex(static_cast<double>(1), static_cast<double>(2)),
         "assigning variable gq_complex_array_2d", stan::model::index_uni(1),
         stan::model::index_uni(1));
       current_statement__ = 100;
@@ -8958,7 +8986,8 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 102;
       stan::model::assign(gq_complex_array_2d,
         std::vector<std::complex<double>>{gq_complex,
-          stan::math::to_complex(1, 2), stan::math::to_complex(2.4, 0)},
+          stan::math::to_complex(static_cast<double>(1),
+            static_cast<double>(2)), stan::math::to_complex(2.4, 0)},
         "assigning variable gq_complex_array_2d", stan::model::index_uni(1));
       current_statement__ = 107;
       for (int gq_j = 1; gq_j <= 2; ++gq_j) {
@@ -8966,7 +8995,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         for (int gq_k = 1; gq_k <= 3; ++gq_k) {
           current_statement__ = 103;
           stan::model::assign(gq_complex_array_2d,
-            stan::math::to_complex(1, 2.2),
+            stan::math::to_complex(static_cast<double>(1), 2.2),
             "assigning variable gq_complex_array_2d",
             stan::model::index_uni(gq_j), stan::model::index_uni(gq_k));
         }
@@ -9042,12 +9071,14 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 14;
-      z = stan::math::to_complex(1, 2);
+      z = stan::math::to_complex(static_cast<double>(1),
+            static_cast<double>(2));
       std::complex<double> y =
         std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 15;
-      y = stan::math::to_complex(3, 4);
+      y = stan::math::to_complex(static_cast<double>(3),
+            static_cast<double>(4));
       std::vector<int> i_arr =
         std::vector<int>(0, std::numeric_limits<int>::min());
       std::vector<int> i_arr_1 =
@@ -9369,11 +9400,12 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 279;
       gq_complex = stan::math::polar(gq_r, gq_r);
       current_statement__ = 280;
-      gq_complex = stan::math::polar(gq_i, gq_i);
+      gq_complex = stan::math::polar(static_cast<double>(gq_i),
+                     static_cast<double>(gq_i));
       current_statement__ = 281;
-      gq_complex = stan::math::polar(gq_r, gq_i);
+      gq_complex = stan::math::polar(gq_r, static_cast<double>(gq_i));
       current_statement__ = 282;
-      gq_complex = stan::math::polar(gq_i, gq_r);
+      gq_complex = stan::math::polar(static_cast<double>(gq_i), gq_r);
       current_statement__ = 283;
       gq_complex = stan::math::polar(p_r, gq_r);
       current_statement__ = 284;
@@ -9481,15 +9513,16 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
       current_statement__ = 329;
       gq_complex = stan::math::to_complex(gq_r, gq_r);
       current_statement__ = 330;
-      gq_complex = stan::math::to_complex(gq_i, gq_i);
+      gq_complex = stan::math::to_complex(static_cast<double>(gq_i),
+                     static_cast<double>(gq_i));
       current_statement__ = 331;
-      gq_complex = stan::math::to_complex(gq_r, gq_i);
+      gq_complex = stan::math::to_complex(gq_r, static_cast<double>(gq_i));
       current_statement__ = 332;
-      gq_complex = stan::math::to_complex(gq_i, gq_r);
+      gq_complex = stan::math::to_complex(static_cast<double>(gq_i), gq_r);
       current_statement__ = 333;
       gq_complex = stan::math::to_complex(gq_r);
       current_statement__ = 334;
-      gq_complex = stan::math::to_complex(gq_i);
+      gq_complex = stan::math::to_complex(static_cast<double>(gq_i));
       current_statement__ = 335;
       gq_complex = stan::math::to_complex(p_r, gq_r);
       current_statement__ = 336;
@@ -9511,7 +9544,7 @@ class complex_scalar_model final : public model_base_crtp<complex_scalar_model> 
         std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
           std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 19;
-      yi = ((stan::math::to_complex(0, 1.1) +
+      yi = ((stan::math::to_complex(static_cast<double>(0), 1.1) +
         stan::math::to_complex(0.0, 2.2)) + stan::math::to_complex());
       double x = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 20;
@@ -10128,20 +10161,27 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<std::complex<double>,1,-1>>{(Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                                    stan::math::to_complex(
-                                                                    1, 0),
+                                                                    static_cast<
+                                                                    double>(1),
+                                                                    0),
                                                                   stan::math::to_complex(
-                                                                    2, 0)).finished(),
+                                                                    static_cast<
+                                                                    double>(2),
+                                                                    0)).finished(),
             (Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                            stan::math::to_complex(
-                                                             3, 0),
+                                                             static_cast<
+                                                               double>(3), 0),
                                                            stan::math::to_complex(
-                                                             4, 0)).finished()}),
+                                                             static_cast<
+                                                               double>(4), 0)).finished()}),
         "assigning variable zs");
       Eigen::Matrix<local_scalar_t__,1,-1> x =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(2, DUMMY_VAR__);
       current_statement__ = 3;
       stan::model::assign(x,
-        (Eigen::Matrix<double,1,-1>(2) << 1, 2).finished(),
+        (Eigen::Matrix<double,1,-1>(2) << static_cast<double>(1),
+                                         static_cast<double>(2)).finished(),
         "assigning variable x");
       Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> zx =
         Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>::Constant(2,
@@ -10157,9 +10197,13 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<std::complex<double>,1,-1>>{(Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                                    stan::math::to_complex(
-                                                                    1, 0),
+                                                                    static_cast<
+                                                                    double>(1),
+                                                                    0),
                                                                   stan::math::to_complex(
-                                                                    2, 0)).finished(),
+                                                                    static_cast<
+                                                                    double>(2),
+                                                                    0)).finished(),
             (Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                            stan::math::to_complex(
                                                              3, 0),
@@ -10182,12 +10226,16 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
           stan::math::to_matrix(
             std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>>{
               (Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>(2) <<
-                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(1),
-                stan::math::promote_scalar<std::complex<local_scalar_t__>>(2)).finished(),
+                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                   static_cast<double>(1)),
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                  static_cast<double>(2))).finished(),
               (Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>(2) <<
-                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(3),
-                stan::math::promote_scalar<std::complex<local_scalar_t__>>(4)).finished()}),
-          cm}, "assigning variable acm");
+                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                   static_cast<double>(3)),
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                  static_cast<double>(4))).finished()}), cm},
+        "assigning variable acm");
       std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>> az =
         std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>(2,
           Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(3,
@@ -10196,7 +10244,9 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
       stan::model::assign(az,
         std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>{z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            (Eigen::Matrix<double,-1,1>(3) << 1, 2, 3).finished())},
+            (Eigen::Matrix<double,-1,1>(3) << static_cast<double>(1),
+                                             static_cast<double>(2),
+                                             static_cast<double>(3)).finished())},
         "assigning variable az");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10249,20 +10299,27 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<std::complex<double>,1,-1>>{(Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                                    stan::math::to_complex(
-                                                                    1, 0),
+                                                                    static_cast<
+                                                                    double>(1),
+                                                                    0),
                                                                   stan::math::to_complex(
-                                                                    2, 0)).finished(),
+                                                                    static_cast<
+                                                                    double>(2),
+                                                                    0)).finished(),
             (Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                            stan::math::to_complex(
-                                                             3, 0),
+                                                             static_cast<
+                                                               double>(3), 0),
                                                            stan::math::to_complex(
-                                                             4, 0)).finished()}),
+                                                             static_cast<
+                                                               double>(4), 0)).finished()}),
         "assigning variable zs");
       Eigen::Matrix<local_scalar_t__,1,-1> x =
         Eigen::Matrix<local_scalar_t__,1,-1>::Constant(2, DUMMY_VAR__);
       current_statement__ = 3;
       stan::model::assign(x,
-        (Eigen::Matrix<double,1,-1>(2) << 1, 2).finished(),
+        (Eigen::Matrix<double,1,-1>(2) << static_cast<double>(1),
+                                         static_cast<double>(2)).finished(),
         "assigning variable x");
       Eigen::Matrix<std::complex<local_scalar_t__>,1,-1> zx =
         Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>::Constant(2,
@@ -10278,9 +10335,13 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<std::complex<double>,1,-1>>{(Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                                    stan::math::to_complex(
-                                                                    1, 0),
+                                                                    static_cast<
+                                                                    double>(1),
+                                                                    0),
                                                                   stan::math::to_complex(
-                                                                    2, 0)).finished(),
+                                                                    static_cast<
+                                                                    double>(2),
+                                                                    0)).finished(),
             (Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                            stan::math::to_complex(
                                                              3, 0),
@@ -10303,12 +10364,16 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
           stan::math::to_matrix(
             std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>>{
               (Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>(2) <<
-                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(1),
-                stan::math::promote_scalar<std::complex<local_scalar_t__>>(2)).finished(),
+                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                   static_cast<double>(1)),
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                  static_cast<double>(2))).finished(),
               (Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>(2) <<
-                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(3),
-                stan::math::promote_scalar<std::complex<local_scalar_t__>>(4)).finished()}),
-          cm}, "assigning variable acm");
+                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                   static_cast<double>(3)),
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                  static_cast<double>(4))).finished()}), cm},
+        "assigning variable acm");
       std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>> az =
         std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>(2,
           Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>::Constant(3,
@@ -10317,7 +10382,9 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
       stan::model::assign(az,
         std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>{z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            (Eigen::Matrix<double,-1,1>(3) << 1, 2, 3).finished())},
+            (Eigen::Matrix<double,-1,1>(3) << static_cast<double>(1),
+                                             static_cast<double>(2),
+                                             static_cast<double>(3)).finished())},
         "assigning variable az");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -10410,18 +10477,25 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<std::complex<double>,1,-1>>{(Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                                    stan::math::to_complex(
-                                                                    1, 0),
+                                                                    static_cast<
+                                                                    double>(1),
+                                                                    0),
                                                                   stan::math::to_complex(
-                                                                    2, 0)).finished(),
+                                                                    static_cast<
+                                                                    double>(2),
+                                                                    0)).finished(),
             (Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                            stan::math::to_complex(
-                                                             3, 0),
+                                                             static_cast<
+                                                               double>(3), 0),
                                                            stan::math::to_complex(
-                                                             4, 0)).finished()}),
+                                                             static_cast<
+                                                               double>(4), 0)).finished()}),
         "assigning variable zs");
       current_statement__ = 3;
       stan::model::assign(x,
-        (Eigen::Matrix<double,1,-1>(2) << 1, 2).finished(),
+        (Eigen::Matrix<double,1,-1>(2) << static_cast<double>(1),
+                                         static_cast<double>(2)).finished(),
         "assigning variable x");
       current_statement__ = 4;
       stan::model::assign(zx, x, "assigning variable zx");
@@ -10430,9 +10504,13 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<std::complex<double>,1,-1>>{(Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                                    stan::math::to_complex(
-                                                                    1, 0),
+                                                                    static_cast<
+                                                                    double>(1),
+                                                                    0),
                                                                   stan::math::to_complex(
-                                                                    2, 0)).finished(),
+                                                                    static_cast<
+                                                                    double>(2),
+                                                                    0)).finished(),
             (Eigen::Matrix<std::complex<double>,1,-1>(2) <<
                                                            stan::math::to_complex(
                                                              3, 0),
@@ -10451,17 +10529,23 @@ class complex_vectors_model final : public model_base_crtp<complex_vectors_model
           stan::math::to_matrix(
             std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>>{
               (Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>(2) <<
-                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(1),
-                stan::math::promote_scalar<std::complex<local_scalar_t__>>(2)).finished(),
+                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                   static_cast<double>(1)),
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                  static_cast<double>(2))).finished(),
               (Eigen::Matrix<std::complex<local_scalar_t__>,1,-1>(2) <<
-                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(3),
-                stan::math::promote_scalar<std::complex<local_scalar_t__>>(4)).finished()}),
-          cm}, "assigning variable acm");
+                 stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                   static_cast<double>(3)),
+                stan::math::promote_scalar<std::complex<local_scalar_t__>>(
+                  static_cast<double>(4))).finished()}), cm},
+        "assigning variable acm");
       current_statement__ = 7;
       stan::model::assign(az,
         std::vector<Eigen::Matrix<std::complex<local_scalar_t__>,-1,1>>{z,
           stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-            (Eigen::Matrix<double,-1,1>(3) << 1, 2, 3).finished())},
+            (Eigen::Matrix<double,-1,1>(3) << static_cast<double>(1),
+                                             static_cast<double>(2),
+                                             static_cast<double>(3)).finished())},
         "assigning variable az");
       if (emit_transformed_parameters__) {
         out__.write(z);

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -131,11 +131,14 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
         "assigning variable theta");
       {
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, sigma));
       }
@@ -186,11 +189,14 @@ class _8_schools_ncp_model final : public model_base_crtp<_8_schools_ncp_model> 
         "assigning variable theta");
       {
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, sigma));
       }
@@ -988,7 +994,8 @@ class builtin_constraint_model final : public model_base_crtp<builtin_constraint
       stan::math::check_sum_to_zero(function__, "beta", beta);
       {
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0,
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0),
                          stan::math::inv(
                            stan::math::sqrt((1 - stan::math::inv(K))))));
       }
@@ -1036,7 +1043,8 @@ class builtin_constraint_model final : public model_base_crtp<builtin_constraint
       stan::math::check_sum_to_zero(function__, "beta", beta);
       {
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0,
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0),
                          stan::math::inv(
                            stan::math::sqrt((1 - stan::math::inv(K))))));
       }
@@ -1490,7 +1498,10 @@ f(const T0__& x, const T1__& x2, std::ostream* pstream__) {
     current_statement__ = 9;
     return std::forward_as_tuple(1,
              std::vector<std::tuple<int, local_scalar_t__>>{std::forward_as_tuple(
-                                                              2, 3.4)});
+                                                              2,
+                                                              stan::math::promote_scalar<
+                                                                local_scalar_t__>(
+                                                                3.4))});
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -1921,8 +1932,11 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                 std::numeric_limits<double>::quiet_NaN()));
       current_statement__ = 15;
       stan::model::assign(Arr,
-        std::vector<std::vector<double>>{std::vector<double>{1, 2},
-          std::vector<double>{3, 4.5}}, "assigning variable Arr");
+        std::vector<std::vector<double>>{std::vector<double>{static_cast<
+                                                               double>(1),
+                                           static_cast<double>(2)},
+          std::vector<double>{static_cast<double>(3), 4.5}},
+        "assigning variable Arr");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -1965,7 +1979,10 @@ class container_promotion_model final : public model_base_crtp<container_promoti
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
       current_statement__ = 8;
       stan::model::assign(V,
-        (Eigen::Matrix<local_scalar_t__,-1,1>(2) << 1, y).finished(),
+        (Eigen::Matrix<local_scalar_t__,-1,1>(2) <<
+                                                   stan::math::promote_scalar<
+                                                     local_scalar_t__>(1),
+                                                   y).finished(),
         "assigning variable V");
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> arRV =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(2,
@@ -1973,8 +1990,18 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       current_statement__ = 9;
       stan::model::assign(arRV,
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                             1, 2).finished(),
-          (Eigen::Matrix<local_scalar_t__,1,-1>(2) << 3, y).finished()},
+                                                             stan::math::promote_scalar<
+                                                               local_scalar_t__>(
+                                                               static_cast<
+                                                                 double>(1)),
+                                                            stan::math::promote_scalar<
+                                                              local_scalar_t__>(
+                                                              static_cast<
+                                                                double>(2))).finished(),
+          (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(3),
+                                                     y).finished()},
         "assigning variable arRV");
       std::vector<std::vector<local_scalar_t__>> Mar =
         std::vector<std::vector<local_scalar_t__>>(2,
@@ -1982,16 +2009,32 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       current_statement__ = 10;
       stan::model::assign(Mar,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                     local_scalar_t__>{1, 2},
-          std::vector<local_scalar_t__>{3, y}}, "assigning variable Mar");
+                                                     local_scalar_t__>{
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(1),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(2)},
+          std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                          local_scalar_t__>(3), y}},
+        "assigning variable Mar");
       Eigen::Matrix<local_scalar_t__,-1,-1> M =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
       current_statement__ = 11;
       stan::model::assign(M,
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                               1, 2).finished(),
-            (Eigen::Matrix<local_scalar_t__,1,-1>(2) << 3, y).finished()}),
+                                                               stan::math::promote_scalar<
+                                                                 local_scalar_t__>(
+                                                                 static_cast<
+                                                                   double>(1)),
+                                                              stan::math::promote_scalar<
+                                                                local_scalar_t__>(
+                                                                static_cast<
+                                                                  double>(2))).finished(),
+            (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(3),
+                                                       y).finished()}),
         "assigning variable M");
       std::vector<std::vector<std::vector<local_scalar_t__>>> deep_Mar =
         std::vector<std::vector<std::vector<local_scalar_t__>>>(2,
@@ -2003,15 +2046,29 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                                                                   std::vector<
                                                                     local_scalar_t__>>{
                                                                   std::vector<
-                                                                    local_scalar_t__>{0,
-                                                                    0},
+                                                                    local_scalar_t__>{
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0),
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0)},
                                                                   std::vector<
-                                                                    local_scalar_t__>{0,
-                                                                    0}},
+                                                                    local_scalar_t__>{
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0),
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0)}},
           std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                       local_scalar_t__>{1,
-                                                       2},
-            std::vector<local_scalar_t__>{3, y}}},
+                                                       local_scalar_t__>{
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(1),
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(2)},
+            std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                            local_scalar_t__>(3), y}}},
         "assigning variable deep_Mar");
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> deep_M =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(2,
@@ -2022,13 +2079,37 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                                                              std::vector<
                                                                Eigen::Matrix<local_scalar_t__,1,-1>>{
                                                                (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                  0, 0).finished(),
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(0)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(0))).finished(),
                                                                (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                  0, 0).finished()}),
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(0)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(0))).finished()}),
           stan::math::to_matrix(
             std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                 1, 2).finished(),
-              (Eigen::Matrix<local_scalar_t__,1,-1>(2) << y, 4).finished()})},
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(1)),
+                                                                stan::math::promote_scalar<
+                                                                  local_scalar_t__>(
+                                                                  static_cast<
+                                                                    double>(2))).finished(),
+              (Eigen::Matrix<local_scalar_t__,1,-1>(2) << y,
+                                                         stan::math::promote_scalar<
+                                                           local_scalar_t__>(
+                                                           4)).finished()})},
         "assigning variable deep_M");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2066,7 +2147,10 @@ class container_promotion_model final : public model_base_crtp<container_promoti
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(2, DUMMY_VAR__);
       current_statement__ = 8;
       stan::model::assign(V,
-        (Eigen::Matrix<local_scalar_t__,-1,1>(2) << 1, y).finished(),
+        (Eigen::Matrix<local_scalar_t__,-1,1>(2) <<
+                                                   stan::math::promote_scalar<
+                                                     local_scalar_t__>(1),
+                                                   y).finished(),
         "assigning variable V");
       std::vector<Eigen::Matrix<local_scalar_t__,1,-1>> arRV =
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>(2,
@@ -2074,8 +2158,18 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       current_statement__ = 9;
       stan::model::assign(arRV,
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                             1, 2).finished(),
-          (Eigen::Matrix<local_scalar_t__,1,-1>(2) << 3, y).finished()},
+                                                             stan::math::promote_scalar<
+                                                               local_scalar_t__>(
+                                                               static_cast<
+                                                                 double>(1)),
+                                                            stan::math::promote_scalar<
+                                                              local_scalar_t__>(
+                                                              static_cast<
+                                                                double>(2))).finished(),
+          (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(3),
+                                                     y).finished()},
         "assigning variable arRV");
       std::vector<std::vector<local_scalar_t__>> Mar =
         std::vector<std::vector<local_scalar_t__>>(2,
@@ -2083,16 +2177,32 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       current_statement__ = 10;
       stan::model::assign(Mar,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                     local_scalar_t__>{1, 2},
-          std::vector<local_scalar_t__>{3, y}}, "assigning variable Mar");
+                                                     local_scalar_t__>{
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(1),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(2)},
+          std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                          local_scalar_t__>(3), y}},
+        "assigning variable Mar");
       Eigen::Matrix<local_scalar_t__,-1,-1> M =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(2, 2, DUMMY_VAR__);
       current_statement__ = 11;
       stan::model::assign(M,
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                               1, 2).finished(),
-            (Eigen::Matrix<local_scalar_t__,1,-1>(2) << 3, y).finished()}),
+                                                               stan::math::promote_scalar<
+                                                                 local_scalar_t__>(
+                                                                 static_cast<
+                                                                   double>(1)),
+                                                              stan::math::promote_scalar<
+                                                                local_scalar_t__>(
+                                                                static_cast<
+                                                                  double>(2))).finished(),
+            (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(3),
+                                                       y).finished()}),
         "assigning variable M");
       std::vector<std::vector<std::vector<local_scalar_t__>>> deep_Mar =
         std::vector<std::vector<std::vector<local_scalar_t__>>>(2,
@@ -2104,15 +2214,29 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                                                                   std::vector<
                                                                     local_scalar_t__>>{
                                                                   std::vector<
-                                                                    local_scalar_t__>{0,
-                                                                    0},
+                                                                    local_scalar_t__>{
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0),
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0)},
                                                                   std::vector<
-                                                                    local_scalar_t__>{0,
-                                                                    0}},
+                                                                    local_scalar_t__>{
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0),
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0)}},
           std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                       local_scalar_t__>{1,
-                                                       2},
-            std::vector<local_scalar_t__>{3, y}}},
+                                                       local_scalar_t__>{
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(1),
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(2)},
+            std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                            local_scalar_t__>(3), y}}},
         "assigning variable deep_Mar");
       std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>> deep_M =
         std::vector<Eigen::Matrix<local_scalar_t__,-1,-1>>(2,
@@ -2123,13 +2247,37 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                                                              std::vector<
                                                                Eigen::Matrix<local_scalar_t__,1,-1>>{
                                                                (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                  0, 0).finished(),
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(0)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(0))).finished(),
                                                                (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                  0, 0).finished()}),
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(0)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(0))).finished()}),
           stan::math::to_matrix(
             std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                 1, 2).finished(),
-              (Eigen::Matrix<local_scalar_t__,1,-1>(2) << y, 4).finished()})},
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(1)),
+                                                                stan::math::promote_scalar<
+                                                                  local_scalar_t__>(
+                                                                  static_cast<
+                                                                    double>(2))).finished(),
+              (Eigen::Matrix<local_scalar_t__,1,-1>(2) << y,
+                                                         stan::math::promote_scalar<
+                                                           local_scalar_t__>(
+                                                           4)).finished()})},
         "assigning variable deep_M");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -2203,25 +2351,54 @@ class container_promotion_model final : public model_base_crtp<container_promoti
       }
       current_statement__ = 8;
       stan::model::assign(V,
-        (Eigen::Matrix<local_scalar_t__,-1,1>(2) << 1, y).finished(),
+        (Eigen::Matrix<local_scalar_t__,-1,1>(2) <<
+                                                   stan::math::promote_scalar<
+                                                     local_scalar_t__>(1),
+                                                   y).finished(),
         "assigning variable V");
       current_statement__ = 9;
       stan::model::assign(arRV,
         std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                             1, 2).finished(),
-          (Eigen::Matrix<local_scalar_t__,1,-1>(2) << 3, y).finished()},
+                                                             stan::math::promote_scalar<
+                                                               local_scalar_t__>(
+                                                               static_cast<
+                                                                 double>(1)),
+                                                            stan::math::promote_scalar<
+                                                              local_scalar_t__>(
+                                                              static_cast<
+                                                                double>(2))).finished(),
+          (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(3),
+                                                     y).finished()},
         "assigning variable arRV");
       current_statement__ = 10;
       stan::model::assign(Mar,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                     local_scalar_t__>{1, 2},
-          std::vector<local_scalar_t__>{3, y}}, "assigning variable Mar");
+                                                     local_scalar_t__>{
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(1),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(2)},
+          std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                          local_scalar_t__>(3), y}},
+        "assigning variable Mar");
       current_statement__ = 11;
       stan::model::assign(M,
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                               1, 2).finished(),
-            (Eigen::Matrix<local_scalar_t__,1,-1>(2) << 3, y).finished()}),
+                                                               stan::math::promote_scalar<
+                                                                 local_scalar_t__>(
+                                                                 static_cast<
+                                                                   double>(1)),
+                                                              stan::math::promote_scalar<
+                                                                local_scalar_t__>(
+                                                                static_cast<
+                                                                  double>(2))).finished(),
+            (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(3),
+                                                       y).finished()}),
         "assigning variable M");
       current_statement__ = 12;
       stan::model::assign(deep_Mar,
@@ -2229,15 +2406,29 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                                                                   std::vector<
                                                                     local_scalar_t__>>{
                                                                   std::vector<
-                                                                    local_scalar_t__>{0,
-                                                                    0},
+                                                                    local_scalar_t__>{
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0),
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0)},
                                                                   std::vector<
-                                                                    local_scalar_t__>{0,
-                                                                    0}},
+                                                                    local_scalar_t__>{
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0),
+                                                                    stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    0)}},
           std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                       local_scalar_t__>{1,
-                                                       2},
-            std::vector<local_scalar_t__>{3, y}}},
+                                                       local_scalar_t__>{
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(1),
+                                                       stan::math::promote_scalar<
+                                                         local_scalar_t__>(2)},
+            std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                            local_scalar_t__>(3), y}}},
         "assigning variable deep_Mar");
       current_statement__ = 13;
       stan::model::assign(deep_M,
@@ -2245,13 +2436,37 @@ class container_promotion_model final : public model_base_crtp<container_promoti
                                                              std::vector<
                                                                Eigen::Matrix<local_scalar_t__,1,-1>>{
                                                                (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                  0, 0).finished(),
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(0)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(0))).finished(),
                                                                (Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                  0, 0).finished()}),
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(0)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(0))).finished()}),
           stan::math::to_matrix(
             std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(2) <<
-                                                                 1, 2).finished(),
-              (Eigen::Matrix<local_scalar_t__,1,-1>(2) << y, 4).finished()})},
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(1)),
+                                                                stan::math::promote_scalar<
+                                                                  local_scalar_t__>(
+                                                                  static_cast<
+                                                                    double>(2))).finished(),
+              (Eigen::Matrix<local_scalar_t__,1,-1>(2) << y,
+                                                         stan::math::promote_scalar<
+                                                           local_scalar_t__>(
+                                                           4)).finished()})},
         "assigning variable deep_M");
       if (emit_transformed_parameters__) {
         out__.write(V);
@@ -4358,8 +4573,9 @@ baz(const T0__& y_arg__, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 14;
-    return stan::model::rvalue(y, "y", stan::model::index_uni(1),
-             stan::model::index_uni(1));
+    return stan::math::promote_scalar<local_scalar_t__>(
+             stan::model::rvalue(y, "y", stan::model::index_uni(1),
+               stan::model::index_uni(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -4380,9 +4596,10 @@ bar(const std::vector<Eigen::Matrix<double,-1,-1>>& z, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 16;
-    return stan::model::rvalue(
-             stan::model::rvalue(z, "z", stan::model::index_uni(1)), "z[1]",
-             stan::model::index_uni(1), stan::model::index_uni(1));
+    return stan::math::promote_scalar<local_scalar_t__>(
+             stan::model::rvalue(
+               stan::model::rvalue(z, "z", stan::model::index_uni(1)),
+               "z[1]", stan::model::index_uni(1), stan::model::index_uni(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -4403,8 +4620,9 @@ foo(const std::vector<std::vector<std::vector<double>>>& x,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 18;
-    return stan::model::rvalue(x, "x", stan::model::index_uni(1),
-             stan::model::index_uni(1), stan::model::index_uni(1));
+    return stan::math::promote_scalar<local_scalar_t__>(
+             stan::model::rvalue(x, "x", stan::model::index_uni(1),
+               stan::model::index_uni(1), stan::model::index_uni(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -5807,11 +6025,14 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
         "assigning variable theta");
       {
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, sigma));
       }
@@ -5862,11 +6083,14 @@ class eight_schools_ncp_model final : public model_base_crtp<eight_schools_ncp_m
         "assigning variable theta");
       {
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau, 0, 5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(tau,
+                         static_cast<double>(0), static_cast<double>(5)));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(theta_tilde,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, sigma));
       }
@@ -7630,7 +7854,8 @@ class laplace_bernoulli_logit_model final : public model_base_crtp<laplace_berno
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
                          propto__>(y, y, prior_mean, K_function_functor__(),
@@ -7718,7 +7943,8 @@ class laplace_bernoulli_logit_model final : public model_base_crtp<laplace_berno
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_bernoulli_logit_lpmf<
                          propto__>(y, y, prior_mean, K_function_functor__(),
@@ -8512,7 +8738,8 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal(ll_function_functor__(),
                          std::forward_as_tuple(eta, log_ye, y),
@@ -8579,7 +8806,8 @@ class laplace_functionals_model final : public model_base_crtp<laplace_functiona
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal(ll_function_functor__(),
                          std::forward_as_tuple(eta, log_ye, y),
@@ -9308,7 +9536,8 @@ class laplace_neg_binomial_2_log_model final : public model_base_crtp<laplace_ne
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
                          propto__>(y, y, log_ye, prior_mean,
@@ -9402,7 +9631,8 @@ class laplace_neg_binomial_2_log_model final : public model_base_crtp<laplace_ne
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_neg_binomial_2_log_lpmf<
                          propto__>(y, y, log_ye, prior_mean,
@@ -11439,7 +11669,8 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal(scalar_tuple_functor__(),
                          std::forward_as_tuple(
@@ -11514,7 +11745,8 @@ class laplace_nested_tuple2_model final : public model_base_crtp<laplace_nested_
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::laplace_marginal(scalar_tuple_functor__(),
                          std::forward_as_tuple(
@@ -12539,7 +12771,8 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::laplace_marginal(ll_nested_functor__(),
                          std::forward_as_tuple(
@@ -12616,7 +12849,8 @@ class laplace_nested_tuple3_model final : public model_base_crtp<laplace_nested_
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::laplace_marginal(ll_nested_functor__(),
                          std::forward_as_tuple(
@@ -13370,7 +13604,8 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 7;
         lp_accum__.add(stan::math::laplace_marginal(my_fun_functor__(),
                          std::forward_as_tuple(eta, log_ye, y),
@@ -13428,7 +13663,8 @@ class laplace_overload_weird_model final : public model_base_crtp<laplace_overlo
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 7;
         lp_accum__.add(stan::math::laplace_marginal(my_fun_functor__(),
                          std::forward_as_tuple(eta, log_ye, y),
@@ -14032,13 +14268,17 @@ class laplace_poisson_model final : public model_base_crtp<laplace_poisson_model
           lp__);
       {
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha, 0, 3));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha,
+                         static_cast<double>(0), static_cast<double>(3)));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 3));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(3)));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(z, 0, sigmaz));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(z,
+                         static_cast<double>(0), sigmaz));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigmaz, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigmaz,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::poisson_log_glm_lpmf<propto__>(y, X,
                          stan::math::add(stan::math::add(z, offsett), alpha),
@@ -14086,13 +14326,17 @@ class laplace_poisson_model final : public model_base_crtp<laplace_poisson_model
           lp__);
       {
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha, 0, 3));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha,
+                         static_cast<double>(0), static_cast<double>(3)));
         current_statement__ = 7;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 3));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(3)));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(z, 0, sigmaz));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(z,
+                         static_cast<double>(0), sigmaz));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigmaz, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigmaz,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::poisson_log_glm_lpmf<propto__>(y, X,
                          stan::math::add(stan::math::add(z, offsett), alpha),
@@ -14822,7 +15066,8 @@ class laplace_poisson_log_model final : public model_base_crtp<laplace_poisson_l
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<
                          propto__>(y, y, prior_mean, K_function_functor__(),
@@ -14910,7 +15155,8 @@ class laplace_poisson_log_model final : public model_base_crtp<laplace_poisson_l
         lp_accum__.add(stan::math::inv_gamma_lpdf<propto__>(alpha,
                          alpha_location_prior, alpha_scale_prior));
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::laplace_marginal_poisson_log_lpmf<
                          propto__>(y, y, prior_mean, K_function_functor__(),
@@ -15368,16 +15614,28 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       current_statement__ = 3;
       stan::model::assign(w,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                     local_scalar_t__>{1.0,
-                                                     2, 3}, xx, xx},
-        "assigning variable w");
+                                                     local_scalar_t__>{
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(1.0),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(
+                                                       static_cast<double>(2)),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(
+                                                       static_cast<double>(3))},
+          xx, xx}, "assigning variable w");
       std::vector<std::vector<local_scalar_t__>> td_arr33 =
         std::vector<std::vector<local_scalar_t__>>(3,
           std::vector<local_scalar_t__>(3, DUMMY_VAR__));
       current_statement__ = 4;
       stan::model::assign(td_arr33,
-        std::vector<std::vector<double>>{std::vector<double>{1, 2, 3},
-          std::vector<double>{1, 2., 3}, std::vector<double>{1., 2., 3}},
+        std::vector<std::vector<double>>{std::vector<double>{static_cast<
+                                                               double>(1),
+                                           static_cast<double>(2),
+                                           static_cast<double>(3)},
+          std::vector<double>{static_cast<double>(1), 2.,
+            static_cast<double>(3)},
+          std::vector<double>{1., 2., static_cast<double>(3)}},
         "assigning variable td_arr33");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15425,16 +15683,28 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       current_statement__ = 3;
       stan::model::assign(w,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                     local_scalar_t__>{1.0,
-                                                     2, 3}, xx, xx},
-        "assigning variable w");
+                                                     local_scalar_t__>{
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(1.0),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(
+                                                       static_cast<double>(2)),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(
+                                                       static_cast<double>(3))},
+          xx, xx}, "assigning variable w");
       std::vector<std::vector<local_scalar_t__>> td_arr33 =
         std::vector<std::vector<local_scalar_t__>>(3,
           std::vector<local_scalar_t__>(3, DUMMY_VAR__));
       current_statement__ = 4;
       stan::model::assign(td_arr33,
-        std::vector<std::vector<double>>{std::vector<double>{1, 2, 3},
-          std::vector<double>{1, 2., 3}, std::vector<double>{1., 2., 3}},
+        std::vector<std::vector<double>>{std::vector<double>{static_cast<
+                                                               double>(1),
+                                           static_cast<double>(2),
+                                           static_cast<double>(3)},
+          std::vector<double>{static_cast<double>(1), 2.,
+            static_cast<double>(3)},
+          std::vector<double>{1., 2., static_cast<double>(3)}},
         "assigning variable td_arr33");
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -15502,13 +15772,25 @@ class mixed_type_arrays_model final : public model_base_crtp<mixed_type_arrays_m
       current_statement__ = 3;
       stan::model::assign(w,
         std::vector<std::vector<local_scalar_t__>>{std::vector<
-                                                     local_scalar_t__>{1.0,
-                                                     2, 3}, xx, xx},
-        "assigning variable w");
+                                                     local_scalar_t__>{
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(1.0),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(
+                                                       static_cast<double>(2)),
+                                                     stan::math::promote_scalar<
+                                                       local_scalar_t__>(
+                                                       static_cast<double>(3))},
+          xx, xx}, "assigning variable w");
       current_statement__ = 4;
       stan::model::assign(td_arr33,
-        std::vector<std::vector<double>>{std::vector<double>{1, 2, 3},
-          std::vector<double>{1, 2., 3}, std::vector<double>{1., 2., 3}},
+        std::vector<std::vector<double>>{std::vector<double>{static_cast<
+                                                               double>(1),
+                                           static_cast<double>(2),
+                                           static_cast<double>(3)},
+          std::vector<double>{static_cast<double>(1), 2.,
+            static_cast<double>(3)},
+          std::vector<double>{1., 2., static_cast<double>(3)}},
         "assigning variable td_arr33");
       if (emit_transformed_parameters__) {
         current_statement__ = 2;
@@ -17576,7 +17858,7 @@ double foo_bar0(std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 602;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17598,7 +17880,7 @@ stan::return_type_t<T0__> foo_bar1(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 604;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17623,7 +17905,7 @@ foo_bar2(const T0__& x, const T1__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 606;
-    return 2.0;
+    return stan::math::promote_scalar<local_scalar_t__>(2.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17644,7 +17926,7 @@ foo_lpmf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 608;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17668,7 +17950,7 @@ foo_lcdf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 610;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17692,7 +17974,7 @@ foo_lccdf(const T0__& y, const T1__& lambda, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 612;
-    return 1.0;
+    return stan::math::promote_scalar<local_scalar_t__>(1.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17740,9 +18022,11 @@ unit_normal_lp(const T0__& u, T_lp__& lp__, T_lp_accum__& lp_accum__,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 616;
-    lp_accum__.add(stan::math::normal_lpdf<false>(u, 0, 1));
+    lp_accum__.add(stan::math::normal_lpdf<false>(u, static_cast<double>(0),
+                     static_cast<double>(1)));
     current_statement__ = 617;
-    lp_accum__.add(stan::math::uniform_lpdf<propto__>(u, -(100), 100));
+    lp_accum__.add(stan::math::uniform_lpdf<propto__>(u,
+                     static_cast<double>(-(100)), static_cast<double>(100)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17870,7 +18154,7 @@ foo_1(const T0__& a, std::ostream* pstream__) {
           v = stan::model::rvalue(vs, "vs", stan::model::index_uni(sym1__),
                 stan::model::index_uni(sym2__));
           current_statement__ = 664;
-          z = 0;
+          z = stan::math::promote_scalar<local_scalar_t__>(0);
           break;
         }
       }
@@ -17901,7 +18185,7 @@ foo_1(const T0__& a, std::ostream* pstream__) {
         current_statement__ = 673;
         v = vs[(sym1__ - 1)];
         current_statement__ = 674;
-        z = 0;
+        z = stan::math::promote_scalar<local_scalar_t__>(0);
         break;
       }
       current_statement__ = 676;
@@ -17925,7 +18209,7 @@ foo_1(const T0__& a, std::ostream* pstream__) {
         current_statement__ = 683;
         v = vs[(sym1__ - 1)];
         current_statement__ = 684;
-        z = 0;
+        z = stan::math::promote_scalar<local_scalar_t__>(0);
         break;
       }
       current_statement__ = 686;
@@ -18158,7 +18442,9 @@ foo_5(const T0__& shared_params_arg__, const T1__& job_params_arg__,
   try {
     current_statement__ = 723;
     return stan::math::promote_scalar<local_scalar_t__>(
-             (Eigen::Matrix<double,-1,1>(3) << 1, 2, 3).finished());
+             (Eigen::Matrix<double,-1,1>(3) << static_cast<double>(1),
+                                              static_cast<double>(2),
+                                              static_cast<double>(3)).finished());
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -19417,13 +19703,129 @@ Eigen::Matrix<double,-1,-1> matfoo(std::ostream* pstream__) {
     current_statement__ = 769;
     return stan::math::to_matrix(
              std::vector<Eigen::Matrix<local_scalar_t__,1,-1>>{(Eigen::Matrix<local_scalar_t__,1,-1>(10) <<
-                                                                  1, 2, 3, 4,
-                                                                 5, 6, 7, 8,
-                                                                 9, 10).finished(),
-               (Eigen::Matrix<local_scalar_t__,1,-1>(10) << 1, 2, 3, 4, 5, 6,
-                                                           7, 8, 9, 10).finished(),
-               (Eigen::Matrix<local_scalar_t__,1,-1>(10) << 1, 2, 3, 4, 5, 6,
-                                                           7, 8, 9, 10).finished()});
+                                                                  stan::math::promote_scalar<
+                                                                    local_scalar_t__>(
+                                                                    static_cast<
+                                                                    double>(1)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(2)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(3)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(4)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(5)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(6)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(7)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(8)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(9)),
+                                                                 stan::math::promote_scalar<
+                                                                   local_scalar_t__>(
+                                                                   static_cast<
+                                                                    double>(
+                                                                    10))).finished(),
+               (Eigen::Matrix<local_scalar_t__,1,-1>(10) <<
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(1)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(2)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(3)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(4)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(5)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(6)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(7)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(8)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(9)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(10))).finished(),
+               (Eigen::Matrix<local_scalar_t__,1,-1>(10) <<
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(1)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(2)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(3)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(4)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(5)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(6)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(7)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(8)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(9)),
+                                                           stan::math::promote_scalar<
+                                                             local_scalar_t__>(
+                                                             static_cast<
+                                                               double>(10))).finished()});
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -19443,7 +19845,16 @@ Eigen::Matrix<double,-1,1> vecfoo(std::ostream* pstream__) {
   try {
     current_statement__ = 771;
     return stan::math::promote_scalar<local_scalar_t__>(
-             (Eigen::Matrix<double,-1,1>(10) << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10).finished());
+             (Eigen::Matrix<double,-1,1>(10) << static_cast<double>(1),
+                                               static_cast<double>(2),
+                                               static_cast<double>(3),
+                                               static_cast<double>(4),
+                                               static_cast<double>(5),
+                                               static_cast<double>(6),
+                                               static_cast<double>(7),
+                                               static_cast<double>(8),
+                                               static_cast<double>(9),
+                                               static_cast<double>(10)).finished());
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -19498,7 +19909,16 @@ vecmubar(const T0__& mu, std::ostream* pstream__) {
     current_statement__ = 776;
     stan::model::assign(l,
       stan::math::multiply(mu,
-        (Eigen::Matrix<double,-1,1>(10) << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10).finished()),
+        (Eigen::Matrix<double,-1,1>(10) << static_cast<double>(1),
+                                          static_cast<double>(2),
+                                          static_cast<double>(3),
+                                          static_cast<double>(4),
+                                          static_cast<double>(5),
+                                          static_cast<double>(6),
+                                          static_cast<double>(7),
+                                          static_cast<double>(8),
+                                          static_cast<double>(9),
+                                          static_cast<double>(10)).finished()),
       "assigning variable l");
     current_statement__ = 777;
     return stan::model::rvalue(l, "l",
@@ -20929,13 +21349,13 @@ class mother_model final : public model_base_crtp<mother_model> {
       current_statement__ = 347;
       stan::model::assign(td_cfcov_54,
         stan::math::diag_matrix(
-          stan::math::rep_vector(1, stan::math::rows(td_cfcov_54))),
-        "assigning variable td_cfcov_54");
+          stan::math::rep_vector(static_cast<double>(1),
+            stan::math::rows(td_cfcov_54))), "assigning variable td_cfcov_54");
       current_statement__ = 348;
       stan::model::assign(td_cfcov_33,
         stan::math::diag_matrix(
-          stan::math::rep_vector(1, stan::math::rows(td_cfcov_33))),
-        "assigning variable td_cfcov_33");
+          stan::math::rep_vector(static_cast<double>(1),
+            stan::math::rows(td_cfcov_33))), "assigning variable td_cfcov_33");
       {
         double z = std::numeric_limits<double>::quiet_NaN();
         Eigen::Matrix<double,1,-1> blocked_tdata_vs =
@@ -20948,7 +21368,7 @@ class mother_model final : public model_base_crtp<mother_model> {
           current_statement__ = 351;
           v = blocked_tdata_vs[(sym1__ - 1)];
           current_statement__ = 352;
-          z = 0;
+          z = static_cast<double>(0);
         }
         std::vector<int> indices =
           std::vector<int>(4, std::numeric_limits<int>::min());
@@ -20967,7 +21387,7 @@ class mother_model final : public model_base_crtp<mother_model> {
             current_statement__ = 355;
             i = sym1__[(sym3__ - 1)];
             current_statement__ = 356;
-            z = i;
+            z = static_cast<double>(i);
           }
         }
       }
@@ -21002,7 +21422,8 @@ class mother_model final : public model_base_crtp<mother_model> {
       x_mul_ind = std::vector<double>(2,
                     std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 364;
-      stan::model::assign(x_mul_ind, std::vector<double>{1, 2},
+      stan::model::assign(x_mul_ind,
+        std::vector<double>{static_cast<double>(1), static_cast<double>(2)},
         "assigning variable x_mul_ind");
       current_statement__ = 365;
       transformed_data_real = std::numeric_limits<double>::quiet_NaN();
@@ -22143,38 +22564,43 @@ class mother_model final : public model_base_crtp<mother_model> {
         current_statement__ = 157;
         r2 = foo_bar1(J, pstream__);
         current_statement__ = 158;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(p_real, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(p_real,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 159;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(offset_multiplier,
-                         0, 1));
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 160;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         no_offset_multiplier, 0, 1));
+                         no_offset_multiplier, static_cast<double>(0),
+                         static_cast<double>(1)));
         current_statement__ = 161;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         offset_no_multiplier, 0, 1));
+                         offset_no_multiplier, static_cast<double>(0),
+                         static_cast<double>(1)));
         current_statement__ = 162;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_real_1d_ar), 0, 1));
+                         stan::math::to_vector(p_real_1d_ar),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 175;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 163;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::math::to_vector(
                              stan::model::rvalue(p_1d_vec, "p_1d_vec",
-                               stan::model::index_uni(n))), 0, 1));
+                               stan::model::index_uni(n))),
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 164;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::math::to_vector(
                              stan::model::rvalue(p_1d_row_vec,
                                "p_1d_row_vec", stan::model::index_uni(n))),
-                           0, 1));
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 165;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::math::to_vector(
                              stan::model::rvalue(p_1d_simplex,
                                "p_1d_simplex", stan::model::index_uni(n))),
-                           0, 1));
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 173;
           for (int m = 1; m <= M; ++m) {
             current_statement__ = 171;
@@ -22189,7 +22615,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(d_3d_vec, "d_3d_vec",
                                  stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
               current_statement__ = 167;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::math::to_vector(
@@ -22200,7 +22627,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(d_3d_row_vec,
                                  "d_3d_row_vec", stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
               current_statement__ = 168;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::math::to_vector(
@@ -22211,7 +22639,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(d_3d_simplex,
                                  "d_3d_simplex", stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
               current_statement__ = 169;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(p_real_3d_ar,
@@ -22221,7 +22650,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(p_real_3d_ar,
                                  "p_real_3d_ar", stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
             }
           }
         }
@@ -22234,7 +22664,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                              stan::math::to_vector(
                                stan::model::rvalue(p_ar_mat, "p_ar_mat",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(j))), 0, 1));
+                                 stan::model::index_uni(j))),
+                             static_cast<double>(0), static_cast<double>(1)));
           }
         }
         current_statement__ = 183;
@@ -22244,23 +22675,28 @@ class mother_model final : public model_base_crtp<mother_model> {
                            stan::math::to_vector(
                              stan::model::rvalue(p_cfcov_33_ar,
                                "p_cfcov_33_ar", stan::model::index_uni(k))),
-                           0, 1));
+                           static_cast<double>(0), static_cast<double>(1)));
         }
         current_statement__ = 184;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_vec), d_vec, 1));
+                         stan::math::to_vector(p_vec), d_vec,
+                         static_cast<double>(1)));
         current_statement__ = 185;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_row_vec), 0, 1));
+                         stan::math::to_vector(p_row_vec),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 186;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_simplex), 0, 1));
+                         stan::math::to_vector(p_simplex),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 187;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_cfcov_54), 0, 1));
+                         stan::math::to_vector(p_cfcov_54),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 188;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_cfcov_33), 0, 1));
+                         stan::math::to_vector(p_cfcov_33),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 189;
         lp_accum__.add(stan::math::map_rect<2, binomialf_functor__>(tmp,
                          tmp2, x_r, x_i, pstream__));
@@ -22602,38 +23038,43 @@ class mother_model final : public model_base_crtp<mother_model> {
         current_statement__ = 157;
         r2 = foo_bar1(J, pstream__);
         current_statement__ = 158;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(p_real, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(p_real,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 159;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(offset_multiplier,
-                         0, 1));
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 160;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         no_offset_multiplier, 0, 1));
+                         no_offset_multiplier, static_cast<double>(0),
+                         static_cast<double>(1)));
         current_statement__ = 161;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         offset_no_multiplier, 0, 1));
+                         offset_no_multiplier, static_cast<double>(0),
+                         static_cast<double>(1)));
         current_statement__ = 162;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_real_1d_ar), 0, 1));
+                         stan::math::to_vector(p_real_1d_ar),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 175;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 163;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::math::to_vector(
                              stan::model::rvalue(p_1d_vec, "p_1d_vec",
-                               stan::model::index_uni(n))), 0, 1));
+                               stan::model::index_uni(n))),
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 164;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::math::to_vector(
                              stan::model::rvalue(p_1d_row_vec,
                                "p_1d_row_vec", stan::model::index_uni(n))),
-                           0, 1));
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 165;
           lp_accum__.add(stan::math::normal_lpdf<propto__>(
                            stan::math::to_vector(
                              stan::model::rvalue(p_1d_simplex,
                                "p_1d_simplex", stan::model::index_uni(n))),
-                           0, 1));
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 173;
           for (int m = 1; m <= M; ++m) {
             current_statement__ = 171;
@@ -22648,7 +23089,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(d_3d_vec, "d_3d_vec",
                                  stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
               current_statement__ = 167;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::math::to_vector(
@@ -22659,7 +23101,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(d_3d_row_vec,
                                  "d_3d_row_vec", stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
               current_statement__ = 168;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::math::to_vector(
@@ -22670,7 +23113,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(d_3d_simplex,
                                  "d_3d_simplex", stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
               current_statement__ = 169;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(p_real_3d_ar,
@@ -22680,7 +23124,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                                stan::model::rvalue(p_real_3d_ar,
                                  "p_real_3d_ar", stan::model::index_uni(n),
                                  stan::model::index_uni(m),
-                                 stan::model::index_uni(k)), 1));
+                                 stan::model::index_uni(k)),
+                               static_cast<double>(1)));
             }
           }
         }
@@ -22693,7 +23138,8 @@ class mother_model final : public model_base_crtp<mother_model> {
                              stan::math::to_vector(
                                stan::model::rvalue(p_ar_mat, "p_ar_mat",
                                  stan::model::index_uni(i),
-                                 stan::model::index_uni(j))), 0, 1));
+                                 stan::model::index_uni(j))),
+                             static_cast<double>(0), static_cast<double>(1)));
           }
         }
         current_statement__ = 183;
@@ -22703,23 +23149,28 @@ class mother_model final : public model_base_crtp<mother_model> {
                            stan::math::to_vector(
                              stan::model::rvalue(p_cfcov_33_ar,
                                "p_cfcov_33_ar", stan::model::index_uni(k))),
-                           0, 1));
+                           static_cast<double>(0), static_cast<double>(1)));
         }
         current_statement__ = 184;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_vec), d_vec, 1));
+                         stan::math::to_vector(p_vec), d_vec,
+                         static_cast<double>(1)));
         current_statement__ = 185;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_row_vec), 0, 1));
+                         stan::math::to_vector(p_row_vec),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 186;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_simplex), 0, 1));
+                         stan::math::to_vector(p_simplex),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 187;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_cfcov_54), 0, 1));
+                         stan::math::to_vector(p_cfcov_54),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 188;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
-                         stan::math::to_vector(p_cfcov_33), 0, 1));
+                         stan::math::to_vector(p_cfcov_33),
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 189;
         lp_accum__.add(stan::math::map_rect<1, binomialf_functor__>(tmp,
                          tmp2, x_r, x_i, pstream__));
@@ -26222,7 +26673,7 @@ integrand(const T0__& x, const T1__& xc, const T2__& theta, const T3__& x_r,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 145;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -26260,7 +26711,9 @@ foo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
   try {
     current_statement__ = 147;
     return stan::math::promote_scalar<local_scalar_t__>(
-             (Eigen::Matrix<double,-1,1>(3) << 1, 2, 3).finished());
+             (Eigen::Matrix<double,-1,1>(3) << static_cast<double>(1),
+                                              static_cast<double>(2),
+                                              static_cast<double>(3)).finished());
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -26298,7 +26751,9 @@ goo(const T0__& shared_params_arg__, const T1__& job_params_arg__,
   try {
     current_statement__ = 149;
     return stan::math::promote_scalar<local_scalar_t__>(
-             (Eigen::Matrix<double,-1,1>(3) << 4, 5, 6).finished());
+             (Eigen::Matrix<double,-1,1>(3) << static_cast<double>(4),
+                                              static_cast<double>(5),
+                                              static_cast<double>(6)).finished());
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -26615,7 +27070,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       auto x_r = in__.template read<local_scalar_t__>();
       local_scalar_t__ abc1_p = DUMMY_VAR__;
       current_statement__ = 8;
-      abc1_p = 3;
+      abc1_p = stan::math::promote_scalar<local_scalar_t__>(3);
       local_scalar_t__ abc2_p = DUMMY_VAR__;
       current_statement__ = 9;
       abc2_p = map_rectfake(abc1_p, pstream__);
@@ -26929,7 +27384,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
       auto x_r = in__.template read<local_scalar_t__>();
       local_scalar_t__ abc1_p = DUMMY_VAR__;
       current_statement__ = 8;
-      abc1_p = 3;
+      abc1_p = stan::math::promote_scalar<local_scalar_t__>(3);
       local_scalar_t__ abc2_p = DUMMY_VAR__;
       current_statement__ = 9;
       abc2_p = map_rectfake(abc1_p, pstream__);
@@ -27291,7 +27746,7 @@ class motherHOF_model final : public model_base_crtp<motherHOF_model> {
         return ;
       }
       current_statement__ = 8;
-      abc1_p = 3;
+      abc1_p = stan::math::promote_scalar<local_scalar_t__>(3);
       current_statement__ = 9;
       abc2_p = map_rectfake(abc1_p, pstream__);
       current_statement__ = 10;
@@ -30798,7 +31253,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
           stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__,
             r, v), "assigning variable zm");
         current_statement__ = 600;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(r, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(r,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -32444,7 +32900,8 @@ class new_integrate_interface_model final : public model_base_crtp<new_integrate
           stan::math::ode_bdf(f_variadic2_functor__(), v, r, ra, pstream__,
             r, v), "assigning variable zm");
         current_statement__ = 600;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(r, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(r,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -34725,18 +35182,21 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
           pstream__, 1e-5, 1e-3, 5e2), "assigning variable z");
       {
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha, 1, 0.5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha,
+                         static_cast<double>(1), 0.5));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(gamma, 1, 0.5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(gamma,
+                         static_cast<double>(1), 0.5));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0.05, 0.05));
         current_statement__ = 11;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(delta, 0.05, 0.05));
         current_statement__ = 12;
-        lp_accum__.add(stan::math::lognormal_lpdf<propto__>(sigma, -(1), 1));
+        lp_accum__.add(stan::math::lognormal_lpdf<propto__>(sigma,
+                         static_cast<double>(-(1)), static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::lognormal_lpdf<propto__>(z_init,
-                         stan::math::log(10), 1));
+                         stan::math::log(10), static_cast<double>(1)));
         current_statement__ = 17;
         for (int k = 1; k <= 2; ++k) {
           current_statement__ = 14;
@@ -34827,18 +35287,21 @@ class old_integrate_interface_model final : public model_base_crtp<old_integrate
           pstream__, 1e-5, 1e-3, 5e2), "assigning variable z");
       {
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha, 1, 0.5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha,
+                         static_cast<double>(1), 0.5));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(gamma, 1, 0.5));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(gamma,
+                         static_cast<double>(1), 0.5));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0.05, 0.05));
         current_statement__ = 11;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(delta, 0.05, 0.05));
         current_statement__ = 12;
-        lp_accum__.add(stan::math::lognormal_lpdf<propto__>(sigma, -(1), 1));
+        lp_accum__.add(stan::math::lognormal_lpdf<propto__>(sigma,
+                         static_cast<double>(-(1)), static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::lognormal_lpdf<propto__>(z_init,
-                         stan::math::log(10), 1));
+                         stan::math::log(10), static_cast<double>(1)));
         current_statement__ = 17;
         for (int k = 1; k <= 2; ++k) {
           current_statement__ = 14;
@@ -38374,7 +38837,7 @@ double foo(const T0__& p, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 17;
-    return (p + 1.0);
+    return stan::math::promote_scalar<local_scalar_t__>((p + 1.0));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -38623,7 +39086,8 @@ double foo(const T0__& p, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 37;
-    return (stan::math::sum(p) + 12);
+    return stan::math::promote_scalar<local_scalar_t__>((stan::math::sum(p) +
+             12));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -38718,49 +39182,57 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
       {
         current_statement__ = 3;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(1, pstream__), 1));
+                         foo(1, pstream__), static_cast<double>(1)));
         current_statement__ = 4;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(1.5, pstream__), 1));
+                         foo(1.5, pstream__), static_cast<double>(1)));
         current_statement__ = 5;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
-                         foo(z, pstream__), 1));
+                         foo(z, pstream__), static_cast<double>(1)));
         current_statement__ = 6;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(a, pstream__), 1));
+                         foo(a, pstream__), static_cast<double>(1)));
         current_statement__ = 7;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(stan::math::transpose(a), pstream__), 1));
+                         foo(stan::math::transpose(a), pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(M, pstream__), 1));
+                         foo(M, pstream__), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
                          foo(
                            stan::model::rvalue(M, "M",
                              stan::model::index_omni(),
-                             stan::model::index_uni(1)), pstream__), 1));
+                             stan::model::index_uni(1)), pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
                          foo(
                            stan::model::rvalue(M, "M",
                              stan::model::index_uni(1),
-                             stan::model::index_omni()), pstream__), 1));
+                             stan::model::index_omni()), pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 11;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
                          foo(std::vector<Eigen::Matrix<double,-1,1>>{a},
-                           pstream__), 1));
+                           pstream__), static_cast<double>(1)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(std::vector<int>{1, 2}, pstream__), 1));
+                         foo(std::vector<int>{1, 2}, pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(std::vector<double>{1, 2.3}, pstream__), 1));
+                         foo(
+                           std::vector<double>{static_cast<double>(1), 2.3},
+                           pstream__), static_cast<double>(1)));
         current_statement__ = 14;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
                          std::vector<double>{5.5, 6.5},
-                         foo(std::vector<local_scalar_t__>{z, 2.3}, pstream__),
-                         1));
+                         foo(
+                           std::vector<local_scalar_t__>{z,
+                             stan::math::promote_scalar<local_scalar_t__>(2.3)},
+                           pstream__), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -38799,49 +39271,57 @@ class overloading_templating_model final : public model_base_crtp<overloading_te
       {
         current_statement__ = 3;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(1, pstream__), 1));
+                         foo(1, pstream__), static_cast<double>(1)));
         current_statement__ = 4;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(1.5, pstream__), 1));
+                         foo(1.5, pstream__), static_cast<double>(1)));
         current_statement__ = 5;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
-                         foo(z, pstream__), 1));
+                         foo(z, pstream__), static_cast<double>(1)));
         current_statement__ = 6;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(a, pstream__), 1));
+                         foo(a, pstream__), static_cast<double>(1)));
         current_statement__ = 7;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(stan::math::transpose(a), pstream__), 1));
+                         foo(stan::math::transpose(a), pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 8;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(M, pstream__), 1));
+                         foo(M, pstream__), static_cast<double>(1)));
         current_statement__ = 9;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
                          foo(
                            stan::model::rvalue(M, "M",
                              stan::model::index_omni(),
-                             stan::model::index_uni(1)), pstream__), 1));
+                             stan::model::index_uni(1)), pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
                          foo(
                            stan::model::rvalue(M, "M",
                              stan::model::index_uni(1),
-                             stan::model::index_omni()), pstream__), 1));
+                             stan::model::index_omni()), pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 11;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
                          foo(std::vector<Eigen::Matrix<double,-1,1>>{a},
-                           pstream__), 1));
+                           pstream__), static_cast<double>(1)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(std::vector<int>{1, 2}, pstream__), 1));
+                         foo(std::vector<int>{1, 2}, pstream__),
+                         static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         foo(std::vector<double>{1, 2.3}, pstream__), 1));
+                         foo(
+                           std::vector<double>{static_cast<double>(1), 2.3},
+                           pstream__), static_cast<double>(1)));
         current_statement__ = 14;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(
                          std::vector<double>{5.5, 6.5},
-                         foo(std::vector<local_scalar_t__>{z, 2.3}, pstream__),
-                         1));
+                         foo(
+                           std::vector<local_scalar_t__>{z,
+                             stan::math::promote_scalar<local_scalar_t__>(2.3)},
+                           pstream__), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -40116,7 +40596,7 @@ class promotion_model final : public model_base_crtp<promotion_model> {
       }
       double z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 1;
-      z = 1;
+      z = static_cast<double>(1);
       std::complex<double> zi =
         std::complex<double>(std::numeric_limits<double>::quiet_NaN(),
           std::numeric_limits<double>::quiet_NaN());
@@ -40487,7 +40967,7 @@ test2(const T0__& gamma_arg__, std::ostream* pstream__) {
     if (stan::math::logical_eq(D, 1)) {
       current_statement__ = 10;
       return stan::math::promote_scalar<local_scalar_t__>(
-               stan::math::rep_vector(D, 0));
+               stan::math::rep_vector(static_cast<double>(D), 0));
     } else {
       current_statement__ = 9;
       return test2(
@@ -40523,7 +41003,8 @@ matrix_pow(const T0__& a_arg__, const T1__& n, std::ostream* pstream__) {
       current_statement__ = 15;
       return stan::math::promote_scalar<local_scalar_t__>(
                stan::math::diag_matrix(
-                 stan::math::rep_vector(1, stan::math::rows(a))));
+                 stan::math::rep_vector(static_cast<double>(1),
+                   stan::math::rows(a))));
     } else {
       current_statement__ = 13;
       return stan::math::multiply(a,
@@ -40557,7 +41038,7 @@ foo(const T0__& a_arg__, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 19;
-    return 1;
+    return stan::math::promote_scalar<local_scalar_t__>(1);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -40616,7 +41097,7 @@ test4(const T0__& gamma_arg__, std::ostream* pstream__) {
     if (stan::math::logical_eq(D, 1)) {
       current_statement__ = 26;
       return stan::math::promote_scalar<local_scalar_t__>(
-               stan::math::rep_vector(D, 0));
+               stan::math::rep_vector(static_cast<double>(D), 0));
     } else {
       current_statement__ = 25;
       return test3(
@@ -40715,7 +41196,7 @@ test7(const T0__& gamma_arg__, std::ostream* pstream__) {
     if (stan::math::logical_eq(D, 1)) {
       current_statement__ = 38;
       return stan::math::promote_scalar<local_scalar_t__>(
-               stan::math::rep_vector(D, 0));
+               stan::math::rep_vector(static_cast<double>(D), 0));
     } else {
       current_statement__ = 37;
       return test7(stan::math::eval(stan::math::head(gamma, (D - 1))),
@@ -40754,8 +41235,8 @@ foo(const T0__& x, const T1__& s_arg__, const T2__& y_arg__, std::ostream*
     current_statement__ = 41;
     return stan::model::rvalue(
              stan::math::ode_rk45(foo_variadic2_functor__(),
-               (Eigen::Matrix<double,-1,1>(1) << 1).finished(), 0.0,
-               std::vector<double>{1.0}, pstream__,
+               (Eigen::Matrix<double,-1,1>(1) << static_cast<double>(1)).finished(),
+               0.0, std::vector<double>{1.0}, pstream__,
                stan::math::eval(
                  stan::model::rvalue(y, "y", stan::model::index_min(2)))),
              "ode_rk45(foo, Transpose__(FnMakeRowVec__(promote(1, real, data))), 0.0,\n         FnMakeArray__(1.0), eval(y[2:]))",
@@ -41349,7 +41830,8 @@ g(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
       return stan::math::reduce_sum<g_rsfunctor__>(y_slice, 1, pstream__);
     } else {
       current_statement__ = 12;
-      return stan::math::normal_lpdf<false>(y_slice, 0, 1);
+      return stan::math::normal_lpdf<false>(y_slice, static_cast<double>(0),
+               static_cast<double>(1));
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -41390,7 +41872,8 @@ h(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
                  stan::model::index_min_max(start, end)));
     } else {
       current_statement__ = 18;
-      return stan::math::normal_lpdf<false>(a, 0, 1);
+      return stan::math::normal_lpdf<false>(a, static_cast<double>(0),
+               static_cast<double>(1));
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -41416,7 +41899,8 @@ foo_lpdf(const T0__& y_slice, const T1__& start, const T2__& end,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 24;
-    return stan::math::normal_lpdf<false>(y_slice, 0, 1);
+    return stan::math::normal_lpdf<false>(y_slice, static_cast<double>(0),
+             static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -42542,7 +43026,8 @@ g1(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 76;
-    return stan::math::normal_lpdf<false>(y_slice, 0, 1);
+    return stan::math::normal_lpdf<false>(y_slice, static_cast<double>(0),
+             static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -42577,7 +43062,7 @@ g2(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
       sum_lpdf = (sum_lpdf +
         stan::math::normal_lpdf<false>(
           stan::model::rvalue(y_slice, "y_slice", stan::model::index_uni(n)),
-          0, 1));
+          static_cast<double>(0), static_cast<double>(1)));
     }
     current_statement__ = 82;
     return sum_lpdf;
@@ -42615,7 +43100,7 @@ g3(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
       sum_lpdf = (sum_lpdf +
         stan::math::normal_lpdf<false>(
           stan::model::rvalue(y_slice, "y_slice", stan::model::index_uni(n)),
-          0, 1));
+          static_cast<double>(0), static_cast<double>(1)));
     }
     current_statement__ = 88;
     return sum_lpdf;
@@ -42654,7 +43139,7 @@ g4(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
         stan::math::normal_lpdf<false>(
           stan::math::to_vector(
             stan::model::rvalue(y_slice, "y_slice", stan::model::index_uni(n))),
-          0, 1));
+          static_cast<double>(0), static_cast<double>(1)));
     }
     current_statement__ = 94;
     return sum_lpdf;
@@ -42701,7 +43186,8 @@ g5(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
         sum_lpdf = (sum_lpdf +
           stan::math::normal_lpdf<false>(
             stan::model::rvalue(y_slice, "y_slice",
-              stan::model::index_uni(n), stan::model::index_uni(m)), 0, 1));
+              stan::model::index_uni(n), stan::model::index_uni(m)),
+            static_cast<double>(0), static_cast<double>(1)));
       }
     }
     current_statement__ = 102;
@@ -42749,7 +43235,8 @@ g6(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
           stan::math::normal_lpdf<false>(
             stan::math::to_vector(
               stan::model::rvalue(y_slice, "y_slice",
-                stan::model::index_uni(n), stan::model::index_uni(m))), 0, 1));
+                stan::model::index_uni(n), stan::model::index_uni(m))),
+            static_cast<double>(0), static_cast<double>(1)));
       }
     }
     current_statement__ = 110;
@@ -42797,7 +43284,8 @@ g7(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
           stan::math::normal_lpdf<false>(
             stan::math::to_vector(
               stan::model::rvalue(y_slice, "y_slice",
-                stan::model::index_uni(n), stan::model::index_uni(m))), 0, 1));
+                stan::model::index_uni(n), stan::model::index_uni(m))),
+            static_cast<double>(0), static_cast<double>(1)));
       }
     }
     current_statement__ = 118;
@@ -42845,7 +43333,8 @@ g8(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
           stan::math::normal_lpdf<false>(
             stan::math::to_vector(
               stan::model::rvalue(y_slice, "y_slice",
-                stan::model::index_uni(n), stan::model::index_uni(m))), 0, 1));
+                stan::model::index_uni(n), stan::model::index_uni(m))),
+            static_cast<double>(0), static_cast<double>(1)));
       }
     }
     current_statement__ = 126;
@@ -42884,7 +43373,8 @@ h1(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
     current_statement__ = 128;
     return stan::math::normal_lpdf<false>(
              stan::model::rvalue(a, "a",
-               stan::model::index_min_max(start, end)), 0, 1);
+               stan::model::index_min_max(start, end)),
+             static_cast<double>(0), static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -42923,7 +43413,8 @@ h2(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
       current_statement__ = 131;
       sum_lpdf = (sum_lpdf +
         stan::math::normal_lpdf<false>(
-          stan::model::rvalue(a, "a", stan::model::index_uni(n)), 0, 1));
+          stan::model::rvalue(a, "a", stan::model::index_uni(n)),
+          static_cast<double>(0), static_cast<double>(1)));
     }
     current_statement__ = 134;
     return sum_lpdf;
@@ -42965,7 +43456,8 @@ h3(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
       current_statement__ = 137;
       sum_lpdf = (sum_lpdf +
         stan::math::normal_lpdf<false>(
-          stan::model::rvalue(a, "a", stan::model::index_uni(n)), 0, 1));
+          stan::model::rvalue(a, "a", stan::model::index_uni(n)),
+          static_cast<double>(0), static_cast<double>(1)));
     }
     current_statement__ = 140;
     return sum_lpdf;
@@ -43008,7 +43500,8 @@ h4(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
       sum_lpdf = (sum_lpdf +
         stan::math::normal_lpdf<false>(
           stan::math::to_vector(
-            stan::model::rvalue(a, "a", stan::model::index_uni(n))), 0, 1));
+            stan::model::rvalue(a, "a", stan::model::index_uni(n))),
+          static_cast<double>(0), static_cast<double>(1)));
     }
     current_statement__ = 146;
     return sum_lpdf;
@@ -43059,7 +43552,8 @@ h5(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
         sum_lpdf = (sum_lpdf +
           stan::math::normal_lpdf<false>(
             stan::model::rvalue(a, "a", stan::model::index_uni(n),
-              stan::model::index_uni(m)), 0, 1));
+              stan::model::index_uni(m)), static_cast<double>(0),
+            static_cast<double>(1)));
       }
     }
     current_statement__ = 154;
@@ -43111,7 +43605,8 @@ h6(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
           stan::math::normal_lpdf<false>(
             stan::math::to_vector(
               stan::model::rvalue(a, "a", stan::model::index_uni(n),
-                stan::model::index_uni(m))), 0, 1));
+                stan::model::index_uni(m))), static_cast<double>(0),
+            static_cast<double>(1)));
       }
     }
     current_statement__ = 162;
@@ -43163,7 +43658,8 @@ h7(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
           stan::math::normal_lpdf<false>(
             stan::math::to_vector(
               stan::model::rvalue(a, "a", stan::model::index_uni(n),
-                stan::model::index_uni(m))), 0, 1));
+                stan::model::index_uni(m))), static_cast<double>(0),
+            static_cast<double>(1)));
       }
     }
     current_statement__ = 170;
@@ -43215,7 +43711,8 @@ h8(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
           stan::math::normal_lpdf<false>(
             stan::math::to_vector(
               stan::model::rvalue(a, "a", stan::model::index_uni(n),
-                stan::model::index_uni(m))), 0, 1));
+                stan::model::index_uni(m))), static_cast<double>(0),
+            static_cast<double>(1)));
       }
     }
     current_statement__ = 178;
@@ -46185,7 +46682,7 @@ f1(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 171;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46213,7 +46710,7 @@ f1a(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 173;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46240,7 +46737,7 @@ f2(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 175;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46267,7 +46764,7 @@ f3(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 177;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46294,7 +46791,7 @@ f4(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 179;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46325,7 +46822,7 @@ f5(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 181;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46355,7 +46852,7 @@ f6(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 183;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46385,7 +46882,7 @@ f7(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 185;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46415,7 +46912,7 @@ f8(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 187;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46441,7 +46938,7 @@ f9(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 189;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46468,7 +46965,7 @@ f10(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 191;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46498,7 +46995,7 @@ f11(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 193;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46533,7 +47030,7 @@ f12(const T0__& y_slice, const T1__& start, const T2__& end, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 195;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46563,7 +47060,7 @@ g1(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 197;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46595,7 +47092,7 @@ g2(const T0__& y_slice, const T1__& start, const T2__& end, const T3__&
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 199;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46627,7 +47124,7 @@ g3(const T0__& y_slice, const T1__& start, const T2__& end, const T3__&
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 201;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46659,7 +47156,7 @@ g4(const T0__& y_slice, const T1__& start, const T2__& end, const T3__&
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 203;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46692,7 +47189,7 @@ g5(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 205;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46724,7 +47221,7 @@ g6(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 207;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46756,7 +47253,7 @@ g7(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 209;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46788,7 +47285,7 @@ g8(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 211;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46824,7 +47321,7 @@ g9(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 213;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46859,7 +47356,7 @@ g10(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 215;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46894,7 +47391,7 @@ g11(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 217;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -46929,7 +47426,7 @@ g12(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 219;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -47367,7 +47864,7 @@ double r(std::ostream* pstream__) {
            y10, y11, y12, y14d, y1, y2, y3, y4, y15d, y5, y6, y7, y8, y16d,
            y17);
     current_statement__ = 340;
-    return 0.0;
+    return stan::math::promote_scalar<local_scalar_t__>(0.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -49560,7 +50057,8 @@ class reject_exit_model final : public model_base_crtp<reject_exit_model> {
       auto x = in__.template read<local_scalar_t__>();
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 5;
         if (stan::math::logical_lt(x, 0)) {
           current_statement__ = 4;
@@ -49616,7 +50114,8 @@ class reject_exit_model final : public model_base_crtp<reject_exit_model> {
       auto x = in__.template read<local_scalar_t__>();
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 5;
         if (stan::math::logical_lt(x, 0)) {
           current_statement__ = 4;
@@ -49929,7 +50428,8 @@ foo(const T0__& a, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 5;
-    return std::vector<local_scalar_t__>{0.1};
+    return std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                           local_scalar_t__>(0.1)};
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -49952,7 +50452,10 @@ baz(const T0__& a, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 7;
-    return std::forward_as_tuple(std::vector<local_scalar_t__>{0.1}, 0.2);
+    return std::forward_as_tuple(
+             std::vector<local_scalar_t__>{stan::math::promote_scalar<
+                                             local_scalar_t__>(0.1)},
+             stan::math::promote_scalar<local_scalar_t__>(0.2));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -52201,7 +52704,7 @@ double foo0_lpmf(const T0__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 1;
-    return -(5);
+    return stan::math::promote_scalar<local_scalar_t__>(-(5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -52219,7 +52722,7 @@ double foo1_lpmf(const T0__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 3;
-    return -(5);
+    return stan::math::promote_scalar<local_scalar_t__>(-(5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -52240,7 +52743,7 @@ foo4_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 5;
-    return -(5);
+    return stan::math::promote_scalar<local_scalar_t__>(-(5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -52259,7 +52762,7 @@ stan::return_type_t<T0__> foo2_lpdf(const T0__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 7;
-    return -(5);
+    return stan::math::promote_scalar<local_scalar_t__>(-(5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -52278,7 +52781,7 @@ stan::return_type_t<T0__> foo3_lpdf(const T0__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 9;
-    return -(5);
+    return stan::math::promote_scalar<local_scalar_t__>(-(5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -52300,7 +52803,7 @@ foo5_lp(const T0__& y, T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 11;
-    return -(5);
+    return stan::math::promote_scalar<local_scalar_t__>(-(5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -54827,25 +55330,32 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
         current_statement__ = 4;
         if (t) {
           current_statement__ = 5;
-          lp_accum__.add(stan::math::student_t_lpdf<propto__>(x, 10, 0, 1));
+          lp_accum__.add(stan::math::student_t_lpdf<propto__>(x,
+                           static_cast<double>(10), static_cast<double>(0),
+                           static_cast<double>(1)));
           current_statement__ = 6;
           if (stan::math::logical_lt(x, 0)) {
             current_statement__ = 6;
             lp_accum__.add(stan::math::negative_infinity());
           } else {
             current_statement__ = 6;
-            lp_accum__.add(-(stan::math::student_t_lccdf(0, 10, 0, 1)));
+            lp_accum__.add(-(stan::math::student_t_lccdf(
+                               static_cast<double>(0),
+                               static_cast<double>(10),
+                               static_cast<double>(0), static_cast<double>(1))));
           }
         } else {
           current_statement__ = 2;
-          lp_accum__.add(stan::math::normal_lpdf<propto__>(x, 0, 1));
+          lp_accum__.add(stan::math::normal_lpdf<propto__>(x,
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 3;
           if (stan::math::logical_lt(x, 0)) {
             current_statement__ = 3;
             lp_accum__.add(stan::math::negative_infinity());
           } else {
             current_statement__ = 3;
-            lp_accum__.add(-(stan::math::normal_lccdf(0, 0, 1)));
+            lp_accum__.add(-(stan::math::normal_lccdf(static_cast<double>(0),
+                               static_cast<double>(0), static_cast<double>(1))));
           }
         }
       }
@@ -54887,25 +55397,32 @@ class tilde_block_model final : public model_base_crtp<tilde_block_model> {
         current_statement__ = 4;
         if (t) {
           current_statement__ = 5;
-          lp_accum__.add(stan::math::student_t_lpdf<propto__>(x, 10, 0, 1));
+          lp_accum__.add(stan::math::student_t_lpdf<propto__>(x,
+                           static_cast<double>(10), static_cast<double>(0),
+                           static_cast<double>(1)));
           current_statement__ = 6;
           if (stan::math::logical_lt(x, 0)) {
             current_statement__ = 6;
             lp_accum__.add(stan::math::negative_infinity());
           } else {
             current_statement__ = 6;
-            lp_accum__.add(-(stan::math::student_t_lccdf(0, 10, 0, 1)));
+            lp_accum__.add(-(stan::math::student_t_lccdf(
+                               static_cast<double>(0),
+                               static_cast<double>(10),
+                               static_cast<double>(0), static_cast<double>(1))));
           }
         } else {
           current_statement__ = 2;
-          lp_accum__.add(stan::math::normal_lpdf<propto__>(x, 0, 1));
+          lp_accum__.add(stan::math::normal_lpdf<propto__>(x,
+                           static_cast<double>(0), static_cast<double>(1)));
           current_statement__ = 3;
           if (stan::math::logical_lt(x, 0)) {
             current_statement__ = 3;
             lp_accum__.add(stan::math::negative_infinity());
           } else {
             current_statement__ = 3;
-            lp_accum__.add(-(stan::math::normal_lccdf(0, 0, 1)));
+            lp_accum__.add(-(stan::math::normal_lccdf(static_cast<double>(0),
+                               static_cast<double>(0), static_cast<double>(1))));
           }
         }
       }
@@ -58365,29 +58882,35 @@ class truncate_model final : public model_base_crtp<truncate_model> {
           lp__);
       {
         current_statement__ = 3;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 5;
         if (stan::math::logical_lt(x, 0.0)) {
           current_statement__ = 5;
           lp_accum__.add(stan::math::negative_infinity());
         } else {
           current_statement__ = 5;
-          lp_accum__.add(-(stan::math::normal_lccdf(0.0, m, 1)));
+          lp_accum__.add(-(stan::math::normal_lccdf(0.0, m,
+                             static_cast<double>(1))));
         }
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 7;
         if (stan::math::logical_gt(x, 10.0)) {
           current_statement__ = 7;
           lp_accum__.add(stan::math::negative_infinity());
         } else {
           current_statement__ = 7;
-          lp_accum__.add(-(stan::math::normal_lcdf(10.0, m, 1)));
+          lp_accum__.add(-(stan::math::normal_lcdf(10.0, m,
+                             static_cast<double>(1))));
         }
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 10;
         if (stan::math::logical_lt(x, 0.0)) {
           current_statement__ = 10;
@@ -58400,8 +58923,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
           } else {
             current_statement__ = 9;
             lp_accum__.add(-(stan::math::log_diff_exp(
-                               stan::math::normal_lcdf(10.0, m, 1),
-                               stan::math::normal_lcdf(0.0, m, 1))));
+                               stan::math::normal_lcdf(10.0, m,
+                                 static_cast<double>(1)),
+                               stan::math::normal_lcdf(0.0, m,
+                                 static_cast<double>(1)))));
           }
         }
         current_statement__ = 11;
@@ -58483,29 +59008,35 @@ class truncate_model final : public model_base_crtp<truncate_model> {
           lp__);
       {
         current_statement__ = 3;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 5;
         if (stan::math::logical_lt(x, 0.0)) {
           current_statement__ = 5;
           lp_accum__.add(stan::math::negative_infinity());
         } else {
           current_statement__ = 5;
-          lp_accum__.add(-(stan::math::normal_lccdf(0.0, m, 1)));
+          lp_accum__.add(-(stan::math::normal_lccdf(0.0, m,
+                             static_cast<double>(1))));
         }
         current_statement__ = 6;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 7;
         if (stan::math::logical_gt(x, 10.0)) {
           current_statement__ = 7;
           lp_accum__.add(stan::math::negative_infinity());
         } else {
           current_statement__ = 7;
-          lp_accum__.add(-(stan::math::normal_lcdf(10.0, m, 1)));
+          lp_accum__.add(-(stan::math::normal_lcdf(10.0, m,
+                             static_cast<double>(1))));
         }
         current_statement__ = 8;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, m,
+                         static_cast<double>(1)));
         current_statement__ = 10;
         if (stan::math::logical_lt(x, 0.0)) {
           current_statement__ = 10;
@@ -58518,8 +59049,10 @@ class truncate_model final : public model_base_crtp<truncate_model> {
           } else {
             current_statement__ = 9;
             lp_accum__.add(-(stan::math::log_diff_exp(
-                               stan::math::normal_lcdf(10.0, m, 1),
-                               stan::math::normal_lcdf(0.0, m, 1))));
+                               stan::math::normal_lcdf(10.0, m,
+                                 static_cast<double>(1)),
+                               stan::math::normal_lcdf(0.0, m,
+                                 static_cast<double>(1)))));
           }
         }
         current_statement__ = 11;
@@ -58919,7 +59452,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       auto x = in__.template read<local_scalar_t__>();
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -58955,7 +59489,8 @@ class udf_tilde_stmt_conflict_model final : public model_base_crtp<udf_tilde_stm
       auto x = in__.template read<local_scalar_t__>();
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(x, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(x,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -60617,8 +61152,9 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
         }
         current_statement__ = 77;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         stan::math::multiply(vector_mu, 4),
-                         stan::math::add(vector_sigma, 1)));
+                         stan::math::multiply(vector_mu,
+                           static_cast<double>(4)),
+                         stan::math::add(vector_sigma, static_cast<double>(1))));
         current_statement__ = 81;
         if (stan::math::logical_lt(stan::math::min(y), L)) {
           current_statement__ = 81;
@@ -60631,11 +61167,13 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
           } else {
             Eigen::Matrix<local_scalar_t__,-1,1> sym2__;
             current_statement__ = 78;
-            stan::model::assign(sym2__, stan::math::multiply(vector_mu, 4),
+            stan::model::assign(sym2__,
+              stan::math::multiply(vector_mu, static_cast<double>(4)),
               "assigning variable sym2__");
             Eigen::Matrix<local_scalar_t__,1,-1> sym1__;
             current_statement__ = 79;
-            stan::model::assign(sym1__, stan::math::add(vector_sigma, 1),
+            stan::model::assign(sym1__,
+              stan::math::add(vector_sigma, static_cast<double>(1)),
               "assigning variable sym1__");
             current_statement__ = 80;
             for (int sym4__ = 1; sym4__ <= stan::math::size(sym2__); ++sym4__) {
@@ -61136,8 +61674,9 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
         }
         current_statement__ = 77;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
-                         stan::math::multiply(vector_mu, 4),
-                         stan::math::add(vector_sigma, 1)));
+                         stan::math::multiply(vector_mu,
+                           static_cast<double>(4)),
+                         stan::math::add(vector_sigma, static_cast<double>(1))));
         current_statement__ = 81;
         if (stan::math::logical_lt(stan::math::min(y), L)) {
           current_statement__ = 81;
@@ -61150,11 +61689,13 @@ class vector_truncate_model final : public model_base_crtp<vector_truncate_model
           } else {
             Eigen::Matrix<local_scalar_t__,-1,1> sym2__;
             current_statement__ = 78;
-            stan::model::assign(sym2__, stan::math::multiply(vector_mu, 4),
+            stan::model::assign(sym2__,
+              stan::math::multiply(vector_mu, static_cast<double>(4)),
               "assigning variable sym2__");
             Eigen::Matrix<local_scalar_t__,1,-1> sym1__;
             current_statement__ = 79;
-            stan::model::assign(sym1__, stan::math::add(vector_sigma, 1),
+            stan::model::assign(sym1__,
+              stan::math::add(vector_sigma, static_cast<double>(1)),
               "assigning variable sym1__");
             current_statement__ = 80;
             for (int sym4__ = 1; sym4__ <= stan::math::size(sym2__); ++sym4__) {

--- a/test/integration/good/code-gen/expressions/cpp.expected
+++ b/test/integration/good/code-gen/expressions/cpp.expected
@@ -680,7 +680,7 @@ foo1(const T0__& a, const T1__& b, const T2__& c, const T3__& d_arg__,
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 5;
-    return 5.0;
+    return stan::math::promote_scalar<local_scalar_t__>(5.0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -1216,8 +1216,11 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
         (stan::math::logical_gt(stan::math::sum(a), 1) ? stan::math::eval(
                                                            stan::math::add(
                                                              stan::math::multiply(
-                                                               2, a), b)) : 
-        stan::math::eval(stan::math::multiply(2, a))), "assigning variable d");
+                                                               static_cast<
+                                                                 double>(2),
+                                                               a), b)) : 
+        stan::math::eval(stan::math::multiply(static_cast<double>(2), a))),
+        "assigning variable d");
       std::complex<local_scalar_t__> z =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
       current_statement__ = 7;
@@ -1227,7 +1230,7 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
         current_statement__ = 8;
         z2 = stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-               (1 ? r : 2));
+               (1 ? r : stan::math::promote_scalar<local_scalar_t__>(2)));
         current_statement__ = 9;
         z2 = (1 ? stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                     0) : zp);
@@ -1287,8 +1290,11 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
         (stan::math::logical_gt(stan::math::sum(a), 1) ? stan::math::eval(
                                                            stan::math::add(
                                                              stan::math::multiply(
-                                                               2, a), b)) : 
-        stan::math::eval(stan::math::multiply(2, a))), "assigning variable d");
+                                                               static_cast<
+                                                                 double>(2),
+                                                               a), b)) : 
+        stan::math::eval(stan::math::multiply(static_cast<double>(2), a))),
+        "assigning variable d");
       std::complex<local_scalar_t__> z =
         std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
       current_statement__ = 7;
@@ -1298,7 +1304,7 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
           std::complex<local_scalar_t__>(DUMMY_VAR__, DUMMY_VAR__);
         current_statement__ = 8;
         z2 = stan::math::promote_scalar<std::complex<local_scalar_t__>>(
-               (1 ? r : 2));
+               (1 ? r : stan::math::promote_scalar<local_scalar_t__>(2)));
         current_statement__ = 9;
         z2 = (1 ? stan::math::promote_scalar<std::complex<local_scalar_t__>>(
                     0) : zp);
@@ -1383,8 +1389,11 @@ class ternary_if_model final : public model_base_crtp<ternary_if_model> {
         (stan::math::logical_gt(stan::math::sum(a), 1) ? stan::math::eval(
                                                            stan::math::add(
                                                              stan::math::multiply(
-                                                               2, a), b)) : 
-        stan::math::eval(stan::math::multiply(2, a))), "assigning variable d");
+                                                               static_cast<
+                                                                 double>(2),
+                                                               a), b)) : 
+        stan::math::eval(stan::math::multiply(static_cast<double>(2), a))),
+        "assigning variable d");
       current_statement__ = 7;
       z = (1 ? stan::math::to_complex(0, 3) : stan::math::to_complex(2, 0));
       if (emit_transformed_parameters__) {

--- a/test/integration/good/code-gen/lir.expected
+++ b/test/integration/good/code-gen/lir.expected
@@ -2623,7 +2623,9 @@
         (Expression (Cast Void (Var DUMMY_VAR__)))
         (TryCatch
          ((Expression (Assign (Var current_statement__) (Literal 602)))
-          (Return ((Literal 0.0))))
+          (Return
+           ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+             ((Literal 0.0))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -2661,7 +2663,9 @@
         (Expression (Cast Void (Var DUMMY_VAR__)))
         (TryCatch
          ((Expression (Assign (Var current_statement__) (Literal 604)))
-          (Return ((Literal 1.0))))
+          (Return
+           ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+             ((Literal 1.0))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -2705,7 +2709,9 @@
         (Expression (Cast Void (Var DUMMY_VAR__)))
         (TryCatch
          ((Expression (Assign (Var current_statement__) (Literal 606)))
-          (Return ((Literal 2.0))))
+          (Return
+           ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+             ((Literal 2.0))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -2740,7 +2746,9 @@
         (Expression (Cast Void (Var DUMMY_VAR__)))
         (TryCatch
          ((Expression (Assign (Var current_statement__) (Literal 608)))
-          (Return ((Literal 1.0))))
+          (Return
+           ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+             ((Literal 1.0))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -2779,7 +2787,9 @@
         (Expression (Cast Void (Var DUMMY_VAR__)))
         (TryCatch
          ((Expression (Assign (Var current_statement__) (Literal 610)))
-          (Return ((Literal 1.0))))
+          (Return
+           ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+             ((Literal 1.0))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -2818,7 +2828,9 @@
         (Expression (Cast Void (Var DUMMY_VAR__)))
         (TryCatch
          ((Expression (Assign (Var current_statement__) (Literal 612)))
-          (Return ((Literal 1.0))))
+          (Return
+           ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+             ((Literal 1.0))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -2901,12 +2913,14 @@
           (Expression
            (MethodCall (Var lp_accum__) add ()
             ((FunCall stan::math::normal_lpdf ((TemplateType false))
-              ((Var u) (Literal 0) (Literal 1))))))
+              ((Var u) (FunCall static_cast (Double) ((Literal 0)))
+               (FunCall static_cast (Double) ((Literal 1))))))))
           (Expression (Assign (Var current_statement__) (Literal 617)))
           (Expression
            (MethodCall (Var lp_accum__) add ()
             ((FunCall stan::math::uniform_lpdf ((TemplateType propto__))
-              ((Var u) (PMinus (Literal 100)) (Literal 100)))))))
+              ((Var u) (FunCall static_cast (Double) ((PMinus (Literal 100))))
+               (FunCall static_cast (Double) ((Literal 100)))))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
            (FunCall stan::lang::rethrow_located ()
@@ -3115,7 +3129,11 @@
                        (FunCall stan::model::index_uni () ((Var sym1__)))
                        (FunCall stan::model::index_uni () ((Var sym2__)))))))
                    (Expression (Assign (Var current_statement__) (Literal 664)))
-                   (Expression (Assign (Var z) (Literal 0))) Break))))))
+                   (Expression
+                    (Assign (Var z)
+                     (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                      ((Literal 0)))))
+                   Break))))))
              (Expression (Assign (Var current_statement__) (Literal 666)))
              (For
               ((static false) (constexpr false) (type_ Int) (name sym1__)
@@ -3176,7 +3194,11 @@
                  (Assign (Var v)
                   (Subscript (Var vs) (Parens (BinOp (Var sym1__) Subtract (Literal 1))))))
                 (Expression (Assign (Var current_statement__) (Literal 674)))
-                (Expression (Assign (Var z) (Literal 0))) Break)))
+                (Expression
+                 (Assign (Var z)
+                  (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                   ((Literal 0)))))
+                Break)))
              (Expression (Assign (Var current_statement__) (Literal 676)))
              (For
               ((static false) (constexpr false) (type_ Int) (name sym1__)
@@ -3222,7 +3244,11 @@
                  (Assign (Var v)
                   (Subscript (Var vs) (Parens (BinOp (Var sym1__) Subtract (Literal 1))))))
                 (Expression (Assign (Var current_statement__) (Literal 684)))
-                (Expression (Assign (Var z) (Literal 0))) Break)))
+                (Expression
+                 (Assign (Var z)
+                  (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                   ((Literal 0)))))
+                Break)))
              (Expression (Assign (Var current_statement__) (Literal 686)))
              (For
               ((static false) (constexpr false) (type_ Int) (name sym1__)
@@ -3649,7 +3675,9 @@
              ((MethodCall
                (Parens
                 (StreamInsertion (Constructor (Matrix Double -1 1 AoS) ((Literal 3)))
-                 ((Literal 1) (Literal 2) (Literal 3))))
+                 ((FunCall static_cast (Double) ((Literal 1)))
+                  (FunCall static_cast (Double) ((Literal 2)))
+                  (FunCall static_cast (Double) ((Literal 3))))))
                finished () ()))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
@@ -5716,24 +5744,78 @@
                   (StreamInsertion
                    (Constructor (Matrix (TypeLiteral local_scalar_t__) 1 -1 AoS)
                     ((Literal 10)))
-                   ((Literal 1) (Literal 2) (Literal 3) (Literal 4) (Literal 5)
-                    (Literal 6) (Literal 7) (Literal 8) (Literal 9) (Literal 10))))
+                   ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 1)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 2)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 3)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 4)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 5)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 6)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 7)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 8)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 9)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 10))))))))
                  finished () ())
                 (MethodCall
                  (Parens
                   (StreamInsertion
                    (Constructor (Matrix (TypeLiteral local_scalar_t__) 1 -1 AoS)
                     ((Literal 10)))
-                   ((Literal 1) (Literal 2) (Literal 3) (Literal 4) (Literal 5)
-                    (Literal 6) (Literal 7) (Literal 8) (Literal 9) (Literal 10))))
+                   ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 1)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 2)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 3)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 4)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 5)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 6)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 7)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 8)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 9)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 10))))))))
                  finished () ())
                 (MethodCall
                  (Parens
                   (StreamInsertion
                    (Constructor (Matrix (TypeLiteral local_scalar_t__) 1 -1 AoS)
                     ((Literal 10)))
-                   ((Literal 1) (Literal 2) (Literal 3) (Literal 4) (Literal 5)
-                    (Literal 6) (Literal 7) (Literal 8) (Literal 9) (Literal 10))))
+                   ((FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 1)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 2)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 3)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 4)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 5)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 6)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 7)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 8)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 9)))))
+                    (FunCall stan::math::promote_scalar ((TypeLiteral local_scalar_t__))
+                     ((FunCall static_cast (Double) ((Literal 10))))))))
                  finished () ()))))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
@@ -5768,8 +5850,16 @@
              ((MethodCall
                (Parens
                 (StreamInsertion (Constructor (Matrix Double -1 1 AoS) ((Literal 10)))
-                 ((Literal 1) (Literal 2) (Literal 3) (Literal 4) (Literal 5) 
-                  (Literal 6) (Literal 7) (Literal 8) (Literal 9) (Literal 10))))
+                 ((FunCall static_cast (Double) ((Literal 1)))
+                  (FunCall static_cast (Double) ((Literal 2)))
+                  (FunCall static_cast (Double) ((Literal 3)))
+                  (FunCall static_cast (Double) ((Literal 4)))
+                  (FunCall static_cast (Double) ((Literal 5)))
+                  (FunCall static_cast (Double) ((Literal 6)))
+                  (FunCall static_cast (Double) ((Literal 7)))
+                  (FunCall static_cast (Double) ((Literal 8)))
+                  (FunCall static_cast (Double) ((Literal 9)))
+                  (FunCall static_cast (Double) ((Literal 10))))))
                finished () ()))))))
          ((Const (Ref (TypeLiteral std::exception))) e)
          ((Expression
@@ -5881,8 +5971,16 @@
                (MethodCall
                 (Parens
                  (StreamInsertion (Constructor (Matrix Double -1 1 AoS) ((Literal 10)))
-                  ((Literal 1) (Literal 2) (Literal 3) (Literal 4) (Literal 5)
-                   (Literal 6) (Literal 7) (Literal 8) (Literal 9) (Literal 10))))
+                  ((FunCall static_cast (Double) ((Literal 1)))
+                   (FunCall static_cast (Double) ((Literal 2)))
+                   (FunCall static_cast (Double) ((Literal 3)))
+                   (FunCall static_cast (Double) ((Literal 4)))
+                   (FunCall static_cast (Double) ((Literal 5)))
+                   (FunCall static_cast (Double) ((Literal 6)))
+                   (FunCall static_cast (Double) ((Literal 7)))
+                   (FunCall static_cast (Double) ((Literal 8)))
+                   (FunCall static_cast (Double) ((Literal 9)))
+                   (FunCall static_cast (Double) ((Literal 10))))))
                 finished () ())))
              (Literal "\"assigning variable l\""))))
           (Expression (Assign (Var current_statement__) (Literal 777)))
@@ -7154,28 +7252,35 @@
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var p_real) (Literal 0) (Literal 1))))))
+                    ((Var p_real) (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 159)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var offset_multiplier) (Literal 0) (Literal 1))))))
+                    ((Var offset_multiplier) (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 160)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var no_offset_multiplier) (Literal 0) (Literal 1))))))
+                    ((Var no_offset_multiplier)
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 161)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var offset_no_multiplier) (Literal 0) (Literal 1))))))
+                    ((Var offset_no_multiplier)
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 162)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_real_1d_ar))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_real_1d_ar)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 175)))
                 (For
                  ((static false) (constexpr false) (type_ Int) (name n)
@@ -7190,7 +7295,8 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_1d_vec) (Literal "\"p_1d_vec\"")
                             (FunCall stan::model::index_uni () ((Var n)))))))
-                        (Literal 0) (Literal 1))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1))))))))
                    (Expression (Assign (Var current_statement__) (Literal 164)))
                    (Expression
                     (MethodCall (Var lp_accum__) add ()
@@ -7199,7 +7305,8 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_1d_row_vec) (Literal "\"p_1d_row_vec\"")
                             (FunCall stan::model::index_uni () ((Var n)))))))
-                        (Literal 0) (Literal 1))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1))))))))
                    (Expression (Assign (Var current_statement__) (Literal 165)))
                    (Expression
                     (MethodCall (Var lp_accum__) add ()
@@ -7208,7 +7315,8 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_1d_simplex) (Literal "\"p_1d_simplex\"")
                             (FunCall stan::model::index_uni () ((Var n)))))))
-                        (Literal 0) (Literal 1))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1))))))))
                    (Expression (Assign (Var current_statement__) (Literal 173)))
                    (For
                     ((static false) (constexpr false) (type_ Int) (name m)
@@ -7236,7 +7344,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1))))))
+                              (FunCall static_cast (Double) ((Literal 1))))))))
                          (Expression (Assign (Var current_statement__) (Literal 167)))
                          (Expression
                           (MethodCall (Var lp_accum__) add ()
@@ -7252,7 +7360,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1))))))
+                              (FunCall static_cast (Double) ((Literal 1))))))))
                          (Expression (Assign (Var current_statement__) (Literal 168)))
                          (Expression
                           (MethodCall (Var lp_accum__) add ()
@@ -7268,7 +7376,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1))))))
+                              (FunCall static_cast (Double) ((Literal 1))))))))
                          (Expression (Assign (Var current_statement__) (Literal 169)))
                          (Expression
                           (MethodCall (Var lp_accum__) add ()
@@ -7283,7 +7391,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1)))))))))))))))
+                              (FunCall static_cast (Double) ((Literal 1)))))))))))))))))
                 (Expression (Assign (Var current_statement__) (Literal 180)))
                 (For
                  ((static false) (constexpr false) (type_ Int) (name i)
@@ -7305,7 +7413,8 @@
                               ((Var p_ar_mat) (Literal "\"p_ar_mat\"")
                                (FunCall stan::model::index_uni () ((Var i)))
                                (FunCall stan::model::index_uni () ((Var j)))))))
-                           (Literal 0) (Literal 1))))))))))))
+                           (FunCall static_cast (Double) ((Literal 0)))
+                           (FunCall static_cast (Double) ((Literal 1))))))))))))))
                 (Expression (Assign (Var current_statement__) (Literal 183)))
                 (For
                  ((static false) (constexpr false) (type_ Int) (name k)
@@ -7320,37 +7429,42 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_cfcov_33_ar) (Literal "\"p_cfcov_33_ar\"")
                             (FunCall stan::model::index_uni () ((Var k)))))))
-                        (Literal 0) (Literal 1)))))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1)))))))))))
                 (Expression (Assign (Var current_statement__) (Literal 184)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
                     ((FunCall stan::math::to_vector () ((Var p_vec))) 
-                     (Var d_vec) (Literal 1))))))
+                     (Var d_vec) (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 185)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_row_vec))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_row_vec)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 186)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_simplex))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_simplex)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 187)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_cfcov_54))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_cfcov_54)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 188)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_cfcov_33))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_cfcov_33)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 189)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
@@ -8111,28 +8225,35 @@
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var p_real) (Literal 0) (Literal 1))))))
+                    ((Var p_real) (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 159)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var offset_multiplier) (Literal 0) (Literal 1))))))
+                    ((Var offset_multiplier) (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 160)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var no_offset_multiplier) (Literal 0) (Literal 1))))))
+                    ((Var no_offset_multiplier)
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 161)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((Var offset_no_multiplier) (Literal 0) (Literal 1))))))
+                    ((Var offset_no_multiplier)
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 162)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_real_1d_ar))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_real_1d_ar)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 175)))
                 (For
                  ((static false) (constexpr false) (type_ Int) (name n)
@@ -8147,7 +8268,8 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_1d_vec) (Literal "\"p_1d_vec\"")
                             (FunCall stan::model::index_uni () ((Var n)))))))
-                        (Literal 0) (Literal 1))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1))))))))
                    (Expression (Assign (Var current_statement__) (Literal 164)))
                    (Expression
                     (MethodCall (Var lp_accum__) add ()
@@ -8156,7 +8278,8 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_1d_row_vec) (Literal "\"p_1d_row_vec\"")
                             (FunCall stan::model::index_uni () ((Var n)))))))
-                        (Literal 0) (Literal 1))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1))))))))
                    (Expression (Assign (Var current_statement__) (Literal 165)))
                    (Expression
                     (MethodCall (Var lp_accum__) add ()
@@ -8165,7 +8288,8 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_1d_simplex) (Literal "\"p_1d_simplex\"")
                             (FunCall stan::model::index_uni () ((Var n)))))))
-                        (Literal 0) (Literal 1))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1))))))))
                    (Expression (Assign (Var current_statement__) (Literal 173)))
                    (For
                     ((static false) (constexpr false) (type_ Int) (name m)
@@ -8193,7 +8317,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1))))))
+                              (FunCall static_cast (Double) ((Literal 1))))))))
                          (Expression (Assign (Var current_statement__) (Literal 167)))
                          (Expression
                           (MethodCall (Var lp_accum__) add ()
@@ -8209,7 +8333,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1))))))
+                              (FunCall static_cast (Double) ((Literal 1))))))))
                          (Expression (Assign (Var current_statement__) (Literal 168)))
                          (Expression
                           (MethodCall (Var lp_accum__) add ()
@@ -8225,7 +8349,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1))))))
+                              (FunCall static_cast (Double) ((Literal 1))))))))
                          (Expression (Assign (Var current_statement__) (Literal 169)))
                          (Expression
                           (MethodCall (Var lp_accum__) add ()
@@ -8240,7 +8364,7 @@
                                 (FunCall stan::model::index_uni () ((Var n)))
                                 (FunCall stan::model::index_uni () ((Var m)))
                                 (FunCall stan::model::index_uni () ((Var k)))))
-                              (Literal 1)))))))))))))))
+                              (FunCall static_cast (Double) ((Literal 1)))))))))))))))))
                 (Expression (Assign (Var current_statement__) (Literal 180)))
                 (For
                  ((static false) (constexpr false) (type_ Int) (name i)
@@ -8262,7 +8386,8 @@
                               ((Var p_ar_mat) (Literal "\"p_ar_mat\"")
                                (FunCall stan::model::index_uni () ((Var i)))
                                (FunCall stan::model::index_uni () ((Var j)))))))
-                           (Literal 0) (Literal 1))))))))))))
+                           (FunCall static_cast (Double) ((Literal 0)))
+                           (FunCall static_cast (Double) ((Literal 1))))))))))))))
                 (Expression (Assign (Var current_statement__) (Literal 183)))
                 (For
                  ((static false) (constexpr false) (type_ Int) (name k)
@@ -8277,37 +8402,42 @@
                          ((FunCall stan::model::rvalue ()
                            ((Var p_cfcov_33_ar) (Literal "\"p_cfcov_33_ar\"")
                             (FunCall stan::model::index_uni () ((Var k)))))))
-                        (Literal 0) (Literal 1)))))))))
+                        (FunCall static_cast (Double) ((Literal 0)))
+                        (FunCall static_cast (Double) ((Literal 1)))))))))))
                 (Expression (Assign (Var current_statement__) (Literal 184)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
                     ((FunCall stan::math::to_vector () ((Var p_vec))) 
-                     (Var d_vec) (Literal 1))))))
+                     (Var d_vec) (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 185)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_row_vec))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_row_vec)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 186)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_simplex))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_simplex)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 187)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_cfcov_54))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_cfcov_54)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 188)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
                   ((FunCall stan::math::normal_lpdf ((TemplateType propto__))
-                    ((FunCall stan::math::to_vector () ((Var p_cfcov_33))) 
-                     (Literal 0) (Literal 1))))))
+                    ((FunCall stan::math::to_vector () ((Var p_cfcov_33)))
+                     (FunCall static_cast (Double) ((Literal 0)))
+                     (FunCall static_cast (Double) ((Literal 1))))))))
                 (Expression (Assign (Var current_statement__) (Literal 189)))
                 (Expression
                  (MethodCall (Var lp_accum__) add ()
@@ -18677,7 +18807,8 @@
              ((Var td_cfcov_54)
               (FunCall stan::math::diag_matrix ()
                ((FunCall stan::math::rep_vector ()
-                 ((Literal 1) (FunCall stan::math::rows () ((Var td_cfcov_54)))))))
+                 ((FunCall static_cast (Double) ((Literal 1)))
+                  (FunCall stan::math::rows () ((Var td_cfcov_54)))))))
               (Literal "\"assigning variable td_cfcov_54\""))))
            (Expression (Assign (Var current_statement__) (Literal 348)))
            (Expression
@@ -18685,7 +18816,8 @@
              ((Var td_cfcov_33)
               (FunCall stan::math::diag_matrix ()
                ((FunCall stan::math::rep_vector ()
-                 ((Literal 1) (FunCall stan::math::rows () ((Var td_cfcov_33)))))))
+                 ((FunCall static_cast (Double) ((Literal 1)))
+                  (FunCall stan::math::rows () ((Var td_cfcov_33)))))))
               (Literal "\"assigning variable td_cfcov_33\""))))
            (Block
             ((VariableDefn
@@ -18715,7 +18847,8 @@
                   (Subscript (Var blocked_tdata_vs)
                    (Parens (BinOp (Var sym1__) Subtract (Literal 1))))))
                 (Expression (Assign (Var current_statement__) (Literal 352)))
-                (Expression (Assign (Var z) (Literal 0))))))
+                (Expression
+                 (Assign (Var z) (FunCall static_cast (Double) ((Literal 0))))))))
              (VariableDefn
               ((static false) (constexpr false) (type_ (StdVector Int)) 
                (name indices)
@@ -18758,7 +18891,7 @@
                     (Subscript (Var sym1__)
                      (Parens (BinOp (Var sym3__) Subtract (Literal 1))))))
                   (Expression (Assign (Var current_statement__) (Literal 356)))
-                  (Expression (Assign (Var z) (Var i))))))))))
+                  (Expression (Assign (Var z) (FunCall static_cast (Double) ((Var i))))))))))))
            (Expression (Assign (Var current_statement__) (Literal 358)))
            (Expression
             (FunCall stan::model::assign ()
@@ -18819,7 +18952,9 @@
            (Expression
             (FunCall stan::model::assign ()
              ((Var x_mul_ind)
-              (InitializerExpr (StdVector Double) ((Literal 1) (Literal 2)))
+              (InitializerExpr (StdVector Double)
+               ((FunCall static_cast (Double) ((Literal 1)))
+                (FunCall static_cast (Double) ((Literal 2)))))
               (Literal "\"assigning variable x_mul_ind\""))))
            (Expression (Assign (Var current_statement__) (Literal 365)))
            (Expression

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -365,7 +365,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
         "assigning variable z");
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -431,7 +432,8 @@ class ode_adjoint_test_model_model final : public model_base_crtp<ode_adjoint_te
         "assigning variable z");
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -1188,11 +1190,11 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
       current_statement__ = 35;
       t0 = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 35;
-      t0 = 0;
+      t0 = static_cast<double>(0);
       current_statement__ = 36;
       kappa = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 36;
-      kappa = 1000000;
+      kappa = static_cast<double>(1000000);
       current_statement__ = 37;
       unused = std::numeric_limits<int>::min();
       current_statement__ = 37;
@@ -1297,13 +1299,17 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
             stan::model::index_uni(n));
         }
         current_statement__ = 13;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 14;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 15;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(stoi, y_diff));
         current_statement__ = 18;
@@ -1429,13 +1435,17 @@ class overloaded_ode_model final : public model_base_crtp<overloaded_ode_model> 
             stan::model::index_uni(n));
         }
         current_statement__ = 13;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 14;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 15;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(stoi, y_diff));
         current_statement__ = 18;

--- a/test/integration/good/code-gen/opencl/cpp.expected
+++ b/test/integration/good/code-gen/opencl/cpp.expected
@@ -953,7 +953,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       local_scalar_t__ transformed_param_real = DUMMY_VAR__;
       current_statement__ = 8;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(d_int,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 9;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(d_int,
                                  d_real);
@@ -980,7 +980,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 17;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(
-                                 d_int_array_opencl__, d_int);
+                                 d_int_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 18;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(
                                  d_int_array_opencl__, d_real);
@@ -1009,311 +1010,406 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  d_int_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 26;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 27;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 28;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 29;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 30;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 31;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 32;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 33;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 34;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 35;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 36;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real, d_real);
       current_statement__ = 37;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_real_array_opencl__);
       current_statement__ = 38;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_vector_opencl__);
       current_statement__ = 39;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_row_vector_opencl__);
       current_statement__ = 40;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real, p_real);
       current_statement__ = 41;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 42;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 43;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 44;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_real_array_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 45;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_real);
       current_statement__ = 46;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_real_array_opencl__);
       current_statement__ = 47;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_vector_opencl__);
       current_statement__ = 48;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_row_vector_opencl__);
       current_statement__ = 49;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, p_real);
       current_statement__ = 50;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 51;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 52;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 53;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_vector_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 54;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_real);
       current_statement__ = 55;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_real_array_opencl__);
       current_statement__ = 56;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_vector_opencl__);
       current_statement__ = 57;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_row_vector_opencl__);
       current_statement__ = 58;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, p_real);
       current_statement__ = 59;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 60;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 61;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 62;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_row_vector_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 63;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_real);
       current_statement__ = 64;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_real_array_opencl__);
       current_statement__ = 65;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_vector_opencl__);
       current_statement__ = 66;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_row_vector_opencl__);
       current_statement__ = 67;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, p_real);
       current_statement__ = 68;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 69;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 70;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 71;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 72;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real, d_real);
       current_statement__ = 73;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_real_array_opencl__);
       current_statement__ = 74;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_vector_opencl__);
       current_statement__ = 75;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_row_vector_opencl__);
       current_statement__ = 76;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real, p_real);
       current_statement__ = 77;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 78;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 79;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 80;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 81;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_real);
       current_statement__ = 82;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_real_array_opencl__);
       current_statement__ = 83;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_vector_opencl__);
       current_statement__ = 84;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_row_vector_opencl__);
       current_statement__ = 85;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  p_real);
       current_statement__ = 86;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 87;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 88;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 89;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 90;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector), d_real);
       current_statement__ = 91;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_real_array_opencl__);
       current_statement__ = 92;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_vector_opencl__);
       current_statement__ = 93;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_row_vector_opencl__);
       current_statement__ = 94;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector), p_real);
       current_statement__ = 95;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 96;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 97;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 98;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 99;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_real);
       current_statement__ = 100;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_real_array_opencl__);
       current_statement__ = 101;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_vector_opencl__);
       current_statement__ = 102;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_row_vector_opencl__);
       current_statement__ = 103;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  p_real);
       current_statement__ = 104;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 105;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 106;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 107;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 108;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 109;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 110;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 111;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 112;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 113;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 114;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 115;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 116;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 117;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_real,
                                  d_real);
@@ -1340,7 +1436,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 125;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 126;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_real_array_opencl__, d_real);
@@ -1370,7 +1467,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 134;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 135;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_vector_opencl__, d_real);
@@ -1400,7 +1498,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 143;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 144;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_row_vector_opencl__, d_real);
@@ -1430,7 +1529,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 152;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 153;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, p_real,
                                  d_real);
@@ -1458,7 +1557,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 161;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 162;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_real_array),
@@ -1493,7 +1592,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 170;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 171;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_vector), d_real);
@@ -1527,7 +1627,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 179;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 180;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -1562,40 +1662,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 188;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 189;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, d_real);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 190;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 191;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 192;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 193;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, p_real);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 194;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 195;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 196;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 197;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_real, d_int);
+                                 d_real_array_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 198;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_real, d_real);
@@ -1629,7 +1740,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 206;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 207;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -1668,7 +1780,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 215;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 216;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_vector_opencl__,
@@ -1704,7 +1816,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 224;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 225;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -1742,7 +1855,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 233;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, p_real, d_int);
+                                 d_real_array_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 234;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, p_real, d_real);
@@ -1777,7 +1891,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 243;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -1821,7 +1935,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 251;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 252;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -1864,7 +1979,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 261;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -1907,39 +2022,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 269;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 270;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_real);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 271;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 272;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_vector_opencl__);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 273;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 274;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, p_real);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 275;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 276;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 277;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 278;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_real, d_int);
+                                 d_vector_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 279;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real, d_real);
@@ -1972,7 +2099,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 287;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real_array_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 288;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real_array_opencl__,
@@ -2007,7 +2134,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 296;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_vector_opencl__, d_int);
+                                 d_vector_opencl__, d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 297;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_vector_opencl__, d_real);
@@ -2041,7 +2169,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 305;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_row_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 306;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_row_vector_opencl__,
@@ -2076,7 +2204,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 314;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, p_real, d_int);
+                                 d_vector_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 315;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, p_real, d_real);
@@ -2110,7 +2239,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 324;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -2154,7 +2283,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 332;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 333;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -2197,7 +2327,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 342;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -2240,40 +2370,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 350;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 351;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, d_real);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 352;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 353;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 354;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 355;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, p_real);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 356;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 357;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 358;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 359;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_real, d_int);
+                                 d_row_vector_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 360;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_real, d_real);
@@ -2307,7 +2448,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 368;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 369;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -2346,7 +2488,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 377;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 378;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_vector_opencl__,
@@ -2382,7 +2524,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 386;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 387;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -2420,7 +2563,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 395;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, p_real, d_int);
+                                 d_row_vector_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 396;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, p_real, d_real);
@@ -2455,7 +2599,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 405;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -2499,7 +2643,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 413;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 414;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -2542,7 +2687,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 423;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -2584,35 +2729,42 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 431;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 432;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 433;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 434;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 435;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 436;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 437;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 438;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 439;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 440;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 441;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_real,
                                  d_real);
@@ -2639,7 +2791,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 449;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 450;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_real_array_opencl__, d_real);
@@ -2669,7 +2822,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 458;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 459;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_vector_opencl__, d_real);
@@ -2699,7 +2853,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 467;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 468;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_row_vector_opencl__, d_real);
@@ -2729,7 +2884,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 476;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 477;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, p_real,
                                  d_real);
@@ -2757,7 +2912,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 485;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 486;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_real_array),
@@ -2792,7 +2947,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 494;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 495;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_vector), d_real);
@@ -2826,7 +2982,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 503;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 504;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -2862,45 +3018,50 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 512;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_int);
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 513;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_real);
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 514;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_real_array_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__);
       current_statement__ = 515;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 516;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_row_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__);
       current_statement__ = 517;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, p_real);
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 518;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 519;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, stan::math::to_matrix_cl(p_vector));
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector));
       current_statement__ = 520;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 521;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_real, d_int);
+                                 d_real, static_cast<double>(d_int));
       current_statement__ = 522;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -2938,7 +3099,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 530;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 531;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -2977,7 +3139,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 539;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 540;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -3016,7 +3179,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 548;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 549;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -3055,7 +3219,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 557;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 p_real, d_int);
+                                 p_real, static_cast<double>(d_int));
       current_statement__ = 558;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -3094,7 +3258,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 567;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -3138,7 +3302,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 575;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 576;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -3181,7 +3346,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 585;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -3224,44 +3389,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 593;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 594;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 d_real);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 595;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 596;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 597;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 598;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 p_real);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 599;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 600;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 601;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 602;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 603;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), d_real,
@@ -3297,7 +3469,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 611;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 612;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -3336,7 +3509,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 620;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 621;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -3375,7 +3549,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 629;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 630;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -3414,7 +3589,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 638;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 639;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), p_real,
@@ -3451,7 +3626,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 648;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -3495,7 +3670,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 656;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 657;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -3538,7 +3714,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 666;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -3582,45 +3758,50 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 674;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_int);
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 675;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_real);
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 676;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_real_array_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__);
       current_statement__ = 677;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 678;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_row_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__);
       current_statement__ = 679;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, p_real);
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 680;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 681;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, stan::math::to_matrix_cl(p_vector));
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector));
       current_statement__ = 682;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 683;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_real, d_int);
+                                 d_real, static_cast<double>(d_int));
       current_statement__ = 684;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3658,7 +3839,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 692;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 693;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3697,7 +3879,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 701;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 702;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3736,7 +3919,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 710;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 711;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3775,7 +3959,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 719;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 p_real, d_int);
+                                 p_real, static_cast<double>(d_int));
       current_statement__ = 720;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3814,7 +3998,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 729;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3858,7 +4042,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 737;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 738;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3901,7 +4086,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 747;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -3944,7 +4129,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       {
         current_statement__ = 755;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
       d_int_array_opencl__.wait_for_read_write_events();
       d_real_array_opencl__.wait_for_read_write_events();
@@ -4000,7 +4186,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       local_scalar_t__ transformed_param_real = DUMMY_VAR__;
       current_statement__ = 8;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(d_int,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 9;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(d_int,
                                  d_real);
@@ -4027,7 +4213,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 17;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(
-                                 d_int_array_opencl__, d_int);
+                                 d_int_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 18;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(
                                  d_int_array_opencl__, d_real);
@@ -4056,311 +4243,406 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  d_int_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 26;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 27;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 28;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 29;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 30;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 31;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 32;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 33;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 34;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 35;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 36;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real, d_real);
       current_statement__ = 37;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_real_array_opencl__);
       current_statement__ = 38;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_vector_opencl__);
       current_statement__ = 39;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_row_vector_opencl__);
       current_statement__ = 40;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real, p_real);
       current_statement__ = 41;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 42;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 43;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 44;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_real_array_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 45;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_real);
       current_statement__ = 46;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_real_array_opencl__);
       current_statement__ = 47;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_vector_opencl__);
       current_statement__ = 48;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_row_vector_opencl__);
       current_statement__ = 49;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, p_real);
       current_statement__ = 50;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 51;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 52;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 53;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_vector_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 54;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_real);
       current_statement__ = 55;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_real_array_opencl__);
       current_statement__ = 56;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_vector_opencl__);
       current_statement__ = 57;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_row_vector_opencl__);
       current_statement__ = 58;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, p_real);
       current_statement__ = 59;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 60;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 61;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 62;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_row_vector_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 63;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_real);
       current_statement__ = 64;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_real_array_opencl__);
       current_statement__ = 65;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_vector_opencl__);
       current_statement__ = 66;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_row_vector_opencl__);
       current_statement__ = 67;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, p_real);
       current_statement__ = 68;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 69;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 70;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 71;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 72;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real, d_real);
       current_statement__ = 73;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_real_array_opencl__);
       current_statement__ = 74;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_vector_opencl__);
       current_statement__ = 75;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_row_vector_opencl__);
       current_statement__ = 76;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real, p_real);
       current_statement__ = 77;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 78;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 79;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 80;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 81;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_real);
       current_statement__ = 82;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_real_array_opencl__);
       current_statement__ = 83;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_vector_opencl__);
       current_statement__ = 84;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_row_vector_opencl__);
       current_statement__ = 85;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  p_real);
       current_statement__ = 86;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 87;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 88;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 89;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 90;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector), d_real);
       current_statement__ = 91;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_real_array_opencl__);
       current_statement__ = 92;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_vector_opencl__);
       current_statement__ = 93;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_row_vector_opencl__);
       current_statement__ = 94;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector), p_real);
       current_statement__ = 95;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 96;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 97;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 98;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 99;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_real);
       current_statement__ = 100;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_real_array_opencl__);
       current_statement__ = 101;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_vector_opencl__);
       current_statement__ = 102;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_row_vector_opencl__);
       current_statement__ = 103;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  p_real);
       current_statement__ = 104;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 105;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 106;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 107;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 108;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 109;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 110;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 111;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 112;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 113;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 114;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 115;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 116;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 117;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_real,
                                  d_real);
@@ -4387,7 +4669,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 125;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 126;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_real_array_opencl__, d_real);
@@ -4417,7 +4700,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 134;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 135;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_vector_opencl__, d_real);
@@ -4447,7 +4731,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 143;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 144;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_row_vector_opencl__, d_real);
@@ -4477,7 +4762,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 152;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 153;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, p_real,
                                  d_real);
@@ -4505,7 +4790,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 161;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 162;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_real_array),
@@ -4540,7 +4825,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 170;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 171;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_vector), d_real);
@@ -4574,7 +4860,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 179;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 180;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -4609,40 +4895,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 188;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 189;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, d_real);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 190;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 191;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 192;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 193;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, p_real);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 194;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 195;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 196;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 197;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_real, d_int);
+                                 d_real_array_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 198;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_real, d_real);
@@ -4676,7 +4973,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 206;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 207;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -4715,7 +5013,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 215;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 216;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_vector_opencl__,
@@ -4751,7 +5049,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 224;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 225;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -4789,7 +5088,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 233;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, p_real, d_int);
+                                 d_real_array_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 234;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, p_real, d_real);
@@ -4824,7 +5124,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 243;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -4868,7 +5168,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 251;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 252;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -4911,7 +5212,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 261;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -4954,39 +5255,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 269;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 270;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_real);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 271;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 272;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_vector_opencl__);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 273;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 274;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, p_real);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 275;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 276;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 277;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 278;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_real, d_int);
+                                 d_vector_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 279;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real, d_real);
@@ -5019,7 +5332,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 287;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real_array_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 288;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real_array_opencl__,
@@ -5054,7 +5367,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 296;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_vector_opencl__, d_int);
+                                 d_vector_opencl__, d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 297;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_vector_opencl__, d_real);
@@ -5088,7 +5402,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 305;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_row_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 306;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_row_vector_opencl__,
@@ -5123,7 +5437,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 314;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, p_real, d_int);
+                                 d_vector_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 315;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, p_real, d_real);
@@ -5157,7 +5472,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 324;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -5201,7 +5516,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 332;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 333;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -5244,7 +5560,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 342;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -5287,40 +5603,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 350;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 351;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, d_real);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 352;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 353;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 354;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 355;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, p_real);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 356;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 357;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 358;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 359;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_real, d_int);
+                                 d_row_vector_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 360;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_real, d_real);
@@ -5354,7 +5681,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 368;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 369;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -5393,7 +5721,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 377;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 378;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_vector_opencl__,
@@ -5429,7 +5757,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 386;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 387;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -5467,7 +5796,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 395;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, p_real, d_int);
+                                 d_row_vector_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 396;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, p_real, d_real);
@@ -5502,7 +5832,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 405;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -5546,7 +5876,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 413;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 414;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -5589,7 +5920,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 423;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -5631,35 +5962,42 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 431;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 432;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 433;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 434;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 435;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 436;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 437;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 438;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 439;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 440;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 441;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_real,
                                  d_real);
@@ -5686,7 +6024,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 449;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 450;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_real_array_opencl__, d_real);
@@ -5716,7 +6055,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 458;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 459;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_vector_opencl__, d_real);
@@ -5746,7 +6086,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 467;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 468;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_row_vector_opencl__, d_real);
@@ -5776,7 +6117,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 476;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 477;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, p_real,
                                  d_real);
@@ -5804,7 +6145,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 485;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 486;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_real_array),
@@ -5839,7 +6180,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 494;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 495;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_vector), d_real);
@@ -5873,7 +6215,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 503;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 504;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -5909,45 +6251,50 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 512;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_int);
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 513;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_real);
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 514;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_real_array_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__);
       current_statement__ = 515;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 516;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_row_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__);
       current_statement__ = 517;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, p_real);
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 518;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 519;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, stan::math::to_matrix_cl(p_vector));
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector));
       current_statement__ = 520;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 521;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_real, d_int);
+                                 d_real, static_cast<double>(d_int));
       current_statement__ = 522;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -5985,7 +6332,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 530;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 531;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6024,7 +6372,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 539;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 540;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6063,7 +6412,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 548;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 549;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6102,7 +6452,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 557;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 p_real, d_int);
+                                 p_real, static_cast<double>(d_int));
       current_statement__ = 558;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6141,7 +6491,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 567;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6185,7 +6535,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 575;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 576;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6228,7 +6579,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 585;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -6271,44 +6622,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 593;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 594;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 d_real);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 595;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 596;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 597;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 598;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 p_real);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 599;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 600;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 601;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 602;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 603;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), d_real,
@@ -6344,7 +6702,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 611;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 612;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -6383,7 +6742,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 620;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 621;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -6422,7 +6782,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 629;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 630;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -6461,7 +6822,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 638;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 639;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), p_real,
@@ -6498,7 +6859,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 648;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -6542,7 +6903,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 656;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 657;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -6585,7 +6947,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 666;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -6629,45 +6991,50 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 674;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_int);
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 675;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_real);
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 676;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_real_array_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__);
       current_statement__ = 677;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 678;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_row_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__);
       current_statement__ = 679;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, p_real);
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 680;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 681;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, stan::math::to_matrix_cl(p_vector));
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector));
       current_statement__ = 682;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 683;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_real, d_int);
+                                 d_real, static_cast<double>(d_int));
       current_statement__ = 684;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6705,7 +7072,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 692;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 693;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6744,7 +7112,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 701;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 702;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6783,7 +7152,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 710;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 711;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6822,7 +7192,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 719;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 p_real, d_int);
+                                 p_real, static_cast<double>(d_int));
       current_statement__ = 720;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6861,7 +7231,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 729;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6905,7 +7275,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 737;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 738;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6948,7 +7319,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 747;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -6991,7 +7362,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       {
         current_statement__ = 755;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
       d_int_array_opencl__.wait_for_read_write_events();
       d_real_array_opencl__.wait_for_read_write_events();
@@ -7070,7 +7442,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       }
       current_statement__ = 8;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(d_int,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 9;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(d_int,
                                  d_real);
@@ -7097,7 +7469,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 17;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(
-                                 d_int_array_opencl__, d_int);
+                                 d_int_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 18;
       transformed_param_real = stan::math::bernoulli_logit_lpmf<false>(
                                  d_int_array_opencl__, d_real);
@@ -7126,311 +7499,406 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  d_int_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 26;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 27;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 28;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 29;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 30;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 31;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 32;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 33;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 34;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 35;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 36;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real, d_real);
       current_statement__ = 37;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_real_array_opencl__);
       current_statement__ = 38;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_vector_opencl__);
       current_statement__ = 39;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  d_row_vector_opencl__);
       current_statement__ = 40;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real, p_real);
       current_statement__ = 41;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 42;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 43;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, d_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), d_real,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 44;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_real_array_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 45;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_real);
       current_statement__ = 46;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_real_array_opencl__);
       current_statement__ = 47;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_vector_opencl__);
       current_statement__ = 48;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, d_row_vector_opencl__);
       current_statement__ = 49;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__, p_real);
       current_statement__ = 50;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 51;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 52;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 53;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_vector_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 54;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_real);
       current_statement__ = 55;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_real_array_opencl__);
       current_statement__ = 56;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_vector_opencl__);
       current_statement__ = 57;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, d_row_vector_opencl__);
       current_statement__ = 58;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__, p_real);
       current_statement__ = 59;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 60;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 61;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 62;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 d_row_vector_opencl__, d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 63;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_real);
       current_statement__ = 64;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_real_array_opencl__);
       current_statement__ = 65;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_vector_opencl__);
       current_statement__ = 66;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, d_row_vector_opencl__);
       current_statement__ = 67;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__, p_real);
       current_statement__ = 68;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 69;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 70;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 71;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 72;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real, d_real);
       current_statement__ = 73;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_real_array_opencl__);
       current_statement__ = 74;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_vector_opencl__);
       current_statement__ = 75;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  d_row_vector_opencl__);
       current_statement__ = 76;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real, p_real);
       current_statement__ = 77;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 78;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 79;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int, p_real,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int), p_real,
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 80;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 81;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_real);
       current_statement__ = 82;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_real_array_opencl__);
       current_statement__ = 83;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_vector_opencl__);
       current_statement__ = 84;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  d_row_vector_opencl__);
       current_statement__ = 85;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  p_real);
       current_statement__ = 86;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 87;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 88;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 89;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 90;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector), d_real);
       current_statement__ = 91;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_real_array_opencl__);
       current_statement__ = 92;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_vector_opencl__);
       current_statement__ = 93;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  d_row_vector_opencl__);
       current_statement__ = 94;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector), p_real);
       current_statement__ = 95;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 96;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 97;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 98;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 99;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_real);
       current_statement__ = 100;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_real_array_opencl__);
       current_statement__ = 101;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_vector_opencl__);
       current_statement__ = 102;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  d_row_vector_opencl__);
       current_statement__ = 103;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  p_real);
       current_statement__ = 104;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 105;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 106;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 107;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 108;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 109;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 110;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 111;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 112;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 113;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 114;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 115;
-      transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(d_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 116;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 117;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, d_real,
                                  d_real);
@@ -7457,7 +7925,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 125;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 126;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_real_array_opencl__, d_real);
@@ -7487,7 +7956,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 134;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 135;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_vector_opencl__, d_real);
@@ -7517,7 +7987,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 143;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 144;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  d_row_vector_opencl__, d_real);
@@ -7547,7 +8018,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 152;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 153;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real, p_real,
                                  d_real);
@@ -7575,7 +8046,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 161;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 162;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_real_array),
@@ -7610,7 +8081,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 170;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 171;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_vector), d_real);
@@ -7644,7 +8116,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 179;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 180;
       transformed_param_real = stan::math::normal_lpdf<false>(d_real,
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -7679,40 +8151,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 188;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 189;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, d_real);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 190;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 191;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 192;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 193;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int, p_real);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 194;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 195;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 196;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_int,
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 197;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, d_real, d_int);
+                                 d_real_array_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 198;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_real, d_real);
@@ -7746,7 +8229,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 206;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 207;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -7785,7 +8269,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 215;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 216;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, d_vector_opencl__,
@@ -7821,7 +8305,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 224;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 225;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -7859,7 +8344,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 233;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_real_array_opencl__, p_real, d_int);
+                                 d_real_array_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 234;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__, p_real, d_real);
@@ -7894,7 +8380,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 243;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -7938,7 +8424,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 251;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 252;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -7981,7 +8468,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 261;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_real_array_opencl__,
@@ -8024,39 +8511,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 269;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 270;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_real);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 271;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 272;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, d_vector_opencl__);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 273;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 274;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int, p_real);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 275;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 276;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 277;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_int,
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 278;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_real, d_int);
+                                 d_vector_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 279;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real, d_real);
@@ -8089,7 +8588,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 287;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real_array_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 288;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_real_array_opencl__,
@@ -8124,7 +8623,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 296;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, d_vector_opencl__, d_int);
+                                 d_vector_opencl__, d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 297;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_vector_opencl__, d_real);
@@ -8158,7 +8658,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 305;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_row_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 306;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, d_row_vector_opencl__,
@@ -8193,7 +8693,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 314;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_vector_opencl__, p_real, d_int);
+                                 d_vector_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 315;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__, p_real, d_real);
@@ -8227,7 +8728,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 324;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -8271,7 +8772,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 332;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 333;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -8314,7 +8816,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 342;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_vector_opencl__,
@@ -8357,40 +8859,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 350;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 351;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, d_real);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 352;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 353;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 354;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 355;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int, p_real);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 356;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 357;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 358;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_int,
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 359;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, d_real, d_int);
+                                 d_row_vector_opencl__, d_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 360;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_real, d_real);
@@ -8424,7 +8937,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 368;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 369;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -8463,7 +8977,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 377;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_vector_opencl__,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 378;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, d_vector_opencl__,
@@ -8499,7 +9013,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 386;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 387;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -8537,7 +9052,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 395;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 d_row_vector_opencl__, p_real, d_int);
+                                 d_row_vector_opencl__, p_real,
+                                 static_cast<double>(d_int));
       current_statement__ = 396;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__, p_real, d_real);
@@ -8572,7 +9088,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 405;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -8616,7 +9132,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 413;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 414;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -8659,7 +9176,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 423;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  d_row_vector_opencl__,
@@ -8701,35 +9218,42 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 431;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 d_int);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 432;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 d_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 433;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 434;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 435;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 436;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
-                                 p_real);
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 437;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 438;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 439;
-      transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_int,
+      transformed_param_real = stan::math::normal_lpdf<false>(p_real,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 440;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 441;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, d_real,
                                  d_real);
@@ -8756,7 +9280,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 449;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 450;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_real_array_opencl__, d_real);
@@ -8786,7 +9311,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 458;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 459;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_vector_opencl__, d_real);
@@ -8816,7 +9342,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 467;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 468;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  d_row_vector_opencl__, d_real);
@@ -8846,7 +9373,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 476;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 477;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real, p_real,
                                  d_real);
@@ -8874,7 +9401,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 485;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 486;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_real_array),
@@ -8909,7 +9436,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 494;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 495;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_vector), d_real);
@@ -8943,7 +9471,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 503;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 504;
       transformed_param_real = stan::math::normal_lpdf<false>(p_real,
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -8979,45 +9507,50 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 512;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_int);
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 513;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_real);
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 514;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_real_array_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__);
       current_statement__ = 515;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 516;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, d_row_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__);
       current_statement__ = 517;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, p_real);
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 518;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 519;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int, stan::math::to_matrix_cl(p_vector));
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector));
       current_statement__ = 520;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 521;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_real, d_int);
+                                 d_real, static_cast<double>(d_int));
       current_statement__ = 522;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9055,7 +9588,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 530;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 531;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9094,7 +9628,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 539;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 540;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9133,7 +9668,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 548;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 549;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9172,7 +9708,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 557;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 p_real, d_int);
+                                 p_real, static_cast<double>(d_int));
       current_statement__ = 558;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9211,7 +9747,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 567;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9255,7 +9791,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 575;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 576;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9298,7 +9835,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 585;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_real_array),
@@ -9341,44 +9878,51 @@ class distributions_model final : public model_base_crtp<distributions_model> {
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 593;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 594;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 d_real);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 595;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_real_array_opencl__);
       current_statement__ = 596;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_vector_opencl__);
       current_statement__ = 597;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  d_row_vector_opencl__);
       current_statement__ = 598;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
-                                 p_real);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 599;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 600;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_vector));
       current_statement__ = 601;
       transformed_param_real = stan::math::normal_lpdf<false>(
-                                 stan::math::to_matrix_cl(p_vector), d_int,
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 602;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), d_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 603;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), d_real,
@@ -9414,7 +9958,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 611;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 612;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -9453,7 +9998,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 620;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 621;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -9492,7 +10038,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 629;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 630;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -9531,7 +10078,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 638;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), p_real,
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 639;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector), p_real,
@@ -9568,7 +10115,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 648;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -9612,7 +10159,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 656;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 657;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -9655,7 +10203,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 666;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_vector),
@@ -9699,45 +10247,50 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 674;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_int);
+                                 static_cast<double>(d_int),
+                                 static_cast<double>(d_int));
       current_statement__ = 675;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_real);
+                                 static_cast<double>(d_int), d_real);
       current_statement__ = 676;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_real_array_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_real_array_opencl__);
       current_statement__ = 677;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_vector_opencl__);
       current_statement__ = 678;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, d_row_vector_opencl__);
+                                 static_cast<double>(d_int),
+                                 d_row_vector_opencl__);
       current_statement__ = 679;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, p_real);
+                                 static_cast<double>(d_int), p_real);
       current_statement__ = 680;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_real_array));
       current_statement__ = 681;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int, stan::math::to_matrix_cl(p_vector));
+                                 static_cast<double>(d_int),
+                                 stan::math::to_matrix_cl(p_vector));
       current_statement__ = 682;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int,
+                                 static_cast<double>(d_int),
                                  stan::math::to_matrix_cl(p_row_vector));
       current_statement__ = 683;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_real, d_int);
+                                 d_real, static_cast<double>(d_int));
       current_statement__ = 684;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -9775,7 +10328,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 692;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_real_array_opencl__, d_int);
+                                 d_real_array_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 693;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -9814,7 +10368,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 701;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_vector_opencl__, d_int);
+                                 d_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 702;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -9853,7 +10408,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 710;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_row_vector_opencl__, d_int);
+                                 d_row_vector_opencl__,
+                                 static_cast<double>(d_int));
       current_statement__ = 711;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -9892,7 +10448,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 719;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 p_real, d_int);
+                                 p_real, static_cast<double>(d_int));
       current_statement__ = 720;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -9931,7 +10487,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_real_array),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 729;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -9975,7 +10531,8 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       current_statement__ = 737;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 stan::math::to_matrix_cl(p_vector), d_int);
+                                 stan::math::to_matrix_cl(p_vector),
+                                 static_cast<double>(d_int));
       current_statement__ = 738;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -10018,7 +10575,7 @@ class distributions_model final : public model_base_crtp<distributions_model> {
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
                                  stan::math::to_matrix_cl(p_row_vector),
-                                 d_int);
+                                 static_cast<double>(d_int));
       current_statement__ = 747;
       transformed_param_real = stan::math::normal_lpdf<false>(
                                  stan::math::to_matrix_cl(p_row_vector),
@@ -10683,7 +11240,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
                                  d_vector_opencl__, p_real, p_real);
       {
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
       d_vector_opencl__.wait_for_read_write_events();
     } catch (const std::exception& e) {
@@ -10783,7 +11341,8 @@ class restricted_model final : public model_base_crtp<restricted_model> {
                                  d_vector_opencl__, p_real, p_real);
       {
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y_p,
+                         static_cast<double>(0), static_cast<double>(1)));
       }
       d_vector_opencl__.wait_for_read_write_events();
     } catch (const std::exception& e) {

--- a/test/integration/good/code-gen/profiling/cpp.expected
+++ b/test/integration/good/code-gen/profiling/cpp.expected
@@ -197,11 +197,14 @@ class simple_function_model final : public model_base_crtp<simple_function_model
             stan::math::profile<local_scalar_t__> profile__("priors",
               const_cast<stan::math::profile_map&>(profiles__));
             current_statement__ = 14;
-            lp_accum__.add(stan::math::gamma_lpdf<propto__>(rho, 25, 4));
+            lp_accum__.add(stan::math::gamma_lpdf<propto__>(rho,
+                             static_cast<double>(25), static_cast<double>(4)));
             current_statement__ = 15;
-            lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha, 0, 2));
+            lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha,
+                             static_cast<double>(0), static_cast<double>(2)));
             current_statement__ = 16;
-            lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 1));
+            lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                             static_cast<double>(0), static_cast<double>(1)));
           }
           current_statement__ = 19;
           {
@@ -210,7 +213,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
               const_cast<stan::math::profile_map&>(profiles__));
             current_statement__ = 18;
             lp_accum__.add(stan::math::multi_normal_cholesky_lpdf<propto__>(
-                             y, stan::math::rep_vector(0, N), L_cov));
+                             y,
+                             stan::math::rep_vector(static_cast<double>(0), N),
+                             L_cov));
           }
         }
       }
@@ -297,11 +302,14 @@ class simple_function_model final : public model_base_crtp<simple_function_model
             stan::math::profile<local_scalar_t__> profile__("priors",
               const_cast<stan::math::profile_map&>(profiles__));
             current_statement__ = 14;
-            lp_accum__.add(stan::math::gamma_lpdf<propto__>(rho, 25, 4));
+            lp_accum__.add(stan::math::gamma_lpdf<propto__>(rho,
+                             static_cast<double>(25), static_cast<double>(4)));
             current_statement__ = 15;
-            lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha, 0, 2));
+            lp_accum__.add(stan::math::normal_lpdf<propto__>(alpha,
+                             static_cast<double>(0), static_cast<double>(2)));
             current_statement__ = 16;
-            lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 1));
+            lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                             static_cast<double>(0), static_cast<double>(1)));
           }
           current_statement__ = 19;
           {
@@ -310,7 +318,9 @@ class simple_function_model final : public model_base_crtp<simple_function_model
               const_cast<stan::math::profile_map&>(profiles__));
             current_statement__ = 18;
             lp_accum__.add(stan::math::multi_normal_cholesky_lpdf<propto__>(
-                             y, stan::math::rep_vector(0, N), L_cov));
+                             y,
+                             stan::math::rep_vector(static_cast<double>(0), N),
+                             L_cov));
           }
         }
       }

--- a/test/integration/good/code-gen/standalone_functions/cpp.expected
+++ b/test/integration/good/code-gen/standalone_functions/cpp.expected
@@ -182,7 +182,7 @@ double int_array_fun(const T0__& a, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 5;
-    return stan::math::sum(a);
+    return stan::math::promote_scalar<local_scalar_t__>(stan::math::sum(a));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -282,7 +282,8 @@ test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 15;
-    lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, 1));
+    lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                     static_cast<double>(0), static_cast<double>(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -327,7 +328,7 @@ test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 19;
-    return stan::math::normal_lpdf<false>(a, b, 1);
+    return stan::math::normal_lpdf<false>(a, b, static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -635,7 +636,7 @@ double int_array_fun(const T0__& a, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 5;
-    return stan::math::sum(a);
+    return stan::math::promote_scalar<local_scalar_t__>(stan::math::sum(a));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -735,7 +736,8 @@ test_lp(const T0__& a, T_lp__& lp__, T_lp_accum__& lp_accum__, std::ostream*
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 15;
-    lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, 1));
+    lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                     static_cast<double>(0), static_cast<double>(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -780,7 +782,7 @@ test_lpdf(const T0__& a, const T1__& b, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 19;
-    return stan::math::normal_lpdf<false>(a, b, 1);
+    return stan::math::normal_lpdf<false>(a, b, static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -2114,17 +2114,18 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       current_statement__ = 24;
       t0 = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 24;
-      t0 = 0;
+      t0 = static_cast<double>(0);
       current_statement__ = 25;
       kappa = std::numeric_limits<double>::quiet_NaN();
-      lcm_sym37__ = 1000000;
-      kappa = 1000000;
+      lcm_sym37__ = static_cast<double>(1000000);
+      kappa = static_cast<double>(1000000);
       current_statement__ = 26;
       x_r = std::vector<double>(0, std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 27;
       x_i = std::vector<int>(0, std::numeric_limits<int>::min());
       current_statement__ = 25;
-      stan::math::check_greater_or_equal(function__, "kappa", 1000000, 0);
+      stan::math::check_greater_or_equal(function__, "kappa",
+        static_cast<double>(1000000), 0);
       current_statement__ = 28;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
     } catch (const std::exception& e) {
@@ -2197,7 +2198,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<double> theta =
           std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
         stan::model::assign(lcm_sym35__,
-          std::vector<local_scalar_t__>{beta, 1000000, gamma, xi, delta},
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(
+              static_cast<double>(1000000)), gamma, xi, delta},
           "assigning variable lcm_sym35__");
         stan::model::assign(lcm_sym30__,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0,
@@ -2209,13 +2212,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "y", lcm_sym30__, 0);
       {
         current_statement__ = 8;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(
                          stan::model::rvalue(stoi_hat, "stoi_hat",
@@ -2320,7 +2327,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<double> theta =
           std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
         stan::model::assign(lcm_sym24__,
-          std::vector<local_scalar_t__>{beta, 1000000, gamma, xi, delta},
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(
+              static_cast<double>(1000000)), gamma, xi, delta},
           "assigning variable lcm_sym24__");
         stan::model::assign(lcm_sym19__,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0,
@@ -2332,13 +2341,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "y", lcm_sym19__, 0);
       {
         current_statement__ = 8;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 9;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(
                          stan::model::rvalue(stoi_hat, "stoi_hat",
@@ -2461,7 +2474,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<double> theta =
           std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
         stan::model::assign(lcm_sym9__,
-          std::vector<double>{beta, 1000000, gamma, xi, delta},
+          std::vector<double>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(
+              static_cast<double>(1000000)), gamma, xi, delta},
           "assigning variable lcm_sym9__");
         stan::model::assign(lcm_sym8__,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0,
@@ -7443,21 +7458,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state,
             DUMMY_VAR__);
         current_statement__ = 21;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 22;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black, 0,
-                         100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 25;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age,
+                         static_cast<double>(0), sigma_age));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu,
+                         static_cast<double>(0), sigma_edu));
         current_statement__ = 27;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region, 0,
-                         sigma_region));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region,
+                         static_cast<double>(0), sigma_region));
         current_statement__ = 31;
         if (stan::math::logical_gte(n_age, 1)) {
           lcm_sym42__ = stan::math::logical_gte(n_edu, 1);
@@ -7466,13 +7486,15 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(1)), 0, sigma_age_edu));
+                               stan::model::index_uni(1)),
+                             static_cast<double>(0), sigma_age_edu));
             for (int i = 2; i <= n_edu; ++i) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(b_age_edu, "b_age_edu",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(i)), 0, sigma_age_edu));
+                                 stan::model::index_uni(i)),
+                               static_cast<double>(0), sigma_age_edu));
             }
           }
           for (int j = 2; j <= n_age; ++j) {
@@ -7482,20 +7504,22 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(b_age_edu, "b_age_edu",
                                  stan::model::index_uni(j),
-                                 stan::model::index_uni(1)), 0, sigma_age_edu));
+                                 stan::model::index_uni(1)),
+                               static_cast<double>(0), sigma_age_edu));
               for (int i = 2; i <= n_edu; ++i) {
                 current_statement__ = 28;
                 lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                  stan::model::rvalue(b_age_edu, "b_age_edu",
                                    stan::model::index_uni(j),
-                                   stan::model::index_uni(i)), 0,
-                                 sigma_age_edu));
+                                   stan::model::index_uni(i)),
+                                 static_cast<double>(0), sigma_age_edu));
               }
             }
           }
         }
         current_statement__ = 32;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 34;
         if (stan::math::logical_gte(n_state, 1)) {
           current_statement__ = 33;
@@ -7533,14 +7557,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                   ((((stan::math::fma((b_female_black *
                         stan::model::rvalue(female, "female",
                           stan::model::index_uni(1))),
-                        stan::model::rvalue(black, "black",
-                          stan::model::index_uni(1)),
-                        stan::math::fma(b_black,
+                        static_cast<double>(
                           stan::model::rvalue(black, "black",
-                            stan::model::index_uni(1)),
+                            stan::model::index_uni(1))),
+                        stan::math::fma(b_black,
+                          static_cast<double>(
+                            stan::model::rvalue(black, "black",
+                              stan::model::index_uni(1))),
                           stan::math::fma(b_female,
-                            stan::model::rvalue(female, "female",
-                              stan::model::index_uni(1)), b_0))) +
+                            static_cast<double>(
+                              stan::model::rvalue(female, "female",
+                                stan::model::index_uni(1))), b_0))) +
                   stan::model::rvalue(b_age, "b_age",
                     stan::model::index_uni(
                       stan::model::rvalue(age, "age",
@@ -7570,14 +7597,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                     ((((stan::math::fma((b_female_black *
                           stan::model::rvalue(female, "female",
                             stan::model::index_uni(i))),
-                          stan::model::rvalue(black, "black",
-                            stan::model::index_uni(i)),
-                          stan::math::fma(b_black,
+                          static_cast<double>(
                             stan::model::rvalue(black, "black",
-                              stan::model::index_uni(i)),
+                              stan::model::index_uni(i))),
+                          stan::math::fma(b_black,
+                            static_cast<double>(
+                              stan::model::rvalue(black, "black",
+                                stan::model::index_uni(i))),
                             stan::math::fma(b_female,
-                              stan::model::rvalue(female, "female",
-                                stan::model::index_uni(i)), b_0))) +
+                              static_cast<double>(
+                                stan::model::rvalue(female, "female",
+                                  stan::model::index_uni(i))), b_0))) +
                     stan::model::rvalue(b_age, "b_age",
                       stan::model::index_uni(
                         stan::model::rvalue(age, "age",
@@ -7717,21 +7747,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state,
             DUMMY_VAR__);
         current_statement__ = 21;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 22;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black, 0,
-                         100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 25;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age,
+                         static_cast<double>(0), sigma_age));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu,
+                         static_cast<double>(0), sigma_edu));
         current_statement__ = 27;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region, 0,
-                         sigma_region));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region,
+                         static_cast<double>(0), sigma_region));
         current_statement__ = 31;
         if (stan::math::logical_gte(n_age, 1)) {
           lcm_sym20__ = stan::math::logical_gte(n_edu, 1);
@@ -7740,13 +7775,15 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
                                stan::model::index_uni(1),
-                               stan::model::index_uni(1)), 0, sigma_age_edu));
+                               stan::model::index_uni(1)),
+                             static_cast<double>(0), sigma_age_edu));
             for (int i = 2; i <= n_edu; ++i) {
               current_statement__ = 28;
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(b_age_edu, "b_age_edu",
                                  stan::model::index_uni(1),
-                                 stan::model::index_uni(i)), 0, sigma_age_edu));
+                                 stan::model::index_uni(i)),
+                               static_cast<double>(0), sigma_age_edu));
             }
           }
           for (int j = 2; j <= n_age; ++j) {
@@ -7756,20 +7793,22 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
               lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                stan::model::rvalue(b_age_edu, "b_age_edu",
                                  stan::model::index_uni(j),
-                                 stan::model::index_uni(1)), 0, sigma_age_edu));
+                                 stan::model::index_uni(1)),
+                               static_cast<double>(0), sigma_age_edu));
               for (int i = 2; i <= n_edu; ++i) {
                 current_statement__ = 28;
                 lp_accum__.add(stan::math::normal_lpdf<propto__>(
                                  stan::model::rvalue(b_age_edu, "b_age_edu",
                                    stan::model::index_uni(j),
-                                   stan::model::index_uni(i)), 0,
-                                 sigma_age_edu));
+                                   stan::model::index_uni(i)),
+                                 static_cast<double>(0), sigma_age_edu));
               }
             }
           }
         }
         current_statement__ = 32;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 34;
         if (stan::math::logical_gte(n_state, 1)) {
           current_statement__ = 33;
@@ -7807,14 +7846,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                   ((((stan::math::fma((b_female_black *
                         stan::model::rvalue(female, "female",
                           stan::model::index_uni(1))),
-                        stan::model::rvalue(black, "black",
-                          stan::model::index_uni(1)),
-                        stan::math::fma(b_black,
+                        static_cast<double>(
                           stan::model::rvalue(black, "black",
-                            stan::model::index_uni(1)),
+                            stan::model::index_uni(1))),
+                        stan::math::fma(b_black,
+                          static_cast<double>(
+                            stan::model::rvalue(black, "black",
+                              stan::model::index_uni(1))),
                           stan::math::fma(b_female,
-                            stan::model::rvalue(female, "female",
-                              stan::model::index_uni(1)), b_0))) +
+                            static_cast<double>(
+                              stan::model::rvalue(female, "female",
+                                stan::model::index_uni(1))), b_0))) +
                   stan::model::rvalue(b_age, "b_age",
                     stan::model::index_uni(
                       stan::model::rvalue(age, "age",
@@ -7844,14 +7886,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                     ((((stan::math::fma((b_female_black *
                           stan::model::rvalue(female, "female",
                             stan::model::index_uni(i))),
-                          stan::model::rvalue(black, "black",
-                            stan::model::index_uni(i)),
-                          stan::math::fma(b_black,
+                          static_cast<double>(
                             stan::model::rvalue(black, "black",
-                              stan::model::index_uni(i)),
+                              stan::model::index_uni(i))),
+                          stan::math::fma(b_black,
+                            static_cast<double>(
+                              stan::model::rvalue(black, "black",
+                                stan::model::index_uni(i))),
                             stan::math::fma(b_female,
-                              stan::model::rvalue(female, "female",
-                                stan::model::index_uni(i)), b_0))) +
+                              static_cast<double>(
+                                stan::model::rvalue(female, "female",
+                                  stan::model::index_uni(i))), b_0))) +
                     stan::model::rvalue(b_age, "b_age",
                       stan::model::index_uni(
                         stan::model::rvalue(age, "age",
@@ -8957,7 +9002,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       current_statement__ = 2;
       z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 2;
-      z = 1;
+      z = static_cast<double>(1);
       current_statement__ = 3;
       y = std::numeric_limits<double>::quiet_NaN();
       {
@@ -9387,11 +9432,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           lp__);
       {
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta, 5, 5));
+        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta,
+                         static_cast<double>(5), static_cast<double>(5)));
         current_statement__ = 8;
         if (stan::math::logical_gte(N, 1)) {
           current_statement__ = 7;
@@ -9480,11 +9528,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           lp__);
       {
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta, 5, 5));
+        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta,
+                         static_cast<double>(5), static_cast<double>(5)));
         current_statement__ = 8;
         if (stan::math::logical_gte(N, 1)) {
           current_statement__ = 7;
@@ -10824,17 +10875,23 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       }
       {
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, sigma_a));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                         static_cast<double>(0), sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b, 0, sigma_b));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b,
+                         static_cast<double>(0), sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(c, 0, sigma_c));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(c,
+                         static_cast<double>(0), sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(d, 0, sigma_d));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(d,
+                         static_cast<double>(0), sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(e, 0, sigma_e));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(e,
+                         static_cast<double>(0), sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
@@ -11016,17 +11073,23 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       }
       {
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, sigma_a));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                         static_cast<double>(0), sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b, 0, sigma_b));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b,
+                         static_cast<double>(0), sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(c, 0, sigma_c));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(c,
+                         static_cast<double>(0), sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(d, 0, sigma_d));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(d,
+                         static_cast<double>(0), sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(e, 0, sigma_e));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(e,
+                         static_cast<double>(0), sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
@@ -12032,7 +12095,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node1)),
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node2))))));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi,
+                         static_cast<double>(1), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -12106,7 +12170,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node1)),
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node2))))));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi,
+                         static_cast<double>(1), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -13455,7 +13520,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         inline_prob_uncaptured_return_sym15__, 1);
       {
         current_statement__ = 30;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 37;
         if (lcm_sym116__) {
           lcm_sym155__ = stan::model::rvalue(first, "first",
@@ -13886,7 +13952,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
         inline_prob_uncaptured_return_sym8__, 1);
       {
         current_statement__ = 30;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 37;
         if (lcm_sym73__) {
           lcm_sym112__ = stan::model::rvalue(first, "first",
@@ -16217,9 +16284,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         inline_prob_uncaptured_return_sym31__, 1);
       {
         current_statement__ = 77;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 78;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta,
+                         static_cast<double>(1), static_cast<double>(1)));
         {
           int inline_js_super_lp_n_ind_sym40__ =
             std::numeric_limits<int>::min();
@@ -17143,9 +17212,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
         inline_prob_uncaptured_return_sym14__, 1);
       {
         current_statement__ = 77;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 78;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta,
+                         static_cast<double>(1), static_cast<double>(1)));
         {
           int inline_js_super_lp_n_ind_sym23__ =
             std::numeric_limits<int>::min();
@@ -18112,7 +18183,7 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             current_statement__ = 44;
             stan::model::assign(z,
               stan::math::bernoulli_rng(
-                stan::math::fma(lcm_sym181__,
+                stan::math::fma(static_cast<double>(lcm_sym181__),
                   stan::model::rvalue(lcm_sym166__, "lcm_sym166__",
                     stan::model::index_uni(1), stan::model::index_uni(1)),
                   (lcm_sym152__ *
@@ -18128,8 +18199,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::model::assign(z,
                 stan::math::bernoulli_rng(
                   stan::math::fma(
-                    stan::model::rvalue(z, "z", stan::model::index_uni(1),
-                      stan::model::index_uni((t - 1))),
+                    static_cast<double>(
+                      stan::model::rvalue(z, "z", stan::model::index_uni(1),
+                        stan::model::index_uni((t - 1)))),
                     stan::model::rvalue(lcm_sym166__, "lcm_sym166__",
                       stan::model::index_uni(1),
                       stan::model::index_uni((t - 1))), (q *
@@ -18164,8 +18236,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
               stan::model::assign(z,
                 stan::math::bernoulli_rng(
                   stan::math::fma(
-                    stan::model::rvalue(z, "z", stan::model::index_uni(i),
-                      stan::model::index_uni(1)),
+                    static_cast<double>(
+                      stan::model::rvalue(z, "z", stan::model::index_uni(i),
+                        stan::model::index_uni(1))),
                     stan::model::rvalue(lcm_sym166__, "lcm_sym166__",
                       stan::model::index_uni(i), stan::model::index_uni(1)),
                     (lcm_sym151__ *
@@ -18181,8 +18254,10 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
                 stan::model::assign(z,
                   stan::math::bernoulli_rng(
                     stan::math::fma(
-                      stan::model::rvalue(z, "z", stan::model::index_uni(i),
-                        stan::model::index_uni((t - 1))),
+                      static_cast<double>(
+                        stan::model::rvalue(z, "z",
+                          stan::model::index_uni(i),
+                          stan::model::index_uni((t - 1)))),
                       stan::model::rvalue(lcm_sym166__, "lcm_sym166__",
                         stan::model::index_uni(i),
                         stan::model::index_uni((t - 1))), (q *
@@ -23440,7 +23515,7 @@ summer(const T0__& et_arg__, std::ostream* pstream__) {
       lcm_sym26__ = stan::math::size(et);
       N = lcm_sym26__;
       local_scalar_t__ running_sum;
-      running_sum = 0;
+      running_sum = stan::math::promote_scalar<local_scalar_t__>(0);
       current_statement__ = 9;
       if (stan::math::logical_gte(lcm_sym26__, 1)) {
         current_statement__ = 14;
@@ -23551,7 +23626,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
           int inline_summer_N_sym16__ = std::numeric_limits<int>::min();
           lcm_sym42__ = stan::math::size(lcm_sym41__);
           double inline_summer_running_sum_sym17__;
-          inline_summer_running_sum_sym17__ = 0;
+          inline_summer_running_sum_sym17__ = stan::math::promote_scalar<
+                                                local_scalar_t__>(0);
           current_statement__ = 9;
           if (stan::math::logical_gte(lcm_sym42__, 1)) {
             double inline_summer_inline_do_something_return_sym4___sym18__;
@@ -23647,7 +23723,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
           int inline_summer_N_sym8__ = std::numeric_limits<int>::min();
           lcm_sym34__ = stan::math::size(lcm_sym33__);
           double inline_summer_running_sum_sym9__;
-          inline_summer_running_sum_sym9__ = 0;
+          inline_summer_running_sum_sym9__ = stan::math::promote_scalar<
+                                               local_scalar_t__>(0);
           current_statement__ = 9;
           if (stan::math::logical_gte(lcm_sym34__, 1)) {
             double inline_summer_inline_do_something_return_sym4___sym10__;
@@ -25670,7 +25747,7 @@ foo(const T0__& N, const T1__& M, std::ostream* pstream__) {
     {
       current_statement__ = 8;
       return stan::math::promote_scalar<local_scalar_t__>(
-               stan::math::rep_matrix(1, N, M));
+               stan::math::rep_matrix(static_cast<double>(1), N, M));
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -28092,7 +28169,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         inline_prob_uncaptured_return_sym37__, 1);
       {
         current_statement__ = 78;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         {
           int inline_jolly_seber_lp_n_ind_sym46__ =
             std::numeric_limits<int>::min();
@@ -28987,7 +29065,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
         inline_prob_uncaptured_return_sym20__, 1);
       {
         current_statement__ = 78;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         {
           int inline_jolly_seber_lp_n_ind_sym29__ =
             std::numeric_limits<int>::min();
@@ -29936,7 +30015,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           lcm_sym181__ = stan::math::fma(
                            stan::model::rvalue(phi, "phi",
                              stan::model::index_uni(1),
-                             stan::model::index_uni(1)), lcm_sym204__,
+                             stan::model::index_uni(1)),
+                           static_cast<double>(lcm_sym204__),
                            (stan::model::rvalue(gamma, "gamma",
                               stan::model::index_uni(2)) * lcm_sym167__));
           current_statement__ = 35;
@@ -29953,9 +30033,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(1),
                                stan::model::index_uni((t - 1))),
-                             stan::model::rvalue(z, "z",
-                               stan::model::index_uni(1),
-                               stan::model::index_uni((t - 1))),
+                             static_cast<double>(
+                               stan::model::rvalue(z, "z",
+                                 stan::model::index_uni(1),
+                                 stan::model::index_uni((t - 1)))),
                              (stan::model::rvalue(gamma, "gamma",
                                 stan::model::index_uni(t)) * q));
             current_statement__ = 35;
@@ -29983,9 +30064,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                              stan::model::rvalue(phi, "phi",
                                stan::model::index_uni(i),
                                stan::model::index_uni(1)),
-                             stan::model::rvalue(z, "z",
-                               stan::model::index_uni(i),
-                               stan::model::index_uni(1)),
+                             static_cast<double>(
+                               stan::model::rvalue(z, "z",
+                                 stan::model::index_uni(i),
+                                 stan::model::index_uni(1))),
                              (stan::model::rvalue(gamma, "gamma",
                                 stan::model::index_uni(2)) * lcm_sym166__));
             current_statement__ = 35;
@@ -30002,9 +30084,10 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
                                stan::model::rvalue(phi, "phi",
                                  stan::model::index_uni(i),
                                  stan::model::index_uni((t - 1))),
-                               stan::model::rvalue(z, "z",
-                                 stan::model::index_uni(i),
-                                 stan::model::index_uni((t - 1))),
+                               static_cast<double>(
+                                 stan::model::rvalue(z, "z",
+                                   stan::model::index_uni(i),
+                                   stan::model::index_uni((t - 1)))),
                                (stan::model::rvalue(gamma, "gamma",
                                   stan::model::index_uni(t)) * q));
               current_statement__ = 35;
@@ -30723,14 +30806,15 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       j = context__.vals_i("j")[(1 - 1)];
       current_statement__ = 2;
       z = std::numeric_limits<double>::quiet_NaN();
-      lcm_sym4__ = 1;
-      z = 1;
+      lcm_sym4__ = static_cast<double>(1);
+      z = static_cast<double>(1);
       current_statement__ = 3;
       x = std::numeric_limits<double>::quiet_NaN();
       {
         current_statement__ = 4;
         x = stan::math::normal_rng(123, 1, base_rng__);
-        lcm_sym3__ = stan::math::fma(stan::math::sqrt(j), 2, 1);
+        lcm_sym3__ = stan::math::fma(stan::math::sqrt(j),
+                       static_cast<double>(2), static_cast<double>(1));
         z = stan::math::normal_rng(lcm_sym3__, 1, base_rng__);
       }
       current_statement__ = 6;
@@ -31490,7 +31574,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       auto theta = in__.template read<std::vector<local_scalar_t__>>(J);
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta,
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -31527,7 +31612,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       auto theta = in__.template read<std::vector<local_scalar_t__>>(J);
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta,
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -33739,7 +33825,7 @@ foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
     double lcm_sym30__;
     {
       current_statement__ = 7;
-      return stan::math::normal_lpdf<propto__>(x, mu, 1);
+      return stan::math::normal_lpdf<propto__>(x, mu, static_cast<double>(1));
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -33864,7 +33950,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       local_scalar_t__ tp = DUMMY_VAR__;
       double inline_foo_lpdf_return_sym23__;
       {
-        lcm_sym41__ = stan::math::normal_lpdf<false>(mu, 1.0, 1);
+        lcm_sym41__ = stan::math::normal_lpdf<false>(mu, 1.0,
+                        static_cast<double>(1));
       }
       tp = lcm_sym41__;
       {
@@ -33872,7 +33959,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
         {
           double inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym26__;
           {
-            lcm_sym42__ = stan::math::normal_lpdf<propto__>(mu, 0.5, 1);
+            lcm_sym42__ = stan::math::normal_lpdf<propto__>(mu, 0.5,
+                            static_cast<double>(1));
           }
         }
         lp_accum__.add(lcm_sym42__);
@@ -33920,7 +34008,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       local_scalar_t__ tp = DUMMY_VAR__;
       double inline_foo_lpdf_return_sym16__;
       {
-        lcm_sym38__ = stan::math::normal_lpdf<false>(mu, 1.0, 1);
+        lcm_sym38__ = stan::math::normal_lpdf<false>(mu, 1.0,
+                        static_cast<double>(1));
       }
       tp = lcm_sym38__;
       {
@@ -33928,7 +34017,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
         {
           double inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym19__;
           {
-            lcm_sym39__ = stan::math::normal_lpdf<propto__>(mu, 0.5, 1);
+            lcm_sym39__ = stan::math::normal_lpdf<propto__>(mu, 0.5,
+                            static_cast<double>(1));
           }
         }
         lp_accum__.add(lcm_sym39__);
@@ -33995,7 +34085,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       }
       double inline_foo_lpdf_return_sym9__;
       {
-        lcm_sym36__ = stan::math::normal_lpdf<false>(mu, 1.0, 1);
+        lcm_sym36__ = stan::math::normal_lpdf<false>(mu, 1.0,
+                        static_cast<double>(1));
       }
       tp = lcm_sym36__;
       if (emit_transformed_parameters__) {
@@ -34009,7 +34100,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       {
         double inline_baz_lpdf_inline_foo_lpdf_return_sym1___sym12__;
         {
-          lcm_sym35__ = stan::math::normal_lpdf<false>(mu, 0.5, 1);
+          lcm_sym35__ = stan::math::normal_lpdf<false>(mu, 0.5,
+                          static_cast<double>(1));
         }
       }
       lbaz = lcm_sym35__;
@@ -34858,7 +34950,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             "assigning variable lcm_sym9__");
           double qT = std::numeric_limits<double>::quiet_NaN();
           lcm_sym16__ = stan::math::prod(lcm_sym9__);
-          lcm_sym19__ = 1;
+          lcm_sym19__ = static_cast<double>(1);
           stan::model::assign(psi_con, ((lcm_sym14__ * lcm_sym16__) /
             stan::math::fma(lcm_sym14__, lcm_sym16__, (1 - lcm_sym14__))),
             "assigning variable psi_con", stan::model::index_uni(1));
@@ -34869,7 +34961,7 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                 stan::model::index_uni(1)), base_rng__),
             "assigning variable z", stan::model::index_uni(1));
         } else {
-          lcm_sym19__ = 1;
+          lcm_sym19__ = static_cast<double>(1);
           stan::model::assign(psi_con, 1, "assigning variable psi_con",
             stan::model::index_uni(1));
           current_statement__ = 10;
@@ -35499,7 +35591,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       Eigen::Matrix<local_scalar_t__,-1,1> y_hat =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       stan::model::assign(lcm_sym29__,
-        stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
+        stan::math::fma(static_cast<double>(10), mu_a1,
+          stan::math::multiply(sigma_a1, eta1)),
         "assigning variable lcm_sym29__");
       stan::model::assign(a1, lcm_sym29__, "assigning variable a1");
       stan::model::assign(lcm_sym26__,
@@ -35547,15 +35640,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       {
         current_statement__ = 14;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 19;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
@@ -35629,7 +35727,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       Eigen::Matrix<local_scalar_t__,-1,1> y_hat =
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       stan::model::assign(lcm_sym18__,
-        stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
+        stan::math::fma(static_cast<double>(10), mu_a1,
+          stan::math::multiply(sigma_a1, eta1)),
         "assigning variable lcm_sym18__");
       stan::model::assign(a1, lcm_sym18__, "assigning variable a1");
       stan::model::assign(lcm_sym15__,
@@ -35677,15 +35776,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       {
         current_statement__ = 14;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 19;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
@@ -35782,7 +35886,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         return ;
       }
       stan::model::assign(lcm_sym13__,
-        stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
+        stan::math::fma(static_cast<double>(10), mu_a1,
+          stan::math::multiply(sigma_a1, eta1)),
         "assigning variable lcm_sym13__");
       stan::model::assign(a1, lcm_sym13__, "assigning variable a1");
       stan::model::assign(lcm_sym10__,
@@ -36825,25 +36930,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 32;
           lp_accum__.add(2);
         }
-        x = 3;
+        x = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 35;
-        lp_accum__.add(3);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(3));
         current_statement__ = 37;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 36;
-          x = 2;
+          x = stan::math::promote_scalar<local_scalar_t__>(2);
         }
         current_statement__ = 38;
         lp_accum__.add(x);
         current_statement__ = 39;
-        lp_accum__.add(247);
-        x = 576;
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(247));
+        x = stan::math::promote_scalar<local_scalar_t__>(576);
         current_statement__ = 40;
-        lp_accum__.add(576);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(576));
         lcm_sym98__ = stan::math::logical_gt(theta, 46);
         if (lcm_sym98__) {
           current_statement__ = 41;
-          x = 5880;
+          x = stan::math::promote_scalar<local_scalar_t__>(5880);
         }
         current_statement__ = 42;
         lp_accum__.add(x);
@@ -36864,12 +36969,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           double y = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 51;
-          lp_accum__.add(24);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(24));
         }
         {
           double y = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 54;
-          lp_accum__.add(245);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(245));
         }
         {
           current_statement__ = 56;
@@ -36947,18 +37052,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         double temp2 = std::numeric_limits<double>::quiet_NaN();
         {
-          lp_accum__.add(4);
-          lp_accum__.add(6);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(4));
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(6));
           {
             current_statement__ = 77;
-            lp_accum__.add(4);
+            lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(4));
             current_statement__ = 78;
-            lp_accum__.add(6);
+            lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(6));
           }
         }
         double dataonlyvar;
         current_statement__ = 80;
-        dataonlyvar = 3;
+        dataonlyvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 81;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
@@ -37362,25 +37467,25 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           current_statement__ = 32;
           lp_accum__.add(2);
         }
-        x = 3;
+        x = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 35;
-        lp_accum__.add(3);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(3));
         current_statement__ = 37;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 36;
-          x = 2;
+          x = stan::math::promote_scalar<local_scalar_t__>(2);
         }
         current_statement__ = 38;
         lp_accum__.add(x);
         current_statement__ = 39;
-        lp_accum__.add(247);
-        x = 576;
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(247));
+        x = stan::math::promote_scalar<local_scalar_t__>(576);
         current_statement__ = 40;
-        lp_accum__.add(576);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(576));
         lcm_sym74__ = stan::math::logical_gt(theta, 46);
         if (lcm_sym74__) {
           current_statement__ = 41;
-          x = 5880;
+          x = stan::math::promote_scalar<local_scalar_t__>(5880);
         }
         current_statement__ = 42;
         lp_accum__.add(x);
@@ -37401,12 +37506,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           double y = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 51;
-          lp_accum__.add(24);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(24));
         }
         {
           double y = std::numeric_limits<double>::quiet_NaN();
           current_statement__ = 54;
-          lp_accum__.add(245);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(245));
         }
         {
           current_statement__ = 56;
@@ -37484,18 +37589,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         double temp2 = std::numeric_limits<double>::quiet_NaN();
         {
-          lp_accum__.add(4);
-          lp_accum__.add(6);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(4));
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(6));
           {
             current_statement__ = 77;
-            lp_accum__.add(4);
+            lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(4));
             current_statement__ = 78;
-            lp_accum__.add(6);
+            lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(6));
           }
         }
         double dataonlyvar;
         current_statement__ = 80;
-        dataonlyvar = 3;
+        dataonlyvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 81;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
@@ -38496,7 +38601,7 @@ double dumb(const T0__& x, std::ostream* pstream__) {
     double lcm_sym2__;
     {
       current_statement__ = 4;
-      return (x - 0.5);
+      return stan::math::promote_scalar<local_scalar_t__>((x - 0.5));
     }
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -39905,12 +40010,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       }
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a, (100 * mu_a),
                          sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
         std::complex<double> z =
@@ -40023,12 +40130,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       }
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a, (100 * mu_a),
                          sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
         std::complex<double> z =
@@ -47846,42 +47955,42 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       }
       double for_loop_var = std::numeric_limits<double>::quiet_NaN();
       {
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
       }
     } catch (const std::exception& e) {
@@ -47936,42 +48045,42 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       }
       double for_loop_var = std::numeric_limits<double>::quiet_NaN();
       {
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
       }
     } catch (const std::exception& e) {
@@ -48045,42 +48154,42 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
         no_init_if = 1.0;
       }
       {
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
         {
           current_statement__ = 10;
-          for_loop_var = 1;
+          for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
         }
       }
       if (emit_transformed_parameters__) {

--- a/test/integration/good/compiler-optimizations/cppO0.expected
+++ b/test/integration/good/compiler-optimizations/cppO0.expected
@@ -888,11 +888,11 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       current_statement__ = 25;
       t0 = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 25;
-      t0 = 0;
+      t0 = static_cast<double>(0);
       current_statement__ = 26;
       kappa = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 26;
-      kappa = 1000000;
+      kappa = static_cast<double>(1000000);
       current_statement__ = 27;
       x_r = std::vector<double>(0, std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 28;
@@ -961,8 +961,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
           std::vector<local_scalar_t__>(5, DUMMY_VAR__);
         current_statement__ = 6;
         stan::model::assign(theta,
-          std::vector<local_scalar_t__>{beta, kappa, gamma, xi, delta},
-          "assigning variable theta");
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(kappa), gamma, xi,
+            delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,
@@ -972,13 +973,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "y", y, 0);
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 10;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 12;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(
                          stan::model::rvalue(stoi_hat, "stoi_hat",
@@ -1061,8 +1066,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
           std::vector<local_scalar_t__>(5, DUMMY_VAR__);
         current_statement__ = 6;
         stan::model::assign(theta,
-          std::vector<local_scalar_t__>{beta, kappa, gamma, xi, delta},
-          "assigning variable theta");
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(kappa), gamma, xi,
+            delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,
@@ -1072,13 +1078,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "y", y, 0);
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 10;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 12;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(
                          stan::model::rvalue(stoi_hat, "stoi_hat",
@@ -1181,8 +1191,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
           std::vector<double>(5, std::numeric_limits<double>::quiet_NaN());
         current_statement__ = 6;
         stan::model::assign(theta,
-          std::vector<local_scalar_t__>{beta, kappa, gamma, xi, delta},
-          "assigning variable theta");
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(kappa), gamma, xi,
+            delta}, "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
           stan::math::integrate_ode_rk45(simple_SIR_functor__(), y0, t0, t,
@@ -3851,21 +3862,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state,
             DUMMY_VAR__);
         current_statement__ = 21;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 22;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black, 0,
-                         100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 25;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age,
+                         static_cast<double>(0), sigma_age));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu,
+                         static_cast<double>(0), sigma_edu));
         current_statement__ = 27;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region, 0,
-                         sigma_region));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region,
+                         static_cast<double>(0), sigma_region));
         current_statement__ = 31;
         for (int j = 1; j <= n_age; ++j) {
           current_statement__ = 29;
@@ -3874,11 +3890,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
                                stan::model::index_uni(j),
-                               stan::model::index_uni(i)), 0, sigma_age_edu));
+                               stan::model::index_uni(i)),
+                             static_cast<double>(0), sigma_age_edu));
           }
         }
         current_statement__ = 32;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 34;
         for (int j = 1; j <= n_state; ++j) {
           current_statement__ = 33;
@@ -4024,21 +4042,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state,
             DUMMY_VAR__);
         current_statement__ = 21;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 22;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black, 0,
-                         100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 25;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age,
+                         static_cast<double>(0), sigma_age));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu,
+                         static_cast<double>(0), sigma_edu));
         current_statement__ = 27;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region, 0,
-                         sigma_region));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region,
+                         static_cast<double>(0), sigma_region));
         current_statement__ = 31;
         for (int j = 1; j <= n_age; ++j) {
           current_statement__ = 29;
@@ -4047,11 +4070,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
                                stan::model::index_uni(j),
-                               stan::model::index_uni(i)), 0, sigma_age_edu));
+                               stan::model::index_uni(i)),
+                             static_cast<double>(0), sigma_age_edu));
           }
         }
         current_statement__ = 32;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 34;
         for (int j = 1; j <= n_state; ++j) {
           current_statement__ = 33;
@@ -5119,7 +5144,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       current_statement__ = 2;
       z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 2;
-      z = 1;
+      z = static_cast<double>(1);
       current_statement__ = 3;
       y = std::numeric_limits<double>::quiet_NaN();
       {
@@ -5530,11 +5555,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           lp__);
       {
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta, 5, 5));
+        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta,
+                         static_cast<double>(5), static_cast<double>(5)));
         current_statement__ = 8;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 7;
@@ -5599,11 +5627,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           lp__);
       {
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta, 5, 5));
+        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta,
+                         static_cast<double>(5), static_cast<double>(5)));
         current_statement__ = 8;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 7;
@@ -6809,17 +6840,23 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       }
       {
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, sigma_a));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                         static_cast<double>(0), sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b, 0, sigma_b));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b,
+                         static_cast<double>(0), sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(c, 0, sigma_c));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(c,
+                         static_cast<double>(0), sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(d, 0, sigma_d));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(d,
+                         static_cast<double>(0), sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(e, 0, sigma_e));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(e,
+                         static_cast<double>(0), sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
@@ -6931,17 +6968,23 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       }
       {
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, sigma_a));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                         static_cast<double>(0), sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b, 0, sigma_b));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b,
+                         static_cast<double>(0), sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(c, 0, sigma_c));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(c,
+                         static_cast<double>(0), sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(d, 0, sigma_d));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(d,
+                         static_cast<double>(0), sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(e, 0, sigma_e));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(e,
+                         static_cast<double>(0), sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
@@ -7799,7 +7842,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node1)),
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node2))))));
         current_statement__ = 29;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi,
+                         static_cast<double>(1), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -7865,7 +7909,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node1)),
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node2))))));
         current_statement__ = 29;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi,
+                         static_cast<double>(1), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8796,7 +8841,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 32;
         for (int i = 1; i <= nind; ++i) {
           current_statement__ = 30;
@@ -8935,7 +8981,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 32;
         for (int i = 1; i <= nind; ++i) {
           current_statement__ = 30;
@@ -10294,9 +10341,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 65;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 66;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta,
+                         static_cast<double>(1), static_cast<double>(1)));
         current_statement__ = 67;
         js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
           lp_accum__, pstream__);
@@ -10430,9 +10479,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 65;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 66;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta,
+                         static_cast<double>(1), static_cast<double>(1)));
         current_statement__ = 67;
         js_super_lp<propto__>(y, first, last, p, phi, psi, nu, chi, lp__,
           lp_accum__, pstream__);
@@ -14160,7 +14211,7 @@ summer(const T0__& et_arg__, std::ostream* pstream__) {
     N = stan::math::size(et);
     local_scalar_t__ running_sum = DUMMY_VAR__;
     current_statement__ = 11;
-    running_sum = 0;
+    running_sum = stan::math::promote_scalar<local_scalar_t__>(0);
     current_statement__ = 14;
     for (int n = 1; n <= N; ++n) {
       current_statement__ = 12;
@@ -15965,7 +16016,7 @@ foo(const T0__& N, const T1__& M, std::ostream* pstream__) {
   try {
     current_statement__ = 8;
     return stan::math::promote_scalar<local_scalar_t__>(
-             stan::math::rep_matrix(1, N, M));
+             stan::math::rep_matrix(static_cast<double>(1), N, M));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -17380,7 +17431,7 @@ seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
       Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
     local_scalar_t__ log_residual_prob = DUMMY_VAR__;
     current_statement__ = 151;
-    log_residual_prob = 0;
+    log_residual_prob = stan::math::promote_scalar<local_scalar_t__>(0);
     current_statement__ = 155;
     for (int n = 1; n <= N; ++n) {
       current_statement__ = 152;
@@ -17644,7 +17695,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 58;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 59;
         jolly_seber_lp<propto__>(y, first, last, p, phi, gamma, chi, lp__,
           lp_accum__, pstream__);
@@ -17741,7 +17793,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 58;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 59;
         jolly_seber_lp<propto__>(y, first, last, p, phi, gamma, chi, lp__,
           lp_accum__, pstream__);
@@ -18459,7 +18512,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       current_statement__ = 2;
       z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 2;
-      z = 1;
+      z = static_cast<double>(1);
       current_statement__ = 3;
       x = std::numeric_limits<double>::quiet_NaN();
       {
@@ -19223,7 +19276,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       auto theta = in__.template read<std::vector<local_scalar_t__>>(J);
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta,
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -19259,7 +19313,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       auto theta = in__.template read<std::vector<local_scalar_t__>>(J);
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta,
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -20541,7 +20596,7 @@ foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 8;
-    return stan::math::normal_lpdf<propto__>(x, mu, 1);
+    return stan::math::normal_lpdf<propto__>(x, mu, static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -22043,15 +22098,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       {
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
@@ -22141,15 +22201,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       {
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
@@ -23011,30 +23076,30 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           lp_accum__.add(2);
         }
         current_statement__ = 37;
-        x = 3;
+        x = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 38;
         lp_accum__.add(x);
         current_statement__ = 40;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 39;
-          x = 2;
+          x = stan::math::promote_scalar<local_scalar_t__>(2);
         }
         current_statement__ = 41;
         lp_accum__.add(x);
         current_statement__ = 42;
-        x = 24;
+        x = stan::math::promote_scalar<local_scalar_t__>(24);
         current_statement__ = 43;
-        x = 247;
+        x = stan::math::promote_scalar<local_scalar_t__>(247);
         current_statement__ = 44;
         lp_accum__.add(x);
         current_statement__ = 45;
-        x = (24 * 24);
+        x = stan::math::promote_scalar<local_scalar_t__>((24 * 24));
         current_statement__ = 46;
         lp_accum__.add(x);
         current_statement__ = 48;
         if (stan::math::logical_gt(theta, 46)) {
           current_statement__ = 47;
-          x = (24 * 245);
+          x = stan::math::promote_scalar<local_scalar_t__>((24 * 245));
         }
         current_statement__ = 49;
         lp_accum__.add(x);
@@ -23057,18 +23122,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 59;
-          y = 2;
+          y = stan::math::promote_scalar<local_scalar_t__>(2);
           current_statement__ = 60;
-          y = 24;
+          y = stan::math::promote_scalar<local_scalar_t__>(24);
           current_statement__ = 61;
           lp_accum__.add(y);
         }
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 63;
-          y = 22;
+          y = stan::math::promote_scalar<local_scalar_t__>(22);
           current_statement__ = 64;
-          y = 245;
+          y = stan::math::promote_scalar<local_scalar_t__>(245);
           current_statement__ = 65;
           lp_accum__.add(y);
         }
@@ -23146,7 +23211,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 119;
         if (stan::math::logical_gt(2, 3)) {
           current_statement__ = 118;
-          temp = (2 * 2);
+          temp = stan::math::promote_scalar<local_scalar_t__>((2 * 2));
         } else {
           current_statement__ = 117;
           if (pstream__) {
@@ -23155,12 +23220,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           }
         }
         current_statement__ = 120;
-        temp = (2 * 2);
+        temp = stan::math::promote_scalar<local_scalar_t__>((2 * 2));
         local_scalar_t__ temp2 = DUMMY_VAR__;
         current_statement__ = 126;
         for (int i = 2; i <= 3; ++i) {
           current_statement__ = 122;
-          temp2 = (2 * 3);
+          temp2 = stan::math::promote_scalar<local_scalar_t__>((2 * 3));
           current_statement__ = 123;
           lp_accum__.add(temp);
           current_statement__ = 124;
@@ -23168,17 +23233,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         local_scalar_t__ dataonlyvar = DUMMY_VAR__;
         current_statement__ = 127;
-        dataonlyvar = 3;
+        dataonlyvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 129;
         if (stan::math::logical_gt(3, 4)) {
           current_statement__ = 128;
-          dataonlyvar = (3 * 53);
+          dataonlyvar = stan::math::promote_scalar<local_scalar_t__>((3 * 53));
         }
         current_statement__ = 130;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
         current_statement__ = 131;
-        paramvar = 3;
+        paramvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 133;
         if (stan::math::logical_gt(42, 1)) {
           current_statement__ = 132;
@@ -23301,30 +23366,30 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           lp_accum__.add(2);
         }
         current_statement__ = 37;
-        x = 3;
+        x = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 38;
         lp_accum__.add(x);
         current_statement__ = 40;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 39;
-          x = 2;
+          x = stan::math::promote_scalar<local_scalar_t__>(2);
         }
         current_statement__ = 41;
         lp_accum__.add(x);
         current_statement__ = 42;
-        x = 24;
+        x = stan::math::promote_scalar<local_scalar_t__>(24);
         current_statement__ = 43;
-        x = 247;
+        x = stan::math::promote_scalar<local_scalar_t__>(247);
         current_statement__ = 44;
         lp_accum__.add(x);
         current_statement__ = 45;
-        x = (24 * 24);
+        x = stan::math::promote_scalar<local_scalar_t__>((24 * 24));
         current_statement__ = 46;
         lp_accum__.add(x);
         current_statement__ = 48;
         if (stan::math::logical_gt(theta, 46)) {
           current_statement__ = 47;
-          x = (24 * 245);
+          x = stan::math::promote_scalar<local_scalar_t__>((24 * 245));
         }
         current_statement__ = 49;
         lp_accum__.add(x);
@@ -23347,18 +23412,18 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 59;
-          y = 2;
+          y = stan::math::promote_scalar<local_scalar_t__>(2);
           current_statement__ = 60;
-          y = 24;
+          y = stan::math::promote_scalar<local_scalar_t__>(24);
           current_statement__ = 61;
           lp_accum__.add(y);
         }
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 63;
-          y = 22;
+          y = stan::math::promote_scalar<local_scalar_t__>(22);
           current_statement__ = 64;
-          y = 245;
+          y = stan::math::promote_scalar<local_scalar_t__>(245);
           current_statement__ = 65;
           lp_accum__.add(y);
         }
@@ -23436,7 +23501,7 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 119;
         if (stan::math::logical_gt(2, 3)) {
           current_statement__ = 118;
-          temp = (2 * 2);
+          temp = stan::math::promote_scalar<local_scalar_t__>((2 * 2));
         } else {
           current_statement__ = 117;
           if (pstream__) {
@@ -23445,12 +23510,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           }
         }
         current_statement__ = 120;
-        temp = (2 * 2);
+        temp = stan::math::promote_scalar<local_scalar_t__>((2 * 2));
         local_scalar_t__ temp2 = DUMMY_VAR__;
         current_statement__ = 126;
         for (int i = 2; i <= 3; ++i) {
           current_statement__ = 122;
-          temp2 = (2 * 3);
+          temp2 = stan::math::promote_scalar<local_scalar_t__>((2 * 3));
           current_statement__ = 123;
           lp_accum__.add(temp);
           current_statement__ = 124;
@@ -23458,17 +23523,17 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         }
         local_scalar_t__ dataonlyvar = DUMMY_VAR__;
         current_statement__ = 127;
-        dataonlyvar = 3;
+        dataonlyvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 129;
         if (stan::math::logical_gt(3, 4)) {
           current_statement__ = 128;
-          dataonlyvar = (3 * 53);
+          dataonlyvar = stan::math::promote_scalar<local_scalar_t__>((3 * 53));
         }
         current_statement__ = 130;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
         current_statement__ = 131;
-        paramvar = 3;
+        paramvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 133;
         if (stan::math::logical_gt(42, 1)) {
           current_statement__ = 132;
@@ -24387,7 +24452,7 @@ double dumb(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 4;
-    return (x - 0.5);
+    return stan::math::promote_scalar<local_scalar_t__>((x - 0.5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -25710,12 +25775,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       }
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a, (100 * mu_a),
                          sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
         std::complex<local_scalar_t__> z =
@@ -25802,12 +25869,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       }
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a, (100 * mu_a),
                          sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
         std::complex<local_scalar_t__> z =
@@ -28933,7 +29002,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 13;
       for (int i = 1; i <= 10; ++i) {
         current_statement__ = 11;
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -28987,7 +29056,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 13;
       for (int i = 1; i <= 10; ++i) {
         current_statement__ = 11;
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -29058,7 +29127,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 13;
       for (int i = 1; i <= 10; ++i) {
         current_statement__ = 11;
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
       }
       if (emit_transformed_parameters__) {
         out__.write(no_init);

--- a/test/integration/good/compiler-optimizations/cppO1.expected
+++ b/test/integration/good/compiler-optimizations/cppO1.expected
@@ -874,17 +874,18 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       current_statement__ = 25;
       t0 = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 25;
-      t0 = 0;
+      t0 = static_cast<double>(0);
       current_statement__ = 26;
       kappa = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 26;
-      kappa = 1000000;
+      kappa = static_cast<double>(1000000);
       current_statement__ = 27;
       x_r = std::vector<double>(0, std::numeric_limits<double>::quiet_NaN());
       current_statement__ = 28;
       x_i = std::vector<int>(0, std::numeric_limits<int>::min());
       current_statement__ = 26;
-      stan::math::check_greater_or_equal(function__, "kappa", 1000000, 0);
+      stan::math::check_greater_or_equal(function__, "kappa",
+        static_cast<double>(1000000), 0);
       current_statement__ = 29;
       stan::math::validate_non_negative_index("y", "N_t", N_t);
     } catch (const std::exception& e) {
@@ -946,7 +947,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<local_scalar_t__> theta;
         current_statement__ = 6;
         stan::model::assign(theta,
-          std::vector<local_scalar_t__>{beta, 1000000, gamma, xi, delta},
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(
+              static_cast<double>(1000000)), gamma, xi, delta},
           "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
@@ -958,13 +961,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "y", y, 0);
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 10;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 12;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(
                          stan::model::rvalue(stoi_hat, "stoi_hat",
@@ -1046,7 +1053,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<local_scalar_t__> theta;
         current_statement__ = 6;
         stan::model::assign(theta,
-          std::vector<local_scalar_t__>{beta, 1000000, gamma, xi, delta},
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(
+              static_cast<double>(1000000)), gamma, xi, delta},
           "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
@@ -1058,13 +1067,17 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
       stan::math::check_greater_or_equal(function__, "y", y, 0);
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta, 0, 2.5));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(beta,
+                         static_cast<double>(0), 2.5));
         current_statement__ = 10;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(gamma,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi, 0, 25));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(xi,
+                         static_cast<double>(0), static_cast<double>(25)));
         current_statement__ = 12;
-        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta, 0, 1));
+        lp_accum__.add(stan::math::cauchy_lpdf<propto__>(delta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 13;
         lp_accum__.add(stan::math::poisson_lpmf<propto__>(
                          stan::model::rvalue(stoi_hat, "stoi_hat",
@@ -1166,7 +1179,9 @@ class ad_level_failing_model final : public model_base_crtp<ad_level_failing_mod
         std::vector<double> theta;
         current_statement__ = 6;
         stan::model::assign(theta,
-          std::vector<local_scalar_t__>{beta, 1000000, gamma, xi, delta},
+          std::vector<local_scalar_t__>{beta,
+            stan::math::promote_scalar<local_scalar_t__>(
+              static_cast<double>(1000000)), gamma, xi, delta},
           "assigning variable theta");
         current_statement__ = 7;
         stan::model::assign(y,
@@ -4001,21 +4016,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state,
             DUMMY_VAR__);
         current_statement__ = 21;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 22;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black, 0,
-                         100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 25;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age,
+                         static_cast<double>(0), sigma_age));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu,
+                         static_cast<double>(0), sigma_edu));
         current_statement__ = 27;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region, 0,
-                         sigma_region));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region,
+                         static_cast<double>(0), sigma_region));
         current_statement__ = 31;
         for (int j = 1; j <= n_age; ++j) {
           current_statement__ = 29;
@@ -4024,11 +4044,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
                                stan::model::index_uni(j),
-                               stan::model::index_uni(i)), 0, sigma_age_edu));
+                               stan::model::index_uni(i)),
+                             static_cast<double>(0), sigma_age_edu));
           }
         }
         current_statement__ = 32;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 34;
         for (int j = 1; j <= n_state; ++j) {
           current_statement__ = 33;
@@ -4054,14 +4076,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                   ((((stan::math::fma((b_female_black *
                         stan::model::rvalue(female, "female",
                           stan::model::index_uni(i))),
-                        stan::model::rvalue(black, "black",
-                          stan::model::index_uni(i)),
-                        stan::math::fma(b_black,
+                        static_cast<double>(
                           stan::model::rvalue(black, "black",
-                            stan::model::index_uni(i)),
+                            stan::model::index_uni(i))),
+                        stan::math::fma(b_black,
+                          static_cast<double>(
+                            stan::model::rvalue(black, "black",
+                              stan::model::index_uni(i))),
                           stan::math::fma(b_female,
-                            stan::model::rvalue(female, "female",
-                              stan::model::index_uni(i)), b_0))) +
+                            static_cast<double>(
+                              stan::model::rvalue(female, "female",
+                                stan::model::index_uni(i))), b_0))) +
                   stan::model::rvalue(b_age, "b_age",
                     stan::model::index_uni(
                       stan::model::rvalue(age, "age",
@@ -4178,21 +4203,26 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
           Eigen::Matrix<local_scalar_t__,-1,1>::Constant(n_state,
             DUMMY_VAR__);
         current_statement__ = 21;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_0,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 22;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 23;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 24;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black, 0,
-                         100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_female_black,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 25;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age, 0, sigma_age));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_age,
+                         static_cast<double>(0), sigma_age));
         current_statement__ = 26;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu, 0, sigma_edu));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_edu,
+                         static_cast<double>(0), sigma_edu));
         current_statement__ = 27;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region, 0,
-                         sigma_region));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_region,
+                         static_cast<double>(0), sigma_region));
         current_statement__ = 31;
         for (int j = 1; j <= n_age; ++j) {
           current_statement__ = 29;
@@ -4201,11 +4231,13 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
             lp_accum__.add(stan::math::normal_lpdf<propto__>(
                              stan::model::rvalue(b_age_edu, "b_age_edu",
                                stan::model::index_uni(j),
-                               stan::model::index_uni(i)), 0, sigma_age_edu));
+                               stan::model::index_uni(i)),
+                             static_cast<double>(0), sigma_age_edu));
           }
         }
         current_statement__ = 32;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b_v_prev,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 34;
         for (int j = 1; j <= n_state; ++j) {
           current_statement__ = 33;
@@ -4231,14 +4263,17 @@ class dce_fail_model final : public model_base_crtp<dce_fail_model> {
                   ((((stan::math::fma((b_female_black *
                         stan::model::rvalue(female, "female",
                           stan::model::index_uni(i))),
-                        stan::model::rvalue(black, "black",
-                          stan::model::index_uni(i)),
-                        stan::math::fma(b_black,
+                        static_cast<double>(
                           stan::model::rvalue(black, "black",
-                            stan::model::index_uni(i)),
+                            stan::model::index_uni(i))),
+                        stan::math::fma(b_black,
+                          static_cast<double>(
+                            stan::model::rvalue(black, "black",
+                              stan::model::index_uni(i))),
                           stan::math::fma(b_female,
-                            stan::model::rvalue(female, "female",
-                              stan::model::index_uni(i)), b_0))) +
+                            static_cast<double>(
+                              stan::model::rvalue(female, "female",
+                                stan::model::index_uni(i))), b_0))) +
                   stan::model::rvalue(b_age, "b_age",
                     stan::model::index_uni(
                       stan::model::rvalue(age, "age",
@@ -5271,7 +5306,7 @@ class expr_prop_experiment2_model final : public model_base_crtp<expr_prop_exper
       current_statement__ = 2;
       z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 2;
-      z = 1;
+      z = static_cast<double>(1);
       current_statement__ = 3;
       y = std::numeric_limits<double>::quiet_NaN();
       {
@@ -5682,11 +5717,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           lp__);
       {
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta, 5, 5));
+        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta,
+                         static_cast<double>(5), static_cast<double>(5)));
         current_statement__ = 8;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 7;
@@ -5751,11 +5789,14 @@ class expr_prop_fail_model final : public model_base_crtp<expr_prop_fail_model> 
           lp__);
       {
         current_statement__ = 4;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(sigma,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 5;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu, 0, 2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu,
+                         static_cast<double>(0), static_cast<double>(2)));
         current_statement__ = 6;
-        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta, 5, 5));
+        lp_accum__.add(stan::math::beta_lpdf<propto__>(theta,
+                         static_cast<double>(5), static_cast<double>(5)));
         current_statement__ = 8;
         for (int n = 1; n <= N; ++n) {
           current_statement__ = 7;
@@ -6969,17 +7010,23 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       }
       {
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, sigma_a));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                         static_cast<double>(0), sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b, 0, sigma_b));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b,
+                         static_cast<double>(0), sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(c, 0, sigma_c));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(c,
+                         static_cast<double>(0), sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(d, 0, sigma_d));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(d,
+                         static_cast<double>(0), sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(e, 0, sigma_e));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(e,
+                         static_cast<double>(0), sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
@@ -7102,17 +7149,23 @@ class expr_prop_fail3_model final : public model_base_crtp<expr_prop_fail3_model
       }
       {
         current_statement__ = 15;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(a, 0, sigma_a));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(a,
+                         static_cast<double>(0), sigma_a));
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(b, 0, sigma_b));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(b,
+                         static_cast<double>(0), sigma_b));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(c, 0, sigma_c));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(c,
+                         static_cast<double>(0), sigma_c));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(d, 0, sigma_d));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(d,
+                         static_cast<double>(0), sigma_d));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(e, 0, sigma_e));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(e,
+                         static_cast<double>(0), sigma_e));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::bernoulli_logit_lpmf<propto__>(y, y_hat));
       }
@@ -7973,7 +8026,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node1)),
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node2))))));
         current_statement__ = 29;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi,
+                         static_cast<double>(1), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8041,7 +8095,8 @@ class expr_prop_fail4_model final : public model_base_crtp<expr_prop_fail4_model
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node1)),
               stan::model::rvalue(phi, "phi", stan::model::index_multi(node2))))));
         current_statement__ = 29;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(tau_phi,
+                         static_cast<double>(1), static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -9028,7 +9083,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 36;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 45;
         for (int i = 1; i <= nind; ++i) {
           current_statement__ = 43;
@@ -9228,7 +9284,8 @@ class expr_prop_fail5_model final : public model_base_crtp<expr_prop_fail5_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 36;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 45;
         for (int i = 1; i <= nind; ++i) {
           current_statement__ = 43;
@@ -10710,9 +10767,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 81;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 82;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta,
+                         static_cast<double>(1), static_cast<double>(1)));
         {
           int inline_js_super_lp_n_ind_sym40__;
           current_statement__ = 83;
@@ -11155,9 +11214,11 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 81;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         current_statement__ = 82;
-        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta, 1, 1));
+        lp_accum__.add(stan::math::gamma_lpdf<propto__>(beta,
+                         static_cast<double>(1), static_cast<double>(1)));
         {
           int inline_js_super_lp_n_ind_sym23__;
           current_statement__ = 83;
@@ -11661,8 +11722,9 @@ class expr_prop_fail6_model final : public model_base_crtp<expr_prop_fail6_model
             stan::model::assign(z,
               stan::math::bernoulli_rng(
                 stan::math::fma(
-                  stan::model::rvalue(z, "z", stan::model::index_uni(i),
-                    stan::model::index_uni((t - 1))),
+                  static_cast<double>(
+                    stan::model::rvalue(z, "z", stan::model::index_uni(i),
+                      stan::model::index_uni((t - 1)))),
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(i),
                     stan::model::index_uni((t - 1))), (q *
                   stan::model::rvalue(nu, "nu", stan::model::index_uni(t)))),
@@ -15393,7 +15455,7 @@ summer(const T0__& et_arg__, std::ostream* pstream__) {
     N = stan::math::size(et);
     local_scalar_t__ running_sum;
     current_statement__ = 5;
-    running_sum = 0;
+    running_sum = stan::math::promote_scalar<local_scalar_t__>(0);
     current_statement__ = 9;
     for (int n = 1; n <= N; ++n) {
       current_statement__ = 14;
@@ -15487,7 +15549,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
         inline_summer_N_sym16__ = stan::math::size(eta);
         local_scalar_t__ inline_summer_running_sum_sym17__;
         current_statement__ = 5;
-        inline_summer_running_sum_sym17__ = 0;
+        inline_summer_running_sum_sym17__ = stan::math::promote_scalar<
+                                              local_scalar_t__>(0);
         current_statement__ = 9;
         for (int inline_summer_n_sym21__ = 1; inline_summer_n_sym21__ <=
              inline_summer_N_sym16__; ++inline_summer_n_sym21__) {
@@ -15557,7 +15620,8 @@ class function_in_function_loops_model final : public model_base_crtp<function_i
         inline_summer_N_sym8__ = stan::math::size(eta);
         local_scalar_t__ inline_summer_running_sum_sym9__;
         current_statement__ = 5;
-        inline_summer_running_sum_sym9__ = 0;
+        inline_summer_running_sum_sym9__ = stan::math::promote_scalar<
+                                             local_scalar_t__>(0);
         current_statement__ = 9;
         for (int inline_summer_n_sym13__ = 1; inline_summer_n_sym13__ <=
              inline_summer_N_sym8__; ++inline_summer_n_sym13__) {
@@ -17320,7 +17384,7 @@ foo(const T0__& N, const T1__& M, std::ostream* pstream__) {
   try {
     current_statement__ = 8;
     return stan::math::promote_scalar<local_scalar_t__>(
-             stan::math::rep_matrix(1, N, M));
+             stan::math::rep_matrix(static_cast<double>(1), N, M));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -18770,7 +18834,7 @@ seq_cprob(const T0__& gamma_arg__, std::ostream* pstream__) {
       Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
     local_scalar_t__ log_residual_prob;
     current_statement__ = 49;
-    log_residual_prob = 0;
+    log_residual_prob = stan::math::promote_scalar<local_scalar_t__>(0);
     current_statement__ = 53;
     for (int n = 1; n <= N; ++n) {
       current_statement__ = 50;
@@ -19103,7 +19167,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 83;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         {
           int inline_jolly_seber_lp_n_ind_sym46__;
           current_statement__ = 84;
@@ -19514,7 +19579,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
       stan::math::check_less_or_equal(function__, "chi", chi, 1);
       {
         current_statement__ = 83;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon, 0, sigma));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(epsilon,
+                         static_cast<double>(0), sigma));
         {
           int inline_jolly_seber_lp_n_ind_sym29__;
           current_statement__ = 84;
@@ -19984,8 +20050,9 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
           mu2 = stan::math::fma(
                   stan::model::rvalue(phi, "phi", stan::model::index_uni(i),
                     stan::model::index_uni((t - 1))),
-                  stan::model::rvalue(z, "z", stan::model::index_uni(i),
-                    stan::model::index_uni((t - 1))),
+                  static_cast<double>(
+                    stan::model::rvalue(z, "z", stan::model::index_uni(i),
+                      stan::model::index_uni((t - 1)))),
                   (stan::model::rvalue(gamma, "gamma",
                      stan::model::index_uni(t)) * q));
           current_statement__ = 39;
@@ -20015,7 +20082,8 @@ class inlining_fail2_model final : public model_base_crtp<inlining_fail2_model> 
               DUMMY_VAR__);
           local_scalar_t__ inline_seq_cprob_log_residual_prob_sym13__;
           current_statement__ = 49;
-          inline_seq_cprob_log_residual_prob_sym13__ = 0;
+          inline_seq_cprob_log_residual_prob_sym13__ = stan::math::promote_scalar<
+                                                         local_scalar_t__>(0);
           current_statement__ = 53;
           for (int inline_seq_cprob_n_sym14__ = 1; inline_seq_cprob_n_sym14__
                <= inline_seq_cprob_N_sym11__; ++inline_seq_cprob_n_sym14__) {
@@ -20591,7 +20659,7 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
       current_statement__ = 2;
       z = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 2;
-      z = 1;
+      z = static_cast<double>(1);
       current_statement__ = 3;
       x = std::numeric_limits<double>::quiet_NaN();
       {
@@ -20599,13 +20667,15 @@ class lcm_experiment_model final : public model_base_crtp<lcm_experiment_model> 
         x = stan::math::normal_rng(123, 1, base_rng__);
         current_statement__ = 5;
         z = stan::math::normal_rng(
-              stan::math::fma(stan::math::sqrt(j), 2, 1), 1, base_rng__);
+              stan::math::fma(stan::math::sqrt(j), static_cast<double>(2),
+                static_cast<double>(1)), 1, base_rng__);
       }
       current_statement__ = 7;
       i = std::numeric_limits<double>::quiet_NaN();
       current_statement__ = 7;
-      i = stan::math::normal_rng(stan::math::fma(stan::math::sqrt(j), 2, 1),
-            1, base_rng__);
+      i = stan::math::normal_rng(
+            stan::math::fma(stan::math::sqrt(j), static_cast<double>(2),
+              static_cast<double>(1)), 1, base_rng__);
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
     }
@@ -21353,7 +21423,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       auto theta = in__.template read<std::vector<local_scalar_t__>>(J);
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta,
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -21389,7 +21460,8 @@ class lcm_fails_model final : public model_base_crtp<lcm_fails_model> {
       auto theta = in__.template read<std::vector<local_scalar_t__>>(J);
       {
         current_statement__ = 2;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(y, theta,
+                         static_cast<double>(1)));
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -22844,7 +22916,7 @@ foo_lpdf(const T0__& x, const T1__& mu, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 5;
-    return stan::math::normal_lpdf<propto__>(x, mu, 1);
+    return stan::math::normal_lpdf<propto__>(x, mu, static_cast<double>(1));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -22961,7 +23033,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       {
         current_statement__ = 5;
         inline_foo_lpdf_return_sym23__ = stan::math::normal_lpdf<false>(mu,
-                                           1.0, 1);
+                                           1.0, static_cast<double>(1));
       }
       tp = inline_foo_lpdf_return_sym23__;
       {
@@ -22974,7 +23046,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
             inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym26__ = stan::math::normal_lpdf<
                                                                     propto__>(
                                                                     mu, 0.5,
-                                                                    1);
+                                                                    static_cast<
+                                                                    double>(1));
           }
           inline_baz_lpdf_return_sym25__ = inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym26__;
         }
@@ -23024,7 +23097,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       {
         current_statement__ = 5;
         inline_foo_lpdf_return_sym16__ = stan::math::normal_lpdf<false>(mu,
-                                           1.0, 1);
+                                           1.0, static_cast<double>(1));
       }
       tp = inline_foo_lpdf_return_sym16__;
       {
@@ -23037,7 +23110,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
             inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym19__ = stan::math::normal_lpdf<
                                                                     propto__>(
                                                                     mu, 0.5,
-                                                                    1);
+                                                                    static_cast<
+                                                                    double>(1));
           }
           inline_baz_lpdf_return_sym18__ = inline_baz_lpdf_inline_foo_lpdf_return_sym7___sym19__;
         }
@@ -23104,7 +23178,7 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
       {
         current_statement__ = 5;
         inline_foo_lpdf_return_sym9__ = stan::math::normal_lpdf<false>(mu,
-                                          1.0, 1);
+                                          1.0, static_cast<double>(1));
       }
       tp = inline_foo_lpdf_return_sym9__;
       if (emit_transformed_parameters__) {
@@ -23122,7 +23196,8 @@ class lupdf_inlining_model final : public model_base_crtp<lupdf_inlining_model> 
           inline_baz_lpdf_inline_foo_lpdf_return_sym1___sym12__ = stan::math::normal_lpdf<
                                                                     false>(
                                                                     mu, 0.5,
-                                                                    1);
+                                                                    static_cast<
+                                                                    double>(1));
         }
         inline_baz_lpdf_return_sym11__ = inline_baz_lpdf_inline_foo_lpdf_return_sym1___sym12__;
       }
@@ -24377,8 +24452,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       current_statement__ = 12;
       stan::model::assign(a1,
-        stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable a1");
+        stan::math::fma(static_cast<double>(10), mu_a1,
+          stan::math::multiply(sigma_a1, eta1)), "assigning variable a1");
       current_statement__ = 13;
       stan::model::assign(a2,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
@@ -24405,15 +24480,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       {
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
@@ -24477,8 +24557,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
         Eigen::Matrix<local_scalar_t__,-1,1>::Constant(N, DUMMY_VAR__);
       current_statement__ = 12;
       stan::model::assign(a1,
-        stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable a1");
+        stan::math::fma(static_cast<double>(10), mu_a1,
+          stan::math::multiply(sigma_a1, eta1)), "assigning variable a1");
       current_statement__ = 13;
       stan::model::assign(a2,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
@@ -24505,15 +24585,20 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       {
         current_statement__ = 16;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 17;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta1,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 18;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 19;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(eta2,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 20;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 21;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
       }
@@ -24604,8 +24689,8 @@ class off_small_model final : public model_base_crtp<off_small_model> {
       }
       current_statement__ = 12;
       stan::model::assign(a1,
-        stan::math::fma(10, mu_a1, stan::math::multiply(sigma_a1, eta1)),
-        "assigning variable a1");
+        stan::math::fma(static_cast<double>(10), mu_a1,
+          stan::math::multiply(sigma_a1, eta1)), "assigning variable a1");
       current_statement__ = 13;
       stan::model::assign(a2,
         stan::math::fma(0.1, mu_a2, stan::math::multiply(sigma_a2, eta2)),
@@ -25399,26 +25484,26 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           lp_accum__.add(2);
         }
         current_statement__ = 36;
-        x = 3;
+        x = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 37;
-        lp_accum__.add(3);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(3));
         current_statement__ = 39;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 38;
-          x = 2;
+          x = stan::math::promote_scalar<local_scalar_t__>(2);
         }
         current_statement__ = 40;
         lp_accum__.add(x);
         current_statement__ = 41;
-        lp_accum__.add(247);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(247));
         current_statement__ = 42;
-        x = 576;
+        x = stan::math::promote_scalar<local_scalar_t__>(576);
         current_statement__ = 43;
-        lp_accum__.add(576);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(576));
         current_statement__ = 45;
         if (stan::math::logical_gt(theta, 46)) {
           current_statement__ = 44;
-          x = 5880;
+          x = stan::math::promote_scalar<local_scalar_t__>(5880);
         }
         current_statement__ = 46;
         lp_accum__.add(x);
@@ -25439,12 +25524,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 55;
-          lp_accum__.add(24);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(24));
         }
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 58;
-          lp_accum__.add(245);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(245));
         }
         {
           current_statement__ = 60;
@@ -25524,13 +25609,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 84;
         for (int i = 2; i <= 3; ++i) {
           current_statement__ = 81;
-          lp_accum__.add(4);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(4));
           current_statement__ = 82;
-          lp_accum__.add(6);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(6));
         }
         local_scalar_t__ dataonlyvar;
         current_statement__ = 85;
-        dataonlyvar = 3;
+        dataonlyvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 86;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
@@ -25730,26 +25815,26 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
           lp_accum__.add(2);
         }
         current_statement__ = 36;
-        x = 3;
+        x = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 37;
-        lp_accum__.add(3);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(3));
         current_statement__ = 39;
         if (stan::math::logical_gt(theta, 2)) {
           current_statement__ = 38;
-          x = 2;
+          x = stan::math::promote_scalar<local_scalar_t__>(2);
         }
         current_statement__ = 40;
         lp_accum__.add(x);
         current_statement__ = 41;
-        lp_accum__.add(247);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(247));
         current_statement__ = 42;
-        x = 576;
+        x = stan::math::promote_scalar<local_scalar_t__>(576);
         current_statement__ = 43;
-        lp_accum__.add(576);
+        lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(576));
         current_statement__ = 45;
         if (stan::math::logical_gt(theta, 46)) {
           current_statement__ = 44;
-          x = 5880;
+          x = stan::math::promote_scalar<local_scalar_t__>(5880);
         }
         current_statement__ = 46;
         lp_accum__.add(x);
@@ -25770,12 +25855,12 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 55;
-          lp_accum__.add(24);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(24));
         }
         {
           local_scalar_t__ y = DUMMY_VAR__;
           current_statement__ = 58;
-          lp_accum__.add(245);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(245));
         }
         {
           current_statement__ = 60;
@@ -25855,13 +25940,13 @@ class optimizations_model final : public model_base_crtp<optimizations_model> {
         current_statement__ = 84;
         for (int i = 2; i <= 3; ++i) {
           current_statement__ = 81;
-          lp_accum__.add(4);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(4));
           current_statement__ = 82;
-          lp_accum__.add(6);
+          lp_accum__.add(stan::math::promote_scalar<local_scalar_t__>(6));
         }
         local_scalar_t__ dataonlyvar;
         current_statement__ = 85;
-        dataonlyvar = 3;
+        dataonlyvar = stan::math::promote_scalar<local_scalar_t__>(3);
         current_statement__ = 86;
         lp_accum__.add(dataonlyvar);
         local_scalar_t__ paramvar = DUMMY_VAR__;
@@ -26777,7 +26862,7 @@ double dumb(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 4;
-    return (x - 0.5);
+    return stan::math::promote_scalar<local_scalar_t__>((x - 0.5));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -28098,12 +28183,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       }
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a, (100 * mu_a),
                          sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
         std::complex<local_scalar_t__> z;
@@ -28189,12 +28276,14 @@ class partial_eval_model final : public model_base_crtp<partial_eval_model> {
       }
       {
         current_statement__ = 9;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a, 0, 1));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(mu_a,
+                         static_cast<double>(0), static_cast<double>(1)));
         current_statement__ = 10;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(a, (100 * mu_a),
                          sigma_a));
         current_statement__ = 11;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta, 0, 100));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(beta,
+                         static_cast<double>(0), static_cast<double>(100)));
         current_statement__ = 12;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y, y_hat, sigma_y));
         std::complex<local_scalar_t__> z;
@@ -31294,7 +31383,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 12;
       for (int i = 1; i <= 10; ++i) {
         current_statement__ = 10;
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -31347,7 +31436,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 12;
       for (int i = 1; i <= 10; ++i) {
         current_statement__ = 10;
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
       }
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -31417,7 +31506,7 @@ class unenforce_initialize_model final : public model_base_crtp<unenforce_initia
       current_statement__ = 12;
       for (int i = 1; i <= 10; ++i) {
         current_statement__ = 10;
-        for_loop_var = 1;
+        for_loop_var = stan::math::promote_scalar<local_scalar_t__>(1);
       }
       if (emit_transformed_parameters__) {
         out__.write(no_init);

--- a/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
+++ b/test/integration/good/compiler-optimizations/mem_patterns/cpp.expected
@@ -189,9 +189,9 @@ class ad_scalar_data_matrix_model final : public model_base_crtp<ad_scalar_data_
         current_statement__ = 7;
         stan::model::assign(aos_deep,
           stan::math::subtract(
-            stan::math::multiply(2,
-              stan::math::Phi(stan::math::divide(y_data, sigma))), 1),
-          "assigning variable aos_deep");
+            stan::math::multiply(static_cast<double>(2),
+              stan::math::Phi(stan::math::divide(y_data, sigma))),
+            static_cast<double>(1)), "assigning variable aos_deep");
         current_statement__ = 8;
         stan::math::validate_non_negative_index("soa_dual_rep", "N", N);
         Eigen::Matrix<local_scalar_t__,-1,1> soa_dual_rep =
@@ -209,7 +209,8 @@ class ad_scalar_data_matrix_model final : public model_base_crtp<ad_scalar_data_
         current_statement__ = 11;
         stan::model::assign(soa_data_rep,
           stan::math::add(stan::math::rep_vector(0.0, N),
-            stan::math::rep_vector(N, N)), "assigning variable soa_data_rep");
+            stan::math::rep_vector(static_cast<double>(N), N)),
+          "assigning variable soa_data_rep");
         current_statement__ = 12;
         stan::math::validate_non_negative_index("soa_mix", "N", N);
         Eigen::Matrix<local_scalar_t__,-1,1> soa_mix =
@@ -355,9 +356,9 @@ class ad_scalar_data_matrix_model final : public model_base_crtp<ad_scalar_data_
         current_statement__ = 7;
         stan::model::assign(aos_deep,
           stan::math::subtract(
-            stan::math::multiply(2,
-              stan::math::Phi(stan::math::divide(y_data, sigma))), 1),
-          "assigning variable aos_deep");
+            stan::math::multiply(static_cast<double>(2),
+              stan::math::Phi(stan::math::divide(y_data, sigma))),
+            static_cast<double>(1)), "assigning variable aos_deep");
         current_statement__ = 8;
         stan::math::validate_non_negative_index("soa_dual_rep", "N", N);
         stan::math::var_value<Eigen::Matrix<double,-1,1>> soa_dual_rep =
@@ -380,7 +381,8 @@ class ad_scalar_data_matrix_model final : public model_base_crtp<ad_scalar_data_
         current_statement__ = 11;
         stan::model::assign(soa_data_rep,
           stan::math::add(stan::math::rep_vector(0.0, N),
-            stan::math::rep_vector(N, N)), "assigning variable soa_data_rep");
+            stan::math::rep_vector(static_cast<double>(N), N)),
+          "assigning variable soa_data_rep");
         current_statement__ = 12;
         stan::math::validate_non_negative_index("soa_mix", "N", N);
         stan::math::var_value<Eigen::Matrix<double,-1,1>> soa_mix =
@@ -1822,7 +1824,7 @@ class constraints_model final : public model_base_crtp<constraints_model> {
         0);
       {
         current_statement__ = 41;
-        lp_accum__.add(stan::math::multiply(-(2),
+        lp_accum__.add(stan::math::multiply(static_cast<double>(-(2)),
                          stan::math::log(sigma_price)));
         current_statement__ = 42;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(Intercept,
@@ -1834,15 +1836,18 @@ class constraints_model final : public model_base_crtp<constraints_model> {
         lp_accum__.add(stan::math::gamma_lpdf<propto__>(sigma2,
                          sigma_prior_shape, sigma_prior_rate));
         current_statement__ = 45;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(ar, 0, .2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(ar,
+                         static_cast<double>(0), .2));
         current_statement__ = 46;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(ma, 0, .2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(ma,
+                         static_cast<double>(0), .2));
         current_statement__ = 47;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(h, h_i_mean,
                          h_i_sigma));
         current_statement__ = 48;
-        lp_accum__.add(stan::math::student_t_lpdf<propto__>(sigma_price, 3,
-                         1, 1));
+        lp_accum__.add(stan::math::student_t_lpdf<propto__>(sigma_price,
+                         static_cast<double>(3), static_cast<double>(1),
+                         static_cast<double>(1)));
         current_statement__ = 49;
         lp_accum__.add(stan::math::uniform_lpdf<propto__>(high_low_est,
                          diff_low_mid, diff_high_mid));
@@ -2131,7 +2136,7 @@ class constraints_model final : public model_base_crtp<constraints_model> {
         0);
       {
         current_statement__ = 41;
-        lp_accum__.add(stan::math::multiply(-(2),
+        lp_accum__.add(stan::math::multiply(static_cast<double>(-(2)),
                          stan::math::log(sigma_price)));
         current_statement__ = 42;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(Intercept,
@@ -2143,15 +2148,18 @@ class constraints_model final : public model_base_crtp<constraints_model> {
         lp_accum__.add(stan::math::gamma_lpdf<propto__>(sigma2,
                          sigma_prior_shape, sigma_prior_rate));
         current_statement__ = 45;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(ar, 0, .2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(ar,
+                         static_cast<double>(0), .2));
         current_statement__ = 46;
-        lp_accum__.add(stan::math::normal_lpdf<propto__>(ma, 0, .2));
+        lp_accum__.add(stan::math::normal_lpdf<propto__>(ma,
+                         static_cast<double>(0), .2));
         current_statement__ = 47;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(h, h_i_mean,
                          h_i_sigma));
         current_statement__ = 48;
-        lp_accum__.add(stan::math::student_t_lpdf<propto__>(sigma_price, 3,
-                         1, 1));
+        lp_accum__.add(stan::math::student_t_lpdf<propto__>(sigma_price,
+                         static_cast<double>(3), static_cast<double>(1),
+                         static_cast<double>(1)));
         current_statement__ = 49;
         lp_accum__.add(stan::math::uniform_lpdf<propto__>(high_low_est,
                          diff_low_mid, diff_high_mid));
@@ -4582,7 +4590,7 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         current_statement__ = 32;
         stan::model::assign(tp_soa_used_with_aos_in_excluded_fun,
           stan::math::multiply(p_soa_used_with_aos_in_excluded_fun,
-            stan::math::size(tp_aos_vec_v)),
+            static_cast<double>(stan::math::size(tp_aos_vec_v))),
           "assigning variable tp_soa_used_with_aos_in_excluded_fun");
         current_statement__ = 33;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
@@ -4962,7 +4970,7 @@ class indexing_model final : public model_base_crtp<indexing_model> {
         current_statement__ = 32;
         stan::model::assign(tp_soa_used_with_aos_in_excluded_fun,
           stan::math::multiply(p_soa_used_with_aos_in_excluded_fun,
-            stan::math::size(tp_aos_vec_v)),
+            static_cast<double>(stan::math::size(tp_aos_vec_v))),
           "assigning variable tp_soa_used_with_aos_in_excluded_fun");
         current_statement__ = 33;
         lp_accum__.add(stan::math::normal_lpdf<propto__>(y,
@@ -7126,8 +7134,10 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
         in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10);
       local_scalar_t__ tp_real_from_soa = DUMMY_VAR__;
       current_statement__ = 4;
-      tp_real_from_soa = (stan::math::logical_gt(5, 0) ? data_r : stan::math::sum(
-                                                                    soa_x));
+      tp_real_from_soa = (stan::math::logical_gt(5, 0) ? stan::math::promote_scalar<
+                                                           local_scalar_t__>(
+                                                           data_r) : 
+        stan::math::sum(soa_x));
       Eigen::Matrix<local_scalar_t__,-1,-1> tp_matrix_aos_from_mix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
       current_statement__ = 5;
@@ -7187,8 +7197,10 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
         in__.template read<Eigen::Matrix<local_scalar_t__,-1,-1>>(5, 10);
       local_scalar_t__ tp_real_from_soa = DUMMY_VAR__;
       current_statement__ = 4;
-      tp_real_from_soa = (stan::math::logical_gt(5, 0) ? data_r : stan::math::sum(
-                                                                    soa_x));
+      tp_real_from_soa = (stan::math::logical_gt(5, 0) ? stan::math::promote_scalar<
+                                                           local_scalar_t__>(
+                                                           data_r) : 
+        stan::math::sum(soa_x));
       Eigen::Matrix<local_scalar_t__,-1,-1> tp_matrix_aos_from_mix =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(5, 10, DUMMY_VAR__);
       current_statement__ = 5;
@@ -7272,8 +7284,10 @@ class reductions_allowed_model final : public model_base_crtp<reductions_allowed
         return ;
       }
       current_statement__ = 4;
-      tp_real_from_soa = (stan::math::logical_gt(5, 0) ? data_r : stan::math::sum(
-                                                                    soa_x));
+      tp_real_from_soa = (stan::math::logical_gt(5, 0) ? stan::math::promote_scalar<
+                                                           local_scalar_t__>(
+                                                           data_r) : 
+        stan::math::sum(soa_x));
       current_statement__ = 5;
       stan::model::assign(tp_matrix_aos_from_mix,
         (stan::math::logical_gt(stan::math::sum(soa_x), 0) ? stan::math::eval(
@@ -7796,14 +7810,15 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 6;
       stan::model::assign(int_aos_mul_aos,
-        stan::math::multiply(stan::math::rows(row_soa), empty_user_func_aos),
-        "assigning variable int_aos_mul_aos");
+        stan::math::multiply(static_cast<double>(stan::math::rows(row_soa)),
+          empty_user_func_aos), "assigning variable int_aos_mul_aos");
       Eigen::Matrix<local_scalar_t__,-1,-1> mul_two_aos =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 7;
       stan::model::assign(mul_two_aos,
         stan::math::multiply(
-          stan::math::multiply(stan::math::cols(row_soa),
+          stan::math::multiply(
+            static_cast<double>(stan::math::cols(row_soa)),
             stan::math::transpose(int_aos_mul_aos)), user_func_aos),
         "assigning variable mul_two_aos");
     } catch (const std::exception& e) {
@@ -7864,14 +7879,15 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 6;
       stan::model::assign(int_aos_mul_aos,
-        stan::math::multiply(stan::math::rows(row_soa), empty_user_func_aos),
-        "assigning variable int_aos_mul_aos");
+        stan::math::multiply(static_cast<double>(stan::math::rows(row_soa)),
+          empty_user_func_aos), "assigning variable int_aos_mul_aos");
       Eigen::Matrix<local_scalar_t__,-1,-1> mul_two_aos =
         Eigen::Matrix<local_scalar_t__,-1,-1>::Constant(10, 10, DUMMY_VAR__);
       current_statement__ = 7;
       stan::model::assign(mul_two_aos,
         stan::math::multiply(
-          stan::math::multiply(stan::math::cols(row_soa),
+          stan::math::multiply(
+            static_cast<double>(stan::math::cols(row_soa)),
             stan::math::transpose(int_aos_mul_aos)), user_func_aos),
         "assigning variable mul_two_aos");
     } catch (const std::exception& e) {
@@ -7956,12 +7972,13 @@ class return_types_and_udfs_demotes_model final : public model_base_crtp<return_
         "assigning variable inner_empty_user_func_aos");
       current_statement__ = 6;
       stan::model::assign(int_aos_mul_aos,
-        stan::math::multiply(stan::math::rows(row_soa), empty_user_func_aos),
-        "assigning variable int_aos_mul_aos");
+        stan::math::multiply(static_cast<double>(stan::math::rows(row_soa)),
+          empty_user_func_aos), "assigning variable int_aos_mul_aos");
       current_statement__ = 7;
       stan::model::assign(mul_two_aos,
         stan::math::multiply(
-          stan::math::multiply(stan::math::cols(row_soa),
+          stan::math::multiply(
+            static_cast<double>(stan::math::cols(row_soa)),
             stan::math::transpose(int_aos_mul_aos)), user_func_aos),
         "assigning variable mul_two_aos");
       if (emit_transformed_parameters__) {

--- a/test/integration/good/tuples/cpp.expected
+++ b/test/integration/good/tuples/cpp.expected
@@ -3363,7 +3363,12 @@ class infer_tuple_ad_model final : public model_base_crtp<infer_tuple_ad_model> 
         current_statement__ = 2;
         stan::model::assign(z,
           std::vector<std::tuple<local_scalar_t__, local_scalar_t__>>{
-            std::forward_as_tuple(1, x), std::forward_as_tuple(x, 1)},
+            std::forward_as_tuple(
+              stan::math::promote_scalar<local_scalar_t__>(1),
+              stan::math::promote_scalar<local_scalar_t__>(x)),
+            std::forward_as_tuple(
+              stan::math::promote_scalar<local_scalar_t__>(x),
+              stan::math::promote_scalar<local_scalar_t__>(1))},
           "assigning variable z");
       }
     } catch (const std::exception& e) {
@@ -3406,7 +3411,12 @@ class infer_tuple_ad_model final : public model_base_crtp<infer_tuple_ad_model> 
         current_statement__ = 2;
         stan::model::assign(z,
           std::vector<std::tuple<local_scalar_t__, local_scalar_t__>>{
-            std::forward_as_tuple(1, x), std::forward_as_tuple(x, 1)},
+            std::forward_as_tuple(
+              stan::math::promote_scalar<local_scalar_t__>(1),
+              stan::math::promote_scalar<local_scalar_t__>(x)),
+            std::forward_as_tuple(
+              stan::math::promote_scalar<local_scalar_t__>(x),
+              stan::math::promote_scalar<local_scalar_t__>(1))},
           "assigning variable z");
       }
     } catch (const std::exception& e) {
@@ -6800,7 +6810,9 @@ std::tuple<double, double> foo(std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 8;
-    return std::forward_as_tuple(1.0, 2.0);
+    return std::forward_as_tuple(
+             stan::math::promote_scalar<local_scalar_t__>(1.0),
+             stan::math::promote_scalar<local_scalar_t__>(2.0));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -8012,7 +8024,7 @@ double foo(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 15;
-    return std::get<0>(x);
+    return stan::math::promote_scalar<local_scalar_t__>(std::get<0>(x));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -8045,7 +8057,9 @@ double bar(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 17;
-    return std::get<1>(stan::model::rvalue(x, "x", stan::model::index_uni(1)));
+    return stan::math::promote_scalar<local_scalar_t__>(
+             std::get<1>(
+               stan::model::rvalue(x, "x", stan::model::index_uni(1))));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -8081,12 +8095,13 @@ double baz(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 19;
-    return stan::model::rvalue(
+    return stan::math::promote_scalar<local_scalar_t__>(
              stan::model::rvalue(
-               std::get<0>(
-                 stan::model::rvalue(x, "x", stan::model::index_uni(1))),
-               "x[1].1", stan::model::index_uni(1)), "x[1].1[1]",
-             stan::model::index_uni(1), stan::model::index_uni(1));
+               stan::model::rvalue(
+                 std::get<0>(
+                   stan::model::rvalue(x, "x", stan::model::index_uni(1))),
+                 "x[1].1", stan::model::index_uni(1)), "x[1].1[1]",
+               stan::model::index_uni(1), stan::model::index_uni(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -8153,7 +8168,7 @@ class tuple_dataonly_model final : public model_base_crtp<tuple_dataonly_model> 
       stan::model::assign(m,
         stan::math::to_matrix(
           std::vector<Eigen::Matrix<double,1,-1>>{(Eigen::Matrix<double,1,-1>(1) <<
-                                                     1).finished()}),
+                                                     static_cast<double>(1)).finished()}),
         "assigning variable m");
       current_statement__ = 12;
       m2 = std::vector<Eigen::Matrix<double,-1,-1>>(1,
@@ -8267,7 +8282,7 @@ class tuple_dataonly_model final : public model_base_crtp<tuple_dataonly_model> 
                                           std::vector<
                                             Eigen::Matrix<double,1,-1>>{
                                             (Eigen::Matrix<double,1,-1>(1) <<
-                                               1).finished()})},
+                                               static_cast<double>(1)).finished()})},
                                       std::get<1>(d))}, pstream__));
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8345,7 +8360,7 @@ class tuple_dataonly_model final : public model_base_crtp<tuple_dataonly_model> 
                                           std::vector<
                                             Eigen::Matrix<double,1,-1>>{
                                             (Eigen::Matrix<double,1,-1>(1) <<
-                                               1).finished()})},
+                                               static_cast<double>(1)).finished()})},
                                       std::get<1>(d))}, pstream__));
     } catch (const std::exception& e) {
       stan::lang::rethrow_located(e, locations_array__[current_statement__]);
@@ -8615,8 +8630,9 @@ double tuple_tester(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 2;
-    return stan::model::rvalue(std::get<0>(x), "x.1",
-             stan::model::index_uni(1));
+    return stan::math::promote_scalar<local_scalar_t__>(
+             stan::model::rvalue(std::get<0>(x), "x.1",
+               stan::model::index_uni(1)));
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -12026,7 +12042,8 @@ class tuple_promotion_model final : public model_base_crtp<tuple_promotion_model
                   std::numeric_limits<double>::quiet_NaN())};
       current_statement__ = 15;
       stan::model::assign(basic,
-        std::forward_as_tuple(std::vector<double>{1, 2},
+        std::forward_as_tuple(
+          std::vector<double>{static_cast<double>(1), static_cast<double>(2)},
           stan::math::to_complex(3, 0)), "assigning variable basic");
       current_statement__ = 16;
       CV = std::tuple<Eigen::Matrix<std::complex<double>,-1,1>, double>{
@@ -13468,8 +13485,11 @@ class tuple_templating_model final : public model_base_crtp<tuple_templating_mod
         std::vector<std::tuple<int, Eigen::Matrix<double,-1,-1>>>{std::forward_as_tuple(
                                                                     1,
                                                                     stan::math::multiply(
-                                                                    m1, 2)),
-          std::forward_as_tuple(2, stan::math::multiply(m2, 3))}, pstream__);
+                                                                    m1,
+                                                                    static_cast<
+                                                                    double>(2))),
+          std::forward_as_tuple(2,
+            stan::math::multiply(m2, static_cast<double>(3)))}, pstream__);
       current_statement__ = 5;
       overly_complicated(
         std::forward_as_tuple(std::vector<Eigen::Matrix<double,-1,-1>>{m1},
@@ -15452,7 +15472,7 @@ foo_lpdf(const T0__& x, const T1__& y, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 2;
-    return 0;
+    return stan::math::promote_scalar<local_scalar_t__>(0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }
@@ -15809,7 +15829,7 @@ foo_lpdf(const T0__& x, std::ostream* pstream__) {
   (void) DUMMY_VAR__;
   try {
     current_statement__ = 2;
-    return 0;
+    return stan::math::promote_scalar<local_scalar_t__>(0);
   } catch (const std::exception& e) {
     stan::lang::rethrow_located(e, locations_array__[current_statement__]);
   }


### PR DESCRIPTION
This is a workaround for https://github.com/stan-dev/math/issues/3259 but will also prevent this _class_ of bug from arising in the future. We should probably still fix the truncation in the math lib, but it's hard to know we've got all of them and this will help.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Generated C++ now always encodes when we expect integers to become doubles.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
