### PR TITLE
Reword error for using unnormalized distribution in the wrong place

### DIFF
--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -493,7 +493,7 @@ module ExpressionError = struct
   type t =
     | InvalidSizeDeclRng
     | InvalidRngFunction
-    | InvalidUnnormalizedFunction
+    | InvalidUnnormalizedFunction of string
     | InvalidUnnormalizedUDF of string
     | ConditionalNotationNotAllowed
     | ConditioningRequired
@@ -519,11 +519,13 @@ module ExpressionError = struct
           "Random number generators are only allowed in transformed data \
            block, generated quantities block or user-defined functions with \
            names ending in _rng."
-    | InvalidUnnormalizedFunction ->
-        Fmt.text ppf
-          "Functions with names ending in _lupdf and _lupmf can only be used \
-           in the model block or user-defined functions with names ending in \
-           _lpdf or _lpmf."
+    | InvalidUnnormalizedFunction name ->
+        Fmt.pf ppf
+          "@[Unnormalized probability functions such as %a can@ only be used \
+           in the model block or in user-defined functions with names@ ending \
+           in _lpdf or _lpmf.@ Did you mean %a?@]"
+          quoted name quoted
+          (Utils.normalized_name name)
     | InvalidUnnormalizedUDF fname ->
         Fmt.pf ppf
           "@[%a is an invalid user-defined function name.@ User-defined \
@@ -970,8 +972,8 @@ let invalid_decl_rng_fn loc =
 let invalid_rng_fn loc =
   (loc, ExpressionError ExpressionError.InvalidRngFunction)
 
-let invalid_unnormalized_fn loc =
-  (loc, ExpressionError ExpressionError.InvalidUnnormalizedFunction)
+let invalid_unnormalized_fn loc name =
+  (loc, ExpressionError (ExpressionError.InvalidUnnormalizedFunction name))
 
 let udf_is_unnormalized_fn loc name =
   (loc, ExpressionError (ExpressionError.InvalidUnnormalizedUDF name))

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -165,7 +165,7 @@ val ident_not_in_scope :
 
 val invalid_decl_rng_fn : Location_span.t -> t
 val invalid_rng_fn : Location_span.t -> t
-val invalid_unnormalized_fn : Location_span.t -> t
+val invalid_unnormalized_fn : Location_span.t -> string -> t
 val udf_is_unnormalized_fn : Location_span.t -> string -> t
 val ident_has_unnormalized_suffix : Location_span.t -> string -> t
 val conditional_notation_not_allowed : Location_span.t -> t

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -268,7 +268,16 @@ let check_postfixop loc op te =
         ~ad_level:te.emeta.ad_level ~type_ ~loc
   | _ -> Semantic_error.illtyped_postfix_op loc op te.emeta.type_ |> error
 
+(** unnormalized _lpdf/_lpmf functions can only be used in _lpdf/_lpmf/_lp udfs
+    or the model block *)
+let verify_unnormalized cf loc id =
+  if
+    Utils.is_unnormalized_distribution id.name
+    && not (in_udf_distribution cf || cf.current_block = Model)
+  then Semantic_error.invalid_unnormalized_fn loc id.name |> error
+
 let check_id cf loc tenv id =
+  verify_unnormalized cf loc id;
   match Env.find tenv (Utils.stdlib_distribution_name id.name) with
   | [] ->
       Semantic_error.ident_not_in_scope loc id.name
@@ -284,12 +293,6 @@ let check_id cf loc tenv id =
     :: _
     when cf.in_toplevel_decl ->
       Semantic_error.non_data_variable_size_decl loc origin prev |> error
-  | _ :: _
-    when Utils.is_unnormalized_distribution id.name
-         && not
-              ((in_udf_distribution cf || in_lp_function cf)
-              || cf.current_block = Model) ->
-      Semantic_error.invalid_unnormalized_fn loc |> error
   | {kind= `Variable {origin; _}; type_; _} :: _ ->
       (calculate_autodifftype cf origin type_, type_)
   | { kind= `UserDefined _ | `UserDeclared _
@@ -491,14 +494,6 @@ let verify_fn_rng cf loc id =
         (in_rng_function cf || cf.current_block = GQuant
        || cf.current_block = TData)
     then Semantic_error.invalid_rng_fn loc |> error
-
-(** unnormalized _lpdf/_lpmf functions can only be used in _lpdf/_lpmf/_lp udfs
-    or the model block *)
-let verify_unnormalized cf loc id =
-  if
-    Utils.is_unnormalized_distribution id.name
-    && not (in_udf_distribution cf || cf.current_block = Model)
-  then Semantic_error.invalid_unnormalized_fn loc |> error
 
 let mk_fun_app ~is_cond_dist ~loc kind name args ~type_ : Ast.typed_expression =
   let fn =

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -277,33 +277,34 @@ let verify_unnormalized cf loc id =
   then Semantic_error.invalid_unnormalized_fn loc id.name |> error
 
 let check_id cf loc tenv id =
+  let (value :: _) =
+    Env.find tenv (Utils.stdlib_distribution_name id.name)
+    |> Common.Nonempty_list.of_list
+    |> Option.value_or_thunk ~default:(fun () ->
+        Semantic_error.ident_not_in_scope loc id.name
+          (Env.nearest_ident tenv id.name)
+        |> error) in
   verify_unnormalized cf loc id;
-  match Env.find tenv (Utils.stdlib_distribution_name id.name) with
-  | [] ->
-      Semantic_error.ident_not_in_scope loc id.name
-        (Env.nearest_ident tenv id.name)
-      |> error
-  | {kind= `StanMath; _} :: _ ->
+  match value with
+  | {kind= `StanMath; _} ->
       ( calculate_autodifftype cf MathLibrary UMathLibraryFunction
       , UnsizedType.UMathLibraryFunction )
   | { kind=
         `Variable
           {origin= (Param | TParam | GQuant) as origin; location= prev; _}
     ; _ }
-    :: _
     when cf.in_toplevel_decl ->
       Semantic_error.non_data_variable_size_decl loc origin prev |> error
-  | {kind= `Variable {origin; _}; type_; _} :: _ ->
+  | {kind= `Variable {origin; _}; type_; _} ->
       (calculate_autodifftype cf origin type_, type_)
   | { kind= `UserDefined _ | `UserDeclared _
     ; type_= UFun (args, rt, (FnLpdf _ | FnLpmf _), mem_pattern)
-    ; _ }
-    :: _ ->
+    ; _ } ->
       let type_ =
         UnsizedType.UFun
           (args, rt, Fun_kind.suffix_from_name id.name, mem_pattern) in
       (calculate_autodifftype cf Functions type_, type_)
-  | {kind= `UserDefined _ | `UserDeclared _; type_; _} :: _ ->
+  | {kind= `UserDefined _ | `UserDeclared _; type_; _} ->
       (calculate_autodifftype cf Functions type_, type_)
 
 let check_variable cf loc tenv id =

--- a/test/integration/bad/stanc.expected
+++ b/test/integration/bad/stanc.expected
@@ -1958,9 +1958,9 @@ Semantic error in 'log_suffix_bad2.stan', line 3, column 12 to column 41:
      5:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "normal_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "normal_lpdf"?
 [exit 1]
   $ stanc lp-error.stan
 Semantic error in 'lp-error.stan', line 5, column 2 to column 6:

--- a/test/integration/bad/unnormalized/not_in_scope.stan
+++ b/test/integration/bad/unnormalized/not_in_scope.stan
@@ -1,0 +1,3 @@
+generated quantities {
+  real x = reduce_sum(foo_lupdf, blah, blah);
+}

--- a/test/integration/bad/unnormalized/stanc.expected
+++ b/test/integration/bad/unnormalized/stanc.expected
@@ -167,6 +167,19 @@ Unnormalized probability functions such as "poisson_lupmf" can
 only be used in the model block or in user-defined functions with names
 ending in _lpdf or _lpmf. Did you mean "poisson_lpmf"?
 [exit 1]
+  $ stanc not_in_scope.stan
+Semantic error in 'not_in_scope.stan', line 2, column 22 to column 31:
+   -------------------------------------------------
+     1:  generated quantities {
+     2:    real x = reduce_sum(foo_lupdf, blah, blah);
+                               ^
+     3:  }
+   -------------------------------------------------
+
+Unnormalized probability functions such as "foo_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "foo_lpdf"?
+[exit 1]
   $ stanc udf_lupdf.stan
 Semantic error in 'udf_lupdf.stan', line 2, column 9 to column 18:
    -------------------------------------------------

--- a/test/integration/bad/unnormalized/stanc.expected
+++ b/test/integration/bad/unnormalized/stanc.expected
@@ -21,9 +21,9 @@ Semantic error in 'lupdf_in_functions.stan', line 3, column 15 to column 34:
      5:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "normal_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "normal_lpdf"?
 [exit 1]
   $ stanc lupdf_in_gq.stan
 Semantic error in 'lupdf_in_gq.stan', line 8, column 13 to column 34:
@@ -35,9 +35,9 @@ Semantic error in 'lupdf_in_gq.stan', line 8, column 13 to column 34:
      9:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "normal_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "normal_lpdf"?
 [exit 1]
   $ stanc lupdf_in_gq_rs.stan
 Semantic error in 'lupdf_in_gq_rs.stan', line 14, column 24 to column 33:
@@ -49,9 +49,9 @@ Semantic error in 'lupdf_in_gq_rs.stan', line 14, column 24 to column 33:
     15:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "foo_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "foo_lpdf"?
 [exit 1]
   $ stanc lupdf_in_lp.stan
 Semantic error in 'lupdf_in_lp.stan', line 3, column 18 to column 42:
@@ -64,9 +64,9 @@ Semantic error in 'lupdf_in_lp.stan', line 3, column 18 to column 42:
      5:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "normal_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "normal_lpdf"?
 [exit 1]
   $ stanc lupdf_in_trans_data.stan
 Semantic error in 'lupdf_in_trans_data.stan', line 3, column 13 to column 34:
@@ -78,9 +78,9 @@ Semantic error in 'lupdf_in_trans_data.stan', line 3, column 13 to column 34:
      4:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "normal_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "normal_lpdf"?
 [exit 1]
   $ stanc lupdf_in_trans_params.stan
 Semantic error in 'lupdf_in_trans_params.stan', line 3, column 13 to column 34:
@@ -92,9 +92,9 @@ Semantic error in 'lupdf_in_trans_params.stan', line 3, column 13 to column 34:
      4:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "normal_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "normal_lpdf"?
 [exit 1]
   $ stanc lupdf_in_trans_params_rs.stan
 Semantic error in 'lupdf_in_trans_params_rs.stan', line 9, column 24 to column 33:
@@ -106,9 +106,9 @@ Semantic error in 'lupdf_in_trans_params_rs.stan', line 9, column 24 to column 3
     10:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "foo_lupdf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "foo_lpdf"?
 [exit 1]
   $ stanc lupmf_in_gq.stan
 Semantic error in 'lupmf_in_gq.stan', line 11, column 13 to column 33:
@@ -120,9 +120,9 @@ Semantic error in 'lupmf_in_gq.stan', line 11, column 13 to column 33:
     12:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "poisson_lupmf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "poisson_lpmf"?
 [exit 1]
   $ stanc lupmf_in_lp.stan
 Semantic error in 'lupmf_in_lp.stan', line 3, column 18 to column 39:
@@ -135,9 +135,9 @@ Semantic error in 'lupmf_in_lp.stan', line 3, column 18 to column 39:
      5:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "poisson_lupmf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "poisson_lpmf"?
 [exit 1]
   $ stanc lupmf_in_trans_data.stan
 Semantic error in 'lupmf_in_trans_data.stan', line 7, column 13 to column 33:
@@ -149,9 +149,9 @@ Semantic error in 'lupmf_in_trans_data.stan', line 7, column 13 to column 33:
      8:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "poisson_lupmf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "poisson_lpmf"?
 [exit 1]
   $ stanc lupmf_in_trans_params.stan
 Semantic error in 'lupmf_in_trans_params.stan', line 6, column 13 to column 33:
@@ -163,9 +163,9 @@ Semantic error in 'lupmf_in_trans_params.stan', line 6, column 13 to column 33:
      7:  }
    -------------------------------------------------
 
-Functions with names ending in _lupdf and _lupmf can only be used in the
-model block or user-defined functions with names ending in _lpdf or
-_lpmf.
+Unnormalized probability functions such as "poisson_lupmf" can
+only be used in the model block or in user-defined functions with names
+ending in _lpdf or _lpmf. Did you mean "poisson_lpmf"?
 [exit 1]
   $ stanc udf_lupdf.stan
 Semantic error in 'udf_lupdf.stan', line 2, column 9 to column 18:

--- a/test/integration/bad/unnormalized/stanc.expected
+++ b/test/integration/bad/unnormalized/stanc.expected
@@ -176,9 +176,7 @@ Semantic error in 'not_in_scope.stan', line 2, column 22 to column 31:
      3:  }
    -------------------------------------------------
 
-Unnormalized probability functions such as "foo_lupdf" can
-only be used in the model block or in user-defined functions with names
-ending in _lpdf or _lpmf. Did you mean "foo_lpdf"?
+Identifier "foo_lupdf" not in scope.
 [exit 1]
   $ stanc udf_lupdf.stan
 Semantic error in 'udf_lupdf.stan', line 2, column 9 to column 18:


### PR DESCRIPTION
The existing message doesn't clarify that the normalized version _is_ available, which tripped up @bob-carpenter 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Improved the error message for using an unnormalized function in an invalid context.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
