### PR TITLE
Improve uninitialized variable warnings

### DIFF
--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -68,6 +68,9 @@ let rec top_var_declarations Stmt.{pattern; _} : string Set.Poly.t =
   | SList l -> Set.Poly.union_list (List.map ~f:top_var_declarations l)
   | _ -> Set.Poly.empty
 
+let function_names {functions_block; _} : string Set.Poly.t =
+  Set.Poly.of_list (List.map functions_block ~f:(fun {fdname; _} -> fdname))
+
 let data_set ?(exclude_transformed = false) ?(exclude_ints = false)
     (mir : Program.Typed.t) : string Set.Poly.t =
   (* Data are input_vars *)

--- a/src/analysis_and_optimization/Mir_utils.mli
+++ b/src/analysis_and_optimization/Mir_utils.mli
@@ -12,6 +12,7 @@ type bound_values =
 val trans_bounds_values : Expr.Typed.t Transformation.t -> bound_values
 val chop_dist_name : string -> string Option.t
 val top_var_declarations : Stmt.Located.t -> string Set.Poly.t
+val function_names : Program.Typed.t -> string Set.Poly.t
 
 val data_set :
      ?exclude_transformed:bool

--- a/test/integration/cli-args/warn-uninitialized/simple.stan
+++ b/test/integration/cli-args/warn-uninitialized/simple.stan
@@ -1,6 +1,49 @@
+functions {
+  real bar(array[] real y_slice, int start, int end) {
+    if (size(y_slice) > 1) {
+      return reduce_sum(bar, y_slice, 1);
+    } else {
+      return normal_lpdf(y_slice | 0, 1);
+    }
+  }
+}
+data {
+  int N;
+}
+transformed data {
+  print(N);
+
+  int p;
+  int q;
+  int p2 = q + 23;
+}
+parameters {
+  array[N] real y1;
+}
+transformed parameters {
+  jacobian += p * p2;
+
+  real h;
+}
 model {
   real theta;
   real zero;
+  // should warn for both theta and zero
   theta ~ normal(zero, 1);
   zero = 0;
+
+  // warning is not transitive
+  int x = p;
+  print(x);
+
+  real g;
+
+  // this should warn for g and h, not 'target'
+  target += normal_lpdf(g | h, 1);
+
+  // this shouldn't warn because the above does.
+  print(g);
+
+  // should have no warnings
+  target += reduce_sum(bar, y1, 1);
 }

--- a/test/integration/cli-args/warn-uninitialized/stanc.expected
+++ b/test/integration/cli-args/warn-uninitialized/stanc.expected
@@ -1,6 +1,16 @@
   $ ../../../../../install/default/bin/stanc --warn-uninitialized  simple.stan
-Warning in 'simple.stan', line 4, column 17 to column 21:
-    The variable zero may not have been assigned a value before its use.
-Warning in 'simple.stan', line 4, column 2 to column 7:
-    The variable theta may not have been assigned a value before its use.
+Warning in 'simple.stan', line 18, column 11 to column 12:
+    The variable q may not have been assigned a value before its first use.
+Warning in 'simple.stan', line 24, column 14 to column 15:
+    The variable p may not have been assigned a value before its first use.
+Warning in 'simple.stan', line 32, column 2 to column 7:
+    The variable theta may not have been assigned a value before its first
+    use.
+Warning in 'simple.stan', line 32, column 17 to column 21:
+    The variable zero may not have been assigned a value before its first
+    use.
+Warning in 'simple.stan', line 42, column 24 to column 25:
+    The variable g may not have been assigned a value before its first use.
+Warning in 'simple.stan', line 42, column 28 to column 29:
+    The variable h may not have been assigned a value before its first use.
 [exit 0]

--- a/test/stancjs/stancjs.expected
+++ b/test/stancjs/stancjs.expected
@@ -387,7 +387,7 @@ Warning in 'string', line 7, column 17 to column 22:
     consider rescaling with a multiplier, see:
     https://mc-stan.org/docs/stan-users-guide/efficiency-tuning.html#standardizing-predictors
 Warning in 'string', line 4, column 9 to column 11:
-    The variable tt may not have been assigned a value before its use.
+    The variable tt may not have been assigned a value before its first use.
 $ node removed.js
 Syntax error in 'string', line 3, column 8 to column 10, parsing error:
    -------------------------------------------------


### PR DESCRIPTION
Fixes several issues:

- Functions are no longer considered uninitialized variables in things like higher-order function calls
- Uses of uninitialized variables from the transformed data block now properly lead to warnings
- Repeated uses of the same variable only warn on the first one

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improved the uninitialized variable warnings raised by pedantic mode and `--warn-uninitialized`. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
