### PR TITLE
Track additional locations for errors

### DIFF
--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -12,7 +12,18 @@ type originblock =
   | Model
   | GQuant
 
-type varinfo = {origin: originblock; global: bool; readonly: bool}
+let block_name = function
+  | MathLibrary -> "Stan Math Library"
+  | Functions -> "functions block"
+  | Data -> "data block"
+  | TData -> "transformed data block"
+  | Param -> "parameters block"
+  | TParam -> "transformed parameters block"
+  | Model -> "model block"
+  | GQuant -> "generated quantities block"
+
+type varinfo =
+  {origin: originblock; global: bool; readonly: bool; location: Location_span.t}
 
 type info =
   { type_: UnsizedType.t
@@ -20,7 +31,14 @@ type info =
       [ `Variable of varinfo
       | `UserDeclared of Location_span.t
       | `StanMath
-      | `UserDefined ] }
+      | `UserDefined of Location_span.t ] }
+
+let location = function
+  | {kind= `Variable {location; _}; _}
+   |{kind= `UserDeclared location; _}
+   |{kind= `UserDefined location; _} ->
+      Some location
+  | {kind= `StanMath; _} -> None
 
 type t = info list String.Map.t
 
@@ -34,7 +52,7 @@ let stan_math_environment =
     |> String.Map.of_alist_exn in
   functions
 
-let add env key type_ kind = Map.add_multi env ~key ~data:{type_; kind}
+let add env name type_ kind = Map.add_multi env ~key:name ~data:{type_; kind}
 let set_raw env key data = Map.set env ~key ~data
 let find env key = Map.find_multi env key
 let mem env key = Map.mem env key
@@ -96,17 +114,25 @@ module Distance = struct
       if name <> suggestion then Some suggestion else None
 end
 
-let max_distance = 3
+let max_distance_for_length l = if l < 10 then 3 else 5
 
 let nearest_ident env name =
-  try
-    (* catch any errors in distance and just ignore them, no big deal *)
-    Option.first_some
-      (Distance.find_min ~max:max_distance (Map.keys env) name)
-      (Utils.(
-         distribution_suffices
-         @ List.map ~f:(fun n -> "_" ^ n) cumulative_distribution_suffices_w_rng)
-      |> List.map ~f:(fun suffix -> name ^ suffix)
-      |> List.filter ~f:(Map.mem env)
-      |> List.hd)
-  with _ -> None
+  let open Common.Let_syntax.Option in
+  let* key =
+    try
+      (* catch any errors in distance and just ignore them, no big deal *)
+      Option.first_some
+        (Distance.find_min
+           ~max:(max_distance_for_length (String.length name))
+           (Map.keys env) name)
+        (Utils.(
+           distribution_suffices
+           @ List.map
+               ~f:(fun n -> "_" ^ n)
+               cumulative_distribution_suffices_w_rng)
+        |> List.map ~f:(fun suffix -> name ^ suffix)
+        |> List.filter ~f:(Map.mem env)
+        |> List.hd)
+    with _ -> None in
+  let+ values = Map.find env key in
+  (key, List.map ~f:location values)

--- a/src/frontend/Environment.mli
+++ b/src/frontend/Environment.mli
@@ -14,8 +14,11 @@ type originblock =
   | Model
   | GQuant
 
+val block_name : originblock -> string
+
 (** Information available for each variable *)
-type varinfo = {origin: originblock; global: bool; readonly: bool}
+type varinfo =
+  {origin: originblock; global: bool; readonly: bool; location: Location_span.t}
 
 type info =
   { type_: UnsizedType.t
@@ -23,7 +26,9 @@ type info =
       [ `Variable of varinfo
       | `UserDeclared of Location_span.t
       | `StanMath
-      | `UserDefined ] }
+      | `UserDefined of Location_span.t ] }
+
+val location : info -> Location_span.t option
 
 type t
 
@@ -36,10 +41,10 @@ val add :
      t
   -> string
   -> Middle.UnsizedType.t
-  -> [ `UserDeclared of Location_span.t
+  -> [ `Variable of varinfo
+     | `UserDeclared of Location_span.t
      | `StanMath
-     | `UserDefined
-     | `Variable of varinfo ]
+     | `UserDefined of Location_span.t ]
   -> t
 (** Add a new item to the type environment. Does not overwrite existing, but
     shadows *)
@@ -50,6 +55,6 @@ val set_raw : t -> string -> info list -> t
 val mem : t -> string -> bool
 val iteri : t -> (string -> info list -> unit) -> unit
 
-val nearest_ident : t -> string -> string option
+val nearest_ident : t -> string -> (string * Location_span.t option list) option
 (** The nearest identifier by edit distance, capped at edit distance 3 (if one
     exists) *)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -45,20 +45,26 @@ module TypeError = struct
         * UnsizedType.t list
         * UnsizedType.argumentlist
         * SignatureMismatch.function_mismatch
+        * Location_span.t option
     | IllTypedVariadic of
         string
         * UnsizedType.t list
         * UnsizedType.argumentlist
         * SignatureMismatch.function_mismatch
         * UnsizedType.t
+        * Location_span.t option
     | IllTypedForwardedFunctionSignature of
-        string * string * SignatureMismatch.details
+        string * string * SignatureMismatch.details * Location_span.t option
     | IllTypedForwardedFunctionApp of
-        string * string * string list * SignatureMismatch.details
+        string
+        * string
+        * string list
+        * SignatureMismatch.details
+        * Location_span.t option
     | IllTypedLaplaceHelperArgs of
         string * UnsizedType.argumentlist * SignatureMismatch.details
     | IllTypedLaplaceMarginal of string * bool * UnsizedType.argumentlist
-    | LaplaceCompatibilityIssue of string
+    | LaplaceCompatibilityIssue of string * Location_span.t
     | IlltypedLaplaceTooMany of string * int
     | IlltypedLaplaceHessianBlockSize of
         string * (UnsizedType.autodifftype * UnsizedType.t) option
@@ -66,17 +72,24 @@ module TypeError = struct
     | AmbiguousFunctionPromotion of
         string
         * UnsizedType.t list option
-        * (UnsizedType.returntype * UnsizedType.argumentlist) list
-    | ReturningFnExpectedNonReturningFound of string
-    | ReturningFnExpectedNonFnFound of string
+        * (UnsizedType.returntype
+          * UnsizedType.argumentlist
+          * Location_span.t option)
+          list
+    | ReturningFnExpectedNonReturningFound of string * Location_span.t option
+    | ReturningFnExpectedNonFnFound of string * Location_span.t option
     | ReturningFnExpectedUndeclaredDistSuffixFound of string * string
     | ReturningFnExpectedWrongDistSuffixFound of string * string
-    | NonReturningFnExpectedReturningFound of string
-    | NonReturningFnExpectedNonFnFound of string
+    | NonReturningFnExpectedReturningFound of string * Location_span.t option
+    | NonReturningFnExpectedNonFnFound of string * Location_span.t
     | FuncOverloadRtOnly of
-        string * UnsizedType.returntype * UnsizedType.returntype
-    | FuncDeclRedefined of string * UnsizedType.t * bool
-    | FunDeclExists of string
+        string
+        * UnsizedType.returntype
+        * UnsizedType.returntype
+        * Location_span.t option
+    | FuncDeclRedefined of string * UnsizedType.t * Location_span.t
+    | StanMathFuncRedefined of string * UnsizedType.t
+    | FunDeclExists of string * Location_span.t
     | FunDeclNoDefn of string
     | FunDeclNeedsBlock
     | NonRealProbFunDef of UnsizedType.returntype
@@ -199,23 +212,30 @@ module TypeError = struct
           (Stan_math_signatures.reduce_sum_slice_types
          |> Common.Nonempty_list.of_list_exn)
           found_type ty
-    | IllTypedReduceSum (name, arg_tys, expected_args, error) ->
-        SignatureMismatch.pp_signature_mismatch ppf
-          (name, arg_tys, ([((ReturnType UReal, expected_args), error)], false))
-    | IllTypedVariadic (name, arg_tys, args, error, return_type) ->
+    | IllTypedReduceSum (name, arg_tys, expected_args, error, _callback_location)
+      ->
         SignatureMismatch.pp_signature_mismatch ppf
           ( name
           , arg_tys
-          , ([((UnsizedType.ReturnType return_type, args), error)], false) )
+          , ([((ReturnType UReal, expected_args, None), error)], false) )
+    | IllTypedVariadic
+        (name, arg_tys, args, error, return_type, _callback_location) ->
+        SignatureMismatch.pp_signature_mismatch ppf
+          ( name
+          , arg_tys
+          , ([((UnsizedType.ReturnType return_type, args, None), error)], false)
+          )
     | IllTypedFunctionApp (name, arg_tys, errors) ->
         SignatureMismatch.pp_signature_mismatch ppf (name, arg_tys, errors)
-    | IllTypedForwardedFunctionApp (caller, name, skipped, details) ->
+    | IllTypedForwardedFunctionApp
+        (caller, name, skipped, details, _callback_location) ->
         Fmt.pf ppf
           "Cannot call %a@ with arguments forwarded from call to@ %a:@ %a"
           quoted name quoted caller
           (SignatureMismatch.pp_mismatch_details ~skipped)
           details
-    | IllTypedForwardedFunctionSignature (caller, name, details) ->
+    | IllTypedForwardedFunctionSignature
+        (caller, name, details, _callback_location) ->
         Fmt.pf ppf
           "Function %a does not have a valid signature for use in %a:@ %a"
           quoted name quoted caller
@@ -248,7 +268,7 @@ module TypeError = struct
              a function."
             n (Fmt.ordinal ()) (n + 1) in
         generic_laplace_usage info ppf (name, supplied)
-    | LaplaceCompatibilityIssue banned_function ->
+    | LaplaceCompatibilityIssue (banned_function, _call_location) ->
         Fmt.pf ppf
           "The function %a, called by this likelihood function,@ does not \
            currently support higher-order derivatives, and@ cannot be used in \
@@ -310,7 +330,7 @@ module TypeError = struct
           (laplace_tolerance_arg_name n)
           quoted name expected_types [expected] found_type found
     | AmbiguousFunctionPromotion (name, arg_tys, signatures) ->
-        let pp_sig ppf (rt, args) =
+        let pp_sig ppf (rt, args, _) =
           Fmt.pf ppf "@[<hov>(@[<hov>%a@]) => %a@]"
             Fmt.(list ~sep:comma UnsizedType.pp_fun_arg)
             args UnsizedType.pp_returntype rt in
@@ -327,22 +347,22 @@ module TypeError = struct
           arg_tys
           (Fmt.list ~sep:Fmt.cut pp_sig)
           signatures
-    | ReturningFnExpectedNonReturningFound fn_name ->
+    | ReturningFnExpectedNonReturningFound (fn_name, _prev_decl) ->
         Fmt.pf ppf
           "A returning function was expected but a non-returning function %a \
            was supplied."
           quoted fn_name
-    | NonReturningFnExpectedReturningFound fn_name ->
+    | NonReturningFnExpectedReturningFound (fn_name, _prev_decl) ->
         Fmt.pf ppf
           "A non-returning function was expected but a returning function %a \
            was supplied."
           quoted fn_name
-    | ReturningFnExpectedNonFnFound fn_name ->
+    | ReturningFnExpectedNonFnFound (fn_name, _prev_decl) ->
         Fmt.pf ppf
           "A returning function was expected but a non-function value %a was \
            supplied."
           quoted fn_name
-    | NonReturningFnExpectedNonFnFound fn_name ->
+    | NonReturningFnExpectedNonFnFound (fn_name, _prev_decl) ->
         Fmt.pf ppf
           "A non-returning function was expected but a non-function value %a \
            was supplied."
@@ -367,17 +387,20 @@ module TypeError = struct
           (prefix ^ "_" ^ suffix)
           quoted prefix quoted
           (prefix ^ "_" ^ newsuffix)
-    | FuncOverloadRtOnly (name, _, rt') ->
+    | FuncOverloadRtOnly (name, _, rt', _prev_decl) ->
         Fmt.pf ppf
           "Function %a cannot be overloaded by return type only. Previously \
            used return type %a"
           quoted name UnsizedType.pp_returntype rt'
-    | FuncDeclRedefined (name, ut, stan_math) ->
-        Fmt.pf ppf "Function %a %s signature %a" quoted name
-          (if stan_math then "is already declared in the Stan Math library with"
-           else "has already been declared for")
-          UnsizedType.pp ut
-    | FunDeclExists name ->
+    | FuncDeclRedefined (name, ut, _prev_decl) ->
+        Fmt.pf ppf "Function %a has already been declared for signature %a"
+          quoted name UnsizedType.pp ut
+    | StanMathFuncRedefined (name, ut) ->
+        Fmt.pf ppf
+          "Function %a is already declared in the Stan Math library with \
+           signature %a"
+          quoted name UnsizedType.pp ut
+    | FunDeclExists (name, _prev_decl) ->
         Fmt.pf ppf
           "Function %a has already been declared. A definition is expected."
           quoted name
@@ -419,15 +442,18 @@ module IdentifierError = struct
     | IsKeyword of string
     | IsModelName of string
     | IsStanMathName of string
-    | InUse of string
-    | NotInScope of string * string option
-    | ReturningFnExpectedUndeclaredIdentFound of string * string option
-    | NonReturningFnExpectedUndeclaredIdentFound of string * string option
+    | InUse of string * Location_span.t
+    | NotInScope of string * (string * Location_span.t option list) option
+    | ReturningFnExpectedUndeclaredIdentFound of
+        string * (string * Location_span.t option list) option
+    | NonReturningFnExpectedUndeclaredIdentFound of
+        string * (string * Location_span.t option list) option
     | UnnormalizedSuffix of string
-    | DuplicateArgNames of string
+    | DuplicateArgNames of Ast.identifier
 
-  let did_you_mean : string option Fmt.t =
-    Fmt.option @@ fun ppf s -> Fmt.pf ppf "@ Did you mean %a?" quoted s
+  let did_you_mean : (string * 'a) option Fmt.t =
+    Fmt.option @@ Fmt.using fst
+    @@ fun ppf s -> Fmt.pf ppf "@ Did you mean %a?" quoted s
 
   let pp ppf = function
     | IsStanMathName name ->
@@ -435,7 +461,8 @@ module IdentifierError = struct
           "Identifier %a clashes with a non-overloadable Stan Math library \
            function."
           quoted name
-    | InUse name -> Fmt.pf ppf "Identifier %a is already in use." quoted name
+    | InUse (name, _prev_decl) ->
+        Fmt.pf ppf "Identifier %a is already in use." quoted name
     | IsModelName name ->
         Fmt.pf ppf "Identifier %a clashes with model name." quoted name
     | IsKeyword name ->
@@ -458,11 +485,11 @@ module IdentifierError = struct
           "Identifier %a has a _lupdf/_lupmf suffix, which is only allowed for \
            functions."
           quoted name
-    | DuplicateArgNames name ->
+    | DuplicateArgNames id ->
         Fmt.pf ppf
           "@[All function arguments must have distinct identifiers.@ Argument \
            %a is duplicated.@]"
-          quoted name
+          quoted id.name
 end
 
 module ExpressionError = struct
@@ -593,8 +620,9 @@ end
 
 module StatementError = struct
   type t =
-    | CannotAssignToReadOnly of string
-    | CannotAssignToGlobal of string
+    | CannotAssignToReadOnly of string * Location_span.t option
+    | CannotAssignToGlobal of
+        string * Environment.originblock * Location_span.t option
     | CannotAssignFunction of string * UnsizedType.t
     | LValueMultiIndexing
     | LValueTupleUnpackDuplicates of Ast.untyped_lval list
@@ -609,20 +637,22 @@ module StatementError = struct
     | ContinueOutsideLoop
     | ExpressionReturnOutsideReturningFn
     | VoidReturnOutsideNonReturningFn
-    | NonDataVariableSizeDecl
+    | NonDataVariableSizeDecl of Environment.originblock * Location_span.t
     | NonIntBounds
     | ComplexTransform
     | IntegerParameter of bool
-    | IllTypedAssignment of Operator.t * UnsizedType.t * UnsizedType.t
+    | IllTypedAssignment of
+        Operator.t * Ast.typed_expr_meta * Ast.typed_expr_meta
 
   let pp ppf = function
-    | CannotAssignToReadOnly name ->
+    | CannotAssignToReadOnly (name, _prev_decl) ->
         Fmt.pf ppf "Cannot assign to function argument or loop identifier %a."
           quoted name
-    | CannotAssignToGlobal name ->
+    | CannotAssignToGlobal (name, block, _prev_decl) ->
         Fmt.pf ppf
-          "Cannot assign to global variable %a declared in previous blocks."
+          "Cannot assign to global variable %a declared previously in %s."
           quoted name
+          (Environment.block_name block)
     | CannotAssignFunction (name, ut) ->
         Fmt.pf ppf "Cannot assign a function type (%a) to variable %a."
           (actual_style UnsizedType.pp)
@@ -706,7 +736,7 @@ module StatementError = struct
            definitions."
           (expected_style Fmt.string)
           "void"
-    | NonDataVariableSizeDecl ->
+    | NonDataVariableSizeDecl (_block, _prev_decl) ->
         Fmt.pf ppf
           "Non-data variables are not allowed in top level size declarations."
     | NonIntBounds ->
@@ -723,7 +753,7 @@ module StatementError = struct
           "@[Ill-typed assignment statement.@ Expected the right hand side to \
            have a type matching the destination (%a).%a@]"
           (expected_style UnsizedType.pp)
-          lt found_type rt
+          lt.type_ found_type rt.type_
     | IllTypedAssignment (op, lt, rt) ->
         let pp_expected_types ppf signatures =
           match Common.Nonempty_list.of_list signatures with
@@ -732,14 +762,15 @@ module StatementError = struct
                 "There are no valid right hand sides for the given left hand \
                  side (%a)."
                 (actual_style UnsizedType.pp)
-                lt
+                lt.type_
           | Some args ->
               Fmt.pf ppf
                 "For the given left hand side (%a), expected the right hand \
                  side to have type@ %a.%a"
                 (expected_style UnsizedType.pp)
-                lt expected_types args found_type rt in
-        let sigs = SignatureMismatch.list_valid_assignmentoperator_rhs lt op in
+                lt.type_ expected_types args found_type rt.type_ in
+        let sigs =
+          SignatureMismatch.list_valid_assignmentoperator_rhs lt.type_ op in
         Fmt.pf ppf "@[Ill-typed assignment operator %a=.@ %a@]" Operator.pp op
           pp_expected_types sigs
 end
@@ -802,8 +833,8 @@ let illtyped_assignment loc assignop lt rt =
 let illtyped_ternary_if loc predt lt rt =
   (loc, ExpressionError (ExpressionError.IllTypedTernaryIf (predt, lt, rt)))
 
-let returning_fn_expected_nonreturning_found loc name =
-  (loc, TypeError (TypeError.ReturningFnExpectedNonReturningFound name))
+let returning_fn_expected_nonreturning_found loc name prev =
+  (loc, TypeError (TypeError.ReturningFnExpectedNonReturningFound (name, prev)))
 
 let illtyped_reduce_sum_not_array loc ty =
   (loc, TypeError (TypeError.IllTypedReduceSumNotArray ty))
@@ -811,24 +842,28 @@ let illtyped_reduce_sum_not_array loc ty =
 let illtyped_reduce_sum_slice loc ty =
   (loc, TypeError (TypeError.IllTypedReduceSumSlice ty))
 
-let illtyped_reduce_sum loc name arg_tys args error =
-  (loc, TypeError (TypeError.IllTypedReduceSum (name, arg_tys, args, error)))
-
-let illtyped_variadic loc name arg_tys args fn_rt error =
+let illtyped_reduce_sum loc name arg_tys args error prev =
   ( loc
-  , TypeError (TypeError.IllTypedVariadic (name, arg_tys, args, error, fn_rt))
+  , TypeError (TypeError.IllTypedReduceSum (name, arg_tys, args, error, prev))
   )
 
-let forwarded_function_application_error loc caller name required_args details =
+let illtyped_variadic loc name arg_tys args fn_rt error prev =
+  ( loc
+  , TypeError
+      (TypeError.IllTypedVariadic (name, arg_tys, args, error, fn_rt, prev)) )
+
+let forwarded_function_application_error loc caller name required_args details
+    prev =
   ( loc
   , TypeError
       (TypeError.IllTypedForwardedFunctionApp
-         (caller, name, required_args, details)) )
+         (caller, name, required_args, details, prev)) )
 
-let forwarded_function_signature_error loc caller name details =
+let forwarded_function_signature_error loc caller name details prev =
   ( loc
   , TypeError
-      (TypeError.IllTypedForwardedFunctionSignature (caller, name, details)) )
+      (TypeError.IllTypedForwardedFunctionSignature (caller, name, details, prev))
+  )
 
 let illtyped_laplace_helper_args loc name lik_args details =
   ( loc
@@ -837,8 +872,10 @@ let illtyped_laplace_helper_args loc name lik_args details =
 let illtyped_laplace_generic loc name early supplied =
   (loc, TypeError (TypeError.IllTypedLaplaceMarginal (name, early, supplied)))
 
-let laplace_compatibility loc banned_function =
-  (loc, TypeError (TypeError.LaplaceCompatibilityIssue banned_function))
+let laplace_compatibility loc banned_function use_location =
+  ( loc
+  , TypeError
+      (TypeError.LaplaceCompatibilityIssue (banned_function, use_location)) )
 
 let illtyped_laplace_extra_args loc name args =
   (loc, TypeError (TypeError.IlltypedLaplaceTooMany (name, args)))
@@ -854,8 +891,8 @@ let ambiguous_function_promotion loc name arg_tys signatures =
   , TypeError (TypeError.AmbiguousFunctionPromotion (name, arg_tys, signatures))
   )
 
-let returning_fn_expected_nonfn_found loc name =
-  (loc, TypeError (TypeError.ReturningFnExpectedNonFnFound name))
+let returning_fn_expected_nonfn_found loc name prev =
+  (loc, TypeError (TypeError.ReturningFnExpectedNonFnFound (name, prev)))
 
 let returning_fn_expected_undeclaredident_found loc name sug =
   ( loc
@@ -873,11 +910,11 @@ let returning_fn_expected_wrong_dist_suffix_found loc (prefix, suffix) =
   , TypeError
       (TypeError.ReturningFnExpectedWrongDistSuffixFound (prefix, suffix)) )
 
-let nonreturning_fn_expected_returning_found loc name =
-  (loc, TypeError (TypeError.NonReturningFnExpectedReturningFound name))
+let nonreturning_fn_expected_returning_found loc name prev =
+  (loc, TypeError (TypeError.NonReturningFnExpectedReturningFound (name, prev)))
 
-let nonreturning_fn_expected_nonfn_found loc name =
-  (loc, TypeError (TypeError.NonReturningFnExpectedNonFnFound name))
+let nonreturning_fn_expected_nonfn_found loc name prev =
+  (loc, TypeError (TypeError.NonReturningFnExpectedNonFnFound (name, prev)))
 
 let nonreturning_fn_expected_undeclaredident_found loc name sug =
   ( loc
@@ -915,7 +952,8 @@ let ident_is_model_name loc name =
 let ident_is_stanmath_name loc name =
   (loc, IdentifierError (IdentifierError.IsStanMathName name))
 
-let ident_in_use loc name = (loc, IdentifierError (IdentifierError.InUse name))
+let ident_in_use loc name prev =
+  (loc, IdentifierError (IdentifierError.InUse (name, prev)))
 
 let ident_not_in_scope loc name sug =
   (loc, IdentifierError (IdentifierError.NotInScope (name, sug)))
@@ -946,11 +984,11 @@ let empty_array loc = (loc, ExpressionError ExpressionError.EmptyArray)
 let empty_tuple loc = (loc, ExpressionError ExpressionError.EmptyTuple)
 let bad_int_literal loc = (loc, ExpressionError ExpressionError.IntTooLarge)
 
-let cannot_assign_to_read_only loc name =
-  (loc, StatementError (StatementError.CannotAssignToReadOnly name))
+let cannot_assign_to_read_only loc name prev =
+  (loc, StatementError (StatementError.CannotAssignToReadOnly (name, prev)))
 
-let cannot_assign_to_global loc name =
-  (loc, StatementError (StatementError.CannotAssignToGlobal name))
+let cannot_assign_to_global loc name block prev =
+  (loc, StatementError (StatementError.CannotAssignToGlobal (name, block, prev)))
 
 let cannot_assign_function loc name ut =
   (loc, StatementError (StatementError.CannotAssignFunction (name, ut)))
@@ -996,8 +1034,8 @@ let expression_return_outside_returning_fn loc =
 let void_outside_nonreturning_fn loc =
   (loc, StatementError StatementError.VoidReturnOutsideNonReturningFn)
 
-let non_data_variable_size_decl loc =
-  (loc, StatementError StatementError.NonDataVariableSizeDecl)
+let non_data_variable_size_decl loc block prev =
+  (loc, StatementError (StatementError.NonDataVariableSizeDecl (block, prev)))
 
 let non_int_bounds loc = (loc, StatementError StatementError.NonIntBounds)
 let complex_transform loc = (loc, StatementError StatementError.ComplexTransform)
@@ -1005,13 +1043,17 @@ let complex_transform loc = (loc, StatementError StatementError.ComplexTransform
 let no_int_params loc transformed =
   (loc, StatementError (StatementError.IntegerParameter transformed))
 
-let fn_overload_rt_only loc name rt1 rt2 =
-  (loc, TypeError (TypeError.FuncOverloadRtOnly (name, rt1, rt2)))
+let fn_overload_rt_only loc name rt1 rt2 prev =
+  (loc, TypeError (TypeError.FuncOverloadRtOnly (name, rt1, rt2, prev)))
 
-let fn_decl_redefined loc name ~stan_math ut =
-  (loc, TypeError (TypeError.FuncDeclRedefined (name, ut, stan_math)))
+let fn_decl_redefined loc name ut prev =
+  (loc, TypeError (TypeError.FuncDeclRedefined (name, ut, prev)))
 
-let fn_decl_exists loc name = (loc, TypeError (TypeError.FunDeclExists name))
+let stan_math_fn_redefined loc name ut =
+  (loc, TypeError (TypeError.StanMathFuncRedefined (name, ut)))
+
+let fn_decl_exists loc name prev =
+  (loc, TypeError (TypeError.FunDeclExists (name, prev)))
 
 let fn_decl_without_def loc name =
   (loc, TypeError (TypeError.FunDeclNoDefn name))
@@ -1027,8 +1069,8 @@ let prob_density_non_real_variate loc ut_opt =
 let prob_mass_non_int_variate loc ut_opt =
   (loc, TypeError (TypeError.ProbMassNonIntVariate ut_opt))
 
-let duplicate_arg_names loc name =
-  (loc, IdentifierError (IdentifierError.DuplicateArgNames name))
+let duplicate_arg_names loc id =
+  (loc, IdentifierError (IdentifierError.DuplicateArgNames id))
 
 let incompatible_return_types loc =
   (loc, TypeError TypeError.IncompatibleReturnType)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -833,8 +833,10 @@ let illtyped_assignment loc assignop lt rt =
 let illtyped_ternary_if loc predt lt rt =
   (loc, ExpressionError (ExpressionError.IllTypedTernaryIf (predt, lt, rt)))
 
-let returning_fn_expected_nonreturning_found loc name prev =
-  (loc, TypeError (TypeError.ReturningFnExpectedNonReturningFound (name, prev)))
+let returning_fn_expected_nonreturning_found loc name decl_loc =
+  ( loc
+  , TypeError (TypeError.ReturningFnExpectedNonReturningFound (name, decl_loc))
+  )
 
 let illtyped_reduce_sum_not_array loc ty =
   (loc, TypeError (TypeError.IllTypedReduceSumNotArray ty))
@@ -842,28 +844,30 @@ let illtyped_reduce_sum_not_array loc ty =
 let illtyped_reduce_sum_slice loc ty =
   (loc, TypeError (TypeError.IllTypedReduceSumSlice ty))
 
-let illtyped_reduce_sum loc name arg_tys args error prev =
-  ( loc
-  , TypeError (TypeError.IllTypedReduceSum (name, arg_tys, args, error, prev))
-  )
-
-let illtyped_variadic loc name arg_tys args fn_rt error prev =
+let illtyped_reduce_sum loc name arg_tys args error callback_loc =
   ( loc
   , TypeError
-      (TypeError.IllTypedVariadic (name, arg_tys, args, error, fn_rt, prev)) )
+      (TypeError.IllTypedReduceSum (name, arg_tys, args, error, callback_loc))
+  )
+
+let illtyped_variadic loc name arg_tys args fn_rt error callback_loc =
+  ( loc
+  , TypeError
+      (TypeError.IllTypedVariadic
+         (name, arg_tys, args, error, fn_rt, callback_loc)) )
 
 let forwarded_function_application_error loc caller name required_args details
-    prev =
+    callback_loc =
   ( loc
   , TypeError
       (TypeError.IllTypedForwardedFunctionApp
-         (caller, name, required_args, details, prev)) )
+         (caller, name, required_args, details, callback_loc)) )
 
-let forwarded_function_signature_error loc caller name details prev =
+let forwarded_function_signature_error loc caller name details callback_loc =
   ( loc
   , TypeError
-      (TypeError.IllTypedForwardedFunctionSignature (caller, name, details, prev))
-  )
+      (TypeError.IllTypedForwardedFunctionSignature
+         (caller, name, details, callback_loc)) )
 
 let illtyped_laplace_helper_args loc name lik_args details =
   ( loc
@@ -891,8 +895,8 @@ let ambiguous_function_promotion loc name arg_tys signatures =
   , TypeError (TypeError.AmbiguousFunctionPromotion (name, arg_tys, signatures))
   )
 
-let returning_fn_expected_nonfn_found loc name prev =
-  (loc, TypeError (TypeError.ReturningFnExpectedNonFnFound (name, prev)))
+let returning_fn_expected_nonfn_found loc name decl_loc =
+  (loc, TypeError (TypeError.ReturningFnExpectedNonFnFound (name, decl_loc)))
 
 let returning_fn_expected_undeclaredident_found loc name sug =
   ( loc
@@ -910,11 +914,13 @@ let returning_fn_expected_wrong_dist_suffix_found loc (prefix, suffix) =
   , TypeError
       (TypeError.ReturningFnExpectedWrongDistSuffixFound (prefix, suffix)) )
 
-let nonreturning_fn_expected_returning_found loc name prev =
-  (loc, TypeError (TypeError.NonReturningFnExpectedReturningFound (name, prev)))
+let nonreturning_fn_expected_returning_found loc name decl_loc =
+  ( loc
+  , TypeError (TypeError.NonReturningFnExpectedReturningFound (name, decl_loc))
+  )
 
-let nonreturning_fn_expected_nonfn_found loc name prev =
-  (loc, TypeError (TypeError.NonReturningFnExpectedNonFnFound (name, prev)))
+let nonreturning_fn_expected_nonfn_found loc name decl_loc =
+  (loc, TypeError (TypeError.NonReturningFnExpectedNonFnFound (name, decl_loc)))
 
 let nonreturning_fn_expected_undeclaredident_found loc name sug =
   ( loc
@@ -952,8 +958,8 @@ let ident_is_model_name loc name =
 let ident_is_stanmath_name loc name =
   (loc, IdentifierError (IdentifierError.IsStanMathName name))
 
-let ident_in_use loc name prev =
-  (loc, IdentifierError (IdentifierError.InUse (name, prev)))
+let ident_in_use loc name decl_loc =
+  (loc, IdentifierError (IdentifierError.InUse (name, decl_loc)))
 
 let ident_not_in_scope loc name sug =
   (loc, IdentifierError (IdentifierError.NotInScope (name, sug)))
@@ -984,11 +990,13 @@ let empty_array loc = (loc, ExpressionError ExpressionError.EmptyArray)
 let empty_tuple loc = (loc, ExpressionError ExpressionError.EmptyTuple)
 let bad_int_literal loc = (loc, ExpressionError ExpressionError.IntTooLarge)
 
-let cannot_assign_to_read_only loc name prev =
-  (loc, StatementError (StatementError.CannotAssignToReadOnly (name, prev)))
+let cannot_assign_to_read_only loc name decl_loc =
+  (loc, StatementError (StatementError.CannotAssignToReadOnly (name, decl_loc)))
 
-let cannot_assign_to_global loc name block prev =
-  (loc, StatementError (StatementError.CannotAssignToGlobal (name, block, prev)))
+let cannot_assign_to_global loc name block decl_loc =
+  ( loc
+  , StatementError (StatementError.CannotAssignToGlobal (name, block, decl_loc))
+  )
 
 let cannot_assign_function loc name ut =
   (loc, StatementError (StatementError.CannotAssignFunction (name, ut)))
@@ -1034,8 +1042,10 @@ let expression_return_outside_returning_fn loc =
 let void_outside_nonreturning_fn loc =
   (loc, StatementError StatementError.VoidReturnOutsideNonReturningFn)
 
-let non_data_variable_size_decl loc block prev =
-  (loc, StatementError (StatementError.NonDataVariableSizeDecl (block, prev)))
+let non_data_variable_size_decl loc block other_decl_loc =
+  ( loc
+  , StatementError
+      (StatementError.NonDataVariableSizeDecl (block, other_decl_loc)) )
 
 let non_int_bounds loc = (loc, StatementError StatementError.NonIntBounds)
 let complex_transform loc = (loc, StatementError StatementError.ComplexTransform)
@@ -1043,17 +1053,17 @@ let complex_transform loc = (loc, StatementError StatementError.ComplexTransform
 let no_int_params loc transformed =
   (loc, StatementError (StatementError.IntegerParameter transformed))
 
-let fn_overload_rt_only loc name rt1 rt2 prev =
-  (loc, TypeError (TypeError.FuncOverloadRtOnly (name, rt1, rt2, prev)))
+let fn_overload_rt_only loc name rt1 rt2 overload_loc =
+  (loc, TypeError (TypeError.FuncOverloadRtOnly (name, rt1, rt2, overload_loc)))
 
-let fn_decl_redefined loc name ut prev =
-  (loc, TypeError (TypeError.FuncDeclRedefined (name, ut, prev)))
+let fn_decl_redefined loc name ut original_loc =
+  (loc, TypeError (TypeError.FuncDeclRedefined (name, ut, original_loc)))
 
 let stan_math_fn_redefined loc name ut =
   (loc, TypeError (TypeError.StanMathFuncRedefined (name, ut)))
 
-let fn_decl_exists loc name prev =
-  (loc, TypeError (TypeError.FunDeclExists (name, prev)))
+let fn_decl_exists loc name original_loc =
+  (loc, TypeError (TypeError.FunDeclExists (name, original_loc)))
 
 let fn_decl_without_def loc name =
   (loc, TypeError (TypeError.FunDeclNoDefn name))

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -24,16 +24,26 @@ val array_vector_rowvector_matrix_expected :
   Location_span.t -> UnsizedType.t -> t
 
 val illtyped_assignment :
-  Location_span.t -> Operator.t -> UnsizedType.t -> UnsizedType.t -> t
+     Location_span.t
+  -> Operator.t
+  -> Ast.typed_expr_meta
+  -> Ast.typed_expr_meta
+  -> t
 
 val illtyped_ternary_if :
   Location_span.t -> UnsizedType.t -> UnsizedType.t -> UnsizedType.t -> t
 
-val returning_fn_expected_nonreturning_found : Location_span.t -> string -> t
-val returning_fn_expected_nonfn_found : Location_span.t -> string -> t
+val returning_fn_expected_nonreturning_found :
+  Location_span.t -> string -> Location_span.t option -> t
+
+val returning_fn_expected_nonfn_found :
+  Location_span.t -> string -> Location_span.t option -> t
 
 val returning_fn_expected_undeclaredident_found :
-  Location_span.t -> string -> string option -> t
+     Location_span.t
+  -> string
+  -> (string * Location_span.t option list) option
+  -> t
 
 val returning_fn_expected_undeclared_dist_suffix_found :
   Location_span.t -> string * string -> t
@@ -50,13 +60,17 @@ val illtyped_reduce_sum :
   -> UnsizedType.t list
   -> UnsizedType.argumentlist
   -> SignatureMismatch.function_mismatch
+  -> Location_span.t option
   -> t
 
 val ambiguous_function_promotion :
      Location_span.t
   -> string
   -> UnsizedType.t list option
-  -> (UnsizedType.returntype * UnsizedType.argumentlist) list
+  -> (UnsizedType.returntype
+     * UnsizedType.argumentlist
+     * Location_span.t option)
+     list
   -> t
 
 val illtyped_variadic :
@@ -66,10 +80,16 @@ val illtyped_variadic :
   -> UnsizedType.argumentlist
   -> UnsizedType.t
   -> SignatureMismatch.function_mismatch
+  -> Location_span.t option
   -> t
 
 val forwarded_function_signature_error :
-  Location_span.t -> string -> string -> SignatureMismatch.details -> t
+     Location_span.t
+  -> string
+  -> string
+  -> SignatureMismatch.details
+  -> Location_span.t option
+  -> t
 
 val forwarded_function_application_error :
      Location_span.t
@@ -77,6 +97,7 @@ val forwarded_function_application_error :
   -> string
   -> string list
   -> SignatureMismatch.details
+  -> Location_span.t option
   -> t
 
 val illtyped_laplace_helper_args :
@@ -92,7 +113,7 @@ val illtyped_laplace_generic :
     function arguments are misplaced, both of which prevent us from giving a
     better message *)
 
-val laplace_compatibility : Location_span.t -> string -> t
+val laplace_compatibility : Location_span.t -> string -> Location_span.t -> t
 val illtyped_laplace_extra_args : Location_span.t -> string -> int -> t
 
 val illtyped_laplace_hessian_block_size_arg :
@@ -104,11 +125,17 @@ val illtyped_laplace_hessian_block_size_arg :
 val illtyped_laplace_tolerance_args :
   Location_span.t -> string -> SignatureMismatch.function_mismatch -> t
 
-val nonreturning_fn_expected_returning_found : Location_span.t -> string -> t
-val nonreturning_fn_expected_nonfn_found : Location_span.t -> string -> t
+val nonreturning_fn_expected_returning_found :
+  Location_span.t -> string -> Location_span.t option -> t
+
+val nonreturning_fn_expected_nonfn_found :
+  Location_span.t -> string -> Location_span.t -> t
 
 val nonreturning_fn_expected_undeclaredident_found :
-  Location_span.t -> string -> string option -> t
+     Location_span.t
+  -> string
+  -> (string * Location_span.t option list) option
+  -> t
 
 val illtyped_fn_app :
      Location_span.t
@@ -128,8 +155,14 @@ val not_indexable : Location_span.t -> UnsizedType.t -> int -> t
 val ident_is_keyword : Location_span.t -> string -> t
 val ident_is_model_name : Location_span.t -> string -> t
 val ident_is_stanmath_name : Location_span.t -> string -> t
-val ident_in_use : Location_span.t -> string -> t
-val ident_not_in_scope : Location_span.t -> string -> string option -> t
+val ident_in_use : Location_span.t -> string -> Location_span.t -> t
+
+val ident_not_in_scope :
+     Location_span.t
+  -> string
+  -> (string * Location_span.t option list) option
+  -> t
+
 val invalid_decl_rng_fn : Location_span.t -> t
 val invalid_rng_fn : Location_span.t -> t
 val invalid_unnormalized_fn : Location_span.t -> t
@@ -141,8 +174,17 @@ val not_printable : Location_span.t -> t
 val empty_array : Location_span.t -> t
 val empty_tuple : Location_span.t -> t
 val bad_int_literal : Location_span.t -> t
-val cannot_assign_to_read_only : Location_span.t -> string -> t
-val cannot_assign_to_global : Location_span.t -> string -> t
+
+val cannot_assign_to_read_only :
+  Location_span.t -> string -> Location_span.t option -> t
+
+val cannot_assign_to_global :
+     Location_span.t
+  -> string
+  -> Environment.originblock
+  -> Location_span.t option
+  -> t
+
 val cannot_assign_function : Location_span.t -> string -> UnsizedType.t -> t
 val cannot_assign_to_multiindex : Location_span.t -> t
 
@@ -163,7 +205,10 @@ val break_outside_loop : Location_span.t -> t
 val continue_outside_loop : Location_span.t -> t
 val expression_return_outside_returning_fn : Location_span.t -> t
 val void_outside_nonreturning_fn : Location_span.t -> t
-val non_data_variable_size_decl : Location_span.t -> t
+
+val non_data_variable_size_decl :
+  Location_span.t -> Environment.originblock -> Location_span.t -> t
+
 val non_int_bounds : Location_span.t -> t
 val complex_transform : Location_span.t -> t
 val no_int_params : Location_span.t -> bool -> t
@@ -173,16 +218,18 @@ val fn_overload_rt_only :
   -> string
   -> UnsizedType.returntype
   -> UnsizedType.returntype
+  -> Location_span.t option
   -> t
 
 val fn_decl_redefined :
-  Location_span.t -> string -> stan_math:bool -> UnsizedType.t -> t
+  Location_span.t -> string -> UnsizedType.t -> Location_span.t -> t
 
-val fn_decl_exists : Location_span.t -> string -> t
+val stan_math_fn_redefined : Location_span.t -> string -> UnsizedType.t -> t
+val fn_decl_exists : Location_span.t -> string -> Location_span.t -> t
 val fn_decl_without_def : Location_span.t -> string -> t
 val fn_decl_needs_block : Location_span.t -> t
 val non_real_prob_fn_def : Location_span.t -> UnsizedType.returntype -> t
 val prob_density_non_real_variate : Location_span.t -> UnsizedType.t option -> t
 val prob_mass_non_int_variate : Location_span.t -> UnsizedType.t option -> t
-val duplicate_arg_names : Location_span.t -> string -> t
+val duplicate_arg_names : Location_span.t -> Ast.identifier -> t
 val incompatible_return_types : Location_span.t -> t

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -77,11 +77,16 @@ and function_mismatch =
   | ArgNumMismatch of int * int
 
 type signature_error =
-  (UnsizedType.returntype * UnsizedType.argumentlist) * function_mismatch
+  (UnsizedType.returntype * UnsizedType.argumentlist * Location_span.t option)
+  * function_mismatch
 
 type ('unique, 'error) generic_match_result =
   | UniqueMatch of 'unique
-  | AmbiguousMatch of (UnsizedType.returntype * UnsizedType.argumentlist) list
+  | AmbiguousMatch of
+      (UnsizedType.returntype
+      * UnsizedType.argumentlist
+      * Location_span.t option)
+      list
   | SignatureErrors of 'error
 [@@deriving sexp]
 
@@ -89,6 +94,7 @@ type match_result =
   ( UnsizedType.returntype
     * (bool Middle.Fun_kind.suffix -> Ast.fun_kind)
     * Promotion.t list
+    * Location_span.t option
   , signature_error list * bool )
   generic_match_result
 
@@ -220,11 +226,12 @@ let check_compatible_arguments_no_promotion t1 t2 =
 let max_n_errors = 5
 
 let extract_function_types f =
+  let location = Environment.location f in
   match f with
   | Environment.{type_= UFun (args, return, _, mem); kind= `StanMath} ->
-      Some (return, args, (fun x -> Ast.StanLib x), mem)
+      Some (return, args, (fun x -> Ast.StanLib x), mem, location)
   | {type_= UFun (args, return, _, mem); _} ->
-      Some (return, args, (fun x -> UserDefined x), mem)
+      Some (return, args, (fun x -> UserDefined x), mem, location)
   | _ -> None
 
 let unique_minimum_promotion promotion_options =
@@ -251,13 +258,13 @@ let find_compatible_rt function_types args =
      here *)
   let matches, errors =
     List.partition_map function_types
-      ~f:(fun (rt, tys, funkind_constructor, _) ->
+      ~f:(fun (rt, tys, funkind_constructor, _, loc) ->
         match check_compatible_arguments 0 tys args with
-        | Ok p -> Either.First (((rt, tys), funkind_constructor), p)
-        | Error e -> Second ((rt, tys), e)) in
+        | Ok p -> Either.First (((rt, tys, loc), funkind_constructor), p)
+        | Error e -> Second ((rt, tys, loc), e)) in
   match unique_minimum_promotion matches with
-  | Ok (((rt, _), funkind_constructor), p) ->
-      UniqueMatch (rt, funkind_constructor, p)
+  | Ok (((rt, _, l), funkind_constructor), p) ->
+      UniqueMatch (rt, funkind_constructor, p, l)
   | Error (Some e) ->
       AmbiguousMatch (List.map ~f:fst e)
       (* return the return types and argument types of ambiguous matches *)
@@ -273,7 +280,7 @@ let matching_function env name args =
   let function_types =
     Environment.find env name
     |> List.filter_map ~f:extract_function_types
-    |> List.sort ~compare:(fun (ret1, _, _, _) (ret2, _, _, _) ->
+    |> List.sort ~compare:(fun (ret1, _, _, _, _) (ret2, _, _, _, _) ->
         UnsizedType.compare_returntype ret1 ret2) in
   find_compatible_rt function_types args
 
@@ -281,13 +288,13 @@ let matching_stanlib_function =
   matching_function Environment.stan_math_environment
 
 let check_variadic_args ~allow_lpdf mandatory_arg_tys mandatory_fun_arg_tys
-    fun_return args =
+    location fun_return args =
   let minimal_func_type =
     UnsizedType.UFun (mandatory_fun_arg_tys, ReturnType fun_return, FnPlain, AoS)
   in
   let minimal_args =
     (UnsizedType.AutoDiffable, minimal_func_type) :: mandatory_arg_tys in
-  let wrap_err x = Error (minimal_args, ArgError (1, x)) in
+  let wrap_err x = Error (minimal_args, ArgError (1, x), location) in
   match args with
   | ( _
     , (UnsizedType.UFun (fun_args, ReturnType return_type, suffix, _) as
@@ -315,11 +322,11 @@ let check_variadic_args ~allow_lpdf mandatory_arg_tys mandatory_fun_arg_tys
                   ((UnsizedType.AutoDiffable, func_type) :: mandatory_arg_tys)
                   @ variadic_arg_tys in
                 check_compatible_arguments 0 expected_args args
-                |> Result.map ~f:(fun x -> (func_type, x))
-                |> Result.map_error ~f:(fun x -> (expected_args, x)))
+                |> Result.map ~f:(fun x -> ((func_type, location), x))
+                |> Result.map_error ~f:(fun x -> (expected_args, x, location)))
       else wrap_func_error (SuffixMismatch (FnPlain, suffix))
   | (_, x) :: _ -> TypeMismatch (minimal_func_type, x, None) |> wrap_err
-  | [] -> Error ([], ArgNumMismatch (List.length mandatory_arg_tys, 0))
+  | [] -> Error ([], ArgNumMismatch (List.length mandatory_arg_tys, 0), location)
 
 let suffix_str = function
   | Fun_kind.FnPlain -> "a pure function"
@@ -483,7 +490,7 @@ let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
   let pp_args =
     pp_with_where ctx (fun ppf ->
         pf ppf "(@[<hov>%a@])" (list ~sep:comma (pp_unsized_type ctx))) in
-  let pp_signature ppf ((rt, args), err) =
+  let pp_signature ppf ((rt, args, _), err) =
     let fun_ty = UnsizedType.UFun (args, rt, FnPlain, AoS) in
     Fmt.pf ppf "%a@ @[<hov 2>  %a@]"
       (pp_with_where ctx (pp_fundef ctx))

--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -15,11 +15,16 @@ and function_mismatch = private
   | ArgNumMismatch of int * int
 
 type signature_error =
-  (UnsizedType.returntype * UnsizedType.argumentlist) * function_mismatch
+  (UnsizedType.returntype * UnsizedType.argumentlist * Location_span.t option)
+  * function_mismatch
 
 type ('unique, 'error) generic_match_result =
   | UniqueMatch of 'unique
-  | AmbiguousMatch of (UnsizedType.returntype * UnsizedType.argumentlist) list
+  | AmbiguousMatch of
+      (UnsizedType.returntype
+      * UnsizedType.argumentlist
+      * Location_span.t option)
+      list
   | SignatureErrors of 'error
 
 (** The match result for general (non-variadic) functions *)
@@ -27,6 +32,7 @@ type match_result =
   ( UnsizedType.returntype
     * (bool Middle.Fun_kind.suffix -> Ast.fun_kind)
     * Promotion.t list
+    * Location_span.t option
   , signature_error list * bool )
   generic_match_result
 
@@ -60,10 +66,11 @@ val check_variadic_args :
      allow_lpdf:bool
   -> UnsizedType.argumentlist
   -> UnsizedType.argumentlist
+  -> Location_span.t option
   -> UnsizedType.t
   -> UnsizedType.argumentlist
-  -> ( UnsizedType.t * Promotion.t list
-     , UnsizedType.argumentlist * function_mismatch )
+  -> ( (UnsizedType.t * Location_span.t option) * Promotion.t list
+     , UnsizedType.argumentlist * function_mismatch * Location_span.t option )
      result
 (** Check variadic function arguments. If a match is found, returns [Ok] of the
     function type and a list of promotions (see [promote]) If none is found,
@@ -88,12 +95,7 @@ val pp_mismatch_details :
 
 val pp_signature_mismatch :
      Format.formatter
-  -> string
-     * UnsizedType.t list
-     * (((UnsizedType.returntype * UnsizedType.argumentlist)
-        * function_mismatch)
-        list
-       * bool)
+  -> string * UnsizedType.t list * (signature_error list * bool)
   -> unit
 
 val list_valid_assignmentoperator_rhs :

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -128,11 +128,14 @@ let verify_identifier id : unit =
 let verify_name_fresh_var loc tenv name =
   if Utils.is_unnormalized_distribution name then
     Semantic_error.ident_has_unnormalized_suffix loc name |> error
-  else if
-    List.exists (Env.find tenv name) ~f:(function
-      | {kind= `Variable _; _} -> true
-      | _ -> false (* user variables can shadow function names *))
-  then Semantic_error.ident_in_use loc name |> error
+  else
+    match
+      List.filter_map (Env.find tenv name) ~f:(function
+        | {kind= `Variable {location; _}; _} -> Some location
+        | _ -> None (* user variables can shadow function names *))
+    with
+    | [] -> ()
+    | prev :: _ -> Semantic_error.ident_in_use loc name prev |> error
 
 (** verify that the variable being declared is previous unused. *)
 let verify_name_fresh_udf loc tenv name =
@@ -143,13 +146,16 @@ let verify_name_fresh_udf loc tenv name =
   then Semantic_error.ident_is_stanmath_name loc name |> error
   else if Utils.is_unnormalized_distribution name then
     Semantic_error.udf_is_unnormalized_fn loc name |> error
-  else if
+  else
     (* if a variable is already defined with this name - not really possible as
        all functions are defined before data, but future-proofing is good *)
-    List.exists
-      ~f:(function {kind= `Variable _; _} -> true | _ -> false)
-      (Env.find tenv name)
-  then Semantic_error.ident_in_use loc name |> error
+    match
+      List.filter_map (Env.find tenv name) ~f:(function
+        | {kind= `Variable {location; _}; _} -> Some location
+        | _ -> None)
+    with
+    | [] -> ()
+    | prev :: _ -> Semantic_error.ident_in_use loc name prev |> error
 
 (** Checks that a variable/function name:
     - a function/identifier does not have the _lupdf/_lupmf suffix
@@ -191,7 +197,7 @@ let check_ternary_if loc pe te fe =
       |> error
 
 let match_to_rt_option = function
-  | SignatureMismatch.UniqueMatch (rt, _, _) -> Some rt
+  | SignatureMismatch.UniqueMatch (rt, _, _, _) -> Some rt
   | _ -> None
 
 let stan_math_return_type name arg_tys =
@@ -212,7 +218,7 @@ let operator_stan_math_return_type op arg_tys =
       Stan_math_signatures.operator_to_stan_math_fns op
       |> List.filter_map ~f:(fun name ->
           SignatureMismatch.matching_stanlib_function name arg_tys |> function
-          | SignatureMismatch.UniqueMatch (rt, _, p) -> Some (rt, p)
+          | SignatureMismatch.UniqueMatch (rt, _, p, _) -> Some (rt, p)
           | _ -> None)
       |> List.hd
 
@@ -271,25 +277,30 @@ let check_id cf loc tenv id =
   | {kind= `StanMath; _} :: _ ->
       ( calculate_autodifftype cf MathLibrary UMathLibraryFunction
       , UnsizedType.UMathLibraryFunction )
-  | {kind= `Variable {origin= Param | TParam | GQuant; _}; _} :: _
+  | { kind=
+        `Variable
+          {origin= (Param | TParam | GQuant) as origin; location= prev; _}
+    ; _ }
+    :: _
     when cf.in_toplevel_decl ->
-      Semantic_error.non_data_variable_size_decl loc |> error
+      Semantic_error.non_data_variable_size_decl loc origin prev |> error
   | _ :: _
     when Utils.is_unnormalized_distribution id.name
          && not
               ((in_udf_distribution cf || in_lp_function cf)
               || cf.current_block = Model) ->
       Semantic_error.invalid_unnormalized_fn loc |> error
-  | {kind= `Variable {origin; _}; type_} :: _ ->
+  | {kind= `Variable {origin; _}; type_; _} :: _ ->
       (calculate_autodifftype cf origin type_, type_)
-  | { kind= `UserDefined | `UserDeclared _
-    ; type_= UFun (args, rt, (FnLpdf _ | FnLpmf _), mem_pattern) }
+  | { kind= `UserDefined _ | `UserDeclared _
+    ; type_= UFun (args, rt, (FnLpdf _ | FnLpmf _), mem_pattern)
+    ; _ }
     :: _ ->
       let type_ =
         UnsizedType.UFun
           (args, rt, Fun_kind.suffix_from_name id.name, mem_pattern) in
       (calculate_autodifftype cf Functions type_, type_)
-  | {kind= `UserDefined | `UserDeclared _; type_} :: _ ->
+  | {kind= `UserDefined _ | `UserDeclared _; type_; _} :: _ ->
       (calculate_autodifftype cf Functions type_, type_)
 
 let check_variable cf loc tenv id =
@@ -504,13 +515,14 @@ let mk_fun_app ~is_cond_dist ~loc kind name args ~type_ : Ast.typed_expression =
 
 let check_normal_fn ~is_cond_dist loc tenv id es =
   match Env.find tenv (Utils.normalized_name id.name) with
-  | {kind= `Variable _; _} :: _
+  | {kind= `Variable {location= prev; _}; _} :: _
   (* variables can sometimes shadow stanlib functions, so we have to check
      this *)
     when not
            (Stan_math_signatures.is_stan_math_function_name
               (Utils.normalized_name id.name)) ->
-      Semantic_error.returning_fn_expected_nonfn_found loc id.name |> error
+      Semantic_error.returning_fn_expected_nonfn_found loc id.name (Some prev)
+      |> error
   | [] ->
       (match Utils.split_distribution_suffix id.name with
         | Some (prefix, suffix) -> (
@@ -549,10 +561,11 @@ let check_normal_fn ~is_cond_dist loc tenv id es =
       match
         SignatureMismatch.matching_function tenv id.name (get_arg_types es)
       with
-      | UniqueMatch (Void, _, _) ->
+      | UniqueMatch (Void, _, _, prev) ->
           Semantic_error.returning_fn_expected_nonreturning_found loc id.name
+            prev
           |> error
-      | UniqueMatch (ReturnType ut, fnk, promotions) ->
+      | UniqueMatch (ReturnType ut, fnk, promotions, _) ->
           mk_fun_app ~is_cond_dist ~loc
             (fnk (Fun_kind.suffix_from_name id.name))
             id
@@ -578,10 +591,11 @@ let find_matching_first_order_fn tenv matches fname =
   let ok, errs = List.partition_map candidates ~f:Result.to_either in
   match SignatureMismatch.unique_minimum_promotion ok with
   | Ok a -> SignatureMismatch.UniqueMatch a
-  | Error (Some promotions) ->
-      List.filter_map promotions ~f:(function
-        | UnsizedType.UFun (args, rt, _, _) -> Some (rt, args)
-        | _ -> None)
+  | Error (Some tys) ->
+      List.filter_map tys ~f:(fun (ty, loc) ->
+          match ty with
+          | UnsizedType.UFun (args, rt, _, _) -> Some (rt, args, loc)
+          | _ -> None)
       |> AmbiguousMatch
   | Error None -> SignatureMismatch.SignatureErrors (List.hd_exn errs)
 
@@ -621,11 +635,11 @@ let verify_second_order_derivative_compatibility (ast : typed_program) =
     if Set.mem visited fn_name then visited
     else
       let rec check_expr seen = function
-        | {expr= FunApp (StanLib _, {name; _}, _); _}
+        | {expr= FunApp (StanLib _, {name; id_loc= call_loc}, _); _}
           when Stan_math_signatures.lacks_higher_order_autodiff name ->
             (* note: we could possibly check all the arguments are DataOnly and
                still allow it, but those seem like mostly useless cases. *)
-            Semantic_error.laplace_compatibility id_loc name |> error
+            Semantic_error.laplace_compatibility id_loc name call_loc |> error
         | {expr= FunApp (UserDefined _, name, es); _} ->
             (* we want the location to be the use-site no matter what *)
             let seen' = check_fun seen {name with id_loc} in
@@ -657,18 +671,22 @@ let check_function_callable_with_tuple cf tenv caller_id fname
          caller_id.name) in
   let required_arg_names, required_arg_types = List.unzip required_args in
   let required = required_arg_types @ arg_types in
-  let matches = function
+  let matches info =
+    let location = Env.location info in
+    match info with
     | Env.{type_= UnsizedType.UFun (args, return_type, sfx, _) as fn_type; _} ->
         let open SignatureMismatch in
         let open Common.Let_syntax.Result in
         if return_type <> required_fn_return_type then
           Error
             (`FnRequirementsError
-               (ReturnTypeMismatch (required_fn_return_type, return_type)))
+               ( ReturnTypeMismatch (required_fn_return_type, return_type)
+               , location ))
         else if sfx <> FnPlain then
           Error
             (`FnRequirementsError
-               (SuffixMismatch (FnPlain, Fun_kind.forget_normalization sfx)))
+               ( SuffixMismatch (FnPlain, Fun_kind.forget_normalization sfx)
+               , location ))
         else
           let no_prom_args, _ =
             List.split_n args (List.length required_arg_types) in
@@ -681,15 +699,15 @@ let check_function_callable_with_tuple cf tenv caller_id fname
              check_compatible_arguments_no_promotion no_prom_args
                required_arg_types)
             |> Result.map_error ~f:(fun x ->
-                `FnRequirementsError (InputMismatch x)) in
+                `FnRequirementsError (InputMismatch x, location)) in
           let+ promotions =
             check_compatible_arguments_mod_conv args required
             |> Result.map_error ~f:(fun x ->
-                `SuppliedArgsMismatch (InputMismatch x)) in
-          (fn_type, promotions)
-    | _ -> Error `NonFunction in
+                `SuppliedArgsMismatch (InputMismatch x, location)) in
+          ((fn_type, location), promotions)
+    | _ -> Error (`NonFunction location) in
   match find_matching_first_order_fn tenv matches fname with
-  | SignatureMismatch.UniqueMatch (ftype, promotions) ->
+  | SignatureMismatch.UniqueMatch ((ftype, _), promotions) ->
       let fn = make_function_variable cf fname.id_loc fname ftype in
       let args =
         Promotion.promote arg_tupl
@@ -701,16 +719,17 @@ let check_function_callable_with_tuple cf tenv caller_id fname
       Semantic_error.ambiguous_function_promotion fname.id_loc fname.name None
         ps
       |> error
-  | SignatureErrors `NonFunction ->
+  | SignatureErrors (`NonFunction prev) ->
       Semantic_error.returning_fn_expected_nonfn_found fname.id_loc fname.name
+        prev
       |> error
-  | SignatureErrors (`FnRequirementsError details) ->
+  | SignatureErrors (`FnRequirementsError (details, prev)) ->
       Semantic_error.forwarded_function_signature_error fname.id_loc
-        caller_id.name fname.name details
+        caller_id.name fname.name details prev
       |> error
-  | SignatureErrors (`SuppliedArgsMismatch details) ->
+  | SignatureErrors (`SuppliedArgsMismatch (details, prev)) ->
       Semantic_error.forwarded_function_application_error arg_tupl.emeta.loc
-        caller_id.name fname.name required_arg_names details
+        caller_id.name fname.name required_arg_names details prev
       |> error
 
 let specialize_loc ~loc err (args : Ast.typed_expression list) =
@@ -777,7 +796,7 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
       UnsizedType.
         [(AutoDiffable, UArray UReal); (DataOnly, UInt); (DataOnly, UInt)] in
     SignatureMismatch.check_variadic_args ~allow_lpdf:true mandatory_args
-      mandatory_fun_args UReal (get_arg_types tes) in
+      mandatory_fun_args None UReal (get_arg_types tes) in
   let matching remaining_es fn =
     match fn with
     | Env.{type_= UnsizedType.UFun (sliced_arg_fun :: _, _, _, _) as ftype; _}
@@ -789,7 +808,7 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
           (calculate_autodifftype cf Functions ftype, ftype)
           :: get_arg_types remaining_es in
         SignatureMismatch.check_variadic_args ~allow_lpdf:true mandatory_args
-          mandatory_fun_args UReal arg_types
+          mandatory_fun_args (Env.location fn) UReal arg_types
     | _ -> basic_mismatch () in
   match tes with
   | {expr= Variable fname; _}
@@ -806,7 +825,7 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
       then
         Semantic_error.illtyped_reduce_sum_slice slice_loc slice_type |> error;
       match find_matching_first_order_fn tenv (matching remaining_es) fname with
-      | SignatureMismatch.UniqueMatch (ftype, promotions) ->
+      | SignatureMismatch.UniqueMatch ((ftype, _), promotions) ->
           (* a valid signature exists *)
           let tes = make_function_variable cf loc fname ftype :: remaining_es in
           mk_fun_app ~is_cond_dist ~loc (StanLib FnPlain) id
@@ -815,19 +834,19 @@ and check_reduce_sum ~is_cond_dist loc cf tenv id tes =
       | AmbiguousMatch ps ->
           Semantic_error.ambiguous_function_promotion loc fname.name None ps
           |> error
-      | SignatureErrors (expected_args, err) ->
+      | SignatureErrors (expected_args, err, prev) ->
           let loc = specialize_loc ~loc err tes in
           Semantic_error.illtyped_reduce_sum loc id.name
             (List.map ~f:type_of_expr_typed tes)
-            expected_args err
+            expected_args err prev
           |> error)
   | _ ->
-      let expected_args, err =
+      let expected_args, err, prev =
         basic_mismatch () |> Result.error |> Option.value_exn in
       let loc = specialize_loc ~loc err tes in
       Semantic_error.illtyped_reduce_sum loc id.name
         (List.map ~f:type_of_expr_typed tes)
-        expected_args err
+        expected_args err prev
       |> error
 
 (** Laplace functions are also special, in two ways:
@@ -917,16 +936,16 @@ and check_variadic ~is_cond_dist loc cf tenv id tes =
       =
     Stan_math_signatures.lookup_stan_math_variadic_function id.name
     |> Option.value_exn in
-  let matching remaining_es Env.{type_= ftype; _} =
+  let matching remaining_es (Env.{type_= ftype; _} as info) =
     let arg_types =
       (calculate_autodifftype cf Functions ftype, ftype)
       :: get_arg_types remaining_es in
     SignatureMismatch.check_variadic_args ~allow_lpdf:false control_args
-      required_fn_args required_fn_rt arg_types in
+      required_fn_args (Env.location info) required_fn_rt arg_types in
   match tes with
   | {expr= Variable fname; _} :: remaining_es -> (
       match find_matching_first_order_fn tenv (matching remaining_es) fname with
-      | SignatureMismatch.UniqueMatch (ftype, promotions) ->
+      | SignatureMismatch.UniqueMatch ((ftype, _), promotions) ->
           let tes = make_function_variable cf loc fname ftype :: remaining_es in
           mk_fun_app ~is_cond_dist ~loc (StanLib FnPlain) id
             (Promotion.promote_list tes promotions)
@@ -934,21 +953,21 @@ and check_variadic ~is_cond_dist loc cf tenv id tes =
       | AmbiguousMatch ps ->
           Semantic_error.ambiguous_function_promotion loc fname.name None ps
           |> error
-      | SignatureErrors (expected_args, err) ->
+      | SignatureErrors (expected_args, err, prev) ->
           let loc = specialize_loc ~loc err tes in
           Semantic_error.illtyped_variadic loc id.name
             (List.map ~f:type_of_expr_typed tes)
-            expected_args required_fn_rt err
+            expected_args required_fn_rt err prev
           |> error)
   | _ ->
-      let expected_args, err =
+      let expected_args, err, prev =
         SignatureMismatch.check_variadic_args ~allow_lpdf:false control_args
-          required_fn_args required_fn_rt (get_arg_types tes)
+          required_fn_args None required_fn_rt (get_arg_types tes)
         |> Result.error |> Option.value_exn in
       let loc = specialize_loc ~loc err tes in
       Semantic_error.illtyped_variadic loc id.name
         (List.map ~f:type_of_expr_typed tes)
-        expected_args required_fn_rt err
+        expected_args required_fn_rt err prev
       |> error
 
 and check_funapp loc cf tenv ~is_cond_dist id (es : Ast.typed_expression list) =
@@ -1162,10 +1181,11 @@ let check_expression_of_scalar_or_type cf tenv t e name =
 
 let check_nrfn loc tenv id es =
   match Env.find tenv id.name with
-  | {kind= `Variable _; _} :: _
+  | {kind= `Variable {location; _}; _} :: _
   (* variables can shadow stanlib functions, so we have to check this *)
     when not (Stan_math_signatures.is_stan_math_function_name id.name) ->
-      Semantic_error.nonreturning_fn_expected_nonfn_found loc id.name |> error
+      Semantic_error.nonreturning_fn_expected_nonfn_found loc id.name location
+      |> error
   | [] ->
       Semantic_error.nonreturning_fn_expected_undeclaredident_found loc id.name
         (Env.nearest_ident tenv id.name)
@@ -1174,7 +1194,7 @@ let check_nrfn loc tenv id es =
       match
         SignatureMismatch.matching_function tenv id.name (get_arg_types es)
       with
-      | UniqueMatch (Void, fnk, promotions) ->
+      | UniqueMatch (Void, fnk, promotions, _) ->
           mk_typed_statement
             ~stmt:
               (NRFunApp
@@ -1182,8 +1202,9 @@ let check_nrfn loc tenv id es =
                  , id
                  , Promotion.promote_list es promotions ))
             ~return_type:Incomplete ~loc
-      | UniqueMatch (ReturnType _, _, _) ->
+      | UniqueMatch (ReturnType _, _, _, prev) ->
           Semantic_error.nonreturning_fn_expected_returning_found loc id.name
+            prev
           |> error
       | AmbiguousMatch sigs ->
           Semantic_error.ambiguous_function_promotion loc id.name
@@ -1231,15 +1252,17 @@ let check_jacobian_pe loc cf tenv e =
   mk_typed_statement ~stmt:(JacobianPE te) ~return_type:Incomplete ~loc
 
 (* assignments *)
-let verify_assignment_read_only loc is_readonly id =
+let verify_assignment_read_only loc is_readonly id decl_location =
   if is_readonly then
-    Semantic_error.cannot_assign_to_read_only loc id.name |> error
+    Semantic_error.cannot_assign_to_read_only loc id.name decl_location |> error
 
 (* Variables from previous blocks are read-only. In particular, data and
    parameters never assigned to *)
-let verify_assignment_global loc cf block is_global id =
+let verify_assignment_global loc cf block is_global id decl_location =
   if (not is_global) || block = cf.current_block then ()
-  else Semantic_error.cannot_assign_to_global loc id.name |> error
+  else
+    Semantic_error.cannot_assign_to_global loc id.name block decl_location
+    |> error
 
 (* Until function types are added to the user language, we disallow assignments
    to function values *)
@@ -1275,45 +1298,55 @@ let warn_self_assignment loc lhs rhs =
         add_warning loc "Assignment of variable to itself.")
 
 let check_assignment_operator loc assop lhs rhs =
-  let rec type_of_lvalue = function
-    | LValue {lmeta; _} -> lmeta.type_
-    | LTuplePack {lvals; _} ->
-        UnsizedType.UTuple (List.map ~f:type_of_lvalue lvals) in
-  let err lhs op rhs =
-    Semantic_error.illtyped_assignment loc op (type_of_lvalue lhs) rhs |> error
-  in
+  let rec meta_of_lvalue lv : Ast.typed_expr_meta =
+    match lv with
+    | LValue {lmeta; _} -> lmeta
+    | LTuplePack {lvals; loc} ->
+        let metas = List.map ~f:meta_of_lvalue lvals in
+        { type_= UnsizedType.UTuple (List.map ~f:(fun {type_; _} -> type_) metas)
+        ; ad_level= TupleAD (List.map ~f:(fun {ad_level; _} -> ad_level) metas)
+        ; loc } in
+  let err lhs op (rhs : Ast.typed_expr_meta) =
+    Semantic_error.illtyped_assignment rhs.loc op (meta_of_lvalue lhs) rhs
+    |> error in
   match assop with
   | Assign ->
       warn_self_assignment loc lhs rhs;
-      let rec typechk lhs rhs =
+      let rec typechk lhs (rhs : Ast.typed_expr_meta) =
         match (lhs, rhs) with
-        | LValue ({lmeta= {type_; ad_level; _}; _} as lval), rhs -> (
-            verify_assignment_non_function loc (name_of_lval lval) rhs;
-            match SignatureMismatch.check_of_same_type_mod_conv type_ rhs with
+        | LValue ({lmeta= {type_; ad_level; _}; _} as lval), _ -> (
+            verify_assignment_non_function loc (name_of_lval lval) rhs.type_;
+            match
+              SignatureMismatch.check_of_same_type_mod_conv type_ rhs.type_
+            with
             | Ok p -> (p, ad_level)
             | Error _ -> err lhs Equals rhs)
-        | LTuplePack {lvals; _}, UnsizedType.UTuple tps ->
+        | ( LTuplePack {lvals; _}
+          , {type_= UnsizedType.UTuple tps; ad_level= TupleAD ads; loc} ) ->
             let proms, ad_levels =
-              match List.map2 ~f:typechk lvals tps with
+              let rvs =
+                List.map2_exn
+                  ~f:(fun t ad -> {type_= t; ad_level= ad; loc})
+                  tps ads in
+              match List.map2 ~f:typechk lvals rvs with
               | Unequal_lengths -> err lhs Equals rhs
               | Ok l -> List.unzip l in
             if
               List.exists ~f:(function NoPromotion -> false | _ -> true) proms
             then (TuplePromotion proms, TupleAD ad_levels)
             else (NoPromotion, TupleAD ad_levels)
-        | LTuplePack _, rhs -> err lhs Equals rhs in
-      let prom, ad_level = typechk lhs rhs.emeta.type_ in
+        | LTuplePack _, _ -> err lhs Equals rhs in
+      let prom, ad_level = typechk lhs rhs.emeta in
       let rhs =
         (* Hack: need RHS to properly get promoted to var if needed *)
         {rhs with emeta= {rhs.emeta with ad_level}} in
       Promotion.promote rhs prom
   | OperatorAssign op -> (
       let args =
-        [(UnsizedType.AutoDiffable, type_of_lvalue lhs); arg_type rhs] in
+        [(UnsizedType.AutoDiffable, (meta_of_lvalue lhs).type_); arg_type rhs]
+      in
       let return_type = assignmentoperator_stan_math_return_type op args in
-      match return_type with
-      | Some Void -> rhs
-      | _ -> err lhs op rhs.emeta.type_)
+      match return_type with Some Void -> rhs | _ -> err lhs op rhs.emeta)
 
 let overlapping_lvalues lvals =
   (* Prevent assigning to multiple indices in the same object at once. In
@@ -1405,19 +1438,20 @@ let verify_lvalue_unique (lv : Ast.typed_lval_pack) =
   | dupes -> Semantic_error.cannot_access_assigning_var loc dupes |> error
 
 let verify_assignable_id loc cf tenv assign_id =
-  let block, global, readonly =
+  let block, global, readonly, decl_location =
     let var = Env.find tenv assign_id.name in
     match var with
-    | {kind= `Variable {origin; global; readonly}; _} :: _ ->
-        (origin, global, readonly)
-    | {kind= `StanMath; _} :: _ -> (MathLibrary, true, false)
-    | {kind= `UserDefined | `UserDeclared _; _} :: _ -> (Functions, true, false)
+    | {kind= `Variable {origin; global; readonly; location}; _} :: _ ->
+        (origin, global, readonly, Some location)
+    | {kind= `StanMath; _} :: _ -> (MathLibrary, true, false, None)
+    | {kind= `UserDefined location | `UserDeclared location; _} :: _ ->
+        (Functions, true, false, Some location)
     | _ ->
         Semantic_error.ident_not_in_scope loc assign_id.name
           (Env.nearest_ident tenv assign_id.name)
         |> error in
-  verify_assignment_global loc cf block global assign_id;
-  verify_assignment_read_only loc readonly assign_id
+  verify_assignment_global loc cf block global assign_id decl_location;
+  verify_assignment_read_only loc readonly assign_id decl_location
 
 let rec check_lvalue cf tenv {lval; lmeta= ({loc} : located_meta)} =
   match lval with
@@ -1518,7 +1552,7 @@ let check_tilde_distribution loc cf tenv id arguments =
     List.min_elt distributions ~compare:(fun (m1, _) (m2, _) ->
         SignatureMismatch.compare_match_results m1 m2)
   with
-  | Some (UniqueMatch (_, f, p), sfx) ->
+  | Some (UniqueMatch (_, f, p, _), sfx) ->
       let suffix =
         Fun_kind.suffix_from_name (name ^ Utils.unnormalized_suffix sfx) in
       (Promotion.promote_list arguments p, f suffix)
@@ -1539,7 +1573,7 @@ let check_tilde_distribution loc cf tenv id arguments =
                   (fn_expr : Ast.typed_expression)]
       else
         (* Otherwise, the function is non existent *)
-        Semantic_error.invalid_tilde_no_such_dist loc name
+        Semantic_error.invalid_tilde_no_such_dist id.id_loc name
           (List.hd_exn argumenttypes |> snd |> UnsizedType.is_int_type)
         |> error
   | Some (AmbiguousMatch sigs, _) ->
@@ -1560,7 +1594,7 @@ let is_cumulative_density_defined tenv id arguments =
     match
       SignatureMismatch.matching_function tenv (name ^ suffix) argumenttypes
     with
-    | UniqueMatch (ReturnType UReal, _, _) -> true
+    | UniqueMatch (ReturnType UReal, _, _, _) -> true
     | _ -> false in
   valid_arg_types_for_suffix "_lcdf" && valid_arg_types_for_suffix "_lccdf"
 
@@ -1776,8 +1810,11 @@ and check_loop_body cf tenv loop_var loop_var_ty loop_body =
      identifiers are not modified in function. (passed by const ref) *)
   let tenv =
     Env.add tenv loop_var.name loop_var_ty
-      (`Variable {origin= cf.current_block; global= false; readonly= true})
-  in
+      (`Variable
+         { origin= cf.current_block
+         ; global= false
+         ; readonly= true
+         ; location= loop_var.id_loc }) in
   snd (check_statement {cf with loop_depth= cf.loop_depth + 1} tenv loop_body)
 
 and check_block loc cf tenv stmts =
@@ -1870,8 +1907,7 @@ and check_var_decl_initial_value loc cf tenv {identifier; initial_value} =
       with
       | Ok p -> Ast.{identifier; initial_value= Some (Promotion.promote rhs p)}
       | Error _ ->
-          Semantic_error.illtyped_assignment loc Equals lhs.lmeta.type_
-            rhs.emeta.type_
+          Semantic_error.illtyped_assignment loc Equals lhs.lmeta rhs.emeta
           |> error)
   | None -> Ast.{identifier; initial_value= None}
 
@@ -1919,8 +1955,10 @@ and check_var_decl loc cf tenv sized_ty trans
         let tenv'' =
           Env.add tenv' identifier.name unsized_type
             (`Variable
-               {origin= cf.current_block; global= is_global; readonly= false})
-        in
+               { origin= cf.current_block
+               ; global= is_global
+               ; readonly= false
+               ; location= identifier.id_loc }) in
         warn_self_declare loc identifier.name initial_value;
         (tenv'', check_var_decl_initial_value loc cf tenv'' var))
       variables in
@@ -1938,11 +1976,11 @@ and check_var_decl loc cf tenv sized_ty trans
 and exists_matching_fn_declared tenv id arg_tys rt =
   let options = Env.find tenv id.name in
   let f = function
-    | Env.{kind= `UserDeclared _; type_= UFun (listedtypes, rt', _, _)}
+    | Env.{kind= `UserDeclared location; type_= UFun (listedtypes, rt', _, _)}
       when arg_tys = listedtypes && rt = rt' ->
-        true
-    | _ -> false in
-  List.exists ~f options
+        Some location
+    | _ -> None in
+  List.find_map ~f options
 
 and verify_unique_signature tenv loc id arg_tys rt =
   let existing = Env.find tenv id.name in
@@ -1953,15 +1991,24 @@ and verify_unique_signature tenv loc id arg_tys rt =
     | _ -> false in
   match List.filter existing ~f:same_args with
   | [] -> ()
-  | {type_= UFun (_, rt', _, _); _} :: _ when rt <> rt' ->
-      Semantic_error.fn_overload_rt_only loc id.name rt rt' |> error
-  | {kind; _} :: _ ->
-      Semantic_error.fn_decl_redefined loc id.name ~stan_math:(kind = `StanMath)
+  | ({type_= UFun (_, rt', _, _); _} as info) :: _ when rt <> rt' ->
+      Semantic_error.fn_overload_rt_only loc id.name rt rt' (Env.location info)
+      |> error
+  | {kind= `StanMath; _} :: _ ->
+      Semantic_error.stan_math_fn_redefined loc id.name
         (UnsizedType.UFun (arg_tys, rt, Fun_kind.suffix_from_name id.name, AoS))
+      |> error
+  | { kind=
+        `UserDeclared prev | `UserDefined prev | `Variable {location= prev; _}
+    ; _ }
+    :: _ ->
+      Semantic_error.fn_decl_redefined loc id.name
+        (UnsizedType.UFun (arg_tys, rt, Fun_kind.suffix_from_name id.name, AoS))
+        prev
       |> error
 
 and verify_fundef_overloaded loc tenv id arg_tys rt =
-  if exists_matching_fn_declared tenv id arg_tys rt then
+  if Option.is_some (exists_matching_fn_declared tenv id arg_tys rt) then
     (* this is the definition to an existing forward declaration *)
     ()
   else
@@ -1971,11 +2018,11 @@ and verify_fundef_overloaded loc tenv id arg_tys rt =
 
 and get_fn_decl_or_defn loc tenv id arg_tys rt body =
   match body with
-  | {stmt= Skip; _} ->
-      if exists_matching_fn_declared tenv id arg_tys rt then
-        Semantic_error.fn_decl_exists loc id.name |> error
-      else `UserDeclared id.id_loc
-  | _ -> `UserDefined
+  | {stmt= Skip; _} -> (
+      match exists_matching_fn_declared tenv id arg_tys rt with
+      | Some prev -> Semantic_error.fn_decl_exists loc id.name prev |> error
+      | None -> `UserDeclared id.id_loc)
+  | _ -> `UserDefined id.id_loc
 
 and verify_fundef_dist_rt loc id return_ty =
   let is_dist =
@@ -2000,7 +2047,7 @@ and verify_pmf_fundef_first_arg_ty loc id arg_tys =
     | _ -> Semantic_error.prob_mass_non_int_variate loc rt |> error
 
 and verify_fundef_distinct_arg_ids loc arg_names =
-  match List.find_a_dup ~compare:String.compare arg_names with
+  match List.find_a_dup ~compare:Ast.compare_identifier arg_names with
   | None -> ()
   | Some dup -> Semantic_error.duplicate_arg_names loc dup |> error
 
@@ -2011,35 +2058,35 @@ and verify_fundef_return_tys loc return_type body =
   then ()
   else Semantic_error.incompatible_return_types loc |> error
 
-and add_function tenv name type_ defined =
+and add_function tenv id type_ defined =
   (* if we're providing a definition, we remove prior declarations to simplify
      the environment *)
-  if defined = `UserDefined then
-    let existing_defns = Env.find tenv name in
-    let defns =
-      List.filter
-        ~f:(function
-          | Env.{kind= `UserDeclared _; type_= type'} when type' = type_ ->
-              false
-          | _ -> true)
-        existing_defns in
-    let new_fn = Env.{kind= `UserDefined; type_} in
-    Env.set_raw tenv name (new_fn :: defns)
-  else Env.add tenv name type_ defined
+  match defined with
+  | `UserDefined _ ->
+      let existing_defns = Env.find tenv id.name in
+      let defns =
+        List.filter
+          ~f:(function
+            | Env.{kind= `UserDeclared _; type_= type'; _} when type' = type_ ->
+                false
+            | _ -> true)
+          existing_defns in
+      let new_fn = Env.{kind= `UserDefined id.id_loc; type_} in
+      Env.set_raw tenv id.name (new_fn :: defns)
+  | _ -> Env.add tenv id.name type_ defined
 
 and check_fundef loc cf tenv return_ty id args body =
   List.iter args ~f:(fun (_, _, id) -> verify_identifier id);
   verify_identifier id;
   let arg_types = List.map ~f:(fun (w, y, _) -> (w, y)) args in
   let arg_identifiers = List.map ~f:(fun (_, _, z) -> z) args in
-  let arg_names = List.map ~f:(fun x -> x.name) arg_identifiers in
   verify_fundef_dist_rt loc id return_ty;
   verify_pdf_fundef_first_arg_ty loc id arg_types;
   verify_pmf_fundef_first_arg_ty loc id arg_types;
   List.iter
     ~f:(fun id -> verify_name_fresh tenv id ~is_udf:false)
     arg_identifiers;
-  verify_fundef_distinct_arg_ids loc arg_names;
+  verify_fundef_distinct_arg_ids loc arg_identifiers;
   (* We treat DataOnly arguments as if they are data and AutoDiffable arguments
      as if they are parameters, for the purposes of type checking. *)
   let arg_types_internal =
@@ -2052,12 +2099,13 @@ and check_fundef loc cf tenv return_ty id args body =
               [%message "TupleAD in function definition, this is unexpected!"])
       arg_types in
   let tenv_body =
-    List.fold2_exn arg_names arg_types_internal ~init:tenv
-      ~f:(fun env name (origin, typ) ->
-        Env.add env name typ
+    List.fold2_exn arg_identifiers arg_types_internal ~init:tenv
+      ~f:(fun env id (origin, typ) ->
+        Env.add env id.name typ
           (* readonly so that function args and loop identifiers are not
              modified in function. (passed by const ref) *)
-          (`Variable {origin; readonly= true; global= false})) in
+          (`Variable {origin; readonly= true; global= false; location= id.id_loc}))
+  in
   let context =
     let kind =
       Fun_kind.suffix_from_name id.name |> Fun_kind.forget_normalization in
@@ -2143,7 +2191,7 @@ let add_userdefined_functions tenv stmts_opt =
             let defined =
               get_fn_decl_or_defn loc tenv funname arg_types returntype body
             in
-            add_function tenv funname.name
+            add_function tenv funname
               (UFun
                  ( arg_types
                  , returntype

--- a/test/integration/bad/complex-numbers/stanc.expected
+++ b/test/integration/bad/complex-numbers/stanc.expected
@@ -1,10 +1,10 @@
   $ ../../../../../install/default/bin/stanc assignment-wrong-way.stan
-Semantic error in 'assignment-wrong-way.stan', line 11, column 2 to column 9:
+Semantic error in 'assignment-wrong-way.stan', line 11, column 6 to column 8:
    -------------------------------------------------
      9:  
     10:    Z1 = R; // fine
     11:    R = Z1; // error
-           ^
+               ^
     12:  }
    -------------------------------------------------
 

--- a/test/integration/bad/compound-assign/stanc.expected
+++ b/test/integration/bad/compound-assign/stanc.expected
@@ -1,10 +1,10 @@
   $ ../../../../../install/default/bin/stanc elt_divide_equals_prim.stan
-Semantic error in 'elt_divide_equals_prim.stan', line 4, column 2 to column 10:
+Semantic error in 'elt_divide_equals_prim.stan', line 4, column 8 to column 9:
    -------------------------------------------------
      2:    real x;
      3:    real y;
      4:    x ./= y;
-           ^
+                 ^
      5:  }
    -------------------------------------------------
 
@@ -12,12 +12,12 @@ Ill-typed assignment operator ./=.
 There are no valid right hand sides for the given left hand side (real).
 [exit 1]
   $ ../../../../../install/default/bin/stanc elt_times_equals_prim.stan
-Semantic error in 'elt_times_equals_prim.stan', line 4, column 2 to column 10:
+Semantic error in 'elt_times_equals_prim.stan', line 4, column 8 to column 9:
    -------------------------------------------------
      2:    real x;
      3:    real y;
      4:    x .*= y;
-           ^
+                 ^
      5:  }
    -------------------------------------------------
 
@@ -49,12 +49,12 @@ Semantic error in 'plus_equals_bad_lhs_idxs.stan', line 4, column 2 to column 8:
 Too many indices. Expression only has 1 dimensions, but received 2 indices.
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_bad_var_lhs.stan
-Semantic error in 'plus_equals_bad_var_lhs.stan', line 3, column 4 to column 14:
+Semantic error in 'plus_equals_bad_var_lhs.stan', line 3, column 11 to column 13:
    -------------------------------------------------
      1:  functions {
      2:    real foo(real a1) {
      3:      foo += a1;
-             ^
+                    ^
      4:      return foo;
      5:    }
    -------------------------------------------------
@@ -72,7 +72,7 @@ Semantic error in 'plus_equals_bad_var_lhs2.stan', line 6, column 2 to column 3:
      7:  }
    -------------------------------------------------
 
-Cannot assign to global variable "x" declared in previous blocks.
+Cannot assign to global variable "x" declared previously in transformed data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_bad_var_rhs.stan
 Semantic error in 'plus_equals_bad_var_rhs.stan', line 4, column 11 to column 13:
@@ -88,12 +88,12 @@ Semantic error in 'plus_equals_bad_var_rhs.stan', line 4, column 11 to column 13
 Identifier "a2" not in scope. Did you mean "a1"?
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_array.stan
-Semantic error in 'plus_equals_matrix_array.stan', line 7, column 2 to column 9:
+Semantic error in 'plus_equals_matrix_array.stan', line 7, column 7 to column 8:
    -------------------------------------------------
      5:    x[3,1] += y[3,1];
      6:    x[3,1,1] += y[3,1,1];
      7:    x += y;
-           ^
+                ^
      8:  }
    -------------------------------------------------
 
@@ -101,12 +101,12 @@ Ill-typed assignment operator +=.
 There are no valid right hand sides for the given left hand side (array[] matrix).
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_matrix_array2.stan
-Semantic error in 'plus_equals_matrix_array2.stan', line 7, column 2 to column 17:
+Semantic error in 'plus_equals_matrix_array2.stan', line 7, column 10 to column 16:
    -------------------------------------------------
      5:    x[3,1] += y[3,1];
      6:    x[3,1,1] += y[3,1,1];
      7:    x[3] += y[3,1];
-           ^
+                   ^
      8:  }
    -------------------------------------------------
 
@@ -128,12 +128,12 @@ Syntax error in 'plus_equals_matrix_shape_mismatch.stan', line 4, column 10 to c
 Ill-formed type. Expected "[" expression "]" for vector size.
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_prim_array.stan
-Semantic error in 'plus_equals_prim_array.stan', line 5, column 2 to column 9:
+Semantic error in 'plus_equals_prim_array.stan', line 5, column 7 to column 8:
    -------------------------------------------------
      3:    array[3] real y = {4.0, 5.0, 6.0};
      4:    x[1] += y[1];
      5:    x += y;
-           ^
+                ^
      6:  }
    -------------------------------------------------
 
@@ -141,12 +141,12 @@ Ill-typed assignment operator +=.
 There are no valid right hand sides for the given left hand side (array[] real).
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_row_vec_array.stan
-Semantic error in 'plus_equals_row_vec_array.stan', line 5, column 2 to column 9:
+Semantic error in 'plus_equals_row_vec_array.stan', line 5, column 7 to column 8:
    -------------------------------------------------
      3:    array[3] row_vector[2] y = {[1,2], [3,4], [5,6]};
      4:    x[1] += y[1];
      5:    x += y;
-           ^
+                ^
      6:  }
    -------------------------------------------------
 
@@ -154,12 +154,12 @@ Ill-typed assignment operator +=.
 There are no valid right hand sides for the given left hand side (array[] row_vector).
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_sliced.stan
-Semantic error in 'plus_equals_sliced.stan', line 6, column 4 to column 27:
+Semantic error in 'plus_equals_sliced.stan', line 6, column 15 to column 26:
    -------------------------------------------------
      4:      matrix[2, 2] aa;
      5:      matrix[3, 4] bb;
      6:      aa[J,1] += bb[1:2,1:2];
-             ^
+                        ^
      7:    }
      8:  }
    -------------------------------------------------
@@ -169,12 +169,12 @@ For the given left hand side (vector), expected the right hand side to have type
 int, real, or vector. Instead found type matrix.
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch.stan
-Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 2 to column 9:
+Semantic error in 'plus_equals_type_mismatch.stan', line 4, column 7 to column 8:
    -------------------------------------------------
      2:    int x = 5;
      3:    real y;
      4:    x += y;
-           ^
+                ^
      5:  }
    -------------------------------------------------
 
@@ -183,12 +183,12 @@ For the given left hand side (int), expected the right hand side to have type
 int. Instead found type real.
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_type_mismatch2.stan
-Semantic error in 'plus_equals_type_mismatch2.stan', line 4, column 2 to column 9:
+Semantic error in 'plus_equals_type_mismatch2.stan', line 4, column 7 to column 8:
    -------------------------------------------------
      2:    real x;
      3:    vector[2] y = [1.0, 2.0]';
      4:    x += y;
-           ^
+                ^
      5:  }
    -------------------------------------------------
 
@@ -197,12 +197,12 @@ For the given left hand side (real), expected the right hand side to have type
 int or real. Instead found type vector.
 [exit 1]
   $ ../../../../../install/default/bin/stanc plus_equals_vector_array.stan
-Semantic error in 'plus_equals_vector_array.stan', line 5, column 2 to column 9:
+Semantic error in 'plus_equals_vector_array.stan', line 5, column 7 to column 8:
    -------------------------------------------------
      3:    array[3] vector[2] y = {[1,2]', [3,4]', [5,6]'};
      4:    x[1] += y[1];
      5:    x += y;
-           ^
+                ^
      6:  }
    -------------------------------------------------
 
@@ -210,12 +210,12 @@ Ill-typed assignment operator +=.
 There are no valid right hand sides for the given left hand side (array[] vector).
 [exit 1]
   $ ../../../../../install/default/bin/stanc times_equals_matrix_array.stan
-Semantic error in 'times_equals_matrix_array.stan', line 5, column 2 to column 19:
+Semantic error in 'times_equals_matrix_array.stan', line 5, column 12 to column 18:
    -------------------------------------------------
      3:    array[3] matrix[2,2] y = {[[4, 5], [6, 7]], [[4, 5], [6, 7]], [[4, 5], [6, 7]]};
      4:    x[3] *= y[3];
      5:    x[3,1] *= y[3,1];
-           ^
+                     ^
      6:    x[3,1,1] *= y[3,1,1];
      7:    x *= y;
    -------------------------------------------------

--- a/test/integration/bad/lang/stanc.expected
+++ b/test/integration/bad/lang/stanc.expected
@@ -49,7 +49,7 @@ Semantic error in 'bad12.stan', line 2, column 2 to column 6:
      3:  }
    -------------------------------------------------
 
-Cannot assign to global variable "beta" declared in previous blocks.
+Cannot assign to global variable "beta" declared previously in Stan Math Library.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad2.stan
 Semantic error in 'bad2.stan', line 1, column 34 to column 35:
@@ -58,7 +58,7 @@ Semantic error in 'bad2.stan', line 1, column 34 to column 35:
                                            ^
    -------------------------------------------------
 
-Cannot assign to global variable "a" declared in previous blocks.
+Cannot assign to global variable "a" declared previously in data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad2.stanfunctions
 Syntax error in 'bad2.stanfunctions', line 5, column 0 to column 1, parsing error:
@@ -136,7 +136,7 @@ Semantic error in 'bad6.stan', line 7, column 3 to column 4:
      9:  model {
    -------------------------------------------------
 
-Cannot assign to global variable "y" declared in previous blocks.
+Cannot assign to global variable "y" declared previously in data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad7.stan
 Semantic error in 'bad7.stan', line 7, column 2 to column 3:
@@ -149,7 +149,7 @@ Semantic error in 'bad7.stan', line 7, column 2 to column 3:
      9:  model { 
    -------------------------------------------------
 
-Cannot assign to global variable "y" declared in previous blocks.
+Cannot assign to global variable "y" declared previously in data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad8.stan
 Semantic error in 'bad8.stan', line 5, column 4 to column 5:
@@ -161,7 +161,7 @@ Semantic error in 'bad8.stan', line 5, column 4 to column 5:
      6:  }
    -------------------------------------------------
 
-Cannot assign to global variable "y" declared in previous blocks.
+Cannot assign to global variable "y" declared previously in data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad9.stan
 Semantic error in 'bad9.stan', line 5, column 3 to column 9:
@@ -484,7 +484,7 @@ Semantic error in 'good_all.stan', line 25, column 2 to column 3:
     27:    s = m[1,2];
    -------------------------------------------------
 
-Cannot assign to global variable "m" declared in previous blocks.
+Cannot assign to global variable "m" declared previously in data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc incomplete.stan
 Syntax error in 'incomplete.stan', line 2, column 18 to column 19, parsing error:

--- a/test/integration/bad/removed_features/stanc.expected
+++ b/test/integration/bad/removed_features/stanc.expected
@@ -196,6 +196,7 @@ Semantic error in 'multiply_log.stan', line 11, column 26 to column 54:
    -------------------------------------------------
 
 A returning function was expected but an undeclared identifier "multiply_log" was supplied.
+Did you mean "multiply"?
 [exit 1]
   $ ../../../../../install/default/bin/stanc old-log-funs.stan
 Semantic error in 'old-log-funs.stan', line 3, column 6 to column 24:
@@ -209,6 +210,7 @@ Semantic error in 'old-log-funs.stan', line 3, column 6 to column 24:
    -------------------------------------------------
 
 A returning function was expected but an undeclared identifier "multiply_log" was supplied.
+Did you mean "multiply"?
 [exit 1]
   $ ../../../../../install/default/bin/stanc pound-comment-deprecated.stan
 Syntax error in 'pound-comment-deprecated.stan', line 2, column 2 to column 3, lexing error:

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -119,12 +119,12 @@ Syntax error in 'assign_invalid_lhs2.stan', line 2, column 3 to column 10, parsi
 Ill-formed assignment. Expected an assignable value but found a general expression.
 [exit 1]
   $ ../../../../install/default/bin/stanc assign_real_to_int.stan
-Semantic error in 'assign_real_to_int.stan', line 11, column 2 to column 8:
+Semantic error in 'assign_real_to_int.stan', line 11, column 6 to column 7:
    -------------------------------------------------
      9:    real b;
     10:    b = 3.2;
     11:    a = b;
-           ^
+               ^
     12:  }
    -------------------------------------------------
 
@@ -197,12 +197,12 @@ Semantic error in 'bad_fundef_returntypes4.stan', line 2, column 2 to line 6, co
 Function bodies must contain a return statement of correct type in every branch.
 [exit 1]
   $ ../../../../install/default/bin/stanc bad_prob_fun_suffix.stan
-Semantic error in 'bad_prob_fun_suffix.stan', line 10, column 2 to column 19:
+Semantic error in 'bad_prob_fun_suffix.stan', line 10, column 10 to column 13:
    -------------------------------------------------
      8:  }
      9:  model {
     10:    theta ~ foo(1.4);
-           ^
+                   ^
     11:  }
    -------------------------------------------------
 
@@ -264,12 +264,12 @@ Available signatures:
 (Additional signatures omitted)
 [exit 1]
   $ ../../../../install/default/bin/stanc bad_var_assignment_type1.stan
-Semantic error in 'bad_var_assignment_type1.stan', line 4, column 2 to column 8:
+Semantic error in 'bad_var_assignment_type1.stan', line 4, column 6 to column 7:
    -------------------------------------------------
      2:    vector[5] y;
      3:    array[5] real z;
      4:    z = y;
-           ^
+               ^
      5:  }
      6:  parameters {
    -------------------------------------------------
@@ -279,12 +279,12 @@ Expected the right hand side to have a type matching the destination (array[] re
 Instead found type vector.
 [exit 1]
   $ ../../../../install/default/bin/stanc bad_var_assignment_type2.stan
-Semantic error in 'bad_var_assignment_type2.stan', line 6, column 2 to column 8:
+Semantic error in 'bad_var_assignment_type2.stan', line 6, column 6 to column 7:
    -------------------------------------------------
      4:  transformed data {
      5:    array[5] real z;
      6:    z = y;
-           ^
+               ^
      7:  }
      8:  parameters {
    -------------------------------------------------
@@ -294,12 +294,12 @@ Expected the right hand side to have a type matching the destination (array[] re
 Instead found type array[,] real.
 [exit 1]
   $ ../../../../install/default/bin/stanc bad_var_assignment_vec_arr.stan
-Semantic error in 'bad_var_assignment_vec_arr.stan', line 10, column 2 to column 35:
+Semantic error in 'bad_var_assignment_vec_arr.stan', line 10, column 7 to column 34:
    -------------------------------------------------
      8:  
      9:    a1 = tail(v, K-1) - head(v, K-1);
     10:    a2 = tail(v, K-1) - head(v, K-1);
-           ^
+                ^
     11:  }
     12:  parameters {
    -------------------------------------------------
@@ -321,12 +321,12 @@ Syntax error in 'bad_while.stan', line 3, column 24 to column 25, parsing error:
 Ill-formed type. Expected "[" expression "]" for size of cholesky_factor_corr.
 [exit 1]
   $ ../../../../install/default/bin/stanc binomial_coefficient_sample.stan
-Semantic error in 'binomial_coefficient_sample.stan', line 5, column 2 to column 30:
+Semantic error in 'binomial_coefficient_sample.stan', line 5, column 6 to column 26:
    -------------------------------------------------
      3:  }
      4:  model {
      5:    y ~ binomial_coefficient(5);
-           ^
+               ^
      6:  }
    -------------------------------------------------
 
@@ -443,7 +443,7 @@ Semantic error in 'call_dist_no_suffix.stan', line 5, column 12 to column 25:
    -------------------------------------------------
 
 A returning function was expected but an undeclared identifier "std_normal" was supplied.
-Did you mean "std_normal_lpdf"?
+Did you mean "std_normal_qf"?
 [exit 1]
   $ ../../../../install/default/bin/stanc ccdf-sample.stan
 Semantic error in 'ccdf-sample.stan', line 5, column 2 to column 24:
@@ -1922,12 +1922,12 @@ Syntax error in 'local_var_constraint4.stan', line 5, column 6 to column 7, pars
 Ill-formed type. Did not expect "<". Constrained types are not supported in local (or model block) variable declarations.
 [exit 1]
   $ ../../../../install/default/bin/stanc log_suffix_bad1.stan
-Semantic error in 'log_suffix_bad1.stan', line 8, column 2 to column 19:
+Semantic error in 'log_suffix_bad1.stan', line 8, column 8 to column 13:
    -------------------------------------------------
      6:  
      7:  model {
      8:    1.5 ~ foo_t(3.4);
-           ^
+                 ^
      9:  }
    -------------------------------------------------
 
@@ -2051,12 +2051,12 @@ Semantic error in 'missing-pmf.stan', line 2, column 2 to line 4, column 3:
 Probability mass functions require integer variates (first argument).
 [exit 1]
   $ ../../../../install/default/bin/stanc multiply_sample.stan
-Semantic error in 'multiply_sample.stan', line 5, column 2 to column 18:
+Semantic error in 'multiply_sample.stan', line 5, column 6 to column 14:
    -------------------------------------------------
      3:  }
      4:  model {
      5:    y ~ multiply(3);
-           ^
+               ^
      6:  }
    -------------------------------------------------
 
@@ -2837,12 +2837,12 @@ Available signatures:
   The second argument must be int but got real
 [exit 1]
   $ ../../../../install/default/bin/stanc signature_sampling_unknown.stan
-Semantic error in 'signature_sampling_unknown.stan', line 8, column 2 to column 24:
+Semantic error in 'signature_sampling_unknown.stan', line 8, column 6 to column 16:
    -------------------------------------------------
      6:  }
      7:  model {
      8:    x ~ foo_whatev(theta);
-           ^
+               ^
      9:  }
    -------------------------------------------------
 
@@ -2850,12 +2850,12 @@ Ill-typed arguments to "~"-statement. No function "foo_whatev_lpdf" was found wh
 "foo_whatev".
 [exit 1]
   $ ../../../../install/default/bin/stanc signature_sampling_unknown2.stan
-Semantic error in 'signature_sampling_unknown2.stan', line 8, column 2 to column 24:
+Semantic error in 'signature_sampling_unknown2.stan', line 8, column 6 to column 16:
    -------------------------------------------------
      6:  }
      7:  model {
      8:    x ~ foo_whatev(theta);
-           ^
+               ^
      9:  }
    -------------------------------------------------
 
@@ -2863,12 +2863,12 @@ Ill-typed arguments to distribution statement (~). No function "foo_whatev_lpmf"
 "foo_whatev_lpdf" was found when looking for distribution "foo_whatev".
 [exit 1]
   $ ../../../../install/default/bin/stanc stanc_helper.stan
-Semantic error in 'stanc_helper.stan', line 5, column 2 to column 18:
+Semantic error in 'stanc_helper.stan', line 5, column 6 to column 11:
    -------------------------------------------------
      3:  }
      4:  model {
      5:    y ~ ormal(0, 1);
-           ^
+               ^
      6:  }
    -------------------------------------------------
 
@@ -3123,12 +3123,12 @@ Semantic error in 'validate_allow_sample_bad3.stan', line 9, column 2 to column 
 Target can only be accessed in the model block or in functions ending with _lp.
 [exit 1]
   $ ../../../../install/default/bin/stanc validate_array_expr_bad1.stan
-Semantic error in 'validate_array_expr_bad1.stan', line 6, column 2 to column 41:
+Semantic error in 'validate_array_expr_bad1.stan', line 6, column 12 to column 40:
    -------------------------------------------------
      4:  model {
      5:    array[5] int int_1_a;
      6:    int_1_a = { 1.0, 2.0, 3.0, 4.0 , 5.0 };  // type mismatch
-           ^
+                     ^
      7:    y ~ normal(0,1);
      8:  }
    -------------------------------------------------
@@ -3138,12 +3138,12 @@ Expected the right hand side to have a type matching the destination (array[] in
 Instead found type array[] real.
 [exit 1]
   $ ../../../../install/default/bin/stanc validate_array_expr_bad2.stan
-Semantic error in 'validate_array_expr_bad2.stan', line 6, column 2 to column 24:
+Semantic error in 'validate_array_expr_bad2.stan', line 6, column 12 to column 23:
    -------------------------------------------------
      4:  model {
      5:    array[3] int int_1_a;
      6:    int_1_a = { { 1*1 } };  // dim mismatch
-           ^
+                     ^
      7:    y ~ normal(0,1);
      8:  }
    -------------------------------------------------
@@ -3206,12 +3206,12 @@ Semantic error in 'validate_conditional_op_bad-2.stan', line 5, column 7 to colu
 Type mismatch in ternary expression, expression when true is: real; expression when false is: array[,] row_vector
 [exit 1]
   $ ../../../../install/default/bin/stanc validate_exponentiation_bad.stan
-Semantic error in 'validate_exponentiation_bad.stan', line 7, column 2 to column 12:
+Semantic error in 'validate_exponentiation_bad.stan', line 7, column 6 to column 11:
    -------------------------------------------------
      5:  transformed data {
      6:    int z;
      7:    z = i ^ j;  // int, int
-           ^
+               ^
      8:  }
      9:  parameters {
    -------------------------------------------------

--- a/test/integration/bad/tuples/stanc.expected
+++ b/test/integration/bad/tuples/stanc.expected
@@ -85,12 +85,12 @@ Semantic error in 'bad-index5.stan', line 3, column 11 to column 18:
 Too many indices. Expression only has 0 dimensions, but received 1 indices.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_addition.stan
-Semantic error in 'bad_addition.stan', line 3, column 2 to column 9:
+Semantic error in 'bad_addition.stan', line 3, column 7 to column 8:
    -------------------------------------------------
      1:  model {
      2:    tuple(real, real) z;
      3:    z += 1;
-           ^
+                ^
      4:  }
    -------------------------------------------------
 
@@ -135,7 +135,7 @@ Semantic error in 'bad_unpack_global.stan', line 8, column 3 to column 4:
     10:  }
    -------------------------------------------------
 
-Cannot assign to global variable "x" declared in previous blocks.
+Cannot assign to global variable "x" declared previously in data block.
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_unpack_lhs.stan
 Syntax error in 'bad_unpack_lhs.stan', line 4, column 2 to column 10, parsing error:
@@ -215,12 +215,12 @@ The same variable cannot be both assigned to and read from on the left hand side
   x2
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_unpack_shape.stan
-Semantic error in 'bad_unpack_shape.stan', line 4, column 2 to column 21:
+Semantic error in 'bad_unpack_shape.stan', line 4, column 11 to column 20:
    -------------------------------------------------
      2:    int x = 3;
      3:    int y = 4;
      4:    (x, y) = (y, x, x);
-           ^
+                    ^
      5:  }
    -------------------------------------------------
 
@@ -255,12 +255,12 @@ The same value cannot be assigned to multiple times in one assignment:
   tup[...].1
 [exit 1]
   $ ../../../../../install/default/bin/stanc bad_unpack_types.stan
-Semantic error in 'bad_unpack_types.stan', line 4, column 2 to column 18:
+Semantic error in 'bad_unpack_types.stan', line 4, column 11 to column 17:
    -------------------------------------------------
      2:    real x = 3.0;
      3:    int y = 4;
      4:    (x, y) = (y, x);
-           ^
+                    ^
      5:  }
    -------------------------------------------------
 


### PR DESCRIPTION
This updates the typechecker to store secondary locations for several types of errors. For example, if an overload is ambiguous, besides the primary location (the call site), it also adds information to the error type about where the misbehaving signatures were defined.

This is not currently utilized in the output, but I hope to soon integrate [grace](https://github.com/johnyob/grace), the primary advantage of which being that it does nicely support multiple locations in one error

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Added additional location tracking in type errors.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
