### PR TITLE
Improve consistency of assignment rhs and lhs overlap checks

### DIFF
--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -331,11 +331,17 @@ let rec expr_of_lvalue {lval; lmeta} =
       | LTupleProjection (l, i) -> TupleProjection (expr_of_lvalue l, i))
   ; emeta= lmeta }
 
+let exprs_in_index = function
+  | All -> []
+  | Single e -> [e]
+  | Upfrom e -> [e]
+  | Downfrom e -> [e]
+  | Between (e1, e2) -> [e1; e2]
+
 let rec extract_ids {expr; _} =
   match expr with
   | Variable id -> [id]
   | Promotion (e, _)
-   |Indexed (e, _)
    |Paren e
    |TupleProjection (e, _)
    |PrefixOp (_, e)
@@ -350,6 +356,9 @@ let rec extract_ids {expr; _} =
    |CondDistApp (_, _, es)
    |FunApp (_, _, es) ->
       List.concat_map ~f:extract_ids es
+  | Indexed (lv, ind) ->
+      List.concat_map ~f:extract_ids
+        (lv :: List.concat_map ~f:exprs_in_index ind)
   | IntNumeral _ | RealNumeral _ | ImagNumeral _ | GetTarget -> []
 
 let rec lvalue_of_expr_opt ({expr; emeta} : untyped_expression) =

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1386,12 +1386,6 @@ let lvalues_written_to lv =
   |> List.map ~f:Ast.untyped_lvalue_of_typed_lvalue
 
 let variables_accessed_in lv =
-  let exprs_in_index = function
-    | All -> []
-    | Single e -> [e]
-    | Upfrom e -> [e]
-    | Downfrom e -> [e]
-    | Between (e1, e2) -> [e1; e2] in
   (* We only care about values being read inside the lvalue here, which means
      only the expressions inside of LIndexed *)
   let rec extract_indices lv =

--- a/test/integration/bad/array-read-write-assign2.stan
+++ b/test/integration/bad/array-read-write-assign2.stan
@@ -1,0 +1,5 @@
+generated quantities {
+array[2] int n = {1, 2};
+array[2] int x = {1,2};
+x[n[x[1]]] = 2;
+}

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -57,6 +57,19 @@ Semantic error in 'array-read-write-assign.stan', line 3, column 0 to column 7:
 The same variable cannot be both assigned to and read from on the left hand side of an assignment:
   x
 [exit 1]
+  $ ../../../../install/default/bin/stanc array-read-write-assign2.stan
+Semantic error in 'array-read-write-assign2.stan', line 4, column 0 to column 10:
+   -------------------------------------------------
+     2:  array[2] int n = {1, 2};
+     3:  array[2] int x = {1,2};
+     4:  x[n[x[1]]] = 2;
+         ^
+     5:  }
+   -------------------------------------------------
+
+The same variable cannot be both assigned to and read from on the left hand side of an assignment:
+  x
+[exit 1]
   $ ../../../../install/default/bin/stanc array_expr_bad1.stan
 Semantic error in 'array_expr_bad1.stan', line 2, column 2 to column 38:
    -------------------------------------------------

--- a/test/integration/good/warning/pretty.expected
+++ b/test/integration/good/warning/pretty.expected
@@ -612,6 +612,10 @@ model {
   // no warnings
   real foo2 = 3;
   foo = (foo, foo2).2;
+  
+  array[2] int n;
+  //line 35: should warn
+  int k = n[k];
 }
 
 Warning in 'self-assign.stan', line 4, column 2 to column 12:
@@ -629,6 +633,9 @@ Warning in 'self-assign.stan', line 15, column 2 to column 14:
 Warning in 'self-assign.stan', line 22, column 2 to column 16:
     Assignment of variable to itself.
 Warning in 'self-assign.stan', line 24, column 2 to column 41:
+    Assignment of variable to itself during declaration. This is almost
+    certainly a bug.
+Warning in 'self-assign.stan', line 35, column 2 to column 15:
     Assignment of variable to itself during declaration. This is almost
     certainly a bug.
 [exit 0]

--- a/test/integration/good/warning/self-assign.stan
+++ b/test/integration/good/warning/self-assign.stan
@@ -29,4 +29,8 @@ model {
   // no warnings
   real foo2 = 3;
   foo = (foo, foo2).2;
+
+  array[2] int n;
+  //line 35: should warn
+  int k = n[k];
 }


### PR DESCRIPTION
Currently, the function `Ast.extract_ids` does not extract variable IDs that appear within an indexing expression. This results in inconsistencies when it is used - I've seen two cases:

The "Assignment of variable to itself." warning is triggered by:
```stan
  array[2] real bar = bar;
```

but not by

```stan
  array[2] int n;
  int k = n[k];
```

And that the "The same variable cannot be both assigned to and read from on the left hand side of an assignment" error is triggered by

```stan
array[2] int x = {1,2};
x[x[1]] = 2;
```

but not by

```stan
array[2] int n = {1, 2};
array[2] int x = {1,2};
x[n[x[1]]] = 2;
```

In this PR I propose to fix this by emitting warning/error also when indexing is used. I think that the warning is clearly justified, though @WardBrian mentioned that emitting the error might not actually be necessary when the expression referencing the lhs has to be evaluated before anything is written to the lhs. 

If that's the case, then it would be consistent to not single out indices, but not emit the error also for references in function calls, distribution calls etc.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] no user-facing changes were made

## Release notes

Improved handling of some edge cases when the same variable is used on both left- and right- hand side of an assignment.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
