### PR TITLE
Mark internal compiler errors with [@coverage off]

### DIFF
--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -17,7 +17,7 @@ let matprod x y =
   let y_T = transpose y in
   if List.length x <> List.length y_T then
     Common.ICE.internal_compiler_error
-      [%message "Matrix multiplication dim. mismatch"]
+      [%message "Matrix multiplication dim. mismatch"] [@coverage off]
   else List.map ~f:(fun row -> List.map ~f:(dotproduct row) y_T) x
 
 let rec vect_to_mat l m =
@@ -25,6 +25,7 @@ let rec vect_to_mat l m =
   if len % m <> 0 then
     Common.ICE.internal_compiler_error
       [%message "The length has to be a whole multiple of the partition size"]
+    [@coverage off]
   else if len = m then [l]
   else
     let hd, tl = List.split_n l m in
@@ -63,7 +64,7 @@ let gen_num_int m t =
         Common.ICE.internal_compiler_error
           [%message
             "Unknown transformation for int" (t : Expr.Typed.t Transformation.t)]
-  in
+        [@coverage off] in
   let low = if low = 0 && up <> 1 then low + 1 else low in
   Random.int (up - low + 1) + low
 
@@ -82,7 +83,7 @@ let gen_num_real m t =
         Common.ICE.internal_compiler_error
           [%message
             "Unknown transformation for real"
-              (t : Expr.Typed.t Transformation.t)] in
+              (t : Expr.Typed.t Transformation.t)] [@coverage off] in
   Random.float_range low up
 
 let repeat n e = List.init n ~f:(Fn.const e)
@@ -128,7 +129,7 @@ let gen_row_vector m n t =
       Common.ICE.internal_compiler_error
         [%message
           "Unknown transformation for row_vector"
-            (t : Expr.Typed.t Transformation.t)]
+            (t : Expr.Typed.t Transformation.t)] [@coverage off]
 
 let sum_to_zero_floats n =
   let l = random_floats n in
@@ -176,7 +177,7 @@ let gen_vector m n t =
       Common.ICE.internal_compiler_error
         [%message
           "Unknown transformation for vector"
-            (t : Expr.Typed.t Transformation.t)]
+            (t : Expr.Typed.t Transformation.t)] [@coverage off]
 
 let gen_cov_unwrapped n =
   let l = random_floats (n * n) in
@@ -268,7 +269,7 @@ let gen_matrix mm m n t =
       Common.ICE.internal_compiler_error
         [%message
           "Unknown transformation for matrix"
-            (t : Expr.Typed.t Transformation.t)]
+            (t : Expr.Typed.t Transformation.t)] [@coverage off]
 
 let gen_complex_unwrapped () =
   ( gen_num_real Map.Poly.empty Transformation.Identity

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -226,7 +226,7 @@ let vexpr_of_expr_exn Expr.{pattern; _} =
   | Var s -> VVar s
   | _ ->
       Common.ICE.internal_compiler_error
-        [%message "Non-var expression found, but var expected"]
+        [%message "Non-var expression found, but var expected"] [@coverage off]
 
 (** See interface file *)
 let rec expr_var_set Expr.{pattern; meta} =
@@ -284,6 +284,7 @@ let expr_assigned_var Expr.{pattern; _} =
   | _ ->
       Common.ICE.internal_compiler_error
         [%message "Unimplemented: analysis of assigning to non-var"]
+      [@coverage off]
 
 (** See interface file *)
 let rec summation_terms (Expr.{pattern; _} as rhs) =
@@ -483,7 +484,7 @@ let unsafe_unsized_to_sized_type (rt : Expr.Typed.t Type.t) =
               [%message
                 ("return type of a function was a void user defined function \
                   or math library function."
-                  : string)] in
+                  : string)] [@coverage off] in
       Type.Sized (to_sized ut)
 
 let%expect_test "cleanup" =

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -41,6 +41,7 @@ let transform_program (mir : Program.Typed.t)
   | _ ->
       ICE.internal_compiler_error
         [%message "Something went wrong with program transformation packing!"]
+      [@coverage off]
 
 (** Apply the transformation to each function body and to each program block
     separately. *)
@@ -54,7 +55,7 @@ let transform_program_blockwise (mir : Program.Typed.t)
     | _ ->
         ICE.internal_compiler_error
           [%message "Something went wrong with program transformation packing!"]
-  in
+        [@coverage off] in
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
         {fs with fdbody= Option.map ~f:(transform (Some fs)) fs.fdbody}) in
@@ -161,13 +162,13 @@ let handle_early_returns (fname : string) opt_var stmt =
               [%message
                 ("Function should return a value but found an empty return \
                   statement."
-                  : string)]
+                  : string)] [@coverage off]
         | None, Some _ ->
             ICE.internal_compiler_error
               [%message
                 ("Expected a void function but found a non-empty return \
                   statement."
-                  : string)])
+                  : string)] [@coverage off])
     | Stmt.Pattern.For _ as loop when num_returns > 1 ->
         Stmt.Pattern.SList
           [ Stmt.{pattern= loop; meta= Location_span.empty}
@@ -1235,7 +1236,7 @@ let optimize_soa (mir : Program.Typed.t) =
     | _ ->
         ICE.internal_compiler_error
           [%message "Something went wrong with program transformation packing!"]
-  in
+        [@coverage off] in
   {mir with reverse_mode_log_prob= transform' mir.reverse_mode_log_prob}
 
 (* Apparently you need to completely copy/paste type definitions between ml and

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -22,7 +22,7 @@ let apply_prefix_operator_int (op : string) i =
         | "PNot__" -> if i = 0 then 1 else 0
         | s ->
             Common.ICE.internal_compiler_error
-              [%message "Not an int prefix operator: " s]) )
+              [%message "Not an int prefix operator: " s] [@coverage off]) )
 
 let apply_prefix_operator_real (op : string) i =
   Expr.Pattern.Lit
@@ -33,7 +33,7 @@ let apply_prefix_operator_real (op : string) i =
         | "PMinus__" -> -.i
         | s ->
             Common.ICE.internal_compiler_error
-              [%message "Not a real prefix operator: " s]) )
+              [%message "Not a real prefix operator: " s] [@coverage off]) )
 
 let apply_operator_int (op : string) i1 i2 =
   Expr.Pattern.Lit
@@ -53,7 +53,7 @@ let apply_operator_int (op : string) i1 i2 =
         | "Geq__" -> Bool.to_int (i1 >= i2)
         | s ->
             Common.ICE.internal_compiler_error
-              [%message "Not an int operator: " s]) )
+              [%message "Not an int operator: " s] [@coverage off]) )
 
 let apply_arithmetic_operator_real (op : string) r1 r2 =
   Expr.Pattern.Lit
@@ -66,7 +66,7 @@ let apply_arithmetic_operator_real (op : string) r1 r2 =
         | "Divide__" -> r1 /. r2
         | s ->
             Common.ICE.internal_compiler_error
-              [%message "Not a real operator: " s]) )
+              [%message "Not a real operator: " s] [@coverage off]) )
 
 let apply_logical_operator_real (op : string) r1 r2 =
   Expr.Pattern.Lit
@@ -81,7 +81,7 @@ let apply_logical_operator_real (op : string) r1 r2 =
         | "Geq__" -> Bool.to_int (r1 >= r2)
         | s ->
             Common.ICE.internal_compiler_error
-              [%message "Not a logical operator: " s]) )
+              [%message "Not a logical operator: " s] [@coverage off]) )
 
 let is_multi_index = function
   | Index.MultiIndex _ | Upfrom _ | Between _ | All -> true
@@ -1117,7 +1117,7 @@ let rec simplify_index_expr pattern =
               [%message
                 " There must be a multi-index."
                   (inner_singles : Expr.Typed.t Index.t list)
-                  (multis : Expr.Typed.t Index.t list)])
+                  (multis : Expr.Typed.t Index.t list)] [@coverage off])
     | e -> e)
 
 let remove_trailing_alls_expr = function

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -242,7 +242,7 @@ let list_param_dependant_fundef_cf (mir : Program.Typed.t)
         Common.ICE.internal_compiler_error
           [%message
             "In finding searching for parameter dependent function arguments, \
-             mismatched function."] in
+             mismatched function."] [@coverage off] in
   let arg_param_deps label arg_expr =
     var_deps info_map ~expr:(Some arg_expr) label (parameter_names_set mir)
   in

--- a/src/analysis_and_optimization/Pedantic_dist_warnings.ml
+++ b/src/analysis_and_optimization/Pedantic_dist_warnings.ml
@@ -160,7 +160,8 @@ let constr_mismatch_warning (constr : var_constraint_named) (arg : arg_info)
         let arg_fail_msg =
           Printf.sprintf "Distribution %s at %s expects more arguments." name
             (Location_span.to_string loc) in
-        Common.ICE.internal_compiler_error [%message arg_fail_msg] in
+        (Common.ICE.internal_compiler_error [%message arg_fail_msg]
+         [@coverage off]) in
   match v with
   | Param (pname, trans), meta
     when transform_mismatch_constraint constr.constr trans ->

--- a/src/common/Nonempty_list.ml
+++ b/src/common/Nonempty_list.ml
@@ -11,7 +11,7 @@ let of_list : _ list -> _ t option = function
 let of_list_exn : _ list -> _ t = function
   | [] ->
       ICE.internal_compiler_error
-        [%message "Nonempty_list.of_list_exn: empty list"]
+        [%message "Nonempty_list.of_list_exn: empty list"] [@coverage off]
   | hd :: tl -> hd :: tl
 
 (** [@@deriving sexp] doesn't like this type, so we do it manually *)

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -275,8 +275,8 @@ let rec untyped_expression_of_typed_expression
       { expr=
           map_expression untyped_expression_of_typed_expression ignore
             (fun _ ->
-              Common.ICE.internal_compiler_error
-                [%message "Promotion snuck through!"])
+              (Common.ICE.internal_compiler_error
+                 [%message "Promotion snuck through!"] [@coverage off]))
             expr
       ; emeta= {loc= emeta.loc} }
 

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -86,7 +86,8 @@ and trans_idx = function
       | UArray _ -> MultiIndex (trans_expr e)
       | _ ->
           Common.ICE.internal_compiler_error
-            [%message "Expecting int or array" (e.emeta.type_ : UnsizedType.t)])
+            [%message "Expecting int or array" (e.emeta.type_ : UnsizedType.t)]
+          [@coverage off])
 
 and trans_exprs exprs = List.map ~f:trans_expr exprs
 
@@ -320,7 +321,7 @@ let rec shrink_helper (f : size_change) f_d2 st =
           [%message
             "To shrink a vector, the first argument must be a univariate \
              function "
-              (st : Expr.Typed.t SizedType.t)] in
+              (st : Expr.Typed.t SizedType.t)] [@coverage off] in
   match st with
   | SizedType.SArray (t, d) -> SizedType.SArray (shrink_helper f f_d2 t, d)
   | SVector (mem_pattern, d) -> SVector (mem_pattern, f_assert_univariate d)
@@ -335,6 +336,7 @@ let rec shrink_helper (f : size_change) f_d2 st =
       Common.ICE.internal_compiler_error
         [%message
           "Expecting SVector or SMatrix, got " (st : Expr.Typed.t SizedType.t)]
+      [@coverage off]
 
 let rec transform_sizedtype transformation sizedtype =
   (* Functions for computing the new sizetype after some transformation *)
@@ -513,6 +515,7 @@ let unwrap_block_or_skip = function
   | x ->
       Common.ICE.internal_compiler_error
         [%message "Expecting a block or skip, not" (x : Stmt.Located.t list)]
+      [@coverage off]
 
 let index_tuple (e : Ast.typed_expression) i =
   let emeta =
@@ -526,7 +529,7 @@ let index_tuple (e : Ast.typed_expression) i =
         Common.ICE.internal_compiler_error
           [%message
             "Attempted to index into a non-tuple during lowering"
-              (e : Ast.typed_expression)] in
+              (e : Ast.typed_expression)] [@coverage off] in
   Ast.{expr= TupleProjection (e, i + 1); emeta}
 
 let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
@@ -558,7 +561,7 @@ let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
               [%message
                 "Impossible: tilde with non-distribution after typechecking"
                   (distribution : Ast.identifier)
-                  (kind : Ast.fun_kind)] in
+                  (kind : Ast.fun_kind)] [@coverage off] in
       let name = distribution.name ^ sfx in
       let add_dist =
         let adlevel =
@@ -633,6 +636,7 @@ let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
       Common.ICE.internal_compiler_error
         [%message
           "Found function definition statement outside of function block"]
+      [@coverage off]
   | Ast.VarDecl {decl_type; transformation; variables; is_global= _} ->
       List.concat_map
         ~f:(fun {identifier; initial_value} ->
@@ -743,6 +747,7 @@ let trans_fun_def ud_dists (ts : Ast.typed_statement) =
   | _ ->
       Common.ICE.internal_compiler_error
         [%message "Found non-function definition statement in function block"]
+      [@coverage off]
 
 let get_block block prog =
   match block with

--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -23,6 +23,7 @@ let rec unsized_basetype_json t =
       Common.ICE.internal_compiler_error
         [%message
           "Unexpected unsized type in unsized_basetype_json" (t : UnsizedType.t)]
+      [@coverage off]
 
 let basetype_dims t = SizedType.to_unsized t |> unsized_basetype_json
 

--- a/src/frontend/Parse.ml
+++ b/src/frontend/Parse.ml
@@ -22,7 +22,8 @@ let drive_parser parse_fun =
       | Interp.HandlingError env -> env
       | _ ->
           Common.ICE.internal_compiler_error
-            [%message "Parser failed but is not in an error state "] in
+            [%message "Parser failed but is not in an error state "]
+          [@coverage off] in
     let message =
       let state = Interp.current_state_number env in
       try
@@ -36,7 +37,8 @@ let drive_parser parse_fun =
       with _ ->
         Common.ICE.internal_compiler_error
           [%message
-            "Failed to find error for parser error state " (state : int)] in
+            "Failed to find error for parser error state " (state : int)]
+        [@coverage off] in
     let location =
       let env =
         match prev with

--- a/src/frontend/Pretty_print_prog.ml
+++ b/src/frontend/Pretty_print_prog.ml
@@ -56,17 +56,17 @@ let check_correctness ?(bare_functions = false) prog pretty =
     | Error e ->
         let error =
           Fmt.str "%a" (Errors.pp ?printed_filename:None ~code:pretty) e in
-        Common.ICE.internal_compiler_error
-          [%message
-            "Pretty-printed program failed to parse" error
-              (prog : Ast.untyped_program)
-              pretty] in
+        (Common.ICE.internal_compiler_error
+           [%message
+             "Pretty-printed program failed to parse" error
+               (prog : Ast.untyped_program)
+               pretty] [@coverage off]) in
   if compare_untyped_program prog result_ast <> 0 then
     Common.ICE.internal_compiler_error
       [%message
         "Pretty-printed program does match the original!"
           (prog : Ast.untyped_program)
-          (result_ast : Ast.untyped_program)]
+          (result_ast : Ast.untyped_program)] [@coverage off]
 
 let pretty_print_program ?(bare_functions = false) ?(line_length = 78)
     ?(inline_includes = false) ?(strip_comments = false) p =

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -86,7 +86,7 @@ let skip_comments loc =
             [%message
               "Unable to format #include in this position!"
                 (l : string list)
-                (loc : Middle.Location_span.t)]
+                (loc : Middle.Location_span.t)] [@coverage off]
       | x, s :: l, loc -> Some (x, (" ^^^:" ^ s) :: l, loc)
       | _, [], _ -> None)
 
@@ -275,7 +275,7 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
       match es with
       | [] ->
           Common.ICE.internal_compiler_error
-            [%message "CondDistApp with no arguments: " id.name]
+            [%message "CondDistApp with no arguments: " id.name] [@coverage off]
       | [e] ->
           pf ppf "%a(@,%a%a)@]" pp_start_funapp id pp_expression e
             (pp_comments_spacing ~before:sp get_comments)

--- a/src/frontend/Promotion.ml
+++ b/src/frontend/Promotion.ml
@@ -59,21 +59,21 @@ let rec promote_unsized_type (typ : UnsizedType.t)
           "Failed to promote type, unexpected type:"
             (prom : t)
             (typ : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)]
+            (ad : UnsizedType.autodifftype)] [@coverage off]
   | TuplePromotion _, _, _ ->
       Common.ICE.internal_compiler_error
         [%message
           "Found Tuple Promotion for a non-tuple type:"
             (prom : t)
             (typ : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)]
+            (ad : UnsizedType.autodifftype)] [@coverage off]
   | _, _, TupleAD _ ->
       Common.ICE.internal_compiler_error
         [%message
           "Found Tuple Autodiff in promotion for a non-tuple type:"
             (prom : t)
             (typ : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)]
+            (ad : UnsizedType.autodifftype)] [@coverage off]
   | _, _, _ -> (typ, ad)
 
 let promote_inner (exp : Ast.typed_expression) prom =
@@ -122,7 +122,7 @@ let promote_inner (exp : Ast.typed_expression) prom =
             [%message
               "Tuple promotion on non-tuple"
                 (exp : Ast.typed_expression)
-                (prom : t)])
+                (prom : t)] [@coverage off])
   | _ -> exp
 
 let rec promote (exp : Ast.typed_expression) prom =
@@ -212,14 +212,14 @@ let rec get_type_promotion_exn (ad_requested, ty_requested)
               (ad_current : UnsizedType.autodifftype)
               "cannot be promoted to "
               (ty_requested : UnsizedType.t)
-              (ad_requested : UnsizedType.autodifftype)]
+              (ad_requested : UnsizedType.autodifftype)] [@coverage off]
   else
     Common.ICE.internal_compiler_error
       [%message
         "Tried to get promotion of incompatible autodifftypes!"
           (ad_current : UnsizedType.autodifftype)
           "cannot be promoted to "
-          (ad_requested : UnsizedType.autodifftype)]
+          (ad_requested : UnsizedType.autodifftype)] [@coverage off]
 
 (** Calculate the "cost"/number of promotions performed. Used to disambiguate
     function signatures *)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -379,7 +379,7 @@ module TypeError = struct
           | "lupmf" -> "lupdf"
           | _ ->
               Common.ICE.internal_compiler_error
-                [%message "Bad suffix:" (suffix : string)] in
+                [%message "Bad suffix:" (suffix : string)] [@coverage off] in
         Fmt.pf ppf
           "Function %a is not implemented for distribution %a, use %a instead."
           quoted

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -611,7 +611,7 @@ let make_function_variable cf loc id = function
       Common.ICE.internal_compiler_error
         [%message
           "Attempting to create function variable out of "
-            (type_ : UnsizedType.t)]
+            (type_ : UnsizedType.t)] [@coverage off]
 
 (** Check that the functions in the list [requires_higher_order_autodiff] cannot
     {b transitively} call stan math functions that don't have second derivative
@@ -1130,12 +1130,12 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
               Common.ICE.internal_compiler_error
                 [%message
                   "Error in internal representation: tuple types don't match AD"]
-          )
+              [@coverage off])
       | UTuple _, ad ->
           Common.ICE.internal_compiler_error
             [%message
               "Error in internal representation: tuple doesn't have tupleAD"
-                (ad : UnsizedType.autodifftype)]
+                (ad : UnsizedType.autodifftype)] [@coverage off]
       | _, _ ->
           Semantic_error.tuple_index_not_tuple emeta.loc te.emeta.type_ |> error
       )
@@ -1466,7 +1466,7 @@ let rec check_lvalue cf tenv {lval; lmeta= ({loc} : located_meta)} =
               Common.ICE.internal_compiler_error
                 [%message
                   "Error in internal representation: tuple types don't match AD"]
-          )
+              [@coverage off])
       | _, _ ->
           Semantic_error.tuple_index_not_tuple loc tlval.lmeta.type_ |> error)
   | LIndexed (lval, idcs) ->
@@ -1560,7 +1560,7 @@ let check_tilde_distribution loc cf tenv id arguments =
             Common.ICE.internal_compiler_error
               [%message
                 "Typechecking a laplace marginal did not return a distribution "
-                  (fn_expr : Ast.typed_expression)]
+                  (fn_expr : Ast.typed_expression)] [@coverage off]
       else
         (* Otherwise, the function is non existent *)
         Semantic_error.invalid_tilde_no_such_dist id.id_loc name
@@ -2086,7 +2086,8 @@ and check_fundef loc cf tenv return_ty id args body =
         | AutoDiffable, ut -> (Param, ut)
         | TupleAD _, _ ->
             Common.ICE.internal_compiler_error
-              [%message "TupleAD in function definition, this is unexpected!"])
+              [%message "TupleAD in function definition, this is unexpected!"]
+            [@coverage off])
       arg_types in
   let tenv_body =
     List.fold2_exn arg_identifiers arg_types_internal ~init:tenv
@@ -2201,7 +2202,7 @@ let verify_correctness_invariant (ast : untyped_program)
       [%message
         "Type checked AST does not match original AST. "
           (detyped : untyped_program)
-          (ast : untyped_program)]
+          (ast : untyped_program)] [@coverage off]
 
 let check_program_exn ~allow_undefined_functions
     ({ functionblock= fb

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -336,7 +336,7 @@ unsized_type:
   | basic_type LBRACK UNREACHABLE
     { (* This code will never be reached *)
        Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"]
+          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
   | bt=basic_type
     {  grammar_logger "unsized_type";
@@ -372,7 +372,7 @@ basic_type:
   | no_constraints
     { (* This code will never be reached. The parser state exists to make the error more specific. *)
        Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"]
+          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
 
 unsized_dims:
@@ -384,7 +384,7 @@ no_assign:
   | UNREACHABLE
     { (* This code will never be reached *)
        Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"]
+          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
 
 optional_assignment(rhs):
@@ -430,7 +430,7 @@ decl(type_rule, rhs):
     }
   | DATABLOCK UNREACHABLE {
     Common.ICE.internal_compiler_error
-      [%message "the UNREACHABLE token should never be produced"]
+      [%message "the UNREACHABLE token should never be produced"] [@coverage off]
   }
   | ty=higher_type(type_rule)
     (* additional indirection only for better error messaging *)
@@ -518,7 +518,7 @@ sized_basic_type:
   | no_constraints
     { (* This code will never be reached. The parser state exists to make the error more specific. *)
        Common.ICE.internal_compiler_error
-          [%message "the UNREACHABLE token should never be produced"]
+          [%message "the UNREACHABLE token should never be produced"] [@coverage off]
     }
 
 top_var_type:

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -187,7 +187,8 @@ module Helpers = struct
       | (UMatrix | UComplexMatrix) as t -> t
       | t ->
           Common.ICE.internal_compiler_error
-            [%message "Cannot transpose " (t : UnsizedType.t)] in
+            [%message "Cannot transpose " (t : UnsizedType.t)] [@coverage off]
+    in
     let expr = unary_op Transpose e in
     {expr with meta= {expr.meta with type_= new_type}}
 
@@ -236,7 +237,7 @@ module Helpers = struct
         UComplex
     | _ ->
         ICE.internal_compiler_error
-          [%message "Can't index" (ut : UnsizedType.t)]
+          [%message "Can't index" (ut : UnsizedType.t)] [@coverage off]
 
   (** [add_index expression index] returns an expression that (additionally)
       indexes into the input [expression] by [index].*)
@@ -249,7 +250,8 @@ module Helpers = struct
       | Indexed (e, indices) -> Indexed (e, indices @ [i])
       | _ ->
           ICE.internal_compiler_error
-            [%message "Expected Var or Indexed but found " (e : Typed.t)] in
+            [%message "Expected Var or Indexed but found " (e : Typed.t)]
+          [@coverage off] in
     {meta; pattern}
 
   (** [add_tuple_index expression index] returns an expression that
@@ -265,7 +267,7 @@ module Helpers = struct
             [%message
               "Internal error: Attempted to apply tuple index to a non-tuple \
                type:"
-                (t : UnsizedType.t)] in
+                (t : UnsizedType.t)] [@coverage off] in
     let meta = Typed.Meta.{e.meta with type_= mtype} in
     let pattern = Pattern.TupleProjection (e, i) in
     {meta; pattern}

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -33,10 +33,10 @@ type 'expr t =
 let to_string
     ?(expr_to_string =
       fun _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "Should not be parsing expression from string in function renaming"])
-    x =
+        (Common.ICE.internal_compiler_error
+           [%message
+             "Should not be parsing expression from string in function renaming"]
+         [@coverage off])) x =
   Sexp.to_string (sexp_of_t expr_to_string x) ^ "__"
 
 let pp (pp_expr : 'a Fmt.t) ppf internal =

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -73,7 +73,7 @@ let rec get_dims_io st =
       Common.ICE.internal_compiler_error
         [%message
           "Tried to get IO dims of a tuple, which is not rectangular"
-            (st : Expr.Typed.t t)]
+            (st : Expr.Typed.t t)] [@coverage off]
 
 let rec io_size st =
   let two = Expr.Helpers.int 2 in

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -235,6 +235,7 @@ module Helpers = struct
     | UMathLibraryFunction | UFun _ | UTuple _ ->
         ICE.internal_compiler_error
           [%message "Can't iterate over " (iteratee : Expr.Typed.t)]
+        [@coverage off]
 
   let contains_fn_kind is_fn_kind ?(init = false) stmt =
     let rec aux accu {pattern; _} =

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -296,7 +296,7 @@ let rec fill_adtype_for_type ad ut =
         [%message
           "Attempting to give a non-tuple a TupleAD type"
             (ut : t)
-            (ad : autodifftype)]
+            (ad : autodifftype)] [@coverage off]
   | _, _ -> ad
 
 (** List all possible tuple sub-names for IO purposes. E.g, the decl

--- a/src/middle/Utils.ml
+++ b/src/middle/Utils.ml
@@ -65,7 +65,7 @@ let tuple_trans_exn = function
       Common.ICE.internal_compiler_error
         [%message
           "Expected TupleTransformation but got"
-            (t : Expr.Typed.t Transformation.t)]
+            (t : Expr.Typed.t Transformation.t)] [@coverage off]
 
 let zip_stuple_trans_exn pst tms =
   let rec tuple_subtypes pst =
@@ -75,7 +75,7 @@ let zip_stuple_trans_exn pst tms =
     | _ ->
         Common.ICE.internal_compiler_error
           [%message "Internal error: expected Tuple with TupleTransformation"]
-  in
+        [@coverage off] in
   let psts = tuple_subtypes pst in
   List.zip_exn psts tms
 
@@ -87,6 +87,6 @@ let zip_utuple_trans_exn pst tms =
     | _ ->
         Common.ICE.internal_compiler_error
           [%message "Internal error: expected Tuple with TupleTransformation"]
-  in
+        [@coverage off] in
   let psts = tuple_psts pst in
   List.zip_exn psts tms

--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -64,6 +64,7 @@ module Types = struct
     | _ ->
         Common.ICE.internal_compiler_error
           [%message "Tried to make an Eigen::Map of" (t : type_)]
+        [@coverage off]
 
   let var_context = TypeLiteral "stan::io::var_context"
   let ostream = TypeLiteral "std::ostream"

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -60,6 +60,7 @@ let constraint_to_string = function
       Common.ICE.internal_compiler_error
         [%message
           "Cannot generate tuple transformation directly; should not be called"]
+      [@coverage off]
 
 let functor_suffix = "_functor__"
 let reduce_sum_functor_suffix = "_rsfunctor__"
@@ -151,7 +152,7 @@ let rec local_scalar ut ad =
         [%message
           "Attempting to make a local scalar tuple"
             (ut : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)]
+            (ad : UnsizedType.autodifftype)] [@coverage off]
 
 let minus_one e =
   let open Cpp.DSL in
@@ -177,7 +178,7 @@ let rec lower_type ?(mem_pattern = Mem_pattern.AoS) (t : UnsizedType.t)
   | UComplexMatrix -> Types.matrix (Types.complex scalar)
   | UMathLibraryFunction | UFun _ ->
       Common.ICE.internal_compiler_error
-        [%message "Function types not implemented"]
+        [%message "Function types not implemented"] [@coverage off]
 
 let rec lower_unsizedtype_local ?(mem_pattern = Mem_pattern.AoS) adtype ut =
   match (adtype, ut) with
@@ -190,7 +191,7 @@ let rec lower_unsizedtype_local ?(mem_pattern = Mem_pattern.AoS) adtype ut =
         [%message
           "Tuple and Tuple AD type not matching!"
             (ut : UnsizedType.t)
-            (adtype : UnsizedType.autodifftype)]
+            (adtype : UnsizedType.autodifftype)] [@coverage off]
   | _, _ ->
       let s = local_scalar ut adtype in
       lower_type ~mem_pattern ut s
@@ -214,6 +215,7 @@ let rec lower_possibly_var_decl adtype ut mem_pattern =
       Common.ICE.internal_compiler_error
         [%message
           "Cannot lower" (x : UnsizedType.t) (ad : UnsizedType.autodifftype)]
+      [@coverage off]
 
 let rec lower_logical_op op e1 e2 =
   let prim e = Exprs.fun_call "stan::math::primitive_value" [lower_expr e] in
@@ -241,7 +243,8 @@ and read_data ut es =
      |UComplexMatrix | UComplexRowVector | UComplexVector | UArray _ | UFun _
      |UMathLibraryFunction ->
         Common.ICE.internal_compiler_error
-          [%message "Can't ReadData of " (ut : UnsizedType.t)] in
+          [%message "Can't ReadData of " (ut : UnsizedType.t)] [@coverage off]
+  in
   let open Cpp.DSL in
   let data_context = Var "context__" in
   data_context.@?(val_method, [lower_expr (List.hd_exn es)])
@@ -290,6 +293,7 @@ and lower_operator_app op es_in =
   | And | Or ->
       Common.ICE.internal_compiler_error
         [%message "And/Or should have been converted to an expression"]
+      [@coverage off]
   | EltTimes -> lower_binary_op Multiply "stan::math::elt_multiply" es
   | EltDivide -> lower_binary_op Divide "stan::math::elt_divide" es
   | Pow -> lower_binary_fun "stan::math::pow" es
@@ -448,7 +452,7 @@ and lower_compiler_internal ad ut f es =
             Common.ICE.internal_compiler_error
               [%message
                 "Array literal must have array type but found "
-                  (ut : UnsizedType.t)] in
+                  (ut : UnsizedType.t)] [@coverage off] in
       Exprs.std_vector_init_expr
         (lower_unsizedtype_local ad ut)
         (lower_exprs es)
@@ -473,7 +477,8 @@ and lower_compiler_internal ad ut f es =
       | _ ->
           Common.ICE.internal_compiler_error
             [%message
-              "Unexpected type for row vector literal" (ut : UnsizedType.t)])
+              "Unexpected type for row vector literal" (ut : UnsizedType.t)]
+          [@coverage off])
   | FnReadData -> read_data ut es
   | FnReadDeserializer ->
       deserializer.@<>(( "read"
@@ -520,18 +525,18 @@ and lower_indexed e indices pretty =
 and lower_indexed_simple (e : expr) idcs =
   let idx_minus_one = function
     | Index.Single e -> minus_one e
-    | MultiIndex e | Between (e, _) | Upfrom e ->
+    | MultiIndex e | Between (e, _) | Upfrom e -> (
         Common.ICE.internal_compiler_error
           [%message
             "No non-Single indices allowed"
               (e : expr)
-              (idcs : Expr.Typed.t Index.t list)]
-    | All ->
+              (idcs : Expr.Typed.t Index.t list)] [@coverage off])
+    | All -> (
         Common.ICE.internal_compiler_error
           [%message
             "No non-Single indices allowed"
               (e : expr)
-              (idcs : Expr.Typed.t Index.t list)] in
+              (idcs : Expr.Typed.t Index.t list)] [@coverage off]) in
   List.fold idcs ~init:e ~f:(fun e id ->
       Subscript (e, idx_minus_one (Index.map lower_expr id)))
 

--- a/src/stan_math_backend/Lower_functions.ml
+++ b/src/stan_math_backend/Lower_functions.ml
@@ -52,6 +52,7 @@ let rec requires ut t =
       Common.ICE.internal_compiler_error
         [%message
           "Cannot formulate require templates for type " (ut : UnsizedType.t)]
+      [@coverage off]
 
 (** Identify the templates which need to be considered in the return type of the
     function (i.e., the scalar types) *)
@@ -79,7 +80,7 @@ let return_optional_arg_types (args : Program.fun_arg_decl) =
                  unwrapped scalar is not tuple"
                   (typ : UnsizedType.t)
                   (internal : UnsizedType.t)
-                  (ad : UnsizedType.autodifftype)])
+                  (ad : UnsizedType.autodifftype)] [@coverage off])
     | UnsizedType.DataOnly, ut when not (UnsizedType.is_eigen_type ut) -> []
     | ( _
       , ( UnsizedType.UArray _ | UComplex | UVector | URowVector | UMatrix

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -63,7 +63,7 @@ let lower_map_decl (vident, ut) : defn =
       Common.ICE.internal_compiler_error
         [%message
           "Error during Map data construction for " vident " of type "
-            (x : UnsizedType.t)]
+            (x : UnsizedType.t)] [@coverage off]
 
 let rec top_level_decls Stmt.{pattern; _} =
   match pattern with

--- a/src/stan_math_backend/Lower_stmt.ml
+++ b/src/stan_math_backend/Lower_stmt.ml
@@ -16,9 +16,10 @@ let check_to_string = function
   | LowerUpper _ ->
       Common.ICE.internal_compiler_error
         [%message "LowerUpper is really two other checks tied together"]
+      [@coverage off]
   | Offset _ | Multiplier _ | OffsetMultiplier _ ->
       Common.ICE.internal_compiler_error
-        [%message "Offset and multiplier don't have a check"]
+        [%message "Offset and multiplier don't have a check"] [@coverage off]
   | t -> constraint_to_string t
 
 let math_fn_translations = function
@@ -94,7 +95,7 @@ let rec initialize_value st adtype =
         [%message
           "Mismatch between Tuple type and Tuple AD in code gen"
             (st : Expr.Typed.t SizedType.t)
-            (adtype : UnsizedType.autodifftype)]
+            (adtype : UnsizedType.autodifftype)] [@coverage off]
 
 (** Initialize an object of a given size.*)
 let lower_assign_sized st adtype (initialize : 'a Stmt.Pattern.decl_init) =
@@ -169,6 +170,7 @@ let rec lower_nonrange_lvalue lvalue =
   | _, _ ->
       Common.ICE.internal_compiler_error
         [%message "Multi-index must be the last (rightmost) index."]
+      [@coverage off]
 
 and lower_nonrange_lbase = function
   | Stmt.Pattern.LVariable v -> Var v


### PR DESCRIPTION
This aligns with what [bisect_ppx already does for `assert false`](https://github.com/aantron/bisect_ppx/blob/2d8dffbbfc0c431a37319d4d9a143836c9ec542e/src/ppx/instrument.ml#L385)

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
