### PR TITLE
Add new overloads for softmax, log_softmax

### DIFF
--- a/src/stan_math_signatures/Generate.ml
+++ b/src/stan_math_signatures/Generate.ml
@@ -322,6 +322,7 @@ let math_sigs =
   ; ([basic_vectorized], "log1p_exp", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "log2", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "log_inv_logit", [DDeepVectorized], SoA)
+  ; ([basic_vectorized], "log_softmax", [DVectors], SoA)
   ; ([basic_vectorized], "logit", [DDeepVectorized], SoA)
   ; ([UnaryVectorized SameAsArg], "minus", [DDeepVectorized], SoA)
   ; ([UnaryVectorized SameAsArg], "minus", [DDeepComplexVectorized], SoA)
@@ -330,6 +331,7 @@ let math_sigs =
   ; ([basic_vectorized], "round", [DDeepVectorized], AoS)
   ; ([basic_vectorized], "sin", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "sinh", [DDeepVectorized], SoA)
+  ; ([basic_vectorized], "softmax", [DVectors], SoA)
   ; ([basic_vectorized], "sqrt", [DDeepVectorized], SoA)
   ; ([basic_vectorized], "square", [DDeepVectorized], SoA)
     (* TODO: Eventually will want to move _qf to be part of the distribution
@@ -1591,7 +1593,6 @@ let () =
     (List.tl_exn vector_types);
   add_binary_vec "log_modified_bessel_first_kind" AoS;
   add_binary_vec "log_rising_factorial" AoS;
-  add_unqualified ("log_softmax", ReturnType UVector, [UVector], SoA);
   add_unqualified ("log_sum_exp", ReturnType UReal, [UArray UReal], SoA);
   add_unqualified ("log_sum_exp", ReturnType UReal, [UVector], SoA);
   add_unqualified ("log_sum_exp", ReturnType UReal, [URowVector], SoA);
@@ -2240,7 +2241,6 @@ let () =
   List.iter
     ~f:(fun t -> add_unqualified ("size", ReturnType UInt, [t], SoA))
     bare_types;
-  add_unqualified ("softmax", ReturnType UVector, [UVector], SoA);
   add_unqualified ("sort_asc", ReturnType (UArray UInt), [UArray UInt], AoS);
   add_unqualified ("sort_asc", ReturnType (UArray UReal), [UArray UReal], AoS);
   add_unqualified ("sort_asc", ReturnType UVector, [UVector], AoS);

--- a/test/integration/good/function-signatures/math/matrix/log_softmax.stan
+++ b/test/integration/good/function-signatures/math/matrix/log_softmax.stan
@@ -1,23 +1,48 @@
-data { 
+data {
   int d_int;
   vector[d_int] d_vector;
+  row_vector[d_int] d_row_vector;
+  array[d_int] vector[d_int] d_vector_array_1d;
+  array[d_int] row_vector[d_int] d_row_vector_array_1d;
+
+
 }
 
 transformed data {
-  vector[d_int] transformed_data_vector;
+  int td_int;
+  vector[d_int] td_vector;
+  row_vector[d_int] td_row_vector;
+  array[d_int] vector[d_int] td_vector_array_1d;
+  array[d_int] row_vector[d_int] td_row_vector_array_1d;
 
-  transformed_data_vector = log_softmax(d_vector);
+  td_row_vector = log_softmax(d_row_vector);
+  td_row_vector_array_1d = log_softmax(d_row_vector_array_1d);
+  td_vector = log_softmax(d_vector);
+  td_vector_array_1d = log_softmax(d_vector_array_1d);
 }
+
 parameters {
-  real y_p;
   vector[d_int] p_vector;
+  row_vector[d_int] p_row_vector;
+  array[d_int] vector[d_int] p_vector_array_1d;
+  array[d_int] row_vector[d_int] p_row_vector_array_1d;
+
+
 }
+
 transformed parameters {
   vector[d_int] transformed_param_vector;
+  row_vector[d_int] transformed_param_row_vector;
+  array[d_int] vector[d_int] transformed_param_vector_array_1d;
+  array[d_int] row_vector[d_int] transformed_param_row_vector_array_1d;
 
+  transformed_param_row_vector = log_softmax(d_row_vector);
+  transformed_param_row_vector = log_softmax(p_row_vector);
+  transformed_param_row_vector_array_1d = log_softmax(d_row_vector_array_1d);
+  transformed_param_row_vector_array_1d = log_softmax(p_row_vector_array_1d);
   transformed_param_vector = log_softmax(d_vector);
   transformed_param_vector = log_softmax(p_vector);
+  transformed_param_vector_array_1d = log_softmax(d_vector_array_1d);
+  transformed_param_vector_array_1d = log_softmax(p_vector_array_1d);
 }
-model {  
-  y_p ~ normal(0,1);
-}
+

--- a/test/integration/good/function-signatures/math/matrix/softmax.stan
+++ b/test/integration/good/function-signatures/math/matrix/softmax.stan
@@ -1,23 +1,48 @@
-data { 
+data {
   int d_int;
   vector[d_int] d_vector;
+  row_vector[d_int] d_row_vector;
+  array[d_int] vector[d_int] d_vector_array_1d;
+  array[d_int] row_vector[d_int] d_row_vector_array_1d;
+
+
 }
 
 transformed data {
-  vector[d_int] transformed_data_vector;
+  int td_int;
+  vector[d_int] td_vector;
+  row_vector[d_int] td_row_vector;
+  array[d_int] vector[d_int] td_vector_array_1d;
+  array[d_int] row_vector[d_int] td_row_vector_array_1d;
 
-  transformed_data_vector = softmax(d_vector);
+  td_row_vector = softmax(d_row_vector);
+  td_row_vector_array_1d = softmax(d_row_vector_array_1d);
+  td_vector = softmax(d_vector);
+  td_vector_array_1d = softmax(d_vector_array_1d);
 }
+
 parameters {
-  real y_p;
   vector[d_int] p_vector;
+  row_vector[d_int] p_row_vector;
+  array[d_int] vector[d_int] p_vector_array_1d;
+  array[d_int] row_vector[d_int] p_row_vector_array_1d;
+
+
 }
+
 transformed parameters {
   vector[d_int] transformed_param_vector;
+  row_vector[d_int] transformed_param_row_vector;
+  array[d_int] vector[d_int] transformed_param_vector_array_1d;
+  array[d_int] row_vector[d_int] transformed_param_row_vector_array_1d;
 
+  transformed_param_row_vector = softmax(d_row_vector);
+  transformed_param_row_vector = softmax(p_row_vector);
+  transformed_param_row_vector_array_1d = softmax(d_row_vector_array_1d);
+  transformed_param_row_vector_array_1d = softmax(p_row_vector_array_1d);
   transformed_param_vector = softmax(d_vector);
   transformed_param_vector = softmax(p_vector);
+  transformed_param_vector_array_1d = softmax(d_vector_array_1d);
+  transformed_param_vector_array_1d = softmax(p_vector_array_1d);
 }
-model {  
-  y_p ~ normal(0,1);
-}
+

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -11129,6 +11129,9 @@ Display all Stan math signatures exposed in the language
   log_rising_factorial(array[,,,,,,,] real, real) => array[,,,,,,,] real
   log_rising_factorial(array[,,,,,,,] real, array[,,,,,,,] real) => array[,,,,,,,] real
   log_softmax(vector) => vector
+  log_softmax(row_vector) => row_vector
+  log_softmax(array[] vector) => array[] vector
+  log_softmax(array[] row_vector) => array[] row_vector
   log_sum_exp(int, int) => real
   log_sum_exp(int, real) => real
   log_sum_exp(int, vector) => vector
@@ -19777,6 +19780,9 @@ Display all Stan math signatures exposed in the language
   skew_normal_rng(array[] real, array[] real, array[] int) => array[] real
   skew_normal_rng(array[] real, array[] real, array[] real) => array[] real
   softmax(vector) => vector
+  softmax(row_vector) => row_vector
+  softmax(array[] vector) => array[] vector
+  softmax(array[] row_vector) => array[] row_vector
   sort_asc(vector) => vector
   sort_asc(row_vector) => row_vector
   sort_asc(array[] int) => array[] int


### PR DESCRIPTION
Closes #1628. Adds signatures from https://github.com/stan-dev/math/pull/3313
#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: TBD

## Release notes

Added new overloads to `softmax` and `log_softmax`. In addition to vectors, they now accept row vectors, arraws of vectors, and arrays of row vectors.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
