### PR TITLE
runjstest: look up node in user PATH

### DIFF
--- a/test/stancjs/run_js_on_args.ml
+++ b/test/stancjs/run_js_on_args.ml
@@ -2,8 +2,8 @@ module Caml_unix = Unix
 open Core
 
 let run_capturing_output cmd =
-  let noflags = Array.create ~len:0 "" in
-  let stdout, stdin, stderr = Caml_unix.open_process_full cmd noflags in
+  let env = [| "PATH=" ^ (Sys.getenv "PATH" |> Option.value ~default:"") |] in
+  let stdout, stdin, stderr = Caml_unix.open_process_full cmd env in
   let chns = [stdout; stderr] in
   let out = List.map ~f:In_channel.input_lines chns in
   ignore (Caml_unix.close_process_full (stdout, stdin, stderr));


### PR DESCRIPTION
This is really just for me, personally, since I recently switched to `node` being installed in my home folder rather than system wide.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
