### PR TITLE
Lazy-load typechecking environment for quicker startup, help, etc

### DIFF
--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -43,14 +43,15 @@ let location = function
 type t = info list String.Map.t
 
 let stan_math_environment =
-  let functions =
-    Stan_math_signatures.get_stan_math_signatures_alist ()
-    |> List.map ~f:(fun (key, values) ->
-        ( key
-        , List.map values ~f:(fun s ->
-              {type_= UnsizedType.UFun s; kind= `StanMath}) ))
-    |> String.Map.of_alist_exn in
-  functions
+  lazy
+    (let functions =
+       Stan_math_signatures.get_stan_math_signatures_alist ()
+       |> List.map ~f:(fun (key, values) ->
+           ( key
+           , List.map values ~f:(fun s ->
+                 {type_= UnsizedType.UFun s; kind= `StanMath}) ))
+       |> String.Map.of_alist_exn in
+     functions)
 
 let add env name type_ kind = Map.add_multi env ~key:name ~data:{type_; kind}
 let set_raw env key data = Map.set env ~key ~data

--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -43,15 +43,12 @@ let location = function
 type t = info list String.Map.t
 
 let stan_math_environment =
-  lazy
-    (let functions =
-       Stan_math_signatures.get_stan_math_signatures_alist ()
-       |> List.map ~f:(fun (key, values) ->
-           ( key
-           , List.map values ~f:(fun s ->
-                 {type_= UnsizedType.UFun s; kind= `StanMath}) ))
-       |> String.Map.of_alist_exn in
-     functions)
+  Lazy.map Stan_math_signatures.signatures_alist ~f:(fun signatures ->
+      List.map signatures ~f:(fun (key, values) ->
+          ( key
+          , List.map values ~f:(fun s ->
+                {type_= UnsizedType.UFun s; kind= `StanMath}) ))
+      |> String.Map.of_alist_exn)
 
 let add env name type_ kind = Map.add_multi env ~key:name ~data:{type_; kind}
 let set_raw env key data = Map.set env ~key ~data

--- a/src/frontend/Environment.mli
+++ b/src/frontend/Environment.mli
@@ -32,7 +32,7 @@ val location : info -> Location_span.t option
 
 type t
 
-val stan_math_environment : t
+val stan_math_environment : t Lazy.t
 (** A type environment which contains the Stan math library functions *)
 
 val find : t -> string -> info list

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -284,8 +284,8 @@ let matching_function env name args =
         UnsizedType.compare_returntype ret1 ret2) in
   find_compatible_rt function_types args
 
-let matching_stanlib_function =
-  matching_function Environment.stan_math_environment
+let matching_stanlib_function name args =
+  matching_function (Lazy.force Environment.stan_math_environment) name args
 
 let check_variadic_args ~allow_lpdf mandatory_arg_tys mandatory_fun_arg_tys
     location fun_return args =

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -2234,7 +2234,7 @@ let check_program_exn ~allow_undefined_functions
   warnings := [];
   requires_higher_order_autodiff := [];
   (* create a new type environment which has only stan-math functions *)
-  let tenv = Env.stan_math_environment in
+  let tenv = Lazy.force Env.stan_math_environment in
   let tenv = add_userdefined_functions tenv fb in
   let tenv, typed_fb = check_toplevel_block Functions tenv fb in
   verify_functions_have_defn ~allow_undefined_functions tenv typed_fb;

--- a/src/stan_math_signatures/Generate.ml
+++ b/src/stan_math_signatures/Generate.ml
@@ -2709,8 +2709,8 @@ let unmarshal_hashtbl s : 'a Core.String.Table.t =
   Printf.printf
     {|
 let stan_math_signatures :
-    Middle.UnsizedType.signature list Core.String.Table.t =
-  unmarshal_hashtbl %S |}
+    Middle.UnsizedType.signature list Core.String.Table.t Lazy.t=
+  lazy (unmarshal_hashtbl %S) |}
     (marshal_hashtbl stan_math_signatures);
   Printf.printf
     {|

--- a/src/stan_math_signatures/Generated_signatures.mli
+++ b/src/stan_math_signatures/Generated_signatures.mli
@@ -6,7 +6,7 @@
 open Core
 open Middle
 
-val stan_math_signatures : UnsizedType.signature list String.Table.t
+val stan_math_signatures : UnsizedType.signature list String.Table.t Lazy.t
 
 val stan_math_variadic_signatures :
   UnsizedType.variadic_signature String.Table.t

--- a/src/stan_math_signatures/Stan_math_signatures.ml
+++ b/src/stan_math_signatures/Stan_math_signatures.ml
@@ -19,10 +19,13 @@ let distributions = Generated_signatures.distributions
 
 let is_stan_math_function_name name =
   let name = Utils.stdlib_distribution_name name in
-  Hashtbl.mem stan_math_signatures name
+  Hashtbl.mem (Lazy.force stan_math_signatures) name
 
-let lookup_stan_math_function = Hashtbl.find_multi stan_math_signatures
-let get_stan_math_signatures_alist () = Hashtbl.to_alist stan_math_signatures
+let lookup_stan_math_function name =
+  Hashtbl.find_multi (Lazy.force stan_math_signatures) name
+
+let get_stan_math_signatures_alist () =
+  Hashtbl.to_alist (Lazy.force stan_math_signatures)
 
 let is_stan_math_variadic_function_name =
   Hashtbl.mem stan_math_variadic_signatures
@@ -65,7 +68,7 @@ let int_divide_type =
 
 let get_sigs name =
   let name = Utils.stdlib_distribution_name name in
-  Hashtbl.find_multi stan_math_signatures name
+  Hashtbl.find_multi (Lazy.force stan_math_signatures) name
   |> List.sort ~compare:UnsizedType.compare_signature
 
 let make_assignmentoperator_stan_math_signatures assop =
@@ -132,7 +135,8 @@ let pretty_print_all_math_sigs ppf () =
       (List.map ~f:(fun t -> (name, t)) (get_sigs name)) in
   pf ppf "@[<v>%a@]"
     (list ~sep:cut pp_sigs_for_name)
-    (List.sort ~compare:String.compare (Hashtbl.keys stan_math_signatures))
+    (List.sort ~compare:String.compare
+       (Hashtbl.keys (Lazy.force stan_math_signatures)))
 
 let pretty_print_all_math_distributions ppf () =
   let open Fmt in

--- a/src/stan_math_signatures/Stan_math_signatures.ml
+++ b/src/stan_math_signatures/Stan_math_signatures.ml
@@ -24,8 +24,7 @@ let is_stan_math_function_name name =
 let lookup_stan_math_function name =
   Hashtbl.find_multi (Lazy.force stan_math_signatures) name
 
-let get_stan_math_signatures_alist () =
-  Hashtbl.to_alist (Lazy.force stan_math_signatures)
+let signatures_alist = Lazy.map stan_math_signatures ~f:Hashtbl.to_alist
 
 let is_stan_math_variadic_function_name =
   Hashtbl.mem stan_math_variadic_signatures

--- a/src/stan_math_signatures/Stan_math_signatures.mli
+++ b/src/stan_math_signatures/Stan_math_signatures.mli
@@ -11,8 +11,7 @@ val lookup_stan_math_function : string -> UnsizedType.signature list
 (** Look up the signature of a Stan Math library function. If it is not found,
     this returns [[]] *)
 
-val get_stan_math_signatures_alist :
-  unit -> (string * UnsizedType.signature list) list
+val signatures_alist : (string * UnsizedType.signature list) list Lazy.t
 (** Get all the signatures in the Stan Math library *)
 
 val is_stan_math_variadic_function_name : string -> bool


### PR DESCRIPTION
This small change inserts a couple strategic [lazy](https://ocaml.org/manual/4.14/api/Lazy.html) statements to improve the loading time of the compiler. 

Many invocations of the compiler never reach typechecking: those for shell completion (#1572), `--help`, or parser errors. Currently, all of those still load the math library signatures, which is sometimes the majority of the runtime.

#### Benchmarks:

<details><summary>Details</summary>
<p>

**No command line**

```
$ hyperfine --warmup 20 -L version master,lazy "./stanc-{version} " -iN
Benchmark 1: ./stanc-master 
  Time (mean ± σ):      15.1 ms ±   1.2 ms    [User: 7.3 ms, System: 7.6 ms]
  Range (min … max):    12.6 ms …  19.4 ms    183 runs
 
Benchmark 2: ./stanc-lazy 
  Time (mean ± σ):       5.6 ms ±   0.8 ms    [User: 1.8 ms, System: 3.6 ms]
  Range (min … max):     4.5 ms …   8.9 ms    570 runs
 
Summary
  ./stanc-lazy  ran
    2.69 ± 0.42 times faster than ./stanc-master
```

**Completion**
```
$ hyperfine --warmup 20 -L version master,lazy "./stanc-{version} --__complete -I --__complete=" -N
Benchmark 1: ./stanc-master --__complete -I --__complete=
  Time (mean ± σ):      14.9 ms ±   1.1 ms    [User: 7.2 ms, System: 7.4 ms]
  Range (min … max):    12.8 ms …  18.5 ms    222 runs
 
Benchmark 2: ./stanc-lazy --__complete -I --__complete=
  Time (mean ± σ):       5.6 ms ±   0.8 ms    [User: 1.8 ms, System: 3.6 ms]
  Range (min … max):     4.5 ms …  10.5 ms    587 runs
 
Summary
  ./stanc-lazy --__complete -I --__complete= ran
    2.64 ± 0.43 times faster than ./stanc-master --__complete -I --__complete=
```

**Syntax error**:

```
$ hyperfine --warmup 20 -L version master,lazy "./stanc-{version} ./test/integration/bad/expect_statement_seq_close_brace_2.stan" -i
Benchmark 1: ./stanc-master ./test/integration/bad/expect_statement_seq_close_brace_2.stan
  Time (mean ± σ):      15.4 ms ±   1.4 ms    [User: 7.4 ms, System: 7.9 ms]
  Range (min … max):    13.0 ms …  20.1 ms    175 runs
 
Benchmark 2: ./stanc-lazy ./test/integration/bad/expect_statement_seq_close_brace_2.stan
  Time (mean ± σ):       6.9 ms ±   0.8 ms    [User: 2.6 ms, System: 4.2 ms]
  Range (min … max):     5.4 ms …  11.6 ms    433 runs
 
Summary
  ./stanc-lazy ./test/integration/bad/expect_statement_seq_close_brace_2.stan ran
    2.24 ± 0.34 times faster than ./stanc-master ./test/integration/bad/expect_statement_seq_close_brace_2.stan
```

**Type error**:

```
$ hyperfine --warmup 20 -L version master,lazy "./stanc-{version} ./test/integration/bad/complex-numbers/bad_bounds1.stan" -i
Benchmark 1: ./stanc-master ./test/integration/bad/complex-numbers/bad_bounds1.stan
  Time (mean ± σ):      15.5 ms ±   1.2 ms    [User: 7.8 ms, System: 7.5 ms]
  Range (min … max):    13.3 ms …  18.8 ms    172 runs
 
Benchmark 2: ./stanc-lazy ./test/integration/bad/complex-numbers/bad_bounds1.stan
  Time (mean ± σ):      15.6 ms ±   1.3 ms    [User: 7.8 ms, System: 7.7 ms]
  Range (min … max):    13.1 ms …  19.7 ms    204 runs
 
Summary
  ./stanc-master ./test/integration/bad/complex-numbers/bad_bounds1.stan ran
    1.01 ± 0.11 times faster than ./stanc-lazy ./test/integration/bad/complex-numbers/bad_bounds1.stan
```

**Successful compile**:

```
$ hyperfine --warmup 20 -L version master,lazy "./stanc-{version} ./test/integration/good/code-gen/laplace_bernoulli_logit.stan" -N
Benchmark 1: ./stanc-master ./test/integration/good/code-gen/laplace_bernoulli_logit.stan
  Time (mean ± σ):      22.0 ms ±   1.6 ms    [User: 13.5 ms, System: 8.3 ms]
  Range (min … max):    19.0 ms …  28.3 ms    130 runs
 
Benchmark 2: ./stanc-lazy ./test/integration/good/code-gen/laplace_bernoulli_logit.stan
  Time (mean ± σ):      21.8 ms ±   1.7 ms    [User: 13.9 ms, System: 7.6 ms]
  Range (min … max):    18.8 ms …  26.7 ms    141 runs
 
Summary
  ./stanc-lazy ./test/integration/good/code-gen/laplace_bernoulli_logit.stan ran
    1.01 ± 0.11 times faster than ./stanc-master ./test/integration/good/code-gen/laplace_bernoulli_logit.stan
```

</p>
</details> 

So overall a tie when the typechecking is needed, but twice or more as fast when it isn't

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improved startup time of the compiler by deferring loading of the math library signatures

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
