### PR TITLE
Format .mll and .mly files with menhirformat

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.5)
+(lang dune 3.12)
 
 (name stanc)
 
@@ -41,8 +41,11 @@
    (and
     :with-dev-setup
     (= 0.28.1)))
+   (menhirformat
+    :with-dev-setup)
   (bisect_ppx :with-dev-setup)
   (ocaml-lsp-server :with-dev-setup)
+  (menhir-lsp :with-dev-setup)
   (odoc :with-doc)
   (sherlodoc :with-doc)))
 
@@ -51,5 +54,23 @@
 (generate_opam_files true)
 
 (using menhir 2.0)
+
+(dialect
+ (name menhir)
+ (implementation
+  (extension mly)
+  (format
+   (setenv
+    PATH "%{env:PATH=''}"
+    (run menhirformat --indent-once %{input-file})))))
+
+(dialect
+ (name ocamllex)
+ (implementation
+  (extension mll)
+  (format
+   (setenv
+    PATH "%{env:PATH=''}"
+    (run menhirformat --indent-once %{input-file})))))
 
 (using directory-targets 0.1)

--- a/scripts/install_ci_deps.sh
+++ b/scripts/install_ci_deps.sh
@@ -6,4 +6,4 @@ set -e
 # ocamlformat, bisect_ppx, and odoc are needed for CI and useful for developers
 opam pin -y ocamlformat 0.28.1 --no-action
 opam pin -y bisect_ppx https://github.com/aantron/bisect_ppx.git#7061d643ff492b0045796357ee6917ded21fb1f0 --no-action
-opam install -y ocamlformat bisect_ppx odoc sherlodoc
+opam install -y ocamlformat bisect_ppx odoc sherlodoc menhirformat

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -7,7 +7,7 @@
   open Debugging
   open Preprocessor
 
-(* Boilerplate for getting line numbers for errors *)
+  (* Boilerplate for getting line numbers for errors *)
   let incr_linenum lexbuf =
     lexer_pos_logger lexbuf.lex_curr_p;
     Lexing.new_line lexbuf
@@ -16,8 +16,7 @@
   let add_line_comment (begin_pos, buffer) end_pos =
     add_comment
     @@ LineComment
-         ( Buffer.contents buffer
-         , location_span_of_positions (begin_pos, end_pos) )
+         (Buffer.contents buffer, location_span_of_positions (begin_pos, end_pos))
 
   let add_multi_comment begin_pos lines end_pos =
     add_comment
@@ -29,202 +28,284 @@
   let add_include fname lexbuf =
     add_comment
     @@ Include
-         ( fname
-         , location_span_of_positions (lexbuf.lex_start_p, lexbuf.lex_curr_p) )
+         ( fname,
+           location_span_of_positions (lexbuf.lex_start_p, lexbuf.lex_curr_p) )
 }
 
 (* Some auxiliary definition for variables and constants *)
-let string_literal = '"' [^ '"' '\r' '\n']* '"'
-let identifier = ['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*   (* TODO: We should probably expand the alphabet *)
+let string_literal = '"' [^'"' '\r' '\n']* '"'
 
-let integer_constant =  ['0'-'9']+ ('_' ['0'-'9']+)*
+let identifier =
+  ['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '0'-'9' '_']* (* TODO: We should probably expand the alphabet *)
+
+let integer_constant = ['0'-'9']+ ('_' ['0'-'9']+)*
 
 let exp_literal = ['e' 'E'] ['+' '-']? integer_constant
-let real_constant1 = integer_constant '.' integer_constant? exp_literal?
+
+let real_constant1 =
+  integer_constant '.' integer_constant? exp_literal?
+
 let real_constant2 = '.' integer_constant exp_literal
+
 let real_constant3 = integer_constant exp_literal
+
 let real_constant_dot = '.' integer_constant
-let real_constant = real_constant1 | real_constant2 | real_constant3
-let imag_constant = (integer_constant | real_constant | real_constant_dot) 'i'
+
+let real_constant =
+  real_constant1 | real_constant2 | real_constant3
+
+let imag_constant =
+  (integer_constant | real_constant | real_constant_dot) 'i'
+
 let space = ' ' | '\t' | '\012'
-let newline = '\r' | '\n' | '\r'*'\n'
-let non_space_or_newline =  [^ ' ' '\t' '\012' '\r' '\n' ]
+
+let newline = '\r' | '\n' | '\r'* '\n'
+
+let non_space_or_newline = [^' ' '\t' '\012' '\r' '\n']
 
 rule token = parse
-(* White space, line numbers and comments *)
-  | newline                   { lexer_logger "newline" ;
-                                incr_linenum lexbuf ; token lexbuf }
-  | space                     { lexer_logger "space" ; token lexbuf }
-  | "/*"                      { lexer_logger "multicomment" ;
-                                multiline_comment ((lexbuf.lex_curr_p, []), Buffer.create 16) lexbuf ; token lexbuf }
-  | "//"                      { lexer_logger "single comment" ;
-                                singleline_comment (lexbuf.lex_curr_p, Buffer.create 16) lexbuf ;
-                                token lexbuf }
-  | "#include"
-    ( ( space | newline)+)
-    ( '"' ([^ '"' '\r' '\n']* as fname) '"'
-    | '<' ([^ '>' '\r' '\n']* as fname) '>'
-    | (non_space_or_newline* as fname)
-    )                         { lexer_logger ("include " ^ fname) ;
-                                add_include fname lexbuf ;
-                                let new_lexbuf =
-                                  try_get_new_lexbuf fname in
-                                token new_lexbuf }
-(* Program blocks *)
-  | "functions"               { lexer_logger "functions" ;
-                                Parser.FUNCTIONBLOCK }
-  | "data"                    { lexer_logger "data" ; Parser.DATABLOCK }
-  | "transformed"
-      ( space+ )
-      "data"                  { lexer_logger "transformed data" ;
-                                Parser.TRANSFORMEDDATABLOCK }
-  | "parameters"              { lexer_logger "parameters" ;
-                                Parser.PARAMETERSBLOCK }
-  | "transformed"
-      ( space+ )
-      "parameters"            { lexer_logger "transformed parameters" ;
-                                Parser.TRANSFORMEDPARAMETERSBLOCK }
-  | "model"                   { lexer_logger "model" ; Parser.MODELBLOCK }
-  | "generated"
-      ( space+ )
-      "quantities"    { lexer_logger "generated quantities" ;
-                                Parser.GENERATEDQUANTITIESBLOCK }
-(* Punctuation *)
-  | '{'                       { lexer_logger "{" ; Parser.LBRACE }
-  | '}'                       { lexer_logger "}" ; Parser.RBRACE }
-  | '('                       { lexer_logger "(" ; Parser.LPAREN }
-  | ')'                       { lexer_logger ")" ; Parser.RPAREN }
-  | '['                       { lexer_logger "[" ; Parser.LBRACK }
-  | ']'                       { lexer_logger "]" ; Parser.RBRACK }
-  | '<'                       { lexer_logger "<" ; add_separator lexbuf ; Parser.LABRACK }
-  | '>'                       { lexer_logger ">" ; add_separator lexbuf ; Parser.RABRACK }
-  | ','                       { lexer_logger "," ; add_separator lexbuf ; Parser.COMMA }
-  | ';'                       { lexer_logger ";" ; Parser.SEMICOLON }
-  | '|'                       { lexer_logger "|" ; add_separator lexbuf ; Parser.BAR }
-(* Control flow keywords *)
-  | "return"                  { lexer_logger "return" ; Parser.RETURN }
-  | "if"                      { lexer_logger "if" ; Parser.IF }
-  | "else"                    { lexer_logger "else" ; add_separator lexbuf ; Parser.ELSE }
-  | "while"                   { lexer_logger "while" ; Parser.WHILE }
-  | "profile"                 { lexer_logger "profile" ; Parser.PROFILE }
-  | "for"                     { lexer_logger "for" ; Parser.FOR }
-  | "in"                      { lexer_logger "in" ; Parser.IN }
-  | "break"                   { lexer_logger "break" ; Parser.BREAK }
-  | "continue"                { lexer_logger "continue" ; Parser.CONTINUE }
-(* Types *)
-  | "void"                    { lexer_logger "void" ; Parser.VOID }
-  | "int"                     { lexer_logger "int" ; Parser.INT }
-  | "real"                    { lexer_logger "real" ; Parser.REAL }
-  | "complex"                 { lexer_logger "complex" ; Parser.COMPLEX }
-  | "vector"                  { lexer_logger "vector" ; Parser.VECTOR }
-  | "row_vector"              { lexer_logger "row_vector" ; Parser.ROWVECTOR }
-  | "complex_vector"          { lexer_logger "complex_vector" ; Parser.COMPLEXVECTOR }
-  | "complex_row_vector"      { lexer_logger "complex_row_vector" ; Parser.COMPLEXROWVECTOR }
-  | "tuple"                   { lexer_logger "tuple" ; Parser.TUPLE }
-  | "array"                   { lexer_logger "array" ; Parser.ARRAY }
-  | "matrix"                  { lexer_logger "matrix" ; Parser.MATRIX }
-  | "complex_matrix"          { lexer_logger "complex_matrix" ; Parser.COMPLEXMATRIX }
-  | "ordered"                 { lexer_logger "ordered" ; Parser.ORDERED }
-  | "positive_ordered"        { lexer_logger "positive_ordered" ;
-                                Parser.POSITIVEORDERED }
-  | "simplex"                 { lexer_logger "simplex" ; Parser.SIMPLEX }
-  | "unit_vector"             { lexer_logger "unit_vector" ; Parser.UNITVECTOR }
-  | "sum_to_zero_vector"      { lexer_logger "sum_to_zero_vector" ; Parser.SUMTOZEROVEC }
-  | "sum_to_zero_matrix"      { lexer_logger "sum_to_zero_matrix" ; Parser.SUMTOZEROMAT }
-  | "cholesky_factor_corr"    { lexer_logger "cholesky_factor_corr" ;
-                                Parser.CHOLESKYFACTORCORR }
-  | "cholesky_factor_cov"     { lexer_logger "cholesky_factor_cov" ;
-                                Parser.CHOLESKYFACTORCOV }
-  | "corr_matrix"             { lexer_logger "corr_matrix" ; Parser.CORRMATRIX }
-  | "cov_matrix"              { lexer_logger "cov_matrix" ; Parser.COVMATRIX }
-  | "column_stochastic_matrix"{ lexer_logger "column_stochastic_matrix" ; Parser.STOCHASTICCOLUMNMATRIX }
-  | "row_stochastic_matrix"   { lexer_logger "row_stochastic_matrix" ; Parser.STOCHASTICROWMATRIX }
-(* Transformation keywords *)
-  | "lower"                   { lexer_logger "lower" ; Parser.LOWER }
-  | "upper"                   { lexer_logger "upper" ; Parser.UPPER }
-  | "offset"                  { lexer_logger "offset" ; Parser.OFFSET }
-  | "multiplier"              { lexer_logger "multiplier" ; Parser.MULTIPLIER }
-  | "jacobian"                { lexer_logger "jacobian" ; Parser.JACOBIAN }
-(* Operators *)
-  | '?'                       { lexer_logger "?" ; add_separator lexbuf ; Parser.QMARK }
-  | ':'                       { lexer_logger ":" ; Parser.COLON }
-  | '!'                       { lexer_logger "!" ; Parser.BANG }
-  | '-'                       { lexer_logger "-" ; add_separator lexbuf ; Parser.MINUS }
-  | '+'                       { lexer_logger "+" ; add_separator lexbuf ; Parser.PLUS }
-  | '^'                       { lexer_logger "^" ; add_separator lexbuf ; Parser.HAT }
-  | '\''                      { lexer_logger "\'" ; Parser.TRANSPOSE }
-  | '*'                       { lexer_logger "*" ; add_separator lexbuf ; Parser.TIMES }
-  | '/'                       { lexer_logger "/" ; add_separator lexbuf ; Parser.DIVIDE }
-  | '%'                       { lexer_logger "%" ; add_separator lexbuf ; Parser.MODULO }
-  | "%/%"                     { lexer_logger "%/%" ; add_separator lexbuf ; Parser.IDIVIDE }
-  | "\\"                      { lexer_logger "\\" ; add_separator lexbuf ; Parser.LDIVIDE }
-  | ".*"                      { lexer_logger ".*" ; add_separator lexbuf ; Parser.ELTTIMES }
-  | ".^"                      { lexer_logger ".^" ; add_separator lexbuf ; Parser.ELTPOW }
-  | "./"                      { lexer_logger "./" ; add_separator lexbuf ; Parser.ELTDIVIDE }
-  | "||"                      { lexer_logger "||" ; add_separator lexbuf ; Parser.OR }
-  | "&&"                      { lexer_logger "&&" ; add_separator lexbuf ; Parser.AND }
-  | "=="                      { lexer_logger "==" ; add_separator lexbuf ; Parser.EQUALS }
-  | "!="                      { lexer_logger "!=" ; add_separator lexbuf ; Parser.NEQUALS }
-  | "<="                      { lexer_logger "<=" ; add_separator lexbuf ; Parser.LEQ }
-  | ">="                      { lexer_logger ">=" ; add_separator lexbuf ; Parser.GEQ }
-  | "~"                       { lexer_logger "~" ; Parser.TILDE }
-(* Assignments *)
-  | '='                       { lexer_logger "=" ; Parser.ASSIGN }
-  | "+="                      { lexer_logger "+=" ; Parser.PLUSASSIGN }
-  | "-="                      { lexer_logger "-=" ; Parser.MINUSASSIGN }
-  | "*="                      { lexer_logger "*=" ; Parser.TIMESASSIGN }
-  | "/="                      { lexer_logger "/=" ; Parser.DIVIDEASSIGN }
-  | ".*="                     { lexer_logger ".*=" ; Parser.ELTTIMESASSIGN }
-  | "./="                     { lexer_logger "./=" ; Parser.ELTDIVIDEASSIGN }
-(* Effects *)
-  | "print"                   { lexer_logger "print" ; Parser.PRINT }
-  | "reject"                  { lexer_logger "reject" ; Parser.REJECT }
-  | "fatal_error"             { lexer_logger "fatal_error" ; Parser.FATAL_ERROR }
-  | 'T'                       { lexer_logger "T" ; Parser.TRUNCATE } (* TODO: this is a hack; we should change to something like truncate and make it a reserved keyword *)
-(* Constants and identifiers *)
-  | integer_constant as i     { lexer_logger ("int_constant " ^ i) ;
-                                Parser.INTNUMERAL (lexeme lexbuf) }
-  | real_constant as r        { lexer_logger ("real_constant " ^ r) ;
-                                Parser.REALNUMERAL (lexeme lexbuf) }
-  | real_constant_dot as r    { lexer_logger ("real_constant_dot " ^ r) ;
-                                (* Separated out because ".1" could be a number or a tuple projection *)
-                                Parser.DOTNUMERAL (lexeme lexbuf) }
-  | imag_constant as z        { lexer_logger ("imag_constant " ^ z) ;
-                                Parser.IMAGNUMERAL (lexeme lexbuf) }
-  | "target"                  { lexer_logger "target" ; Parser.TARGET }
-  | string_literal as s       { lexer_logger ("string_literal " ^ s) ;
-                                Parser.STRINGLITERAL (lexeme lexbuf) }
-  | identifier as id          { lexer_logger ("identifier " ^ id) ;
-                                lexer_pos_logger (lexeme_start_p lexbuf);
-                                Parser.IDENTIFIER (lexeme lexbuf) }
-(* End of file *)
-  | eof                       { lexer_logger "eof" ;
-                                if Preprocessor.size () = 1
-                                then Parser.EOF
-                                else
-                                  let old_lexbuf = restore_prior_lexbuf () in
-                                  token old_lexbuf }
+  (* White space, line numbers and comments *)
+  | newline
+    { lexer_logger "newline"; incr_linenum lexbuf; token lexbuf }
+  | space { lexer_logger "space"; token lexbuf }
+  | "/*"
+    {
+      lexer_logger "multicomment";
+      multiline_comment ((lexbuf.lex_curr_p, []), Buffer.create 16) lexbuf;
+      token lexbuf
+    }
+  | "//"
+    {
+      lexer_logger "single comment";
+      singleline_comment (lexbuf.lex_curr_p, Buffer.create 16) lexbuf;
+      token lexbuf
+    }
+  | "#include" ((space | newline)+) ('"' ([^'"' '\r' '\n']* as fname) '"'
+                                     | '<' ([^'>' '\r' '\n']* as fname) '>'
+                                     | (non_space_or_newline* as fname))
+    {
+      lexer_logger ("include " ^ fname);
+      add_include fname lexbuf;
+      let new_lexbuf = try_get_new_lexbuf fname in
+      token new_lexbuf
+    }
+  (* Program blocks *)
+  | "functions" { lexer_logger "functions"; Parser.FUNCTIONBLOCK }
+  | "data" { lexer_logger "data"; Parser.DATABLOCK }
+  | "transformed" (space+) "data"
+    { lexer_logger "transformed data"; Parser.TRANSFORMEDDATABLOCK }
+  | "parameters"
+    { lexer_logger "parameters"; Parser.PARAMETERSBLOCK }
+  | "transformed" (space+) "parameters"
+    {
+      lexer_logger "transformed parameters";
+      Parser.TRANSFORMEDPARAMETERSBLOCK
+    }
+  | "model" { lexer_logger "model"; Parser.MODELBLOCK }
+  | "generated" (space+) "quantities"
+    {
+      lexer_logger "generated quantities";
+      Parser.GENERATEDQUANTITIESBLOCK
+    }
+  (* Punctuation *)
+  | '{' { lexer_logger "{"; Parser.LBRACE }
+  | '}' { lexer_logger "}"; Parser.RBRACE }
+  | '(' { lexer_logger "("; Parser.LPAREN }
+  | ')' { lexer_logger ")"; Parser.RPAREN }
+  | '[' { lexer_logger "["; Parser.LBRACK }
+  | ']' { lexer_logger "]"; Parser.RBRACK }
+  | '<' { lexer_logger "<"; add_separator lexbuf; Parser.LABRACK }
+  | '>' { lexer_logger ">"; add_separator lexbuf; Parser.RABRACK }
+  | ',' { lexer_logger ","; add_separator lexbuf; Parser.COMMA }
+  | ';' { lexer_logger ";"; Parser.SEMICOLON }
+  | '|' { lexer_logger "|"; add_separator lexbuf; Parser.BAR }
+  (* Control flow keywords *)
+  | "return" { lexer_logger "return"; Parser.RETURN }
+  | "if" { lexer_logger "if"; Parser.IF }
+  | "else"
+    { lexer_logger "else"; add_separator lexbuf; Parser.ELSE }
+  | "while" { lexer_logger "while"; Parser.WHILE }
+  | "profile" { lexer_logger "profile"; Parser.PROFILE }
+  | "for" { lexer_logger "for"; Parser.FOR }
+  | "in" { lexer_logger "in"; Parser.IN }
+  | "break" { lexer_logger "break"; Parser.BREAK }
+  | "continue" { lexer_logger "continue"; Parser.CONTINUE }
+  (* Types *)
+  | "void" { lexer_logger "void"; Parser.VOID }
+  | "int" { lexer_logger "int"; Parser.INT }
+  | "real" { lexer_logger "real"; Parser.REAL }
+  | "complex" { lexer_logger "complex"; Parser.COMPLEX }
+  | "vector" { lexer_logger "vector"; Parser.VECTOR }
+  | "row_vector" { lexer_logger "row_vector"; Parser.ROWVECTOR }
+  | "complex_vector"
+    { lexer_logger "complex_vector"; Parser.COMPLEXVECTOR }
+  | "complex_row_vector"
+    { lexer_logger "complex_row_vector"; Parser.COMPLEXROWVECTOR }
+  | "tuple" { lexer_logger "tuple"; Parser.TUPLE }
+  | "array" { lexer_logger "array"; Parser.ARRAY }
+  | "matrix" { lexer_logger "matrix"; Parser.MATRIX }
+  | "complex_matrix"
+    { lexer_logger "complex_matrix"; Parser.COMPLEXMATRIX }
+  | "ordered" { lexer_logger "ordered"; Parser.ORDERED }
+  | "positive_ordered"
+    { lexer_logger "positive_ordered"; Parser.POSITIVEORDERED }
+  | "simplex" { lexer_logger "simplex"; Parser.SIMPLEX }
+  | "unit_vector"
+    { lexer_logger "unit_vector"; Parser.UNITVECTOR }
+  | "sum_to_zero_vector"
+    { lexer_logger "sum_to_zero_vector"; Parser.SUMTOZEROVEC }
+  | "sum_to_zero_matrix"
+    { lexer_logger "sum_to_zero_matrix"; Parser.SUMTOZEROMAT }
+  | "cholesky_factor_corr"
+    {
+      lexer_logger "cholesky_factor_corr";
+      Parser.CHOLESKYFACTORCORR
+    }
+  | "cholesky_factor_cov"
+    { lexer_logger "cholesky_factor_cov"; Parser.CHOLESKYFACTORCOV }
+  | "corr_matrix"
+    { lexer_logger "corr_matrix"; Parser.CORRMATRIX }
+  | "cov_matrix" { lexer_logger "cov_matrix"; Parser.COVMATRIX }
+  | "column_stochastic_matrix"
+    {
+      lexer_logger "column_stochastic_matrix";
+      Parser.STOCHASTICCOLUMNMATRIX
+    }
+  | "row_stochastic_matrix"
+    {
+      lexer_logger "row_stochastic_matrix";
+      Parser.STOCHASTICROWMATRIX
+    }
+  (* Transformation keywords *)
+  | "lower" { lexer_logger "lower"; Parser.LOWER }
+  | "upper" { lexer_logger "upper"; Parser.UPPER }
+  | "offset" { lexer_logger "offset"; Parser.OFFSET }
+  | "multiplier" { lexer_logger "multiplier"; Parser.MULTIPLIER }
+  | "jacobian" { lexer_logger "jacobian"; Parser.JACOBIAN }
+  (* Operators *)
+  | '?' { lexer_logger "?"; add_separator lexbuf; Parser.QMARK }
+  | ':' { lexer_logger ":"; Parser.COLON }
+  | '!' { lexer_logger "!"; Parser.BANG }
+  | '-' { lexer_logger "-"; add_separator lexbuf; Parser.MINUS }
+  | '+' { lexer_logger "+"; add_separator lexbuf; Parser.PLUS }
+  | '^' { lexer_logger "^"; add_separator lexbuf; Parser.HAT }
+  | '\'' { lexer_logger "'"; Parser.TRANSPOSE }
+  | '*' { lexer_logger "*"; add_separator lexbuf; Parser.TIMES }
+  | '/' { lexer_logger "/"; add_separator lexbuf; Parser.DIVIDE }
+  | '%' { lexer_logger "%"; add_separator lexbuf; Parser.MODULO }
+  | "%/%"
+    { lexer_logger "%/%"; add_separator lexbuf; Parser.IDIVIDE }
+  | "\\"
+    { lexer_logger "\\"; add_separator lexbuf; Parser.LDIVIDE }
+  | ".*"
+    { lexer_logger ".*"; add_separator lexbuf; Parser.ELTTIMES }
+  | ".^"
+    { lexer_logger ".^"; add_separator lexbuf; Parser.ELTPOW }
+  | "./"
+    { lexer_logger "./"; add_separator lexbuf; Parser.ELTDIVIDE }
+  | "||" { lexer_logger "||"; add_separator lexbuf; Parser.OR }
+  | "&&" { lexer_logger "&&"; add_separator lexbuf; Parser.AND }
+  | "=="
+    { lexer_logger "=="; add_separator lexbuf; Parser.EQUALS }
+  | "!="
+    { lexer_logger "!="; add_separator lexbuf; Parser.NEQUALS }
+  | "<=" { lexer_logger "<="; add_separator lexbuf; Parser.LEQ }
+  | ">=" { lexer_logger ">="; add_separator lexbuf; Parser.GEQ }
+  | "~" { lexer_logger "~"; Parser.TILDE }
+  (* Assignments *)
+  | '=' { lexer_logger "="; Parser.ASSIGN }
+  | "+=" { lexer_logger "+="; Parser.PLUSASSIGN }
+  | "-=" { lexer_logger "-="; Parser.MINUSASSIGN }
+  | "*=" { lexer_logger "*="; Parser.TIMESASSIGN }
+  | "/=" { lexer_logger "/="; Parser.DIVIDEASSIGN }
+  | ".*=" { lexer_logger ".*="; Parser.ELTTIMESASSIGN }
+  | "./=" { lexer_logger "./="; Parser.ELTDIVIDEASSIGN }
+  (* Effects *)
+  | "print" { lexer_logger "print"; Parser.PRINT }
+  | "reject" { lexer_logger "reject"; Parser.REJECT }
+  | "fatal_error"
+    { lexer_logger "fatal_error"; Parser.FATAL_ERROR }
+  | 'T' { lexer_logger "T"; Parser.TRUNCATE } (* TODO: this is a hack; we should change to something like truncate and make it a reserved keyword *)
+  (* Constants and identifiers *)
+  | integer_constant as i
+    {
+      lexer_logger ("int_constant " ^ i);
+      Parser.INTNUMERAL (lexeme lexbuf)
+    }
+  | real_constant as r
+    {
+      lexer_logger ("real_constant " ^ r);
+      Parser.REALNUMERAL (lexeme lexbuf)
+    }
+  | real_constant_dot as r
+    {
+      lexer_logger ("real_constant_dot " ^ r);
+      (* Separated out because .1 could be a number or a tuple projection *)
+      Parser.DOTNUMERAL (lexeme lexbuf)
+    }
+  | imag_constant as z
+    {
+      lexer_logger ("imag_constant " ^ z);
+      Parser.IMAGNUMERAL (lexeme lexbuf)
+    }
+  | "target" { lexer_logger "target"; Parser.TARGET }
+  | string_literal as s
+    {
+      lexer_logger ("string_literal " ^ s);
+      Parser.STRINGLITERAL (lexeme lexbuf)
+    }
+  | identifier as id
+    {
+      lexer_logger ("identifier " ^ id);
+      lexer_pos_logger (lexeme_start_p lexbuf);
+      Parser.IDENTIFIER (lexeme lexbuf)
+    }
+  (* End of file *)
+  | eof
+    {
+      lexer_logger "eof";
+      if Preprocessor.size () = 1 then Parser.EOF
+      else
+        let old_lexbuf = restore_prior_lexbuf () in
+        token old_lexbuf
+    }
+  | _ { Syntax_error.unexpected_character (current_location ()) }
 
-  | _                         { Syntax_error.unexpected_character (current_location ()) }
-
-(* Multi-line comment terminated by "*/" *)
+(* Multi-line comment terminated by */ *)
 and multiline_comment state = parse
-  | "*/"     { let ((pos, lines), buffer) = state in
-               let lines = (Buffer.contents buffer) :: lines in
-               add_multi_comment pos (List.rev lines) lexbuf.lex_curr_p }
-  | eof      { Syntax_error.unexpected_eof (current_location ()) }
-  | newline  { incr_linenum lexbuf;
-               let ((pos, lines), buffer) = state in
-               let lines = (Buffer.contents buffer) :: lines in
-               let newbuf = Buffer.create 16 in
-               multiline_comment ((pos, lines), newbuf) lexbuf }
-  | _        { Buffer.add_string (snd state) (lexeme lexbuf) ; multiline_comment state lexbuf }
+  | "*/"
+    {
+      let (pos, lines), buffer = state in
+      let lines = Buffer.contents buffer :: lines in
+      add_multi_comment pos (List.rev lines) lexbuf.lex_curr_p
+    }
+  | eof { Syntax_error.unexpected_eof (current_location ()) }
+  | newline
+    {
+      incr_linenum lexbuf;
+      let (pos, lines), buffer = state in
+      let lines = Buffer.contents buffer :: lines in
+      let newbuf = Buffer.create 16 in
+      multiline_comment ((pos, lines), newbuf) lexbuf
+    }
+  | _
+    {
+      Buffer.add_string (snd state) (lexeme lexbuf);
+      multiline_comment state lexbuf
+    }
 
 (* Single-line comment terminated by a newline *)
 and singleline_comment state = parse
-  | newline  { add_line_comment state lexbuf.lex_curr_p ; incr_linenum lexbuf }
-  | eof      { add_line_comment state lexbuf.lex_curr_p }
-  | _        { Buffer.add_string (snd state) (lexeme lexbuf) ; singleline_comment state lexbuf }
+  | newline
+    {
+      add_line_comment state lexbuf.lex_curr_p;
+      incr_linenum lexbuf
+    }
+  | eof { add_line_comment state lexbuf.lex_curr_p }
+  | _
+    {
+      Buffer.add_string (snd state) (lexeme lexbuf);
+      singleline_comment state lexbuf
+    }
 
-{
-}
+{  }

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -1,92 +1,108 @@
 (** The parser for Stan. A Menhir file. *)
 %{
-open Core
-open Middle
-open Ast
-open Debugging
-open Preprocessor
+  open Core
+  open Middle
+  open Ast
+  open Debugging
+  open Preprocessor
 
-let parse_error msg loc =
-  Syntax_error.parse_error (Scanf.format_from_string msg "") (location_span_of_positions loc)
+  let parse_error msg loc =
+    Syntax_error.parse_error
+      (Scanf.format_from_string msg "")
+      (location_span_of_positions loc)
 
-(* Takes a sized_basic_type and a list of sizes and repeatedly applies then
-   SArray constructor, taking sizes off the list *)
-let reducearray (sbt, l) =
-  List.fold_right l ~f:(fun z y -> SizedType.SArray (y, z)) ~init:sbt
+  (* Takes a sized_basic_type and a list of sizes and repeatedly applies then
+     SArray constructor, taking sizes off the list *)
+  let reducearray (sbt, l) =
+    List.fold_right l ~f:(fun z y -> SizedType.SArray (y, z)) ~init:sbt
 
-let build_id id loc =
-  grammar_logger ("identifier " ^ id);
-  {name= id; id_loc= location_span_of_positions loc}
+  let build_id id loc =
+    grammar_logger ("identifier " ^ id);
+    { name = id; id_loc = location_span_of_positions loc }
 
-let reserved (name, loc, _) =
-  parse_error
-    ("@{<light_red>Ill-formed identifier.@} Expected a new identifier but \
-      found reserved keyword @{<green>\"" ^ name ^ "\"@}.\n")
-    loc
-
-let reserved_decl (name, loc, is_type) =
-  if is_type then
+  let reserved (name, loc, _) =
     parse_error
-      ("@[@{<light_red>Ill-formed identifier.@} Found a type (@{<green>\"" ^ name
-     ^ "\"@}) where an identifier was expected.@ \
-        All variables declared in a comma-separated list must be of the same \
-        type.@]")
+      ("@{<light_red>Ill-formed identifier.@} Expected a new identifier but \
+        found reserved keyword @{<green>\"" ^ name ^ "\"@}.\n")
       loc
-  else reserved (name, loc, is_type)
 
-let build_expr expr loc = {expr; emeta= {loc= location_span_of_positions loc}}
-let rec iterate_n f x = function 0 -> x | n -> iterate_n f (f x) (n - 1)
-
-let parse_tuple_slot ix_str (start, stop) =
-  let slot = String.drop_prefix ix_str 1 in
-  match Int.of_string_opt slot with
-  | None ->
+  let reserved_decl (name, loc, is_type) =
+    if is_type then
       parse_error
-        ("@[@{<light_red>Ill-formed index.@} Failed to parse integer from string \
-          @{<green>\"" ^ slot
-       ^ "\"@} in tuple index.@ The index is likely too large.@]")
-        (* Move start by one character to avoid pointing at the . *)
-        (Lexing.{start with pos_cnum = start.pos_cnum + 1}, stop)
-  | Some ix -> ix
-
-(** Given a parsed expression, try to convert it to
-    a valid assignable lvalue. Raises a syntax error on failure *)
-let try_convert_to_lvalue expr loc =
-  match Ast.lvalue_of_expr_opt expr with
-  | Some l -> l
-  | None ->
-      parse_error
-        "@{<light_red>Ill-formed assignment.@} Expected an assignable value \
-         but found a general expression."
+        ("@[@{<light_red>Ill-formed identifier.@} Found a type (@{<green>\""
+       ^ name
+       ^ "\"@}) where an identifier was expected.@ All variables declared in a \
+          comma-separated list must be of the same type.@]")
         loc
+    else reserved (name, loc, is_type)
 
+  let build_expr expr loc =
+    { expr; emeta = { loc = location_span_of_positions loc } }
 
-let nest_unsized_array basic_type n =
-  iterate_n (fun t -> UnsizedType.UArray t) basic_type n
+  let rec iterate_n f x = function 0 -> x | n -> iterate_n f (f x) (n - 1)
 
+  let parse_tuple_slot ix_str (start, stop) =
+    let slot = String.drop_prefix ix_str 1 in
+    match Int.of_string_opt slot with
+    | None ->
+        parse_error
+          ("@[@{<light_red>Ill-formed index.@} Failed to parse integer from \
+            string @{<green>\"" ^ slot
+         ^ "\"@} in tuple index.@ The index is likely too large.@]")
+          (* Move start by one character to avoid pointing at the . *)
+          (Lexing.{ start with pos_cnum = start.pos_cnum + 1 }, stop)
+    | Some ix -> ix
+
+  (** Given a parsed expression, try to convert it to a valid assignable lvalue.
+      Raises a syntax error on failure *)
+  let try_convert_to_lvalue expr loc =
+    match Ast.lvalue_of_expr_opt expr with
+    | Some l -> l
+    | None ->
+        parse_error
+          "@{<light_red>Ill-formed assignment.@} Expected an assignable value \
+           but found a general expression."
+          loc
+
+  let nest_unsized_array basic_type n =
+    iterate_n (fun t -> UnsizedType.UArray t) basic_type n
 %}
 
 (* Token definitions. The quoted strings are aliases, used in the examples generated in
    parser.messages. They have no semantic meaning; see
    http://gallium.inria.fr/~fpottier/menhir/manual.html#sec%3Atokens
 *)
-%token FUNCTIONBLOCK "functions" DATABLOCK "data"
-       TRANSFORMEDDATABLOCK "transformed data" PARAMETERSBLOCK "parameters"
-       TRANSFORMEDPARAMETERSBLOCK "transformed parameters" MODELBLOCK "model"
-       GENERATEDQUANTITIESBLOCK "generated quantities"
-%token LBRACE "{" RBRACE "}" LPAREN "(" RPAREN ")" LBRACK "[" RBRACK "]"
-       LABRACK "<" RABRACK ">" COMMA "," SEMICOLON ";" BAR "|"
-%token RETURN "return" IF "if" ELSE "else" WHILE "while" FOR "for" IN "in"
-       BREAK "break" CONTINUE "continue" PROFILE "profile"
-%token VOID "void" INT "int" REAL "real" COMPLEX "complex" VECTOR "vector"
-       ROWVECTOR "row_vector" ARRAY "array" TUPLE "tuple" MATRIX "matrix" ORDERED "ordered"
-       COMPLEXVECTOR "complex_vector" COMPLEXROWVECTOR "complex_row_vector"
-       POSITIVEORDERED "positive_ordered" SIMPLEX "simplex" UNITVECTOR "unit_vector"
-       SUMTOZEROVEC "sum_to_zero_vector" CHOLESKYFACTORCORR "cholesky_factor_corr"
-       CHOLESKYFACTORCOV "cholesky_factor_cov" CORRMATRIX "corr_matrix" COVMATRIX "cov_matrix"
-       COMPLEXMATRIX "complex_matrix" STOCHASTICCOLUMNMATRIX "column_stochastic_matrix"
-       STOCHASTICROWMATRIX "row_stochastic_matrix" SUMTOZEROMAT "sum_to_zero_matrix"
-%token LOWER "lower" UPPER "upper" OFFSET "offset" MULTIPLIER "multiplier"
+%token
+  FUNCTIONBLOCK "functions" DATABLOCK "data"
+  TRANSFORMEDDATABLOCK "transformed data"
+  PARAMETERSBLOCK "parameters"
+  TRANSFORMEDPARAMETERSBLOCK "transformed parameters"
+  MODELBLOCK "model"
+  GENERATEDQUANTITIESBLOCK "generated quantities"
+%token
+  LBRACE "{" RBRACE "}" LPAREN "(" RPAREN ")" LBRACK "["
+  RBRACK "]" LABRACK "<" RABRACK ">" COMMA "," SEMICOLON ";"
+  BAR "|"
+%token
+  RETURN "return" IF "if" ELSE "else" WHILE "while" FOR "for"
+  IN "in" BREAK "break" CONTINUE "continue" PROFILE "profile"
+%token
+  VOID "void" INT "int" REAL "real" COMPLEX "complex"
+  VECTOR "vector" ROWVECTOR "row_vector" ARRAY "array"
+  TUPLE "tuple" MATRIX "matrix" ORDERED "ordered"
+  COMPLEXVECTOR "complex_vector"
+  COMPLEXROWVECTOR "complex_row_vector"
+  POSITIVEORDERED "positive_ordered" SIMPLEX "simplex"
+  UNITVECTOR "unit_vector" SUMTOZEROVEC "sum_to_zero_vector"
+  CHOLESKYFACTORCORR "cholesky_factor_corr"
+  CHOLESKYFACTORCOV "cholesky_factor_cov" CORRMATRIX "corr_matrix"
+  COVMATRIX "cov_matrix" COMPLEXMATRIX "complex_matrix"
+  STOCHASTICCOLUMNMATRIX "column_stochastic_matrix"
+  STOCHASTICROWMATRIX "row_stochastic_matrix"
+  SUMTOZEROMAT "sum_to_zero_matrix"
+%token
+  LOWER "lower" UPPER "upper" OFFSET "offset"
+  MULTIPLIER "multiplier"
 %token JACOBIAN "jacobian"
 %token <string> INTNUMERAL "24"
 %token <string> REALNUMERAL "3.1415" DOTNUMERAL ".2"
@@ -94,15 +110,17 @@ let nest_unsized_array basic_type n =
 %token <string> STRINGLITERAL "\"hello world\""
 %token <string> IDENTIFIER "foo"
 %token TARGET "target"
-%token QMARK "?" COLON ":" BANG "!" MINUS "-" PLUS "+" HAT "^" ELTPOW ".^" TRANSPOSE "'"
-       TIMES "*" DIVIDE "/" MODULO "%" IDIVIDE "%/%" LDIVIDE "\\" ELTTIMES ".*"
-       ELTDIVIDE "./" OR "||" AND "&&" EQUALS "==" NEQUALS "!=" LEQ "<=" GEQ ">=" TILDE "~"
-%token ASSIGN "=" PLUSASSIGN "+=" MINUSASSIGN "-=" TIMESASSIGN "*="
-       DIVIDEASSIGN "/=" ELTDIVIDEASSIGN "./=" ELTTIMESASSIGN ".*="
+%token
+  QMARK "?" COLON ":" BANG "!" MINUS "-" PLUS "+" HAT "^"
+  ELTPOW ".^" TRANSPOSE "'" TIMES "*" DIVIDE "/" MODULO "%"
+  IDIVIDE "%/%" LDIVIDE "\\" ELTTIMES ".*" ELTDIVIDE "./" OR "||"
+  AND "&&" EQUALS "==" NEQUALS "!=" LEQ "<=" GEQ ">=" TILDE "~"
+%token
+  ASSIGN "=" PLUSASSIGN "+=" MINUSASSIGN "-=" TIMESASSIGN "*="
+  DIVIDEASSIGN "/=" ELTDIVIDEASSIGN "./=" ELTTIMESASSIGN ".*="
 %token PRINT "print" REJECT "reject" FATAL_ERROR "fatal_error"
 %token TRUNCATE "T"
 %token EOF "<EOF>"
-
 (* UNREACHABLE tokens will never be produced by the lexer, so we can use them as
    "a thing that will never parse". This is useful in a few places. For example,
    when we the parser to differentiate between different failing states for
@@ -110,6 +128,9 @@ let nest_unsized_array basic_type n =
    requiring an UNREACHABLE token.
  *)
 %token UNREACHABLE "<<<<UNREACHABLE>>>"
+
+(* Top level rule *)
+%start <Ast.untyped_program> program functions_only
 
 %right COMMA
 %right QMARK COLON
@@ -126,98 +147,117 @@ let nest_unsized_array basic_type n =
 %nonassoc below_ELSE
 %nonassoc ELSE
 
-(* Top level rule *)
-%start <Ast.untyped_program> program functions_only
 %%
 
 (* Grammar *)
 
 (* program *)
 program:
-  | ofb=option(function_block)
-    odb=option(data_block)
-    otdb=option(transformed_data_block)
-    opb=option(parameters_block)
-    otpb=option(transformed_parameters_block)
-    omb=option(model_block)
-    ogb=option(generated_quantities_block)
-    EOF
+  | ofb = option(function_block) odb = option(data_block)
+    otdb = option(transformed_data_block)
+    opb = option(parameters_block)
+    otpb = option(transformed_parameters_block)
+    omb = option(model_block)
+    ogb = option(generated_quantities_block) EOF
     {
-      grammar_logger "program" ;
+      grammar_logger "program";
       (* check for empty programs *)
-      if List.is_empty (List.filter_opt [ofb; odb; otdb; opb; otpb; omb; ogb])
-      then Input_warnings.empty ();
-      { functionblock= ofb
-      ; datablock= odb
-      ; transformeddatablock= otdb
-      ; parametersblock= opb
-      ; transformedparametersblock= otpb
-      ; modelblock= omb
-      ; generatedquantitiesblock= ogb
-      ; comments= [] }
+      if List.is_empty (List.filter_opt [ ofb; odb; otdb; opb; otpb; omb; ogb ]) then
+        Input_warnings.empty ();
+      {
+        functionblock = ofb;
+        datablock = odb;
+        transformeddatablock = otdb;
+        parametersblock = opb;
+        transformedparametersblock = otpb;
+        modelblock = omb;
+        generatedquantitiesblock = ogb;
+        comments = [];
+      }
     }
 
 functions_only:
   | fd = list(function_def) EOF
-    { grammar_logger "functions_only";
-      { functionblock= Some {stmts= fd; xloc= location_span_of_positions $loc}
-      ; datablock= None
-      ; transformeddatablock= None
-      ; parametersblock= None
-      ; transformedparametersblock= None
-      ; modelblock= None
-      ; generatedquantitiesblock= None
-      ; comments= [] }
+    {
+      grammar_logger "functions_only";
+      {
+        functionblock = Some { stmts = fd; xloc = location_span_of_positions $loc };
+        datablock = None;
+        transformeddatablock = None;
+        parametersblock = None;
+        transformedparametersblock = None;
+        modelblock = None;
+        generatedquantitiesblock = None;
+        comments = [];
+      }
     }
 
 (* blocks *)
 function_block:
-  | FUNCTIONBLOCK LBRACE fd=list(function_def) RBRACE
-    { grammar_logger "function_block" ;
-      {stmts= fd; xloc= location_span_of_positions $loc} }
+  | FUNCTIONBLOCK LBRACE fd = list(function_def) RBRACE
+    {
+      grammar_logger "function_block";
+      { stmts = fd; xloc = location_span_of_positions $loc }
+    }
 
 data_block:
-  | DATABLOCK LBRACE tvd=list(top_var_decl_no_assign) RBRACE
-    { grammar_logger "data_block" ;
-      {stmts= tvd; xloc= location_span_of_positions $loc} }
+  | DATABLOCK LBRACE tvd = list(top_var_decl_no_assign) RBRACE
+    {
+      grammar_logger "data_block";
+      { stmts = tvd; xloc = location_span_of_positions $loc }
+    }
 
 transformed_data_block:
-  | TRANSFORMEDDATABLOCK LBRACE tvds=list(top_vardecl_or_statement) RBRACE
-    { grammar_logger "transformed_data_block" ;
-      {stmts= tvds; xloc= location_span_of_positions $loc} }
+  | TRANSFORMEDDATABLOCK LBRACE
+    tvds = list(top_vardecl_or_statement) RBRACE
+    {
+      grammar_logger "transformed_data_block";
+      { stmts = tvds; xloc = location_span_of_positions $loc }
+    }
 
 parameters_block:
-  | PARAMETERSBLOCK LBRACE tvd=list(top_var_decl_no_assign) RBRACE
-    { grammar_logger "parameters_block" ;
-      {stmts= tvd; xloc= location_span_of_positions $loc} }
+  | PARAMETERSBLOCK LBRACE tvd = list(top_var_decl_no_assign)
+    RBRACE
+    {
+      grammar_logger "parameters_block";
+      { stmts = tvd; xloc = location_span_of_positions $loc }
+    }
 
 transformed_parameters_block:
-  | TRANSFORMEDPARAMETERSBLOCK LBRACE tvds=list(top_vardecl_or_statement) RBRACE
-    { grammar_logger "transformed_parameters_block" ;
-      {stmts= tvds; xloc= location_span_of_positions $loc} }
+  | TRANSFORMEDPARAMETERSBLOCK LBRACE
+    tvds = list(top_vardecl_or_statement) RBRACE
+    {
+      grammar_logger "transformed_parameters_block";
+      { stmts = tvds; xloc = location_span_of_positions $loc }
+    }
 
 model_block:
-  | MODELBLOCK LBRACE vds=list(vardecl_or_statement) RBRACE
-    { grammar_logger "model_block" ;
-      {stmts= vds; xloc= location_span_of_positions $loc} }
+  | MODELBLOCK LBRACE vds = list(vardecl_or_statement) RBRACE
+    {
+      grammar_logger "model_block";
+      { stmts = vds; xloc = location_span_of_positions $loc }
+    }
 
 generated_quantities_block:
-  | GENERATEDQUANTITIESBLOCK LBRACE tvds=list(top_vardecl_or_statement) RBRACE
-    { grammar_logger "generated_quantities_block" ;
-      {stmts= tvds; xloc= location_span_of_positions $loc} }
+  | GENERATEDQUANTITIESBLOCK LBRACE
+    tvds = list(top_vardecl_or_statement) RBRACE
+    {
+      grammar_logger "generated_quantities_block";
+      { stmts = tvds; xloc = location_span_of_positions $loc }
+    }
 
 (* function definitions *)
 identifier:
-  | id=IDENTIFIER { build_id id $loc }
-  | TRUNCATE { build_id "T" $loc}
+  | id = IDENTIFIER { build_id id $loc }
+  | TRUNCATE { build_id "T" $loc }
 
 decl_identifier:
-  | id=identifier { id }
-  | err=reserved_word { reserved err }
+  | id = identifier { id }
+  | err = reserved_word { reserved err }
 
 decl_identifier_after_comma:
-  | id=identifier { id }
-  | err=reserved_word { reserved_decl err }
+  | id = identifier { id }
+  | err = reserved_word { reserved_decl err }
 
 reserved_word:
   (* Keywords cannot be identifiers but it is nice to
@@ -253,8 +293,9 @@ reserved_word:
   | CHOLESKYFACTORCORR { "cholesky_factor_corr", $loc, true }
   | CHOLESKYFACTORCOV { "cholesky_factor_cov", $loc, true }
   | CORRMATRIX { "corr_matrix", $loc, true }
-  | COVMATRIX { "cov_matrix", $loc, true  }
-  | STOCHASTICCOLUMNMATRIX { "column_stochastic_matrix", $loc, true }
+  | COVMATRIX { "cov_matrix", $loc, true }
+  | STOCHASTICCOLUMNMATRIX
+    { "column_stochastic_matrix", $loc, true }
   | STOCHASTICROWMATRIX { "row_stochastic_matrix", $loc, true }
   | PRINT { "print", $loc, false }
   | REJECT { "reject", $loc, false }
@@ -271,132 +312,146 @@ reserved_word:
 
 (* useful for generating better messages in locations where these are not permitted *)
 %inline no_constraints:
-  | basic_type LABRACK UNREACHABLE
-    { () }
-  | constrained_vector UNREACHABLE
-    { () }
-  | constrained_matrix UNREACHABLE
-    { () }
+  | basic_type LABRACK UNREACHABLE { () }
+  | constrained_vector UNREACHABLE { () }
+  | constrained_matrix UNREACHABLE { () }
 
 constrained_vector:
   | ORDERED
-  | POSITIVEORDERED
-  | SIMPLEX
-  | UNITVECTOR
-  | SUMTOZEROVEC
+    | POSITIVEORDERED
+    | SIMPLEX
+    | UNITVECTOR
+    | SUMTOZEROVEC
     { () }
 
 constrained_matrix:
   | CHOLESKYFACTORCORR
-  | CHOLESKYFACTORCOV
-  | CORRMATRIX
-  | COVMATRIX
-  | SUMTOZEROMAT
-  | STOCHASTICCOLUMNMATRIX
-  | STOCHASTICROWMATRIX
+    | CHOLESKYFACTORCOV
+    | CORRMATRIX
+    | COVMATRIX
+    | SUMTOZEROMAT
+    | STOCHASTICCOLUMNMATRIX
+    | STOCHASTICROWMATRIX
     { () }
 
-
 %inline function_start:
-  | rt=return_type name=decl_identifier LPAREN args=separated_list(COMMA, arg_decl)
-    RPAREN
-    { (rt, name, args) }
+  | rt = return_type name = decl_identifier LPAREN
+    args = separated_list(COMMA, arg_decl) RPAREN
+    { rt, name, args }
 
 function_def:
-  | fn=function_start body=located_statement(semi_statement)
-  | fn=function_start body=located_statement(block_statement)
+  | fn = function_start body = located_statement(semi_statement)
+    | fn = function_start body = located_statement(block_statement)
     {
-      grammar_logger "function_def" ;
-      let (returntype, funname, arguments) = fn in
-      { stmt = FunDef { returntype; funname; arguments; body }
-      ; smeta = { loc = location_span_of_positions $sloc}
+      grammar_logger "function_def";
+      let returntype, funname, arguments = fn in
+      {
+        stmt = FunDef { returntype; funname; arguments; body };
+        smeta = { loc = location_span_of_positions $sloc };
       }
     }
 
 return_type:
-  | VOID
-    { grammar_logger "return_type VOID" ; Void }
-  | ut=unsized_type
-    {  grammar_logger "return_type unsized_type" ; UnsizedType.ReturnType ut }
+  | VOID { grammar_logger "return_type VOID"; Void }
+  | ut = unsized_type
+    {
+      grammar_logger "return_type unsized_type";
+      UnsizedType.ReturnType ut
+    }
 
 arg_decl:
-  | od=option(DATABLOCK) ut=unsized_type id=decl_identifier
-    {  grammar_logger "arg_decl" ;
-       if Option.is_some od then (UnsizedType.DataOnly, ut, id) else (AutoDiffable, ut, id)   }
+  | od = option(DATABLOCK) ut = unsized_type id = decl_identifier
+    {
+      grammar_logger "arg_decl";
+      if Option.is_some od then (UnsizedType.DataOnly, ut, id)
+      else (AutoDiffable, ut, id)
+    }
 
 unsized_type:
-  | ARRAY n=unsized_dims t=basic_type
-  | ARRAY n=unsized_dims t=unsized_tuple_type
-    {  grammar_logger "unsized_type";
-        nest_unsized_array t n
-    }
+  | ARRAY n = unsized_dims t = basic_type
+    | ARRAY n = unsized_dims t = unsized_tuple_type
+    { grammar_logger "unsized_type"; nest_unsized_array t n }
   (* This is just a helper for the fact that we don't support the old array syntax any more
     It can go away at some point if it starts causing conflicts.
   *)
   | basic_type LBRACK UNREACHABLE
-    { (* This code will never be reached *)
-       Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+    {
+      (* This code will never be reached *)
+      Common.ICE.internal_compiler_error
+        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
-  | bt=basic_type
-    {  grammar_logger "unsized_type";
-       bt
-    }
-  | t=unsized_tuple_type
-    { t }
+  | bt = basic_type { grammar_logger "unsized_type"; bt }
+  | t = unsized_tuple_type { t }
 
 %inline unsized_tuple_type:
-  | TUPLE LPAREN hd=unsized_type COMMA ts=separated_list(COMMA, unsized_type) RPAREN
-    {  UnsizedType.UTuple (hd::ts)
-    }
+  | TUPLE LPAREN hd = unsized_type COMMA
+    ts = separated_list(COMMA, unsized_type) RPAREN
+    { UnsizedType.UTuple (hd :: ts) }
 
 basic_type:
-  | INT
-    {  grammar_logger "basic_type INT" ; UnsizedType.UInt  }
-  | REAL
-    {  grammar_logger "basic_type REAL"  ; UnsizedType.UReal }
+  | INT { grammar_logger "basic_type INT"; UnsizedType.UInt }
+  | REAL { grammar_logger "basic_type REAL"; UnsizedType.UReal }
   | COMPLEX
-    { grammar_logger "basic_type COMPLEX" ; UnsizedType.UComplex }
+    { grammar_logger "basic_type COMPLEX"; UnsizedType.UComplex }
   | VECTOR
-    {  grammar_logger "basic_type VECTOR" ; UnsizedType.UVector }
+    { grammar_logger "basic_type VECTOR"; UnsizedType.UVector }
   | ROWVECTOR
-    {  grammar_logger "basic_type ROWVECTOR" ; UnsizedType.URowVector }
+    {
+      grammar_logger "basic_type ROWVECTOR";
+      UnsizedType.URowVector
+    }
   | MATRIX
-    {  grammar_logger "basic_type MATRIX" ; UnsizedType.UMatrix }
+    { grammar_logger "basic_type MATRIX"; UnsizedType.UMatrix }
   | COMPLEXVECTOR
-    {  grammar_logger "basic_type COMPLEXVECTOR" ; UnsizedType.UComplexVector }
+    {
+      grammar_logger "basic_type COMPLEXVECTOR";
+      UnsizedType.UComplexVector
+    }
   | COMPLEXROWVECTOR
-    {  grammar_logger "basic_type COMPLEXROWVECTOR" ; UnsizedType.UComplexRowVector }
+    {
+      grammar_logger "basic_type COMPLEXROWVECTOR";
+      UnsizedType.UComplexRowVector
+    }
   | COMPLEXMATRIX
-    {  grammar_logger "basic_type COMPLEXMATRIX" ; UnsizedType.UComplexMatrix }
+    {
+      grammar_logger "basic_type COMPLEXMATRIX";
+      UnsizedType.UComplexMatrix
+    }
   | no_constraints
-    { (* This code will never be reached. The parser state exists to make the error more specific. *)
-       Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+    {
+      (* This code will never be reached. The parser state exists to make the error
+         more specific. *)
+      Common.ICE.internal_compiler_error
+        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
 
 unsized_dims:
-  | LBRACK cs=list(COMMA) RBRACK
-    { grammar_logger "unsized_dims" ; List.length(cs) + 1 }
+  | LBRACK cs = list(COMMA) RBRACK
+    { grammar_logger "unsized_dims"; List.length cs + 1 }
 
 (* Never accept this rule, but return the same type as expression *)
 no_assign:
   | UNREACHABLE
-    { (* This code will never be reached *)
-       Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+    {
+      (* This code will never be reached *)
+      Common.ICE.internal_compiler_error
+        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
 
 optional_assignment(rhs):
-  | rhs_opt=option(pair(ASSIGN, rhs))
+  | rhs_opt = option(pair(ASSIGN, rhs))
     { Option.map ~f:snd rhs_opt }
 
 id_and_optional_assignment(rhs, decl):
-  | identifier=decl initial_value=optional_assignment(rhs)
-    { Ast.{identifier; initial_value} }
+  | identifier = decl initial_value = optional_assignment(rhs)
+    { Ast.{ identifier; initial_value } }
 
 remaining_declarations(rhs):
-  | COMMA decls=separated_nonempty_list(COMMA, id_and_optional_assignment(rhs, decl_identifier_after_comma))
+  | COMMA
+    decls = separated_nonempty_list(
+      COMMA,
+      id_and_optional_assignment(rhs, decl_identifier_after_comma)
+    )
     { decls }
 
 (*
@@ -415,490 +470,601 @@ remaining_declarations(rhs):
  *)
 decl(type_rule, rhs):
   (* This is just a helper for the fact that we don't support the old array syntax any more *)
-  | ty=type_rule id=decl_identifier LBRACK dims=separated_nonempty_list(COMMA, expression) RBRACK {
-    let (ty, trans) = ty in
-    let ty = List.fold_right ~f:(fun e ty -> SizedType.SArray (ty, e)) ~init:ty dims in
-    let ty = (ty, trans) in
-    parse_error
-      (Fmt.str
-         "@[<v 2>%@{<light_red>Ill-formed declaration.%@} %@{<green>\";\"%@} expected \
-          after variable declaration.@ %@{<i>It looks like you are trying \
-          to use the old array syntax.@ Please use the new syntax:%@}@ @[<h>%a \
-          %s;@]@]@\n"
-         Pretty_printing.pp_transformed_type ty id.name)
-      $loc(dims)
-    }
-  | DATABLOCK UNREACHABLE {
-    Common.ICE.internal_compiler_error
-      [%message "the UNREACHABLE token should never be produced"] [@coverage off]
-  }
-  | ty=higher_type(type_rule)
-    (* additional indirection only for better error messaging *)
-    v = id_and_optional_assignment(rhs, decl_identifier) vs=option(remaining_declarations(rhs)) SEMICOLON
-    { (fun ~is_global ->
-      let vs = v :: Option.value vs ~default:[]
+  | ty = type_rule id = decl_identifier LBRACK
+    dims = separated_nonempty_list(COMMA, expression) RBRACK
+    {
+      let ty, trans = ty in
+      let ty =
+        List.fold_right ~f:(fun e ty -> SizedType.SArray (ty, e)) ~init:ty dims
       in
-      { stmt=
-          VarDecl {
-              decl_type= fst ty
-            ; transformation= snd ty
-            ; variables=vs
-            ; is_global
-            }
-      ; smeta= {
-          loc= location_span_of_positions $sloc
+      let ty = (ty, trans) in
+      parse_error
+        (Fmt.str
+           "@[<v 2>%@{<light_red>Ill-formed declaration.%@} %@{<green>\";\"%@} \
+            expected after variable declaration.@ %@{<i>It looks like you are trying \
+            to use the old array syntax.@ Please use the new syntax:%@}@ @[<h>%a \
+            %s;@]@]@\n"
+           Pretty_printing.pp_transformed_type ty id.name)
+        $loc(dims)
+    }
+  | DATABLOCK UNREACHABLE
+    {
+      Common.ICE.internal_compiler_error
+        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+    }
+  | ty = higher_type(type_rule)
+    (* additional indirection only for better error messaging *)
+    v = id_and_optional_assignment(rhs, decl_identifier)
+    vs = option(remaining_declarations(rhs)) SEMICOLON
+    {
+      fun ~is_global ->
+        let vs = v :: Option.value vs ~default:[] in
+        {
+          stmt =
+            VarDecl
+              {
+                decl_type = fst ty;
+                transformation = snd ty;
+                variables = vs;
+                is_global;
+              };
+          smeta = { loc = location_span_of_positions $sloc };
         }
-      })
     }
 
 (* Take a type matched by type_rule and produce that type or any (possibly nested) container of that type *)
+
 (* Can't do the fully recursive array_type(higher_type) because arrays can't hold arrays *)
 %inline higher_type(type_rule):
-  | ty=array_type(type_rule)
-  | ty=tuple_type(type_rule)
-  | ty=type_rule
-  { grammar_logger "higher_type" ;
-    ty
-  }
+  | ty = array_type(type_rule)
+    | ty = tuple_type(type_rule)
+    | ty = type_rule
+    { grammar_logger "higher_type"; ty }
 
 array_type(type_rule):
-  | dims=arr_dims ty=type_rule
-  | dims=arr_dims ty=tuple_type(type_rule)
-  { grammar_logger "array_type" ;
-    let (type_, trans) = ty in
-    ((reducearray (type_, dims)), trans)
-  }
+  | dims = arr_dims ty = type_rule
+    | dims = arr_dims ty = tuple_type(type_rule)
+    {
+      grammar_logger "array_type";
+      let type_, trans = ty in
+      (reducearray (type_, dims), trans)
+    }
 
 tuple_type(type_rule):
-  | TUPLE LPAREN head=higher_type(type_rule) COMMA rest=separated_list(COMMA, higher_type(type_rule)) RPAREN
-  { grammar_logger "tuple_type" ;
-    let ts = head::rest in
-    let types, trans = List.unzip ts in
-    (SizedType.STuple types, Transformation.TupleTransformation trans)
-  }
+  | TUPLE LPAREN head = higher_type(type_rule) COMMA
+    rest = separated_list(COMMA, higher_type(type_rule)) RPAREN
+    {
+      grammar_logger "tuple_type";
+      let ts = head :: rest in
+      let types, trans = List.unzip ts in
+      (SizedType.STuple types, Transformation.TupleTransformation trans)
+    }
 
 var_decl:
-  | d_fn=decl(sized_basic_type, expression)
-    { grammar_logger "var_decl" ;
-      d_fn ~is_global:false
-    }
+  | d_fn = decl(sized_basic_type, expression)
+    { grammar_logger "var_decl"; d_fn ~is_global:false }
 
 top_var_decl:
-  | d_fn=decl(top_var_type, expression)
-    { grammar_logger "top_var_decl" ;
-      d_fn ~is_global:true
-    }
+  | d_fn = decl(top_var_type, expression)
+    { grammar_logger "top_var_decl"; d_fn ~is_global:true }
 
 top_var_decl_no_assign:
-  | d_fn=decl(top_var_type, no_assign)
-    { grammar_logger "top_var_decl_no_assign" ;
+  | d_fn = decl(top_var_type, no_assign)
+    {
+      grammar_logger "top_var_decl_no_assign";
       d_fn ~is_global:true
     }
-  | s=located_statement(semi_statement ) { s }
+  | s = located_statement(semi_statement) { s }
 
 sized_basic_type:
   | INT
-    { grammar_logger "INT_var_type" ; (SizedType.SInt, Identity) }
+    { grammar_logger "INT_var_type"; (SizedType.SInt, Identity) }
   | REAL
-    { grammar_logger "REAL_var_type" ; (SizedType.SReal, Identity) }
+    { grammar_logger "REAL_var_type"; (SizedType.SReal, Identity) }
   | COMPLEX
-    { grammar_logger "COMPLEX_var_type" ; (SizedType.SComplex, Identity) }
-  | VECTOR LBRACK e=expression RBRACK
-    { grammar_logger "VECTOR_var_type" ; (SizedType.SVector (Mem_pattern.AoS, e), Identity) }
-  | ROWVECTOR LBRACK e=expression RBRACK
-    { grammar_logger "ROWVECTOR_var_type" ; (SizedType.SRowVector (AoS, e) , Identity) }
-  | MATRIX LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "MATRIX_var_type" ; (SizedType.SMatrix (AoS, e1, e2), Identity) }
-  | COMPLEXVECTOR LBRACK e=expression RBRACK
-    { grammar_logger "COMPLEXVECTOR_var_type" ; (SizedType.SComplexVector e, Identity) }
-  | COMPLEXROWVECTOR LBRACK e=expression RBRACK
-    { grammar_logger "COMPLEXROWVECTOR_var_type" ; (SizedType.SComplexRowVector e , Identity) }
-  | COMPLEXMATRIX LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "COMPLEXMATRIX_var_type" ; (SizedType.SComplexMatrix (e1, e2), Transformation.Identity) }
+    {
+      grammar_logger "COMPLEX_var_type";
+      (SizedType.SComplex, Identity)
+    }
+  | VECTOR LBRACK e = expression RBRACK
+    {
+      grammar_logger "VECTOR_var_type";
+      (SizedType.SVector (Mem_pattern.AoS, e), Identity)
+    }
+  | ROWVECTOR LBRACK e = expression RBRACK
+    {
+      grammar_logger "ROWVECTOR_var_type";
+      (SizedType.SRowVector (AoS, e), Identity)
+    }
+  | MATRIX LBRACK e1 = expression COMMA e2 = expression RBRACK
+    {
+      grammar_logger "MATRIX_var_type";
+      (SizedType.SMatrix (AoS, e1, e2), Identity)
+    }
+  | COMPLEXVECTOR LBRACK e = expression RBRACK
+    {
+      grammar_logger "COMPLEXVECTOR_var_type";
+      (SizedType.SComplexVector e, Identity)
+    }
+  | COMPLEXROWVECTOR LBRACK e = expression RBRACK
+    {
+      grammar_logger "COMPLEXROWVECTOR_var_type";
+      (SizedType.SComplexRowVector e, Identity)
+    }
+  | COMPLEXMATRIX LBRACK e1 = expression COMMA e2 = expression
+    RBRACK
+    {
+      grammar_logger "COMPLEXMATRIX_var_type";
+      (SizedType.SComplexMatrix (e1, e2), Transformation.Identity)
+    }
   | no_constraints
-    { (* This code will never be reached. The parser state exists to make the error more specific. *)
-       Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+    {
+      (* This code will never be reached. The parser state exists to make the error
+         more specific. *)
+      Common.ICE.internal_compiler_error
+        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
 
 top_var_type:
-  | INT r=range_constraint
-    { grammar_logger "INT_top_var_type" ; (SInt, r) }
-  | REAL c=type_constraint
-    { grammar_logger "REAL_top_var_type" ; (SReal, c) }
-  | COMPLEX c=type_constraint
-    { grammar_logger "COMPLEX_var_type" ; (SComplex, c) }
-  | VECTOR c=type_constraint LBRACK e=expression RBRACK
-    { grammar_logger "VECTOR_top_var_type" ; (SVector (AoS, e), c) }
-  | ROWVECTOR c=type_constraint LBRACK e=expression RBRACK
-    { grammar_logger "ROWVECTOR_top_var_type" ; (SRowVector (AoS, e), c) }
-  | MATRIX c=type_constraint LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "MATRIX_top_var_type" ; (SMatrix (AoS, e1, e2), c) }
-  | COMPLEXVECTOR c=type_constraint LBRACK e=expression RBRACK
-    { grammar_logger "COMPLEXVECTOR_top_var_type" ; (SComplexVector e, c) }
-  | COMPLEXROWVECTOR c=type_constraint LBRACK e=expression RBRACK
-    { grammar_logger "COMPLEXROWVECTOR_top_var_type" ; (SComplexRowVector e, c) }
-  | COMPLEXMATRIX c=type_constraint LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "COMPLEXMATRIX_top_var_type" ; (SComplexMatrix (e1, e2), c) }
-  | ORDERED LBRACK e=expression RBRACK
-    { grammar_logger "ORDERED_top_var_type" ; (SVector (AoS, e), Ordered) }
-  | POSITIVEORDERED LBRACK e=expression RBRACK
+  | INT r = range_constraint
+    { grammar_logger "INT_top_var_type"; (SInt, r) }
+  | REAL c = type_constraint
+    { grammar_logger "REAL_top_var_type"; (SReal, c) }
+  | COMPLEX c = type_constraint
+    { grammar_logger "COMPLEX_var_type"; (SComplex, c) }
+  | VECTOR c = type_constraint LBRACK e = expression RBRACK
+    { grammar_logger "VECTOR_top_var_type"; (SVector (AoS, e), c) }
+  | ROWVECTOR c = type_constraint LBRACK e = expression RBRACK
     {
-      grammar_logger "POSITIVEORDERED_top_var_type" ;
-      (SVector (AoS, e), PositiveOrdered)
+      grammar_logger "ROWVECTOR_top_var_type";
+      (SRowVector (AoS, e), c)
     }
-  | SIMPLEX LBRACK e=expression RBRACK
-    { grammar_logger "SIMPLEX_top_var_type" ; (SVector (AoS, e), Simplex) }
-  | UNITVECTOR LBRACK e=expression RBRACK
-    { grammar_logger "UNITVECTOR_top_var_type" ; (SVector (AoS, e), UnitVector) }
-  | SUMTOZEROVEC LBRACK e=expression RBRACK
-    { grammar_logger "SUMTOZEROVEC_top_var_type" ; (SVector (AoS, e), SumToZero) }
-  | CHOLESKYFACTORCORR LBRACK e=expression RBRACK
+  | MATRIX c = type_constraint LBRACK e1 = expression COMMA
+    e2 = expression RBRACK
     {
-      grammar_logger "CHOLESKYFACTORCORR_top_var_type" ;
-      (SMatrix (AoS, e, e), CholeskyCorr)
+      grammar_logger "MATRIX_top_var_type";
+      (SMatrix (AoS, e1, e2), c)
     }
-  | CHOLESKYFACTORCOV LBRACK e1=expression oe2=option(pair(COMMA, expression))
+  | COMPLEXVECTOR c = type_constraint LBRACK e = expression RBRACK
+    {
+      grammar_logger "COMPLEXVECTOR_top_var_type";
+      (SComplexVector e, c)
+    }
+  | COMPLEXROWVECTOR c = type_constraint LBRACK e = expression
     RBRACK
     {
-      grammar_logger "CHOLESKYFACTORCOV_top_var_type" ;
-      match oe2 with Some (_,e2) -> ( SMatrix (AoS, e1, e2), CholeskyCov)
-                   | _           ->  (SMatrix (AoS, e1, e1),  CholeskyCov)
+      grammar_logger "COMPLEXROWVECTOR_top_var_type";
+      (SComplexRowVector e, c)
     }
-  | CORRMATRIX LBRACK e=expression RBRACK
-    { grammar_logger "CORRMATRIX_top_var_type" ; (SMatrix (AoS, e, e), Correlation) }
-  | COVMATRIX LBRACK e=expression RBRACK
-    { grammar_logger "COVMATRIX_top_var_type" ; (SizedType.SMatrix (AoS, e, e), Transformation.Covariance) }
-  | SUMTOZEROMAT LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "SUMTOZEROMAT_top_var_type" ; (SizedType.SMatrix (AoS, e1, e2), Transformation.SumToZero) }
-  | STOCHASTICCOLUMNMATRIX LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "STOCHASTICCOLUMNMATRIX_top_var_type" ; (SizedType.SMatrix (AoS, e1, e2), Transformation.StochasticColumn) }
-  | STOCHASTICROWMATRIX LBRACK e1=expression COMMA e2=expression RBRACK
-    { grammar_logger "STOCHASTICROWMATRIX_top_var_type" ; (SizedType.SMatrix (AoS, e1, e2), Transformation.StochasticRow) }
+  | COMPLEXMATRIX c = type_constraint LBRACK e1 = expression COMMA
+    e2 = expression RBRACK
+    {
+      grammar_logger "COMPLEXMATRIX_top_var_type";
+      (SComplexMatrix (e1, e2), c)
+    }
+  | ORDERED LBRACK e = expression RBRACK
+    {
+      grammar_logger "ORDERED_top_var_type";
+      (SVector (AoS, e), Ordered)
+    }
+  | POSITIVEORDERED LBRACK e = expression RBRACK
+    {
+      grammar_logger "POSITIVEORDERED_top_var_type";
+      (SVector (AoS, e), PositiveOrdered)
+    }
+  | SIMPLEX LBRACK e = expression RBRACK
+    {
+      grammar_logger "SIMPLEX_top_var_type";
+      (SVector (AoS, e), Simplex)
+    }
+  | UNITVECTOR LBRACK e = expression RBRACK
+    {
+      grammar_logger "UNITVECTOR_top_var_type";
+      (SVector (AoS, e), UnitVector)
+    }
+  | SUMTOZEROVEC LBRACK e = expression RBRACK
+    {
+      grammar_logger "SUMTOZEROVEC_top_var_type";
+      (SVector (AoS, e), SumToZero)
+    }
+  | CHOLESKYFACTORCORR LBRACK e = expression RBRACK
+    {
+      grammar_logger "CHOLESKYFACTORCORR_top_var_type";
+      (SMatrix (AoS, e, e), CholeskyCorr)
+    }
+  | CHOLESKYFACTORCOV LBRACK e1 = expression
+    oe2 = option(pair(COMMA, expression)) RBRACK
+    {
+      grammar_logger "CHOLESKYFACTORCOV_top_var_type";
+      match oe2 with
+      | Some (_, e2) -> (SMatrix (AoS, e1, e2), CholeskyCov)
+      | _ -> (SMatrix (AoS, e1, e1), CholeskyCov)
+    }
+  | CORRMATRIX LBRACK e = expression RBRACK
+    {
+      grammar_logger "CORRMATRIX_top_var_type";
+      (SMatrix (AoS, e, e), Correlation)
+    }
+  | COVMATRIX LBRACK e = expression RBRACK
+    {
+      grammar_logger "COVMATRIX_top_var_type";
+      (SizedType.SMatrix (AoS, e, e), Transformation.Covariance)
+    }
+  | SUMTOZEROMAT LBRACK e1 = expression COMMA e2 = expression
+    RBRACK
+    {
+      grammar_logger "SUMTOZEROMAT_top_var_type";
+      (SizedType.SMatrix (AoS, e1, e2), Transformation.SumToZero)
+    }
+  | STOCHASTICCOLUMNMATRIX LBRACK e1 = expression COMMA
+    e2 = expression RBRACK
+    {
+      grammar_logger "STOCHASTICCOLUMNMATRIX_top_var_type";
+      (SizedType.SMatrix (AoS, e1, e2), Transformation.StochasticColumn)
+    }
+  | STOCHASTICROWMATRIX LBRACK e1 = expression COMMA
+    e2 = expression RBRACK
+    {
+      grammar_logger "STOCHASTICROWMATRIX_top_var_type";
+      (SizedType.SMatrix (AoS, e1, e2), Transformation.StochasticRow)
+    }
 
 type_constraint:
-  | r=range_constraint
-    {  grammar_logger "type_constraint_range" ; r }
-  | LABRACK l=offset_mult RABRACK
-    {  grammar_logger "type_constraint_offset_mult" ; l }
+  | r = range_constraint
+    { grammar_logger "type_constraint_range"; r }
+  | LABRACK l = offset_mult RABRACK
+    { grammar_logger "type_constraint_offset_mult"; l }
 
 range_constraint:
-  | (* nothing *)
-    { grammar_logger "empty_constraint" ; Transformation.Identity }
-  | LABRACK r=range RABRACK
-    {  grammar_logger "range_constraint" ; r }
+  |  (* nothing *)
+    { grammar_logger "empty_constraint"; Transformation.Identity }
+  | LABRACK r = range RABRACK
+    { grammar_logger "range_constraint"; r }
 
 range:
-  | LOWER ASSIGN e1=constr_expression COMMA UPPER ASSIGN e2=constr_expression
-  | UPPER ASSIGN e2=constr_expression COMMA LOWER ASSIGN e1=constr_expression
-    { grammar_logger "lower_upper_range" ; Transformation.LowerUpper (e1, e2) }
-  | LOWER ASSIGN e=constr_expression
-    {  grammar_logger "lower_range" ; Lower e }
-  | UPPER ASSIGN e=constr_expression
-    { grammar_logger "upper_range" ; Upper e }
+  | LOWER ASSIGN e1 = constr_expression COMMA UPPER ASSIGN
+    e2 = constr_expression
+    | UPPER ASSIGN e2 = constr_expression COMMA LOWER ASSIGN
+    e1 = constr_expression
+    {
+      grammar_logger "lower_upper_range";
+      Transformation.LowerUpper (e1, e2)
+    }
+  | LOWER ASSIGN e = constr_expression
+    { grammar_logger "lower_range"; Lower e }
+  | UPPER ASSIGN e = constr_expression
+    { grammar_logger "upper_range"; Upper e }
 
 offset_mult:
-  | OFFSET ASSIGN e1=constr_expression COMMA MULTIPLIER ASSIGN e2=constr_expression
-  | MULTIPLIER ASSIGN e2=constr_expression COMMA OFFSET ASSIGN e1=constr_expression
-    { grammar_logger "offset_mult" ; Transformation.OffsetMultiplier (e1, e2) }
-  | OFFSET ASSIGN e=constr_expression
-    { grammar_logger "offset" ; Offset e }
-  | MULTIPLIER ASSIGN e=constr_expression
-    { grammar_logger "multiplier" ; Multiplier e }
+  | OFFSET ASSIGN e1 = constr_expression COMMA MULTIPLIER ASSIGN
+    e2 = constr_expression
+    | MULTIPLIER ASSIGN e2 = constr_expression COMMA OFFSET ASSIGN
+    e1 = constr_expression
+    {
+      grammar_logger "offset_mult";
+      Transformation.OffsetMultiplier (e1, e2)
+    }
+  | OFFSET ASSIGN e = constr_expression
+    { grammar_logger "offset"; Offset e }
+  | MULTIPLIER ASSIGN e = constr_expression
+    { grammar_logger "multiplier"; Multiplier e }
 
- arr_dims:
-    | ARRAY LBRACK l=separated_nonempty_list(COMMA, expression) RBRACK
-                 { grammar_logger "array dims" ; l  }
+arr_dims:
+  | ARRAY LBRACK l = separated_nonempty_list(COMMA, expression)
+    RBRACK
+    { grammar_logger "array dims"; l }
 
 (* Expressions that can be used everywhere except constraint expressions *)
 expression:
-  | e1=expression  QMARK e2=expression COLON e3=expression
-    { grammar_logger "ifthenelse_expr" ; build_expr (TernaryIf (e1, e2, e3)) $loc }
-  | e1=expression op=infixOp e2=expression
-    { grammar_logger "infix_expr" ; build_expr (BinOp (e1, op, e2)) $loc  }
-  | op=prefixOp e=expression %prec unary_over_binary
-    { grammar_logger "prefix_expr" ; build_expr (PrefixOp (op, e)) $loc }
-  | e=expression op=postfixOp
-    { grammar_logger "postfix_expr" ; build_expr (PostfixOp (e, op)) $loc}
-  | e=common_expression
-    { grammar_logger "common_expr" ; e }
-
-(* Same as the above, but leave out logical binary operators *)
-(* TODO: why do we not simply disallow greater than in constraints? No need to disallow all logical operations, right? *)
-constr_expression:
-  | e1=constr_expression op=arithmeticBinOp e2=constr_expression
+  | e1 = expression QMARK e2 = expression COLON e3 = expression
     {
-      grammar_logger "constr_expression_arithmetic" ;
+      grammar_logger "ifthenelse_expr";
+      build_expr (TernaryIf (e1, e2, e3)) $loc
+    }
+  | e1 = expression op = infixOp e2 = expression
+    {
+      grammar_logger "infix_expr";
       build_expr (BinOp (e1, op, e2)) $loc
     }
-  | op=prefixOp e=constr_expression %prec unary_over_binary
+  | op = prefixOp e = expression
+    %prec unary_over_binary
     {
-      grammar_logger "constr_expression_prefixOp" ;
+      grammar_logger "prefix_expr";
       build_expr (PrefixOp (op, e)) $loc
     }
-  | e=constr_expression op=postfixOp
+  | e = expression op = postfixOp
     {
-      grammar_logger "constr_expression_postfix" ;
+      grammar_logger "postfix_expr";
       build_expr (PostfixOp (e, op)) $loc
     }
-  | e=common_expression
-    { grammar_logger "constr_expression_common_expr" ; e }
+  | e = common_expression { grammar_logger "common_expr"; e }
 
+(* Same as the above, but leave out logical binary operators *)
+
+(* TODO: why do we not simply disallow greater than in constraints? No need to disallow all logical operations, right? *)
+constr_expression:
+  | e1 = constr_expression op = arithmeticBinOp
+    e2 = constr_expression
+    {
+      grammar_logger "constr_expression_arithmetic";
+      build_expr (BinOp (e1, op, e2)) $loc
+    }
+  | op = prefixOp e = constr_expression
+    %prec unary_over_binary
+    {
+      grammar_logger "constr_expression_prefixOp";
+      build_expr (PrefixOp (op, e)) $loc
+    }
+  | e = constr_expression op = postfixOp
+    {
+      grammar_logger "constr_expression_postfix";
+      build_expr (PostfixOp (e, op)) $loc
+    }
+  | e = common_expression
+    { grammar_logger "constr_expression_common_expr"; e }
 
 common_expression:
-  | id=identifier
-    { grammar_logger "identifier_expr" ;
-      build_expr (Variable id) $loc }
-  | i=INTNUMERAL
-    { grammar_logger ("intnumeral " ^ i) ;
-      build_expr (IntNumeral i) $loc }
-  | r=REALNUMERAL
-  | r=DOTNUMERAL
-    { grammar_logger ("realnumeral " ^ r) ;
-      build_expr (RealNumeral r) $loc }
-  | z=IMAGNUMERAL
-    { grammar_logger ("imagnumeral " ^ z) ;
-      build_expr (ImagNumeral (String.drop_suffix z 1)) $loc }
-  | LBRACE xs=separated_nonempty_list(COMMA, expression) RBRACE
-    { grammar_logger "array_expression" ;
-      build_expr (ArrayExpr xs) $loc }
-  | LBRACK xs=separated_list(COMMA, expression) RBRACK
-    { grammar_logger "row_vector_expression" ;
-      build_expr (RowVectorExpr xs) $loc }
-  | id=identifier LPAREN args=separated_list(COMMA, expression) RPAREN
-    { grammar_logger "fun_app" ;
+  | id = identifier
+    {
+      grammar_logger "identifier_expr";
+      build_expr (Variable id) $loc
+    }
+  | i = INTNUMERAL
+    {
+      grammar_logger ("intnumeral " ^ i);
+      build_expr (IntNumeral i) $loc
+    }
+  | r = REALNUMERAL
+    | r = DOTNUMERAL
+    {
+      grammar_logger ("realnumeral " ^ r);
+      build_expr (RealNumeral r) $loc
+    }
+  | z = IMAGNUMERAL
+    {
+      grammar_logger ("imagnumeral " ^ z);
+      build_expr (ImagNumeral (String.drop_suffix z 1)) $loc
+    }
+  | LBRACE xs = separated_nonempty_list(COMMA, expression) RBRACE
+    {
+      grammar_logger "array_expression";
+      build_expr (ArrayExpr xs) $loc
+    }
+  | LBRACK xs = separated_list(COMMA, expression) RBRACK
+    {
+      grammar_logger "row_vector_expression";
+      build_expr (RowVectorExpr xs) $loc
+    }
+  | id = identifier LPAREN
+    args = separated_list(COMMA, expression) RPAREN
+    {
+      grammar_logger "fun_app";
       let app =
-       if
-         List.length args = 1
-         && List.exists ~f:(fun x -> String.is_suffix ~suffix:x id.name) Utils.conditioning_suffices
-       then CondDistApp ((), id, args)
-       else FunApp ((), id, args)
-       in build_expr app $loc }
+        if
+          List.length args = 1
+          && List.exists
+               ~f:(fun x -> String.is_suffix ~suffix:x id.name)
+               Utils.conditioning_suffices
+        then CondDistApp ((), id, args)
+        else FunApp ((), id, args)
+      in
+      build_expr app $loc
+    }
   | TARGET LPAREN RPAREN
-    { grammar_logger "target_read" ;
-      build_expr GetTarget $loc }
-  | id=identifier LPAREN e=expression BAR args=separated_list(COMMA, expression)
-    RPAREN
-    { grammar_logger "conditional_dist_app" ;
-      build_expr (CondDistApp ((), id, e :: args)) $loc }
-  | LPAREN x_head=expression COMMA xs=separated_list(COMMA, expression) RPAREN
-    { grammar_logger "tuple_expression" ;
-      build_expr (TupleExpr (x_head::xs)) $loc  }
-  | e=common_expression ix_str=DOTNUMERAL
-    { grammar_logger "common_expression_tuple_index" ;
+    { grammar_logger "target_read"; build_expr GetTarget $loc }
+  | id = identifier LPAREN e = expression BAR
+    args = separated_list(COMMA, expression) RPAREN
+    {
+      grammar_logger "conditional_dist_app";
+      build_expr (CondDistApp ((), id, e :: args)) $loc
+    }
+  | LPAREN x_head = expression COMMA
+    xs = separated_list(COMMA, expression) RPAREN
+    {
+      grammar_logger "tuple_expression";
+      build_expr (TupleExpr (x_head :: xs)) $loc
+    }
+  | e = common_expression ix_str = DOTNUMERAL
+    {
+      grammar_logger "common_expression_tuple_index";
       build_expr (TupleProjection (e, parse_tuple_slot ix_str $loc(ix_str))) $loc
     }
-  | e=common_expression LBRACK indices=indexes RBRACK
-    { grammar_logger "common_expression_indexed";
-      build_expr (Indexed (e, indices)) $loc }
-  | LPAREN e=expression RPAREN
-    { grammar_logger "extra_paren" ;
-      build_expr (Paren e) $loc }
+  | e = common_expression LBRACK indices = indexes RBRACK
+    {
+      grammar_logger "common_expression_indexed";
+      build_expr (Indexed (e, indices)) $loc
+    }
+  | LPAREN e = expression RPAREN
+    { grammar_logger "extra_paren"; build_expr (Paren e) $loc }
 
 %inline prefixOp:
-  | BANG
-    {   grammar_logger "prefix_bang" ; Operator.PNot }
-  | MINUS
-    {  grammar_logger "prefix_minus" ; Operator.PMinus }
-  | PLUS
-    {   grammar_logger "prefix_plus" ; Operator.PPlus }
+  | BANG { grammar_logger "prefix_bang"; Operator.PNot }
+  | MINUS { grammar_logger "prefix_minus"; Operator.PMinus }
+  | PLUS { grammar_logger "prefix_plus"; Operator.PPlus }
 
 %inline postfixOp:
   | TRANSPOSE
-    {  grammar_logger "postfix_transpose" ; Operator.Transpose }
+    { grammar_logger "postfix_transpose"; Operator.Transpose }
 
 %inline infixOp:
-  | a=arithmeticBinOp
-    {   grammar_logger "infix_arithmetic" ; a }
-  | l=logicalBinOp
-    {  grammar_logger "infix_logical" ; l }
+  | a = arithmeticBinOp { grammar_logger "infix_arithmetic"; a }
+  | l = logicalBinOp { grammar_logger "infix_logical"; l }
 
 %inline arithmeticBinOp:
-  | PLUS
-    {  grammar_logger "infix_plus" ; Operator.Plus }
-  | MINUS
-    {   grammar_logger "infix_minus" ;Operator.Minus }
-  | TIMES
-    {  grammar_logger "infix_times" ; Operator.Times }
-  | DIVIDE
-    {  grammar_logger "infix_divide" ; Operator.Divide }
+  | PLUS { grammar_logger "infix_plus"; Operator.Plus }
+  | MINUS { grammar_logger "infix_minus"; Operator.Minus }
+  | TIMES { grammar_logger "infix_times"; Operator.Times }
+  | DIVIDE { grammar_logger "infix_divide"; Operator.Divide }
   | IDIVIDE
-    {  grammar_logger "infix_intdivide" ; Operator.IntDivide }
-  | MODULO
-    {  grammar_logger "infix_modulo" ; Operator.Modulo }
-  | LDIVIDE
-    {  grammar_logger "infix_ldivide" ; Operator.LDivide }
+    { grammar_logger "infix_intdivide"; Operator.IntDivide }
+  | MODULO { grammar_logger "infix_modulo"; Operator.Modulo }
+  | LDIVIDE { grammar_logger "infix_ldivide"; Operator.LDivide }
   | ELTTIMES
-    {  grammar_logger "infix_elttimes" ; Operator.EltTimes }
+    { grammar_logger "infix_elttimes"; Operator.EltTimes }
   | ELTDIVIDE
-    {   grammar_logger "infix_eltdivide" ; Operator.EltDivide }
-  | HAT
-    {  grammar_logger "infix_hat" ; Operator.Pow }
-  | ELTPOW
-    {  grammar_logger "infix_eltpow" ; Operator.EltPow }
+    { grammar_logger "infix_eltdivide"; Operator.EltDivide }
+  | HAT { grammar_logger "infix_hat"; Operator.Pow }
+  | ELTPOW { grammar_logger "infix_eltpow"; Operator.EltPow }
 
 %inline logicalBinOp:
-  | OR
-    {   grammar_logger "infix_or" ; Operator.Or }
-  | AND
-    {   grammar_logger "infix_and" ; Operator.And }
-  | EQUALS
-    {   grammar_logger "infix_equals" ; Operator.Equals }
-  | NEQUALS
-    {   grammar_logger "infix_nequals" ; Operator.NEquals}
-  | LABRACK
-    {   grammar_logger "infix_less" ; Operator.Less }
-  | LEQ
-    {   grammar_logger "infix_leq" ; Operator.Leq }
-  | RABRACK
-    {   grammar_logger "infix_greater" ; Operator.Greater }
-  | GEQ
-    {   grammar_logger "infix_geq" ; Operator.Geq }
+  | OR { grammar_logger "infix_or"; Operator.Or }
+  | AND { grammar_logger "infix_and"; Operator.And }
+  | EQUALS { grammar_logger "infix_equals"; Operator.Equals }
+  | NEQUALS { grammar_logger "infix_nequals"; Operator.NEquals }
+  | LABRACK { grammar_logger "infix_less"; Operator.Less }
+  | LEQ { grammar_logger "infix_leq"; Operator.Leq }
+  | RABRACK { grammar_logger "infix_greater"; Operator.Greater }
+  | GEQ { grammar_logger "infix_geq"; Operator.Geq }
 
 indexes:
-  | (* nothing *)
-    {   grammar_logger "index_nothing" ; [All] }
-  | COLON
-    {   grammar_logger "index_all" ; [All] }
-  | e=expression
-    {  grammar_logger "index_single" ; [Single e] }
-  | e=expression COLON
-    {  grammar_logger "index_upper" ; [Upfrom e] }
-  | COLON e=expression
-    {   grammar_logger "index_lower" ; [Downfrom e] }
-  | e1=expression COLON e2=expression
-    {  grammar_logger "index_twosided" ; [Between (e1, e2)] }
-  | i1=indexes COMMA i2=indexes
-    {  grammar_logger "indexes" ; i1 @ i2 }
+  |  (* nothing *) { grammar_logger "index_nothing"; [ All ] }
+  | COLON { grammar_logger "index_all"; [ All ] }
+  | e = expression { grammar_logger "index_single"; [ Single e ] }
+  | e = expression COLON
+    { grammar_logger "index_upper"; [ Upfrom e ] }
+  | COLON e = expression
+    { grammar_logger "index_lower"; [ Downfrom e ] }
+  | e1 = expression COLON e2 = expression
+    { grammar_logger "index_twosided"; [ Between (e1, e2) ] }
+  | i1 = indexes COMMA i2 = indexes
+    { grammar_logger "indexes"; i1 @ i2 }
 
 printables:
-  | e=expression
-    {  grammar_logger "printable expression" ; [PExpr e] }
-  | s=string_literal
-    {  grammar_logger "printable string" ; [PString s] }
-  | p1=printables COMMA p2=printables
-    { grammar_logger "printables" ; p1 @ p2 }
+  | e = expression
+    { grammar_logger "printable expression"; [ PExpr e ] }
+  | s = string_literal
+    { grammar_logger "printable string"; [ PString s ] }
+  | p1 = printables COMMA p2 = printables
+    { grammar_logger "printables"; p1 @ p2 }
 
 %inline located_statement(stmt_rule):
-  | stmt=stmt_rule
-    { { stmt; smeta = { loc = location_span_of_positions $sloc} } }
-
+  | stmt = stmt_rule
+    { { stmt; smeta = { loc = location_span_of_positions $sloc } } }
 
 (* statements *)
 statement:
-  | s=located_statement(atomic_statement)
-    { grammar_logger "atomic_statement" ;
-      s
-    }
-  | s=located_statement(nested_statement)
-    { grammar_logger "nested_statement" ;
-      s
-    }
+  | s = located_statement(atomic_statement)
+    { grammar_logger "atomic_statement"; s }
+  | s = located_statement(nested_statement)
+    { grammar_logger "nested_statement"; s }
 
 atomic_statement:
-  | l=common_expression op=assignment_op e=expression SEMICOLON
-    {  grammar_logger "assignment_statement" ;
-       (* slight hack: we over-parse but only allow ids, tuples of ids, or id projections *)
-       Assignment {assign_lhs=try_convert_to_lvalue l $loc(l);
-                   assign_op=op;
-                   assign_rhs=e} }
-  | id=identifier LPAREN args=separated_list(COMMA, expression) RPAREN SEMICOLON
-    {  grammar_logger "funapp_statement" ; NRFunApp ((),id, args)  }
-  | e=expression TILDE id=identifier LPAREN es=separated_list(COMMA, expression)
-    RPAREN ot=option(truncation) SEMICOLON
-    {  grammar_logger "tilde_statement" ;
-       let t = match ot with Some tt -> tt | None -> NoTruncate in
-       Tilde {arg= e; distribution= id; args= es; truncation= t; kind=() }
+  | l = common_expression op = assignment_op e = expression
+    SEMICOLON
+    {
+      grammar_logger "assignment_statement";
+      (* slight hack: we over-parse but only allow ids, tuples of ids, or id
+         projections *)
+      Assignment
+        {
+          assign_lhs = try_convert_to_lvalue l $loc(l);
+          assign_op = op;
+          assign_rhs = e;
+        }
     }
-  | TARGET PLUSASSIGN e=expression SEMICOLON
-    {   grammar_logger "targetpe_statement" ; TargetPE e }
-  | JACOBIAN PLUSASSIGN e=expression SEMICOLON
-    {   grammar_logger "jacobianpe_statement" ; JacobianPE e }
-  | BREAK SEMICOLON
-    {  grammar_logger "break_statement" ; Break }
+  | id = identifier LPAREN
+    args = separated_list(COMMA, expression) RPAREN SEMICOLON
+    { grammar_logger "funapp_statement"; NRFunApp ((), id, args) }
+  | e = expression TILDE id = identifier LPAREN
+    es = separated_list(COMMA, expression) RPAREN
+    ot = option(truncation) SEMICOLON
+    {
+      grammar_logger "tilde_statement";
+      let t = match ot with Some tt -> tt | None -> NoTruncate in
+      Tilde { arg = e; distribution = id; args = es; truncation = t; kind = () }
+    }
+  | TARGET PLUSASSIGN e = expression SEMICOLON
+    { grammar_logger "targetpe_statement"; TargetPE e }
+  | JACOBIAN PLUSASSIGN e = expression SEMICOLON
+    { grammar_logger "jacobianpe_statement"; JacobianPE e }
+  | BREAK SEMICOLON { grammar_logger "break_statement"; Break }
   | CONTINUE SEMICOLON
-    {  grammar_logger "continue_statement" ; Continue }
-  | PRINT LPAREN l=printables RPAREN SEMICOLON
-    {  grammar_logger "print_statement" ; Print l }
-  | REJECT LPAREN l=printables RPAREN SEMICOLON
-    {  grammar_logger "reject_statement" ; Reject l  }
-  | FATAL_ERROR LPAREN l=printables RPAREN SEMICOLON
-    {  grammar_logger "exit_statement" ; FatalError l  }
-  | RETURN e=expression SEMICOLON
-    {  grammar_logger "return_statement" ; Return e }
+    { grammar_logger "continue_statement"; Continue }
+  | PRINT LPAREN l = printables RPAREN SEMICOLON
+    { grammar_logger "print_statement"; Print l }
+  | REJECT LPAREN l = printables RPAREN SEMICOLON
+    { grammar_logger "reject_statement"; Reject l }
+  | FATAL_ERROR LPAREN l = printables RPAREN SEMICOLON
+    { grammar_logger "exit_statement"; FatalError l }
+  | RETURN e = expression SEMICOLON
+    { grammar_logger "return_statement"; Return e }
   | RETURN SEMICOLON
-    {  grammar_logger "return_nothing_statement" ; ReturnVoid }
-  | s=semi_statement { s }
+    { grammar_logger "return_nothing_statement"; ReturnVoid }
+  | s = semi_statement { s }
 
 %inline semi_statement:
-  | SEMICOLON
-    {  grammar_logger "skip" ; Skip }
+  | SEMICOLON { grammar_logger "skip"; Skip }
 
 %inline assignment_op:
-  | ASSIGN
-    {  grammar_logger "assign_plain" ; Assign }
+  | ASSIGN { grammar_logger "assign_plain"; Assign }
   | PLUSASSIGN
-    { grammar_logger "assign_plus" ; OperatorAssign Plus }
+    { grammar_logger "assign_plus"; OperatorAssign Plus }
   | MINUSASSIGN
-    { grammar_logger "assign_minus" ; OperatorAssign Minus }
+    { grammar_logger "assign_minus"; OperatorAssign Minus }
   | TIMESASSIGN
-    { grammar_logger "assign_times"  ; OperatorAssign Times }
+    { grammar_logger "assign_times"; OperatorAssign Times }
   | DIVIDEASSIGN
-    { grammar_logger "assign_divide" ; OperatorAssign Divide }
+    { grammar_logger "assign_divide"; OperatorAssign Divide }
   | ELTTIMESASSIGN
-    { grammar_logger "assign_elttimes"  ; OperatorAssign EltTimes }
+    { grammar_logger "assign_elttimes"; OperatorAssign EltTimes }
   | ELTDIVIDEASSIGN
-    { grammar_logger "assign_eltdivide" ; OperatorAssign EltDivide  }
+    { grammar_logger "assign_eltdivide"; OperatorAssign EltDivide }
 
 string_literal:
-  | s=STRINGLITERAL
-    {  grammar_logger ("string_literal " ^ s) ; s }
+  | s = STRINGLITERAL
+    { grammar_logger ("string_literal " ^ s); s }
 
 truncation:
-  | TRUNCATE LBRACK e1=option(expression) COMMA e2=option(expression)
-    RBRACK
-    {  grammar_logger "truncation" ;
-       match (e1, e2) with
-       | Some tt1, Some tt2 -> TruncateBetween (tt1, tt2)
-       | Some tt1, None -> TruncateUpFrom tt1
-       | None, Some tt2 -> TruncateDownFrom tt2
-       | None, None -> NoTruncate  }
+  | TRUNCATE LBRACK e1 = option(expression) COMMA
+    e2 = option(expression) RBRACK
+    {
+      grammar_logger "truncation";
+      match (e1, e2) with
+      | Some tt1, Some tt2 -> TruncateBetween (tt1, tt2)
+      | Some tt1, None -> TruncateUpFrom tt1
+      | None, Some tt2 -> TruncateDownFrom tt2
+      | None, None -> NoTruncate
+    }
 
 nested_statement:
-  | IF LPAREN e=expression RPAREN s1=vardecl_or_statement ELSE s2=vardecl_or_statement
-    {  grammar_logger "ifelse_statement" ; IfThenElse (e, s1, Some s2) }
-  | IF LPAREN e=expression RPAREN s=vardecl_or_statement %prec below_ELSE
-    {  grammar_logger "if_statement" ; IfThenElse (e, s, None) }
-  | WHILE LPAREN e=expression RPAREN s=vardecl_or_statement
-    {  grammar_logger "while_statement" ; While (e, s) }
-  | FOR LPAREN id=identifier IN e1=expression COLON e2=expression RPAREN
-    s=vardecl_or_statement
+  | IF LPAREN e = expression RPAREN s1 = vardecl_or_statement ELSE
+    s2 = vardecl_or_statement
     {
-      grammar_logger "for_statement" ;
-      For {loop_variable= id;
-           lower_bound= e1;
-           upper_bound= e2;
-           loop_body= s;}
+      grammar_logger "ifelse_statement";
+      IfThenElse (e, s1, Some s2)
     }
-  | FOR LPAREN id=identifier IN e=expression RPAREN s=vardecl_or_statement
-    {  grammar_logger "foreach_statement" ; ForEach (id, e, s) }
-  | PROFILE LPAREN st=string_literal RPAREN LBRACE l=list(vardecl_or_statement) RBRACE
-    {  grammar_logger "profile_statement" ; Profile (st, l) }
- | b=block_statement { b }
+  | IF LPAREN e = expression RPAREN s = vardecl_or_statement
+    %prec below_ELSE
+    { grammar_logger "if_statement"; IfThenElse (e, s, None) }
+  | WHILE LPAREN e = expression RPAREN s = vardecl_or_statement
+    { grammar_logger "while_statement"; While (e, s) }
+  | FOR LPAREN id = identifier IN e1 = expression COLON
+    e2 = expression RPAREN s = vardecl_or_statement
+    {
+      grammar_logger "for_statement";
+      For { loop_variable = id; lower_bound = e1; upper_bound = e2; loop_body = s }
+    }
+  | FOR LPAREN id = identifier IN e = expression RPAREN
+    s = vardecl_or_statement
+    { grammar_logger "foreach_statement"; ForEach (id, e, s) }
+  | PROFILE LPAREN st = string_literal RPAREN LBRACE
+    l = list(vardecl_or_statement) RBRACE
+    { grammar_logger "profile_statement"; Profile (st, l) }
+  | b = block_statement { b }
 
 %inline block_statement:
-  | LBRACE l=list(vardecl_or_statement) RBRACE
-    {  grammar_logger "block_statement" ; Block l }
+  | LBRACE l = list(vardecl_or_statement) RBRACE
+    { grammar_logger "block_statement"; Block l }
 
 (* statement or var decls *)
 vardecl_or_statement:
-  | s=statement
-    { grammar_logger "vardecl_or_statement_statement" ; s }
-  | v=var_decl
-    { grammar_logger "vardecl_or_statement_vardecl" ; v }
+  | s = statement
+    { grammar_logger "vardecl_or_statement_statement"; s }
+  | v = var_decl
+    { grammar_logger "vardecl_or_statement_vardecl"; v }
 
 top_vardecl_or_statement:
-  | s=statement
-    { grammar_logger "top_vardecl_or_statement_statement" ; s }
-  | v=top_var_decl
-    { grammar_logger "top_vardecl_or_statement_top_vardecl" ; v }
+  | s = statement
+    { grammar_logger "top_vardecl_or_statement_statement"; s }
+  | v = top_var_decl
+    { grammar_logger "top_vardecl_or_statement_top_vardecl"; v }


### PR DESCRIPTION
Menhirformat was recently released (and has an accompanying menhir-lsp), so we can finally stop worrying about the manual formatting of our menhir and ocamllex files. 

There are not many settings at the moment, but I think the output is acceptable.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
