### PR TITLE
Ignore duplicate includes of `.stanfunctions` files

### DIFF
--- a/src/common/Files.ml
+++ b/src/common/Files.ml
@@ -1,0 +1,11 @@
+open Core
+
+let stanfunctions_suffix = ".stanfunctions"
+
+let remove_dotstan s =
+  Option.first_some
+    (String.chop_suffix ~suffix:stanfunctions_suffix s)
+    (String.chop_suffix ~suffix:".stan" s)
+  |> Option.value ~default:s
+
+let is_stanfunctions = String.is_suffix ~suffix:stanfunctions_suffix

--- a/src/common/Files.mli
+++ b/src/common/Files.mli
@@ -1,0 +1,5 @@
+val remove_dotstan : string -> string
+(** Strip '.stan' or '.stanfunctions' from a filename *)
+
+val is_stanfunctions : string -> bool
+(** Test if a filename ends in '.stanfunctions' *)

--- a/src/driver/Entry.ml
+++ b/src/driver/Entry.ml
@@ -20,8 +20,8 @@ let set_model_name model_name =
           else match c with '-' -> "_" | _ -> "x" ^ Int.to_string (to_int c)))
   in
   let model_name_munged =
-    Flags.remove_dotstan List.(hd_exn (rev (String.split model_name ~on:'/')))
-  in
+    Common.Files.remove_dotstan
+      List.(hd_exn (rev (String.split model_name ~on:'/'))) in
   if String.equal model_name model_name_munged then
     (* model name was not file-like, so we leave as is (e.g. from --name
        argument) *)

--- a/src/driver/Flags.ml
+++ b/src/driver/Flags.ml
@@ -82,9 +82,3 @@ let set_backend_args_list flags =
     flags |> List.filter ~f:sans_model_and_hpp_paths |> String.concat ~sep:" "
   in
   Stan_math_backend.Lower_program.stanc_args_to_print := stanc_args_to_print
-
-let remove_dotstan s =
-  Option.first_some
-    (String.chop_suffix ~suffix:".stanfunctions" s)
-    (String.chop_suffix ~suffix:".stan" s)
-  |> Option.value ~default:s

--- a/src/driver/Flags.mli
+++ b/src/driver/Flags.mli
@@ -51,6 +51,3 @@ val get_optimization_settings :
 val set_backend_args_list : string list -> unit
 (** This is a helper function to set the [model_compile_info] method of the
     generated C++ to contain a copy of the (relevant) compiler flags *)
-
-val remove_dotstan : string -> string
-(** Strip '.stan' or '.stanfunctions' from a filename *)

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -137,6 +137,7 @@ let try_get_new_lexbuf fname =
       Lexing.from_string "")
     else (
       lexer_logger ("opened " ^ file);
+      included_files := file :: !included_files;
       new_lexbuf) in
   new_file_start_position new_lexbuf file (Some prior_loc);
   let dup_exists {Middle.Location.filename; included_from; _} =
@@ -149,7 +150,6 @@ let try_get_new_lexbuf fname =
   if dup_exists prior_loc then
     include_error (Printf.sprintf "File %s recursively included itself." fname);
   Stack.push include_stack new_lexbuf;
-  included_files := file :: !included_files;
   new_lexbuf
 
 let included_files () = List.rev !included_files

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -127,19 +127,21 @@ let try_get_new_lexbuf fname =
   let prior_loc =
     let lexbuf = Stack.top_exn include_stack in
     location_of_position lexbuf.lex_start_p in
-  let new_lexbuf, file = find_include fname in
   let new_lexbuf =
-    if
-      String.is_suffix ~suffix:".stanfunctions" file
-      && List.mem !included_files file ~equal:String.equal
-    then (
-      lexer_logger ("ignoring duplicated include  " ^ file);
-      Lexing.from_string "")
-    else (
-      lexer_logger ("opened " ^ file);
-      included_files := file :: !included_files;
-      new_lexbuf) in
-  new_file_start_position new_lexbuf file (Some prior_loc);
+    let buf, file = find_include fname in
+    let buf =
+      if
+        Common.Files.is_stanfunctions file
+        && List.mem !included_files file ~equal:String.equal
+      then (
+        lexer_logger ("ignoring duplicated include  " ^ file);
+        Lexing.from_string "")
+      else (
+        lexer_logger ("opened " ^ file);
+        included_files := file :: !included_files;
+        buf) in
+    new_file_start_position buf file (Some prior_loc);
+    buf in
   let dup_exists {Middle.Location.filename; included_from; _} =
     let is_dup = String.equal filename in
     let rec go = function

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -128,7 +128,16 @@ let try_get_new_lexbuf fname =
     let lexbuf = Stack.top_exn include_stack in
     location_of_position lexbuf.lex_start_p in
   let new_lexbuf, file = find_include fname in
-  lexer_logger ("opened " ^ file);
+  let new_lexbuf =
+    if
+      String.is_suffix ~suffix:".stanfunctions" file
+      && List.mem !included_files file ~equal:String.equal
+    then (
+      lexer_logger ("ignoring duplicated include  " ^ file);
+      Lexing.from_string "")
+    else (
+      lexer_logger ("opened " ^ file);
+      new_lexbuf) in
   new_file_start_position new_lexbuf file (Some prior_loc);
   let dup_exists {Middle.Location.filename; included_from; _} =
     let is_dup = String.equal filename in

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -53,7 +53,7 @@ let stanc ?tty_colors ?(debug_lex : bool = false) ?(debug_parse : bool = false)
   Debugging.grammar_logging := debug_parse;
   (* if we only have functions, always compile as standalone *)
   let flags =
-    if String.is_suffix model_file ~suffix:".stanfunctions" then
+    if Common.Files.is_stanfunctions model_file then
       {flags with standalone_functions= true; functions_only= true}
     else flags in
   let model_file_name, model_source, printed_filename =
@@ -73,7 +73,7 @@ let stanc ?tty_colors ?(debug_lex : bool = false) ?(debug_parse : bool = false)
       if print_cpp then print_endline cpp_str;
       let out =
         if String.equal output_file "" then
-          Driver.Flags.remove_dotstan model_file_name ^ ".hpp"
+          Common.Files.remove_dotstan model_file_name ^ ".hpp"
         else output_file in
       write out cpp_str
   | Error e ->

--- a/test/integration/cli-args/canonicalize/include/c.stanfunctions
+++ b/test/integration/cli-args/canonicalize/include/c.stanfunctions
@@ -6,3 +6,5 @@ int baz(real z){
   else return 3;
   // trailing coment in c
 }
+
+#include "a.stanfunctions"

--- a/test/integration/cli-args/canonicalize/include/inlined.expected
+++ b/test/integration/cli-args/canonicalize/include/inlined.expected
@@ -47,6 +47,13 @@ int baz(real z) {
     return 3;
   // trailing coment in c
 }
+
+// line comment a
+/*weird block a*/
+void foo(real x) {
+  return;
+}
+// another line comment a
 [exit 0]
   $ stanc --auto-format --include-paths=. --canonicalize=includes data.stan
 data {

--- a/test/integration/cli-args/canonicalize/include/main.stan
+++ b/test/integration/cli-args/canonicalize/include/main.stan
@@ -1,4 +1,5 @@
 functions {
+   #include a.stanfunctions
    #include b.stanfunctions
    #include c.stanfunctions
 }

--- a/test/integration/cli-args/canonicalize/include/stanc.expected
+++ b/test/integration/cli-args/canonicalize/include/stanc.expected
@@ -32,6 +32,8 @@ int baz(real z) {
     return 3;
   // trailing coment in c
 }
+
+#include a.stanfunctions
 [exit 0]
   $ stanc --auto-format --include-paths=. data.stan
 data {
@@ -52,6 +54,7 @@ functions {
 [exit 0]
   $ stanc --auto-format --include-paths=. main.stan
 functions {
+  #include a.stanfunctions
   #include b.stanfunctions
   #include c.stanfunctions
 }

--- a/test/integration/cli-args/info/dune
+++ b/test/integration/cli-args/info/dune
@@ -5,7 +5,8 @@
   info.stan
   included.stan
   includes/recursive.stan
-  includes/another_include.stan)
+  includes/another_include.stan
+  includes/foo.stanfunctions)
  (action
   (with-stdout-to
    %{targets}

--- a/test/integration/cli-args/info/includes/foo.stanfunctions
+++ b/test/integration/cli-args/info/includes/foo.stanfunctions
@@ -1,0 +1,3 @@
+  real foo(real a) {
+    return sin(a);
+  }

--- a/test/integration/cli-args/info/info.expected
+++ b/test/integration/cli-args/info/info.expected
@@ -53,7 +53,7 @@
   ],
   "included_files": [
     "./included.stan", "includes/recursive.stan",
-    "includes/another_include.stan"
+    "includes/another_include.stan", "includes/foo.stanfunctions"
   ]
 }
 [exit 0]

--- a/test/integration/cli-args/info/info.stan
+++ b/test/integration/cli-args/info/info.stan
@@ -2,9 +2,10 @@
 #include <recursive.stan>
 
 functions {
-  real foo(real a) {
-    return sin(a);
-  }
+  #include <foo.stanfunctions>
+  #include <foo.stanfunctions>
+  #include <foo.stanfunctions>
+
   real goo_lpdf(real a) {
     return a;
   }


### PR DESCRIPTION
Closes #1450. This is particularly useful for things like https://github.com/spinkney/helpful_stan_functions or anyone who wants to write tiny files that reference each other. 
At the moment, this will lead to errors if they transitively include the same function. But we don't need to worry about that when it's literally the same file, since stan functions are order-independent anyway. 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

The same `.stanfunctions` file can be included multiple times, with later times being ignored. This is particularly useful when `.stanfunctions` files include other `.stanfunctions` files


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
