### PR TITLE
stancjs: Use js_of_ocaml-ppx for type safety

### DIFF
--- a/scripts/install_js_deps.sh
+++ b/scripts/install_js_deps.sh
@@ -3,7 +3,7 @@
 # exit when any command fails
 set -e
 
-opam pin -y js_of_ocaml 5.9.1
+opam pin -y js_of_ocaml-ppx 5.9.1
 
 echo "You should also install node in order to run the tests."
 echo "Tests are run with dune build @runjstest"

--- a/src/stancjs/conversion.ml
+++ b/src/stancjs/conversion.ml
@@ -179,6 +179,10 @@ let js_of_warnings warnings =
   warnings |> List.map ~f:Js.string |> Array.of_list |> Js.array
 
 let wrap_error ~warnings e =
+  (* NB: The "0" entry is due to a historical mistake that led the first entry
+     always being a 0 (this element is a 'tag' used by jsoo internally, but was
+     not meant to be exposed to the user). For backward compatibility with
+     existing consumers of stanc.js we have to keep this behavior. *)
   let errors = [| Js.string "0"; Js.string e |] |> Js.array in
   object%js
     val result = Js.undefined [@@optdef]

--- a/src/stancjs/conversion.ml
+++ b/src/stancjs/conversion.ml
@@ -1,0 +1,200 @@
+open Core
+open Frontend
+open Js_of_ocaml
+
+let typecheck e typ = String.equal (Js.to_string (Js.typeof e)) typ
+
+let bad_arg_message ~name ~expected value =
+  Fmt.str
+    "Failed to convert stanc.js argument '%s'!@ It had type '%s' instead of \
+     '%s'."
+    name
+    (Js.typeof value |> Js.to_string)
+    expected
+
+let checked_to_string ~name value =
+  if not (typecheck value "string") then
+    Error (bad_arg_message ~name ~expected:"string" value)
+  else Ok (Js.to_string value)
+
+let checked_to_array ~name value =
+  let is_array a = Js.Unsafe.global##._Array##isArray a |> Js.to_bool in
+  if not (is_array value) then
+    Error
+      (Fmt.str
+         "Failed to convert stanc.js argument '%s'!@ Array.isArray returned \
+          false for value of type '%s'."
+         name
+         (Js.typeof value |> Js.to_string))
+  else Ok (Js.to_array value)
+
+let get_includes_lenient includes : string String.Map.t * string list =
+  let open Common.Let_syntax.Result in
+  let map, warnings =
+    match Js.Opt.to_option includes with
+    | None -> (String.Map.empty, [] (* normal use: argument not supplied *))
+    | Some includes when not (typecheck includes "object") ->
+        ( String.Map.empty
+        , [bad_arg_message ~name:"includes" ~expected:"object" includes] )
+    | Some includes ->
+        let keys = Js.object_keys includes |> Js.to_array |> List.of_array in
+        let lookup k =
+          let value_js = Js.Unsafe.get includes k in
+          let k_str = Js.to_string k in
+          let+ value_str =
+            checked_to_string ~name:("includes[\"" ^ k_str ^ "\"]") value_js
+          in
+          (k_str, value_str) in
+        let alist, warnings = List.map keys ~f:lookup |> List.partition_result in
+        ( (* JS objects cannot have duplicate keys *)
+          String.Map.of_alist_exn alist
+        , warnings ) in
+  ( map
+  , List.map
+      ~f:
+        (Fmt.str
+           "@[<v>Warning: stanc.js failed to parse included file mapping:@ %s@]")
+      warnings )
+
+type flags =
+  {name: string; code: string; driver_flags: Driver.Flags.t; color_output: bool}
+
+let process_flags name code (flags : 'a Js.opt) includes :
+    (flags, string) result =
+  let open Common.Let_syntax.Result in
+  let* name = checked_to_string ~name:"name" name in
+  let* code = checked_to_string ~name:"code" code in
+  let+ flags =
+    match Js.Opt.to_option flags with
+    | None -> Ok None
+    | Some flags ->
+        let* flags_array = checked_to_array ~name:"flags" flags in
+        let+ ocaml_flags =
+          let open Result in
+          Array.mapi flags_array ~f:(fun i v ->
+              checked_to_string ~name:("flags[" ^ string_of_int i ^ "]") v)
+          |> Array.to_list |> Result.all >>| Array.of_list in
+        Driver.Flags.set_backend_args_list
+          (ocaml_flags |> Array.to_list |> List.map ~f:(fun o -> "--" ^ o));
+        Some ocaml_flags in
+  match flags with
+  | None ->
+      { name
+      ; code
+      ; driver_flags=
+          { Driver.Flags.default with
+            include_source= Include_files.InMemory includes }
+      ; color_output= false }
+  | Some flags ->
+      let is_flag_set flag = Array.mem ~equal:String.equal flags flag in
+      let flag_val flag =
+        let prefix = flag ^ "=" in
+        Array.find_map flags ~f:(String.chop_prefix ~prefix) in
+      { name
+      ; code
+      ; driver_flags=
+          { optimization_level=
+              (let open Analysis_and_optimization in
+               if is_flag_set "O0" then Optimize.O0
+               else if is_flag_set "O1" || is_flag_set "O" then Optimize.O1
+               else if is_flag_set "Oexperimental" then Optimize.Oexperimental
+               else Optimize.O0)
+          ; allow_undefined= is_flag_set "allow-undefined"
+          ; functions_only= is_flag_set "functions-only"
+          ; standalone_functions= is_flag_set "standalone-functions"
+          ; use_opencl= is_flag_set "use-opencl"
+          ; include_source= Include_files.InMemory includes
+          ; info= is_flag_set "info"
+          ; version= is_flag_set "version"
+          ; auto_format=
+              is_flag_set "auto-format" || is_flag_set "print-canonical"
+          ; debug_settings=
+              { print_ast= is_flag_set "debug-ast"
+              ; print_typed_ast= is_flag_set "debug-typed-ast"
+              ; print_mir=
+                  (if is_flag_set "debug-mir" then Basic
+                   else if is_flag_set "debug-mir-pretty" then Pretty
+                   else Off)
+              ; print_transformed_mir=
+                  (if is_flag_set "debug-transformed-mir" then Basic
+                   else if is_flag_set "debug-transformed-mir-pretty" then
+                     Pretty
+                   else Off)
+              ; print_optimized_mir=
+                  (if is_flag_set "debug-optimized-mir" then Basic
+                   else if is_flag_set "debug-optimized-mir-pretty" then Pretty
+                   else Off)
+              ; print_mem_patterns= is_flag_set "debug-mem-patterns"
+              ; force_soa= None
+              ; print_lir= is_flag_set "debug-lir"
+              ; debug_generate_data= is_flag_set "debug-generate-data"
+              ; debug_generate_inits= is_flag_set "debug-generate-inits"
+              ; debug_data_json=
+                  flag_val "debug-data-json"
+                  |> Option.map ~f:(fun s -> ("debug-data-json", s)) }
+          ; line_length=
+              flag_val "max-line-length"
+              |> Option.map ~f:int_of_string
+              |> Option.value ~default:78
+          ; canonicalizer_settings=
+              (if is_flag_set "print-canonical" then Canonicalize.legacy
+               else
+                 match flag_val "canonicalize" with
+                 | None -> Canonicalize.none
+                 | Some s ->
+                     let parse settings s =
+                       match String.lowercase s with
+                       | "deprecations" ->
+                           Canonicalize.{settings with deprecations= true}
+                       | "parentheses" -> {settings with parentheses= true}
+                       | "braces" -> {settings with braces= true}
+                       | "strip-comments" -> {settings with strip_comments= true}
+                       | "includes" -> {settings with inline_includes= true}
+                       | _ -> settings in
+                     List.fold ~f:parse ~init:Canonicalize.none
+                       (String.split ~on:',' s))
+          ; warn_pedantic= is_flag_set "warn-pedantic"
+          ; warn_uninitialized= is_flag_set "warn-uninitialized"
+          ; filename_in_msg= flag_val "filename-in-msg" }
+      ; color_output= is_flag_set "color-output" }
+
+let str_color ~color_output =
+  let buf = Buffer.create 64 in
+  let ppf = Format.formatter_of_buffer buf in
+  Fmt.set_style_renderer ppf (if color_output then `Ansi_tty else `None);
+  let flush ppf =
+    Format.pp_print_flush ppf ();
+    let s = Buffer.contents buf in
+    Buffer.reset buf;
+    s in
+  Format.kfprintf flush ppf
+
+class type stancReturn = object
+  method result : Js.js_string Js.t Js.optdef_prop
+  method errors : Js.js_string Js.t Js.js_array Js.t Js.optdef_prop
+  method warnings : Js.js_string Js.t Js.js_array Js.t Js.readonly_prop
+end
+
+let js_of_warnings warnings =
+  warnings |> List.map ~f:Js.string |> Array.of_list |> Js.array
+
+let wrap_error ~warnings e =
+  let errors = [| Js.string "0"; Js.string e |] |> Js.array in
+  object%js
+    val result = Js.undefined [@@optdef]
+    val errors = Js.def errors [@@optdef]
+    val warnings = js_of_warnings warnings
+  end
+
+let wrap_result ?printed_filename ~code ~color_output ~warnings res =
+  match res with
+  | Result.Ok s ->
+      object%js
+        val result = Js.def (Js.string s) [@@optdef]
+        val errors = Js.undefined [@@optdef]
+        val warnings = js_of_warnings warnings
+      end
+  | Error e ->
+      let e =
+        str_color ~color_output "%a" (Errors.pp ?printed_filename ~code) e in
+      wrap_error ~warnings e

--- a/src/stancjs/conversion.mli
+++ b/src/stancjs/conversion.mli
@@ -1,0 +1,38 @@
+open Js_of_ocaml
+
+val get_includes_lenient :
+  'a Js.t Js.opt -> string Core.String.Map.t * string list
+(** Converts from a [{ [s:string]:string }] JS object type to an OCaml map, with
+    warnings for bad input. *)
+
+type flags =
+  {name: string; code: string; driver_flags: Driver.Flags.t; color_output: bool}
+
+val process_flags :
+     Js.js_string Js.t
+  -> Js.js_string Js.t
+  -> Js.js_string Js.t Js.js_array Js.t Js.opt
+  -> string Core.String.Map.t
+  -> (flags, string) result
+(** Turn function inputs into a [Driver.Flags.t] *)
+
+val str_color :
+  color_output:bool -> ('a, Format.formatter, unit, string) format4 -> 'a
+(** similar to [Fmt.str_like] but directly sets style rendering rather than
+    copying from another ppf *)
+
+class type stancReturn = object
+  method errors : Js.js_string Js.t Js.js_array Js.t Js.optdef_prop
+  method result : Js.js_string Js.t Js.optdef_prop
+  method warnings : Js.js_string Js.t Js.js_array Js.t Js.readonly_prop
+end
+
+val wrap_error : warnings:string list -> string -> stancReturn Js.t
+
+val wrap_result :
+     ?printed_filename:string
+  -> code:string
+  -> color_output:bool
+  -> warnings:string list
+  -> (string, Frontend.Errors.t) result
+  -> stancReturn Js.t

--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -1,8 +1,9 @@
 (executable
  (name stancjs)
  (libraries core fmt js_of_ocaml driver stan_math_signatures)
+ (modules Stancjs Conversion)
  (preprocess
-  (pps ppx_jane))
+  (pps ppx_jane js_of_ocaml-ppx))
  (modes js))
 
 (env

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -1,6 +1,6 @@
 open Core
 open Frontend
-open Analysis_and_optimization
+open Conversion
 open Js_of_ocaml
 
 let invoke_driver model_name model flags =
@@ -21,217 +21,19 @@ let invoke_driver model_name model flags =
     Driver.Entry.stan2cpp model_name (`Code model) flags output_callback in
   (compilation_result, !warnings)
 
-let wrap_warnings ~warnings =
-  ( "warnings"
-  , Js.Unsafe.coerce (Js.array (List.to_array (List.map ~f:Js.string warnings)))
-  )
-
-let wrap_error ~warnings e =
-  Js.Unsafe.obj
-    [| ( "errors"
-       , (* NB: The "0" entry is due to a historical mistake that led the first
-            entry always being a 0 (this element is a 'tag' used by jsoo
-            internally, but was not meant to be exposed to the user). For
-            backward compatibility with existing consumers of stanc.js we have
-            to keep this behavior. *)
-         Js.Unsafe.coerce (Js.array (Array.map ~f:Js.string [| "0"; e |])) )
-     ; wrap_warnings ~warnings |]
-
-(** similar to [Fmt.str_like] but directly sets style rendering rather than
-    copying from another ppf *)
-let str_color ~color_output =
-  let buf = Buffer.create 64 in
-  let ppf = Format.formatter_of_buffer buf in
-  Fmt.set_style_renderer ppf (if color_output then `Ansi_tty else `None);
-  let flush ppf =
-    Format.pp_print_flush ppf ();
-    let s = Buffer.contents buf in
-    Buffer.reset buf;
-    s in
-  Format.kfprintf flush ppf
-
-let wrap_result ?printed_filename ~color_output ~code ~warnings res =
-  match res with
-  | Result.Ok s ->
-      Js.Unsafe.obj
-        [| ("result", Js.Unsafe.coerce (Js.string s)); wrap_warnings ~warnings
-        |]
-  | Error e ->
-      let e =
-        str_color ~color_output "%a"
-          (Errors.pp ?printed_filename ?code:(Some (Js.to_string code)))
-          e in
-      wrap_error ~warnings e
-
-let typecheck e typ = String.equal (Js.to_string (Js.typeof e)) typ
-
-let bad_arg_message ~name ~expected value =
-  Fmt.str
-    "Failed to convert stanc.js argument '%s'!@ It had type '%s' instead of \
-     '%s'."
-    name
-    (Js.typeof value |> Js.to_string)
-    expected
-
-let checked_to_string ~name value =
-  if not (typecheck value "string") then
-    Error (bad_arg_message ~name ~expected:"string" value)
-  else Ok (Js.to_string value)
-
-let checked_to_array ~name value =
-  if
-    not
-      (Js.to_bool
-         (Js.Unsafe.meth_call
-            (Js.Unsafe.pure_js_expr "Array")
-            "isArray"
-            [| Js.Unsafe.coerce value |]))
-  then
-    Error
-      (Fmt.str
-         "Failed to convert stanc.js argument '%s'!@ Array.isArray returned \
-          false for value of type '%s'."
-         name
-         (Js.typeof value |> Js.to_string))
-  else Ok (Js.to_array value)
-
-(** Converts from a [{ [s:string]:string }] JS object type to an OCaml map, with
-    error messages on bad input. *)
-let get_includes includes : string String.Map.t * string list =
-  let open Common.Let_syntax.Result in
-  let map, warnings =
-    match Js.Opt.to_option includes with
-    | None -> (String.Map.empty, [] (* normal use: argument not supplied *))
-    | Some includes when not (typecheck includes "object") ->
-        ( String.Map.empty
-        , [bad_arg_message ~name:"includes" ~expected:"object" includes] )
-    | Some includes ->
-        let keys = Js.object_keys includes |> Js.to_array |> List.of_array in
-        let lookup k =
-          let value_js = Js.Unsafe.get includes k in
-          let k_str = Js.to_string k in
-          let+ value_str =
-            checked_to_string ~name:("includes[\"" ^ k_str ^ "\"]") value_js
-          in
-          (k_str, value_str) in
-        let alist, warnings = List.map keys ~f:lookup |> List.partition_result in
-        ( (* JS objects cannot have duplicate keys *)
-          String.Map.of_alist_exn alist
-        , warnings ) in
-  ( map
-  , List.map
-      ~f:
-        (Fmt.str "Warning: stanc.js failed to parse included file mapping:@ %s")
-      warnings )
-
-type flags = {driver_flags: Driver.Flags.t; color_output: bool}
-
-(** Turn our array of flags into a Driver.Flags.t *)
-let process_flags (flags : 'a Js.opt) includes : (flags, string) result =
-  let open Result in
-  let open Common.Let_syntax.Result in
-  let+ flags =
-    match Js.Opt.to_option flags with
-    | None -> Ok None
-    | Some flags ->
-        let* flags_array = checked_to_array ~name:"flags" flags in
-        let+ ocaml_flags =
-          Array.mapi flags_array ~f:(fun i v ->
-              checked_to_string ~name:("flags[" ^ string_of_int i ^ "]") v)
-          |> Array.to_list |> Result.all >>| Array.of_list in
-        Driver.Flags.set_backend_args_list
-          (ocaml_flags |> Array.to_list |> List.map ~f:(fun o -> "--" ^ o));
-        Some ocaml_flags in
-  match flags with
-  | None ->
-      { driver_flags=
-          { Driver.Flags.default with
-            include_source= Include_files.InMemory includes }
-      ; color_output= false }
-  | Some flags ->
-      let is_flag_set flag = Array.mem ~equal:String.equal flags flag in
-      let flag_val flag =
-        let prefix = flag ^ "=" in
-        Array.find_map flags ~f:(String.chop_prefix ~prefix) in
-      { driver_flags=
-          { optimization_level=
-              (if is_flag_set "O0" then Optimize.O0
-               else if is_flag_set "O1" || is_flag_set "O" then Optimize.O1
-               else if is_flag_set "Oexperimental" then Optimize.Oexperimental
-               else Optimize.O0)
-          ; allow_undefined= is_flag_set "allow-undefined"
-          ; functions_only= is_flag_set "functions-only"
-          ; standalone_functions= is_flag_set "standalone-functions"
-          ; use_opencl= is_flag_set "use-opencl"
-          ; include_source= Include_files.InMemory includes
-          ; info= is_flag_set "info"
-          ; version= is_flag_set "version"
-          ; auto_format=
-              is_flag_set "auto-format" || is_flag_set "print-canonical"
-          ; debug_settings=
-              { print_ast= is_flag_set "debug-ast"
-              ; print_typed_ast= is_flag_set "debug-typed-ast"
-              ; print_mir=
-                  (if is_flag_set "debug-mir" then Basic
-                   else if is_flag_set "debug-mir-pretty" then Pretty
-                   else Off)
-              ; print_transformed_mir=
-                  (if is_flag_set "debug-transformed-mir" then Basic
-                   else if is_flag_set "debug-transformed-mir-pretty" then
-                     Pretty
-                   else Off)
-              ; print_optimized_mir=
-                  (if is_flag_set "debug-optimized-mir" then Basic
-                   else if is_flag_set "debug-optimized-mir-pretty" then Pretty
-                   else Off)
-              ; print_mem_patterns= is_flag_set "debug-mem-patterns"
-              ; force_soa= None
-              ; print_lir= is_flag_set "debug-lir"
-              ; debug_generate_data= is_flag_set "debug-generate-data"
-              ; debug_generate_inits= is_flag_set "debug-generate-inits"
-              ; debug_data_json=
-                  flag_val "debug-data-json"
-                  |> Option.map ~f:(fun s -> ("debug-data-json", s)) }
-          ; line_length=
-              flag_val "max-line-length"
-              |> Option.map ~f:int_of_string
-              |> Option.value ~default:78
-          ; canonicalizer_settings=
-              (if is_flag_set "print-canonical" then Canonicalize.legacy
-               else
-                 match flag_val "canonicalize" with
-                 | None -> Canonicalize.none
-                 | Some s ->
-                     let parse settings s =
-                       match String.lowercase s with
-                       | "deprecations" ->
-                           Canonicalize.{settings with deprecations= true}
-                       | "parentheses" -> {settings with parentheses= true}
-                       | "braces" -> {settings with braces= true}
-                       | "strip-comments" -> {settings with strip_comments= true}
-                       | "includes" -> {settings with inline_includes= true}
-                       | _ -> settings in
-                     List.fold ~f:parse ~init:Canonicalize.none
-                       (String.split ~on:',' s))
-          ; warn_pedantic= is_flag_set "warn-pedantic"
-          ; warn_uninitialized= is_flag_set "warn-uninitialized"
-          ; filename_in_msg= flag_val "filename-in-msg" }
-      ; color_output= is_flag_set "color-output" }
-
 (** Handle conversion of JS <-> OCaml values invoke driver *)
-let stan2cpp_wrapped name code flags includes =
-  let open Common.Let_syntax.Result in
-  let includes, include_reader_warnings = get_includes includes in
+let stan2cpp_wrapped name code flags includes : stancReturn Js.t =
+  let includes, include_reader_warnings = get_includes_lenient includes in
   let compilation_result =
-    let* name = checked_to_string ~name:"name" name in
-    let* code = checked_to_string ~name:"code" code in
-    let* {driver_flags; color_output} = process_flags flags includes in
+    let open Common.Let_syntax.Result in
+    let* {name; code; driver_flags; color_output} =
+      process_flags name code flags includes in
     let+ result, warnings =
       Common.ICE.with_exn_message (fun () ->
           invoke_driver name code driver_flags) in
-    (result, warnings, driver_flags.filename_in_msg, color_output) in
+    (result, warnings, driver_flags.filename_in_msg, code, color_output) in
   match compilation_result with
-  | Ok (result, warnings, printed_filename, color_output) ->
+  | Ok (result, warnings, printed_filename, code, color_output) ->
       let warnings =
         include_reader_warnings
         @ List.map


### PR DESCRIPTION
This PR dramatically reduces the number of calls to `Js.Unsafe` APIs. The main upside is that the return type of `stan2cpp_wrapped` is no longer `'a`, which makes it much harder to make mistakes by having different branches return different types (ask me how I know this is a problem...)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes



## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
