### PR TITLE
Replace core dependency with base + stdio

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,8 +15,24 @@
  (depends
   (ocaml
    (= 5.5.0))
-  (core
-   (= v0.17.2))
+  (base
+   (= v0.17.3))
+  (stdio
+   (= v0.17.0))
+  (sexplib0
+   (= v0.17.0))
+  (ppx_base
+   (= v0.17.0))
+  (ppx_pipebang
+   (= v0.17.0))
+  (ppx_sexp_message
+   (= v0.17.0))
+  (ppx_sexp_value
+   (= v0.17.0))
+  (ppx_expect
+   (= v0.17.3))
+  (ppx_inline_test
+   (= v0.17.1))
   (menhir
    (= 20260209))
   (ppx_deriving

--- a/src/analysis_and_optimization/Dataflow_types.ml
+++ b/src/analysis_and_optimization/Dataflow_types.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 (***********************************)
 (* Basic datatypes                 *)

--- a/src/analysis_and_optimization/Dataflow_utils.ml
+++ b/src/analysis_and_optimization/Dataflow_utils.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 open Dataflow_types
 open Mir_utils

--- a/src/analysis_and_optimization/Dataflow_utils.mli
+++ b/src/analysis_and_optimization/Dataflow_utils.mli
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 open Dataflow_types
 

--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 
 let rec transpose = function
@@ -134,7 +134,7 @@ let gen_row_vector m n t =
 let sum_to_zero_floats n =
   let l = random_floats n in
   let sum = List.fold l ~init:0. ~f:( +. ) in
-  List.map l ~f:(fun x -> x -. (sum /. float_of_int n))
+  List.map l ~f:(fun x -> x -. (sum /. Float.of_int n))
 
 let simplex_floats n =
   let l = random_floats n in
@@ -162,7 +162,7 @@ let gen_vector m n t =
       let l = random_floats n in
       let sum =
         Float.sqrt
-          (List.fold l ~init:0. ~f:(fun accum elt -> accum +. (elt ** 2.)))
+          (List.fold l ~init:0. ~f:(fun accum elt -> accum +. (elt *. elt)))
       in
       let l = List.map l ~f:(fun x -> x /. sum) in
       Expr.Helpers.vector l
@@ -337,9 +337,9 @@ open Yojson
 let json_to_mir (decls : (Expr.Typed.t SizedType.t * 'a * string) list)
     (json : Yojson.Basic.t) =
   let rec create_expr (type_ : UnsizedType.t) (json : Basic.t) =
-    let as_float = function `Int i -> float_of_int i | `Float f -> f in
+    let as_float = function `Int i -> Float.of_int i | `Float f -> f in
     let try_float = function
-      | `Int i -> Some (float_of_int i)
+      | `Int i -> Some (Float.of_int i)
       | `Float f -> Some f
       | _ -> None in
     let try_complex = function
@@ -371,15 +371,15 @@ let json_to_mir (decls : (Expr.Typed.t SizedType.t * 'a * string) list)
     | `Assoc l, UTuple ts ->
         l
         |> List.sort ~compare:(fun (x, _) (y, _) ->
-            Int.compare (int_of_string x) (int_of_string y))
+            Int.compare (Int.of_string x) (Int.of_string y))
         |> List.map2_exn ~f:(fun typ_ (_, json) -> create_expr typ_ json) ts
         |> Option.all
         |> Option.map ~f:(fun l -> Expr.Helpers.tuple_expr l)
     | _ -> None in
   let map =
     match json with
-    | `Assoc l -> String.Map.of_alist_reduce ~f:Fn.const l
-    | _ -> String.Map.empty in
+    | `Assoc l -> Map.of_alist_reduce (module String) ~f:Fn.const l
+    | _ -> (Map.empty (module String)) in
   List.filter_map decls ~f:(fun (st, _, name) ->
       Map.find map name
       |> Option.bind ~f:(fun value ->
@@ -398,7 +398,7 @@ let generate_json_entries (name, expr) : string * t =
         `List (List.map ~f:expr_to_json l)
     | FunApp (CompilerInternal FnMakeTuple, l) ->
         `Assoc
-          (List.mapi ~f:(fun i t -> (string_of_int (i + 1), expr_to_json t)) l)
+          (List.mapi ~f:(fun i t -> (Int.to_string (i + 1), expr_to_json t)) l)
     | FunApp (StanLib (transpose, _, _), [e])
       when String.equal transpose (Operator.to_string Transpose) ->
         expr_to_json e

--- a/src/analysis_and_optimization/Debug_data_generation.mli
+++ b/src/analysis_and_optimization/Debug_data_generation.mli
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 
 val json_to_mir :
@@ -12,7 +12,7 @@ val gen_values_json :
      ?new_only:bool
   -> ?context:(string, Expr.Typed.t) Map.Poly.t
   -> (Expr.Typed.t SizedType.t * Expr.Typed.t Transformation.t * string) list
-  -> (string, Frontend.Errors.t) result
+  -> (string, Frontend.Errors.t) Result.t
 (** Generates values matching the given declarations and formats them as a JSON
     string. The declarations may depend on additional values supplied in
     `context`. If `new_only` is true (defaults to false) the output does not

--- a/src/analysis_and_optimization/Dependence_analysis.ml
+++ b/src/analysis_and_optimization/Dependence_analysis.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Dataflow_types
 open Mir_utils
@@ -160,7 +160,7 @@ let mir_uninitialized_variables (mir : Program.Typed.t) :
   let globals = Set.union function_names (Set.Poly.of_list flag_variables) in
   let parameters =
     Set.Poly.of_list
-      (List.map ~f:fst3
+      (List.map ~f:(fun (x, _, _) -> x)
          (List.filter
             ~f:(fun (_, _, {out_block; _}) -> out_block = Parameters)
             mir.output_vars)) in

--- a/src/analysis_and_optimization/Dependence_analysis.mli
+++ b/src/analysis_and_optimization/Dependence_analysis.mli
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 open Dataflow_types
 

--- a/src/analysis_and_optimization/Factor_graph.ml
+++ b/src/analysis_and_optimization/Factor_graph.ml
@@ -1,4 +1,5 @@
-open Core
+open Base
+open Common.Poly_containers
 open Middle
 open Dataflow_types
 open Dataflow_utils
@@ -14,7 +15,7 @@ type factor =
 type factor_graph =
   { factor_map: (factor * label, vexpr Set.Poly.t) Map.Poly.t
   ; var_map: (vexpr, (factor * label) Set.Poly.t) Map.Poly.t }
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 let extract_factors_statement stmt =
   match stmt with

--- a/src/analysis_and_optimization/Memory_patterns.ml
+++ b/src/analysis_and_optimization/Memory_patterns.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 
 type demotion = int * Mem_pattern.t * string [@@deriving compare]
@@ -606,7 +606,7 @@ and modify_expr ?force_demotion:(force = false)
     @param modifiable_set The name of the variable we are searching for. *)
 let rec modify_stmt_pattern
     (pattern : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t)
-    (modifiable_set : string Core.Set.Poly.t) =
+    (modifiable_set : string Base.Set.Poly.t) =
   let mod_expr force = modify_expr ~force_demotion:force modifiable_set in
   let mod_stmt stmt = modify_stmt stmt modifiable_set in
   match pattern with

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Middle.Program
 open Middle.Expr
@@ -24,7 +24,7 @@ let rec num_expr_value (v : Expr.Typed.t) : (float * string) option =
   (* internal type promotions should be ignored *)
   | {pattern= Pattern.Promotion (e, _, _); _} -> num_expr_value e
   | {pattern= Pattern.Lit ((Real | Int), str); _} ->
-      Some (float_of_string str, str)
+      Some (Float.of_string str, str)
   | {pattern= Pattern.FunApp (StanLib ("PMinus__", FnPlain, _), [v]); _} -> (
       match num_expr_value v with
       | Some (v, s) -> Some (-.v, "-" ^ s)
@@ -78,7 +78,7 @@ let data_set ?(exclude_transformed = false) ?(exclude_ints = false)
   (* Possibly remove ints from the data set *)
   let filtered_data =
     let remove_ints = Set.filter ~f:(fun (_, _, st) -> st <> SizedType.SInt) in
-    Set.Poly.map ~f:fst3 ((if exclude_ints then remove_ints else Fn.id) data)
+    Set.Poly.map ~f:(fun (x, _, _) -> x) ((if exclude_ints then remove_ints else Fn.id) data)
   in
   (* Transformed data are declarations in prepare_data but excluding data *)
   if exclude_transformed then filtered_data
@@ -87,7 +87,7 @@ let data_set ?(exclude_transformed = false) ?(exclude_ints = false)
       Set.diff
         (Set.Poly.union_list
            (List.map ~f:top_var_declarations mir.prepare_data))
-        (Set.Poly.map ~f:fst3 data) in
+        (Set.Poly.map ~f:(fun (x, _, _) -> x) data) in
     Set.union trans_data filtered_data
 
 let parameter_set ?(include_transformed = false) (mir : Program.Typed.t) =
@@ -102,7 +102,7 @@ let parameter_set ?(include_transformed = false) (mir : Program.Typed.t) =
        mir.output_vars)
 
 let parameter_names_set ?(include_transformed = false) (mir : Program.Typed.t) =
-  Set.Poly.map ~f:fst3 (parameter_set ~include_transformed mir)
+  Set.Poly.map ~f:(fun (x, _, _) -> x) (parameter_set ~include_transformed mir)
 
 let rec var_declarations Stmt.{pattern; _} : string Set.Poly.t =
   match pattern with
@@ -271,7 +271,7 @@ let stmt_rhs stmt =
    |Break | Continue | Skip | Decl _ | Profile _ | Block _ | SList _ ->
       Set.Poly.empty
 
-let union_map (set : ('a, 'c) Set_intf.Set.t) ~(f : 'a -> 'b Set.Poly.t) =
+let union_map (set : ('a, 'c) Set.t) ~(f : 'a -> 'b Set.Poly.t) =
   Set.fold set ~init:Set.Poly.empty ~f:(fun s a -> Set.union s (f a))
 
 let stmt_rhs_var_set stmt = union_map (stmt_rhs stmt) ~f:expr_var_set
@@ -495,6 +495,6 @@ let%expect_test "cleanup" =
   let body = Block [Skip |> swrap] |> swrap in
   let s = For {loopvar= "i"; lower= loop_bottom; upper= loop_bottom; body} in
   let res = [s |> swrap] |> cleanup_empty_stmts in
-  [%sexp (res : Stmt.Located.t list)] |> print_s;
+  [%sexp (res : Stmt.Located.t list)] |> Stdio.print_s;
   [%expect {|
     () |}]

--- a/src/analysis_and_optimization/Mir_utils.mli
+++ b/src/analysis_and_optimization/Mir_utils.mli
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 open Dataflow_types
 
@@ -116,7 +116,7 @@ val index_var_set :
 (** The set of variables in an index. For use in RHS sets, not LHS assignment
     sets, except in a target term *)
 
-val expr_var_names_set : Expr.Typed.t -> string Core.Set.Poly.t
+val expr_var_names_set : Expr.Typed.t -> string Base.Set.Poly.t
 (** Return the names of the variables in an expression. *)
 
 val stmt_rhs : (Expr.Typed.t, 's) Stmt.Pattern.t -> Expr.Typed.t Set.Poly.t

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -1,7 +1,8 @@
 (** The common elements of a monotone framework *)
 
-open Core
-open Core.Poly
+open Base
+open Common.Poly_containers
+open Base.Poly
 open Monotone_framework_sigs
 open Mir_utils
 open Middle
@@ -15,8 +16,8 @@ let print_mfp to_string (mfp : (int, 'a entry_exit) Map.Poly.t)
   let print_stmt s =
     [%sexp (s : Stmt.Located.Non_recursive.t)] |> Sexp.to_string_hum in
   Map.iteri mfp ~f:(fun ~key ~data ->
-      print_endline
-        (string_of_int key ^ ":\n "
+      Stdio.print_endline
+        (Int.to_string key ^ ":\n "
         ^ print_stmt (Map.Poly.find_exn flowgraph_to_mir key)
         ^ ":\n " ^ print_set data.entry ^ " \t-> " ^ print_set data.exit))
 
@@ -129,7 +130,8 @@ let reverse (type l) (module F : FLOWGRAPH with type labels = l) =
     let compare = F.compare
     let hash = F.hash
     let sexp_of_t = F.sexp_of_t
-    let initials = Set.of_map_keys (Map.filter F.successors ~f:Set.is_empty)
+    let initials =
+      Set.Poly.of_list (Map.keys (Map.filter F.successors ~f:Set.is_empty))
 
     let successors =
       Map.fold F.successors
@@ -925,8 +927,8 @@ let propagation_mfp (prog : Program.Typed.t)
 
       let total =
         Set.Poly.union_list
-          [ Set.Poly.of_list (List.map ~f:fst3 prog.input_vars)
-          ; Set.Poly.of_list (List.map ~f:fst3 prog.output_vars)
+          [ Set.Poly.of_list (List.map ~f:(fun (x, _, _) -> x) prog.input_vars)
+          ; Set.Poly.of_list (List.map ~f:(fun (x, _, _) -> x) prog.output_vars)
           ; declared_variables_stmt
               (stmt_loc_of_stmt_loc_num flowgraph_to_mir mir).pattern ]
     end : TOTALTYPE
@@ -953,8 +955,8 @@ let reaching_definitions_mfp (mir : Program.Typed.t)
 
       let initial =
         Set.Poly.union_list
-          [ Set.Poly.of_list (List.map ~f:fst3 mir.input_vars)
-          ; Set.Poly.of_list (List.map ~f:fst3 mir.output_vars) ]
+          [ Set.Poly.of_list (List.map ~f:(fun (x, _, _) -> x) mir.input_vars)
+          ; Set.Poly.of_list (List.map ~f:(fun (x, _, _) -> x) mir.output_vars) ]
     end : INITIALTYPE
       with type vals = string) in
   let labels =
@@ -987,7 +989,7 @@ let initialized_vars_mfp (total : string Set.Poly.t)
 
 let globals (prog : Program.Typed.t) =
   Set.Poly.union_list
-    [ Set.Poly.of_list (List.map ~f:fst3 prog.output_vars)
+    [ Set.Poly.of_list (List.map ~f:(fun (x, _, _) -> x) prog.output_vars)
       (* It is not strictly necessary to exclude data variables from DCE.
          However,
 
@@ -996,7 +998,7 @@ let globals (prog : Program.Typed.t) =
 
          2. There is code added in codegen that is never represented in the MIR
          that may use data variables as if they're initialized *)
-    ; Set.Poly.of_list (List.map ~f:fst3 prog.input_vars)
+    ; Set.Poly.of_list (List.map ~f:(fun (x, _, _) -> x) prog.input_vars)
     ; Set.Poly.union_list (List.map ~f:var_declarations prog.prepare_data)
     ; Set.Poly.singleton "target" ]
 

--- a/src/analysis_and_optimization/Monotone_framework_sigs.mli
+++ b/src/analysis_and_optimization/Monotone_framework_sigs.mli
@@ -1,7 +1,7 @@
 (** The API for a monotone framework, as described in 2.3-2.4 of Nielson,
     Nielson, and Hankin or 9.3 of Aho et al.. This gives a modular way of
     implementing many static analyses. *)
-open Core
+open Base
 
 (** The API for a flowgraph, needed for the mfp algorithm in the monotone
     framework. Assumed invariants: successors contains all graph nodes as keys

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -1,7 +1,7 @@
 (** Code for optimization passes on the MIR *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Common
 open Middle
 open Mir_utils
@@ -80,7 +80,7 @@ let gen_inline_var (name : string) (id_var : string) =
   Gensym.generate ~prefix:("inline_" ^ name ^ "_" ^ id_var ^ "_") ()
 
 let replace_fresh_local_vars (fname : string) stmt =
-  let f (m : (string, string) Core.Map.Poly.t) = function
+  let f (m : (string, string) Base.Map.Poly.t) = function
     | Stmt.Pattern.Decl {decl_adtype; decl_type; decl_id; initialize} ->
         let new_name =
           match Map.Poly.find m decl_id with
@@ -509,7 +509,7 @@ let function_inlining (mir : Program.Typed.t) =
   (* We add only the functions with a single definition to the inline map.
      Overloaded functions cannot be inlined. *)
   let can_inline =
-    List.fold mir.functions_block ~init:String.Map.empty
+    List.fold mir.functions_block ~init:(Map.empty (module String))
       ~f:(fun accum Program.{fdname; _} ->
         Map.update accum fdname
           ~f:(Option.value_map ~default:true ~f:(fun _ -> false))) in
@@ -1117,7 +1117,7 @@ let optimize_minimal_variables
     ~(update_expr : string Set.Poly.t -> Expr.Typed.t -> Expr.Typed.t)
     ~(update_stmt :
           (Expr.Typed.t, (Expr.Typed.Meta.t, 'a) Stmt.t) Stmt.Pattern.t
-       -> string Core.Set.Poly.t
+       -> string Base.Set.Poly.t
        -> (Expr.Typed.t, (Expr.Typed.Meta.t, 'a) Stmt.t) Stmt.Pattern.t)
     ~(extra_variables : string -> string Set.Poly.t)
     ~(initial_variables : string Set.Poly.t) (stmt : Stmt.Located.t) =

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -1,14 +1,14 @@
 (* A partial evaluator for use in static analysis and optimization *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 
 exception Rejected of Location_span.t * string
 
 let rec is_int query Expr.{pattern; _} =
   match pattern with
-  | Lit (Int, i) | Lit (Real, i) -> float_of_string i = float_of_int query
+  | Lit (Int, i) | Lit (Real, i) -> Float.of_string i = Float.of_int query
   | Promotion (e, _, _) -> is_int query e
   | _ -> false
 

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Optimize
 open Middle
 open Middle.Program
@@ -18,7 +18,7 @@ let list_unused_params (factor_graph : factor_graph) (mir : Program.Typed.t) :
     (string * Location_span.t) Set.Poly.t =
   (* Build a factor graph of the program, check for missing parameters *)
   let param_info = parameter_set ~include_transformed:false mir in
-  let params = Set.Poly.map ~f:fst3 param_info in
+  let params = Set.Poly.map ~f:(fun (x, _, _) -> x) param_info in
   let used_params =
     Set.Poly.map
       ~f:(fun (VVar v) -> v)
@@ -81,7 +81,7 @@ let list_possible_nonlinear (mir : Program.Typed.t) : Location_span.t Set.Poly.t
       ; "positive_infinity"; "segment"; "subtract"; "sum"; "to_vector"
       ; "to_row_vector"; "to_matrix"; "to_array_1d"; "to_array_2d"; "transpose"
       ]
-    |> String.Set.of_list in
+    |> Set.of_list (module String) in
   (* A simple check of linearity of an expression. allow_var is used for
      expressions like a*b, where at most one of a and b can be a variable *)
   let rec is_linear allow_var Expr.{pattern; _} =
@@ -466,7 +466,7 @@ let uninitialized_warnings (mir : Program.Typed.t) =
     Set.filter
       ~f:(fun (span, _) -> span <> Location_span.empty)
       (Dependence_analysis.mir_uninitialized_variables mir) in
-  let vars = String.Hash_set.create () in
+  let vars = Hash_set.create (module String) in
   let deduplicated =
     Set.Poly.filter_map uninit_vars ~f:(fun (loc, var) ->
         if Hash_set.mem vars var then None

--- a/src/analysis_and_optimization/Pedantic_dist_warnings.ml
+++ b/src/analysis_and_optimization/Pedantic_dist_warnings.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Mir_utils
 

--- a/src/analysis_and_optimization/dune
+++ b/src/analysis_and_optimization/dune
@@ -1,10 +1,16 @@
 (library
  (name analysis_and_optimization)
  (public_name stanc.analysis)
- (libraries core middle yojson frontend stan_math_signatures)
+ (libraries base stdio middle yojson frontend stan_math_signatures)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)
  (modules_without_implementation monotone_framework_sigs)
  (preprocess
-  (pps ppx_jane)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test)))

--- a/src/common/Files.ml
+++ b/src/common/Files.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 let stanfunctions_suffix = ".stanfunctions"
 

--- a/src/common/Gensym.ml
+++ b/src/common/Gensym.ml
@@ -2,7 +2,7 @@ let _counter = ref 0
 
 let generate ?(prefix : string = "") () =
   _counter := !_counter + 1;
-  Format.sprintf "%ssym%d__" prefix !_counter
+  Stdlib.Format.sprintf "%ssym%d__" prefix !_counter
 
 let enter () =
   let old_counter = !_counter in

--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -1,8 +1,8 @@
 (** Internal compiler errors *)
 
-open Core
+open Base
 
-(** An alias of [Core.raise_s]. This used to do more processing, for now it is
+(** An alias of [Base.raise_s]. This used to do more processing, for now it is
     preserved just as a nicer marker in the code *)
 let internal_compiler_error = raise_s
 
@@ -13,7 +13,8 @@ let with_exn_message f =
   try Ok (f ())
   with e ->
     let bt =
-      if Printexc.backtrace_status () then Printexc.get_backtrace ()
+      if Backtrace.Exn.am_recording () then
+        Backtrace.to_string (Backtrace.Exn.most_recent ())
       else "Backtrace missing." in
     Error
       (Fmt.str

--- a/src/common/Let_syntax.ml
+++ b/src/common/Let_syntax.ml
@@ -3,11 +3,11 @@
     https://blog.janestreet.com/let-syntax-and-why-you-should-use-it/ *)
 
 module Result = struct
-  let ( let* ) = Core.Result.( >>= )
-  let ( let+ ) = Core.Result.( >>| )
+  let ( let* ) = Base.Result.( >>= )
+  let ( let+ ) = Base.Result.( >>| )
 end
 
 module Option = struct
-  let ( let* ) = Core.Option.( >>= )
-  let ( let+ ) = Core.Option.( >>| )
+  let ( let* ) = Base.Option.( >>= )
+  let ( let+ ) = Base.Option.( >>| )
 end

--- a/src/common/Nonempty_list.ml
+++ b/src/common/Nonempty_list.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 type 'a t = ( :: ) of 'a * 'a list
 

--- a/src/common/Nonempty_list.mli
+++ b/src/common/Nonempty_list.mli
@@ -3,7 +3,8 @@
 
     [let x : _ Nonempty_list.t = [1;2;3]]
 
-    In Core v0.18, we can replace this with [Core.Nonempty_list] *)
+    (Core, but not Base, provides an equivalent [Nonempty_list] since
+    v0.18) *)
 
 type 'a t = ( :: ) of 'a * 'a list [@@deriving sexp]
 

--- a/src/common/Poly_containers.ml
+++ b/src/common/Poly_containers.ml
@@ -1,0 +1,31 @@
+(** [Base]'s [Set.Poly] and [Map.Poly] do not provide the sexp converters that
+    Core's versions do. Opening this module (after [Base]) shadows [Set] and
+    [Map] with versions whose [Poly] submodules support [sexp_of_t], printing
+    in the same format as Core: a set as the list of its elements, a map as a
+    list of [(key value)] pairs. *)
+
+open Base
+
+module Set = struct
+  include Set
+
+  module Poly = struct
+    include Set.Poly
+
+    let sexp_of_t sexp_of_elt s =
+      List.sexp_of_t sexp_of_elt (Base.Set.to_list s)
+  end
+end
+
+module Map = struct
+  include Map
+
+  module Poly = struct
+    include Map.Poly
+
+    let sexp_of_t sexp_of_key sexp_of_data m =
+      List.sexp_of_t
+        (fun (k, v) -> Sexp.List [sexp_of_key k; sexp_of_data v])
+        (Base.Map.to_alist m)
+  end
+end

--- a/src/common/dune
+++ b/src/common/dune
@@ -1,8 +1,14 @@
 (library
  (name common)
  (public_name stanc.common)
- (libraries core fmt)
+ (libraries base stdio fmt)
  (preprocess
-  (pps ppx_jane ppx_deriving.fold ppx_deriving.map))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_deriving.fold
+   ppx_deriving.map))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/driver/Entry.ml
+++ b/src/driver/Entry.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Frontend
 open Stan_math_backend
 open Analysis_and_optimization
@@ -7,10 +7,10 @@ open Middle
 let version = "%%NAME%%3 %%VERSION%%"
 
 let fmt_sexp s =
-  let ppf = Format.str_formatter in
-  Format.pp_set_margin ppf 90;
+  let ppf = Stdlib.Format.str_formatter in
+  Stdlib.Format.pp_set_margin ppf 90;
   Sexp.pp_hum ppf s;
-  Format.flush_str_formatter ()
+  Stdlib.Format.flush_str_formatter ()
 
 let set_model_name model_name =
   let mangle =
@@ -45,7 +45,7 @@ type other_output =
   | Generated of string
   | Warnings of Warnings.t list
 
-type compilation_result = (string, Errors.t) result
+type compilation_result = (string, Errors.t) Result.t
 
 let debug_output_mir output mir = function
   | Flags.Off -> ()

--- a/src/driver/Entry.mli
+++ b/src/driver/Entry.mli
@@ -3,7 +3,7 @@
 open Frontend
 
 (** Either the C++ a model compiled to, or an error *)
-type compilation_result = (string, Errors.t) result
+type compilation_result = (string, Errors.t) Result.t
 
 (** The type of all non-C++-code outputs from the compiler *)
 type other_output =

--- a/src/driver/Flags.ml
+++ b/src/driver/Flags.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 type t =
   { optimization_level: Analysis_and_optimization.Optimize.optimization_level

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -2,7 +2,8 @@
  (name driver)
  (public_name stanc.driver)
  (libraries
-  core
+  base
+  stdio
   fmt
   frontend
   middle
@@ -12,4 +13,10 @@
   (backend bisect_ppx))
  (inline_tests)
  (preprocess
-  (pps ppx_jane)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test)))

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -8,7 +8,7 @@
     later be filled in with something like
     [type expr_with_meta = metadata expression] *)
 
-open Core
+open Base
 open Middle
 
 (** Our type for identifiers, on which we record a location *)
@@ -62,7 +62,7 @@ type ('m, 'f, 'p) expr_with =
 type located_meta = {loc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
 [@@deriving sexp, compare, hash]
 
-type untyped_expression = (located_meta, unit, Core.Nothing.t) expr_with
+type untyped_expression = (located_meta, unit, Base.Nothing.t) expr_with
 [@@deriving sexp, compare, hash]
 
 (** Typed expressions also have meta-data after type checking: a location_span,

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 
 let trans_fn_kind kind name =
@@ -22,11 +22,11 @@ let drop_leading_zeros s =
 let format_number s = s |> without_underscores |> drop_leading_zeros
 
 let%expect_test "format_number0" =
-  format_number "0_000." |> print_endline;
+  format_number "0_000." |> Stdio.print_endline;
   [%expect "0."]
 
 let%expect_test "format_number1" =
-  format_number ".123_456" |> print_endline;
+  format_number ".123_456" |> Stdio.print_endline;
   [%expect ".123456"]
 
 let rec op_to_funapp op args type_ =
@@ -428,7 +428,7 @@ let rec check_decl var decl_type' decl_trans smeta adlevel =
 
 let check_sizedtype name st =
   let check x = function
-    | {Expr.pattern= Lit (Int, i); _} when float_of_string i >= 0. -> []
+    | {Expr.pattern= Lit (Int, i); _} when Float.of_string i >= 0. -> []
     | n ->
         [ Stmt.Helpers.internal_nrfunapp FnValidateSize
             Expr.Helpers.
@@ -762,7 +762,7 @@ let rec trans_sizedtype_decl declc tr name st =
         [str name; str (Fmt.str "%a" Pretty_printing.pp_typed_expression x); n]
       n.meta.loc in
   let grab_size fn n = function
-    | Ast.{expr= IntNumeral i; _} as s when float_of_string i >= 2. ->
+    | Ast.{expr= IntNumeral i; _} as s when Float.of_string i >= 2. ->
         ([], trans_expr s)
     | Ast.({expr= IntNumeral _; _} | {expr= Variable _; _}) as s ->
         let e = trans_expr s in
@@ -857,7 +857,7 @@ let rec trans_sizedtype_decl declc tr name st =
                (List.zip_exn subtypes Utils.(tuple_trans_exn tr))
                ~f:(fun ix (st, trans) ->
                  trans_sizedtype_decl declc trans
-                   (name ^ former_array_indices ^ "." ^ string_of_int (ix + 1))
+                   (name ^ former_array_indices ^ "." ^ Int.to_string (ix + 1))
                    st)) in
         (List.concat stmts, SizedType.STuple subtypes') in
   go 1 st
@@ -988,7 +988,8 @@ let trans_prog filename (p : Ast.typed_program) : Program.Typed.t =
     | hd :: _ -> [{pattern= Block modelb; meta= hd.meta}] in
   let txparam_decls, txparam_checks, txparam_stmts =
     txparam_gq
-    |> List.partition3_map ~f:(function
+    |> List.partition3_map ~f:(fun (s : Stmt.Located.t) ->
+      match s with
       | {pattern= Decl _; _} as d -> `Fst d
       | s when stmt_contains_check s -> `Snd s
       | s -> `Trd s) in

--- a/src/frontend/Canonicalize.ml
+++ b/src/frontend/Canonicalize.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Ast
 open Deprecation_analysis
 

--- a/src/frontend/Debugging.ml
+++ b/src/frontend/Debugging.ml
@@ -3,14 +3,14 @@
 (** Controls whether the lexing operations get logged *)
 let lexer_logging = ref false
 
-let lexer_logger s = if !lexer_logging then print_endline ("Lexer: " ^ s)
+let lexer_logger s = if !lexer_logging then Stdio.print_endline ("Lexer: " ^ s)
 
 let lexer_pos_logger (pos : Lexing.position) =
   if !lexer_logging then
-    print_endline
-      ("{fname=" ^ pos.pos_fname ^ "; line=" ^ string_of_int pos.pos_lnum ^ "}")
+    Stdio.print_endline
+      ("{fname=" ^ pos.pos_fname ^ "; line=" ^ Int.to_string pos.pos_lnum ^ "}")
 
 (** Controls whether the parsing operations get logged *)
 let grammar_logging = ref false
 
-let grammar_logger s = if !grammar_logging then print_endline ("Parser: " ^ s)
+let grammar_logger s = if !grammar_logging then Stdio.print_endline ("Parser: " ^ s)

--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Ast
 open Middle
 
@@ -8,12 +8,12 @@ let expired (major, minor) =
   let removal_major, removal_minor = current_removal_version in
   removal_major > major || (removal_major = major && removal_minor >= minor)
 
-let deprecated_functions = String.Map.of_alist_exn []
+let deprecated_functions = Map.of_alist_exn (module String) []
 let stan_lib_deprecations = deprecated_functions
 
 (* TODO deprecate other pre-variadics like algebra_solver? *)
 let deprecated_odes =
-  String.Map.of_alist_exn
+  Map.of_alist_exn (module String)
     [ ("integrate_ode", ("ode_rk45", (3, 0)))
     ; ("integrate_ode_rk45", ("ode_rk45", (3, 0)))
     ; ("integrate_ode_bdf", ("ode_bdf", (3, 0)))
@@ -49,7 +49,7 @@ let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
       let w =
         match Map.find stan_lib_deprecations name with
         | Some (rename, (major, minor)) when not (expired (major, minor)) ->
-            let version = string_of_int major ^ "." ^ string_of_int minor in
+            let version = Int.to_string major ^ "." ^ Int.to_string minor in
             [ ( id_loc
               , name ^ " is deprecated and will be removed in Stan " ^ version
                 ^ ". Use " ^ rename
@@ -58,7 +58,7 @@ let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
         | _ -> (
             match Map.find deprecated_odes name with
             | Some (rename, (major, minor)) ->
-                let version = string_of_int major ^ "." ^ string_of_int minor in
+                let version = Int.to_string major ^ "." ^ Int.to_string minor in
                 [ ( id_loc
                   , name ^ " is deprecated and will be removed in Stan "
                     ^ version ^ ". Use " ^ rename

--- a/src/frontend/Deprecation_analysis.mli
+++ b/src/frontend/Deprecation_analysis.mli
@@ -1,12 +1,12 @@
 (** Utilities for emitting deprecation warnings and finding proper replacements
     for deprecated features *)
 
-open Core
+open Base
 open Ast
 
 val expired : int * int -> bool
-val deprecated_functions : (string * (int * int)) String.Map.t
-val rename_deprecated : (string * (int * int)) String.Map.t -> string -> string
-val stan_lib_deprecations : (string * (int * int)) String.Map.t
+val deprecated_functions : (string * (int * int)) Map.M(String).t
+val rename_deprecated : (string * (int * int)) Map.M(String).t -> string -> string
+val stan_lib_deprecations : (string * (int * int)) Map.M(String).t
 val collect_warnings : typed_program -> Warnings.t list
 val remove_unneeded_forward_decls : typed_program -> typed_program

--- a/src/frontend/Environment.ml
+++ b/src/frontend/Environment.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 
 type originblock =
@@ -40,7 +40,7 @@ let location = function
       Some location
   | {kind= `StanMath; _} -> None
 
-type t = info list String.Map.t
+type t = info list Map.M(String).t
 
 let stan_math_environment =
   Lazy.map Stan_math_signatures.signatures_alist ~f:(fun signatures ->
@@ -48,7 +48,7 @@ let stan_math_environment =
           ( key
           , List.map values ~f:(fun s ->
                 {type_= UnsizedType.UFun s; kind= `StanMath}) ))
-      |> String.Map.of_alist_exn)
+      |> Map.of_alist_exn (module String))
 
 let add env name type_ kind = Map.add_multi env ~key:name ~data:{type_; kind}
 let set_raw env key data = Map.set env ~key ~data

--- a/src/frontend/Errors.ml
+++ b/src/frontend/Errors.ml
@@ -1,6 +1,6 @@
 (** Setup of our compiler errors *)
 
-open Core
+open Base
 
 type t =
   | FileNotFound of string
@@ -21,7 +21,7 @@ let get_context ?code Middle.Location.{filename; included_from; _} =
       match !Include_files.include_provider with
       | FileSystemPaths _ ->
           (* So we can read directly from the filesystem *)
-          In_channel.read_lines filename
+          Stdio.In_channel.read_lines filename
       | InMemory m ->
           (* Or, we know we can find it in the map *)
           String.split_lines (Map.find_exn m filename))

--- a/src/frontend/Include_files.ml
+++ b/src/frontend/Include_files.ml
@@ -1,6 +1,6 @@
-open Core
+open Base
 
-type t = FileSystemPaths of string list | InMemory of string String.Map.t
+type t = FileSystemPaths of string list | InMemory of string Map.M(String).t
 
 (** Where and how to look for #include-d files *)
 let include_provider : t ref = ref (FileSystemPaths [])

--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Ast
 open Middle
 open Yojson.Basic
@@ -83,7 +83,7 @@ let function_calls_json p =
   let funs, distrs =
     fold_program
       (get_function_calls_stmt ud_dists)
-      (String.Set.empty, String.Set.empty)
+      ((Set.empty (module String)), (Set.empty (module String)))
       p in
   let set_to_List s =
     `List (Set.to_list s |> List.map ~f:(fun str -> `String str)) in

--- a/src/frontend/Input_warnings.ml
+++ b/src/frontend/Input_warnings.ml
@@ -1,4 +1,4 @@
-open! Core
+open! Base
 
 let warnings = ref []
 let init () = warnings := []

--- a/src/frontend/Parse.ml
+++ b/src/frontend/Parse.ml
@@ -1,7 +1,7 @@
 (** Some complicated stuff to get the custom syntax errors out of Menhir's
     Incremental API *)
 
-open Core
+open Base
 open Common.Let_syntax.Result
 module Interp = Parser.MenhirInterpreter
 
@@ -27,13 +27,13 @@ let drive_parser parse_fun =
     let message =
       let state = Interp.current_state_number env in
       try
-        Parsing_errors.message state
-        ^^
-        if !Debugging.grammar_logging then
-          Scanf.format_from_string
-            ("(Parse error state " ^ string_of_int state ^ ")\n")
-            ""
-        else ""
+        Stdlib.( ^^ )
+          (Parsing_errors.message state)
+          (if !Debugging.grammar_logging then
+             Stdlib.Scanf.format_from_string
+               ("(Parse error state " ^ Int.to_string state ^ ")\n")
+               ""
+           else "")
       with _ ->
         Common.ICE.internal_compiler_error
           [%message
@@ -58,7 +58,7 @@ let to_lexbuf file_or_code =
   match file_or_code with
   | `File path ->
       let+ chan =
-        try Ok (In_channel.create path)
+        try Ok (Stdio.In_channel.create path)
         with _ -> Error (Errors.FileNotFound path) in
       (Lexing.from_channel chan, path)
   | `Code code -> Ok (Lexing.from_string code, "string")

--- a/src/frontend/Parse.mli
+++ b/src/frontend/Parse.mli
@@ -2,11 +2,11 @@
 
 val parse_program :
      [< `Code of string | `File of string]
-  -> (Ast.untyped_program, Errors.t) result * Warnings.t list
+  -> (Ast.untyped_program, Errors.t) Result.t * Warnings.t list
 (** Parse a full Stan program *)
 
 val parse_stanfunctions :
      [< `Code of string | `File of string]
-  -> (Ast.untyped_program, Errors.t) result * Warnings.t list
+  -> (Ast.untyped_program, Errors.t) Result.t * Warnings.t list
 (** Parse a "functions-only" [.stanfunctions] file, returning an AST (which will
     only ever have a functions block) or error, and warnings *)

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -1,6 +1,6 @@
 (** Preprocessor for handling include directives *)
 
-open Core
+open Base
 open Lexing
 open Debugging
 
@@ -11,8 +11,8 @@ let include_stack = Stack.create ()
 let included_files : string list ref = ref []
 let size () = Stack.length include_stack
 
-let locations_map : (string * Middle.Location.t option) String.Table.t =
-  String.Table.create ()
+let locations_map : (string, string * Middle.Location.t option) Hashtbl.t =
+  Hashtbl.create (module String)
 
 let new_file_start_position buf filename included_from =
   (* Lexing.position does not have a field to store `included_from` so we store
@@ -29,7 +29,7 @@ let new_file_start_position buf filename included_from =
     if Option.is_none included_from then
       {Lexing.pos_fname= filename; pos_lnum= 1; pos_bol= 0; pos_cnum= 0}
     else
-      let key = "\u{0}" ^ string_of_int (Hashtbl.length locations_map) in
+      let key = "\u{0}" ^ Int.to_string (Hashtbl.length locations_map) in
       Hashtbl.add_exn locations_map ~key ~data:(filename, included_from);
       {Lexing.pos_fname= key; pos_lnum= 1; pos_bol= 0; pos_cnum= 0} in
   buf.lex_start_p <- pos;
@@ -99,7 +99,7 @@ let find_include_fs lookup_paths fname =
     | path :: rest_of_paths -> (
         try
           let full_path = path ^ "/" ^ fname in
-          (In_channel.create full_path |> Lexing.from_channel, full_path)
+          (Stdio.In_channel.create full_path |> Lexing.from_channel, full_path)
         with _ -> loop rest_of_paths) in
   loop lookup_paths
 

--- a/src/frontend/Pretty_print_prog.ml
+++ b/src/frontend/Pretty_print_prog.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Ast
 open Fmt
 open Pretty_printing
@@ -31,10 +31,10 @@ let pp_program ~bare_functions ~line_length ~inline_includes ~strip_comments ppf
     ; modelblock= bm
     ; generatedquantitiesblock= bgq
     ; comments } =
-  Format.pp_set_margin ppf line_length;
+  Stdlib.Format.pp_set_margin ppf line_length;
   set_comments ~inline_includes ~strip_comments comments;
   print_included := inline_includes;
-  Format.pp_open_vbox ppf 0;
+  Stdlib.Format.pp_open_vbox ppf 0;
   if bare_functions then pp_bare_block ppf @@ Option.value_exn bf
   else
     let blocks =

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -1,8 +1,8 @@
 (** Some helpers to produce nice error messages and for auto-formatting Stan
     programs *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Ast
 open Fmt
 
@@ -177,7 +177,7 @@ let pp_comments_spacing ?(no_comment = Fmt.nop) ?before f ppf loc =
       | ((block, _, _) as comment) :: tl ->
           let is_block = match block with `Block -> true | _ -> false in
           pp_comment ppf comment;
-          if not is_block then Format.pp_force_newline ppf ();
+          if not is_block then Stdlib.Format.pp_force_newline ppf ();
           go is_block tl
       | [] -> if was_block && not (Option.is_some before) then sp ppf () in
     go true comments)
@@ -203,9 +203,9 @@ let pp_operator = Middle.Operator.pp
 let pp_start_funapp ppf id =
   let long = String.length id.name > 16 in
   pf ppf "%a%a%a"
-    (if' long Format.pp_open_box)
+    (if' long Stdlib.Format.pp_open_box)
     2 pp_identifier id
-    (if' (not long) Format.pp_open_box)
+    (if' (not long) Stdlib.Format.pp_open_box)
     1
 
 let pp_list_of pp (loc_of : 'a -> Middle.Location_span.t) ppf
@@ -283,7 +283,8 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
       | e :: es' ->
           let begin_loc =
             List.hd es'
-            |> Option.map ~f:(fun e -> e.emeta.loc.begin_loc)
+            |> Option.map ~f:(fun (e : untyped_expression) ->
+                e.emeta.loc.begin_loc)
             |> Option.value ~default:loc.end_loc in
           pf ppf "%a(@,%a%a |@ %a%a)@]" pp_start_funapp id pp_expression e
             (pp_comments_spacing ~before:sp get_comments_until_separator)
@@ -355,16 +356,16 @@ let rec pp_transformed_type ppf (st, trans) =
        |SRowVector (_, e)
        |SComplexVector e
        |SComplexRowVector e ->
-          Format.dprintf "[%a]" pp_expression e
+          Stdlib.Format.dprintf "[%a]" pp_expression e
       | SMatrix (_, e1, e2) | SComplexMatrix (e1, e2) ->
-          Format.dprintf "[%a, %a]" pp_expression e1 pp_expression e2
+          Stdlib.Format.dprintf "[%a, %a]" pp_expression e1 pp_expression e2
       | SArray _ | SInt | SReal | SComplex | STuple _ -> ignore in
     let cov_sizes_fmt =
       match st with
       | SMatrix (_, e1, e2) when e1 = e2 ->
-          Format.dprintf "[%a]" pp_expression e1
+          Stdlib.Format.dprintf "[%a]" pp_expression e1
       | SMatrix (_, e1, e2) ->
-          Format.dprintf "[%a, %a]" pp_expression e1 pp_expression e2
+          Stdlib.Format.dprintf "[%a, %a]" pp_expression e1 pp_expression e2
       | _ -> ignore in
     match trans with
     | Transformation.Identity ->
@@ -496,7 +497,7 @@ and pp_statement ppf ({stmt= s_content; smeta= {loc}} as ss : untyped_statement)
       (* similar to [pp_start_funapp]: - if a name is long, start the box early
          in the name - if there are a lot of args, or a long name, display them
          one-per-line *)
-      let max_line_length = Format.pp_get_margin ppf () in
+      let max_line_length = Stdlib.Format.pp_get_margin ppf () in
       (* these values are picked heuristically so they look decent on the
          default line-length, where they work out to 26+ characters being a
          'long' name, and 8+ args being 'many' arguments *)
@@ -507,7 +508,7 @@ and pp_statement ppf ({stmt= s_content; smeta= {loc}} as ss : untyped_statement)
           pp_identifier id pp_args pp_body
       else
         pf ppf "@[%a@ @]%a(%a%t)@]%t" pp_returntype rt pp_identifier id
-          (if many_args then Format.pp_open_hvbox else Format.pp_open_box)
+          (if many_args then Stdlib.Format.pp_open_hvbox else Stdlib.Format.pp_open_box)
           0 pp_args pp_body
 
 and pp_list_of_statements ppf (l, xloc) =

--- a/src/frontend/Promotion.ml
+++ b/src/frontend/Promotion.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 module UnsizedType = Middle.UnsizedType
 
 (** Type to represent promotions in the typechecker. This can be used to return

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 
 (* The following categories (type, identifier, expression, statement) are fairly

--- a/src/frontend/Semantic_error.mli
+++ b/src/frontend/Semantic_error.mli
@@ -2,7 +2,7 @@ open Middle
 
 type t
 
-val pp : Format.formatter -> t -> unit
+val pp : Stdlib.Format.formatter -> t -> unit
 val location : t -> Location_span.t
 val invalid_return : Location_span.t -> UnsizedType.t -> UnsizedType.t -> t
 

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -1,7 +1,6 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
-module TypeMap = Core.Map.Make_using_comparator (UnsizedType)
 
 let set ctx key data = ctx := Map.set !ctx ~key ~data
 
@@ -153,7 +152,7 @@ let%expect_test "compare_matches" =
     [ UniqueMatch (); AmbiguousMatch []; SignatureErrors ([], ()); UniqueMatch ()
     ; AmbiguousMatch []; SignatureErrors ([()], ()) ] in
   let matches = List.sort matches ~compare:compare_match_results in
-  print_s [%sexp (matches : (unit, unit list * unit) generic_match_result list)];
+  Stdio.print_s [%sexp (matches : (unit, unit list * unit) generic_match_result list)];
   [%expect
     "\n\
     \    ((UniqueMatch ()) (UniqueMatch ()) (AmbiguousMatch ()) \
@@ -202,7 +201,7 @@ let rec check_same_type depth t1 t2 =
   | t1, t2 -> Error (TypeMismatch (t1, t2, None))
 
 and check_compatible_arguments depth typs args2 :
-    (Promotion.t list, function_mismatch) result =
+    (Promotion.t list, function_mismatch) Result.t =
   match List.zip typs args2 with
   | List.Or_unequal_lengths.Unequal_lengths ->
       Error (ArgNumMismatch (List.length typs, List.length args2))
@@ -358,7 +357,7 @@ let quoted = Fmt.styled (`Fg `Green) Fmt.(quote string)
 
 let pp_mismatch_details ~skipped ppf details =
   let open Fmt in
-  let ctx = ref TypeMap.empty in
+  let ctx = ref (Map.empty (module UnsizedType)) in
   let n_skipped = List.length skipped in
   let pp_excluded_message =
     Fmt.if' (n_skipped > 0)
@@ -410,7 +409,7 @@ let pp_mismatch_details ~skipped ppf details =
 
 let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
   let open Fmt in
-  let ctx = ref TypeMap.empty in
+  let ctx = ref (Map.empty (module UnsizedType)) in
   let rec pp_explain_rec ppf = function
     | ArgError (n, DataOnlyError) ->
         pf ppf "@[<hov>The@ %s@ argument%a@]" (index_str n) text

--- a/src/frontend/SignatureMismatch.mli
+++ b/src/frontend/SignatureMismatch.mli
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 
 type type_mismatch = private
@@ -37,20 +37,20 @@ type match_result =
   generic_match_result
 
 val check_of_same_type_mod_conv :
-  UnsizedType.t -> UnsizedType.t -> (Promotion.t, type_mismatch) result
+  UnsizedType.t -> UnsizedType.t -> (Promotion.t, type_mismatch) Result.t
 
 val check_compatible_arguments_mod_conv :
      UnsizedType.argumentlist
   -> UnsizedType.argumentlist
-  -> (Promotion.t list, function_mismatch) result
+  -> (Promotion.t list, function_mismatch) Result.t
 
 val check_compatible_arguments_no_promotion :
      UnsizedType.argumentlist
   -> UnsizedType.argumentlist
-  -> (unit, function_mismatch) result
+  -> (unit, function_mismatch) Result.t
 
 val unique_minimum_promotion :
-  ('a * Promotion.t list) list -> ('a * Promotion.t list, 'a list option) result
+  ('a * Promotion.t list) list -> ('a * Promotion.t list, 'a list option) Result.t
 
 val matching_function :
   Environment.t -> string -> UnsizedType.argumentlist -> match_result
@@ -71,7 +71,7 @@ val check_variadic_args :
   -> UnsizedType.argumentlist
   -> ( (UnsizedType.t * Location_span.t option) * Promotion.t list
      , UnsizedType.argumentlist * function_mismatch * Location_span.t option )
-     result
+     Result.t
 (** Check variadic function arguments. If a match is found, returns [Ok] of the
     function type and a list of promotions (see [promote]) If none is found,
     returns [Error] of the list of args and a function_mismatch. *)
@@ -91,10 +91,10 @@ val quoted : string Fmt.t
 (** Formatter for quoting a string *)
 
 val pp_mismatch_details :
-  skipped:string list -> Format.formatter -> details -> unit
+  skipped:string list -> Stdlib.Format.formatter -> details -> unit
 
 val pp_signature_mismatch :
-     Format.formatter
+     Stdlib.Format.formatter
   -> string * UnsizedType.t list * (signature_error list * bool)
   -> unit
 

--- a/src/frontend/Syntax_error.ml
+++ b/src/frontend/Syntax_error.ml
@@ -1,6 +1,6 @@
-open Core
+open Base
 
-type styled_text = (unit, Format.formatter, unit) format
+type styled_text = (unit, Stdlib.Format.formatter, unit) format
 
 (** Our type of syntax error information *)
 type err = Lexing | UnexpectedEOF | Include of string | Parsing of styled_text
@@ -16,7 +16,7 @@ let kind (_, err) =
   | Include _ -> "include error"
 
 (** Sets up the semantic tag machinery
-    (https://ocaml.org/manual/api/Format.html#tags) to print ANSI escape codes
+    (https://ocaml.org/manual/api/Stdlib.Format.html#tags) to print ANSI escape codes
     for formatting *)
 let pp_styled_text : styled_text Fmt.t =
  fun ppf format_string ->
@@ -61,8 +61,8 @@ let pp_styled_text : styled_text Fmt.t =
         |> List.take_while ~f:(String.( <> ) "0")
         |> List.rev in
       let escs = String.concat ~sep:";" ("0" :: styles_until_reset) in
-      sprintf "\027[%sm" escs in
-    Format.
+      Printf.sprintf "\027[%sm" escs in
+    Stdlib.Format.
       { former with
         mark_open_stag=
           (function
@@ -82,17 +82,17 @@ let pp_styled_text : styled_text Fmt.t =
   match Fmt.style_renderer ppf with
   | `None -> Fmt.pf ppf format_string
   | `Ansi_tty ->
-      let former = Format.pp_get_formatter_stag_functions ppf () in
-      let marks = Format.pp_get_mark_tags ppf () in
-      Format.pp_set_formatter_stag_functions ppf (ansi_stags former);
-      Format.pp_set_mark_tags ppf true;
-      Fun.protect
-        (fun () ->
+      let former = Stdlib.Format.pp_get_formatter_stag_functions ppf () in
+      let marks = Stdlib.Format.pp_get_mark_tags ppf () in
+      Stdlib.Format.pp_set_formatter_stag_functions ppf (ansi_stags former);
+      Stdlib.Format.pp_set_mark_tags ppf true;
+      Exn.protect
+        ~f:(fun () ->
           Fmt.pf ppf format_string;
           Fmt.flush ppf ())
         ~finally:(fun () ->
-          Format.pp_set_formatter_stag_functions ppf former;
-          Format.pp_set_mark_tags ppf marks)
+          Stdlib.Format.pp_set_formatter_stag_functions ppf former;
+          Stdlib.Format.pp_set_mark_tags ppf marks)
 
 let pp ppf (_, err) =
   match err with
@@ -127,7 +127,7 @@ module Tests = struct
        want@}!@}" in
     Fmt.set_style_renderer Fmt.stdout `None;
     pp_styled_text Fmt.stdout s;
-    Format.pp_print_newline Fmt.stdout ();
+    Stdlib.Format.pp_print_newline Fmt.stdout ();
     Fmt.set_style_renderer Fmt.stdout `Ansi_tty;
     pp_styled_text Fmt.stdout s;
     [%expect
@@ -172,7 +172,7 @@ module Tests = struct
     in
     Fmt.set_style_renderer Fmt.stdout `None;
     pp_styled_text Fmt.stdout s;
-    Format.pp_print_newline Fmt.stdout ();
+    Stdlib.Format.pp_print_newline Fmt.stdout ();
     Fmt.set_style_renderer Fmt.stdout `Ansi_tty;
     pp_styled_text Fmt.stdout s;
     [%expect

--- a/src/frontend/Syntax_error.mli
+++ b/src/frontend/Syntax_error.mli
@@ -4,11 +4,11 @@ type t
     can still include other formatting indicators, including semantic tags used
     for things like ["@{<green>Colored text@}"]. These strings usually come from
     the [parser.messages] text file. *)
-type styled_text = (unit, Format.formatter, unit) format
+type styled_text = (unit, Stdlib.Format.formatter, unit) format
 
 val location : t -> Middle.Location_span.t
 val kind : t -> string
-val pp : Format.formatter -> t -> unit
+val pp : Stdlib.Format.formatter -> t -> unit
 
 (** Exception-based control flow is useful during parsing/lexing. These helpers
     are used to try to keep all that logic in one place *)
@@ -17,4 +17,4 @@ val unexpected_eof : Middle.Location_span.t -> 'a
 val unexpected_character : Middle.Location_span.t -> 'a
 val include_error : string -> Middle.Location_span.t -> 'a
 val parse_error : styled_text -> Middle.Location_span.t -> 'a
-val try_with : (unit -> 'a) -> ('a, t) result
+val try_with : (unit -> 'a) -> ('a, t) Result.t

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -13,8 +13,8 @@
     including stan math functions. This is a functional map, meaning it is
     handled immutably. *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Ast
 module Env = Environment
@@ -231,7 +231,7 @@ let assignmentoperator_stan_math_return_type assop arg_tys =
         operator_stan_math_return_type assop arg_tys |> Option.map ~f:fst
     | _ -> None)
   |> Option.bind ~f:(function
-    | ReturnType rtype
+    | UnsizedType.ReturnType rtype
       when rtype = snd (List.hd_exn arg_tys)
            && not
                 ((assop = Operator.EltTimes || assop = Operator.EltDivide)
@@ -627,7 +627,7 @@ let verify_second_order_derivative_compatibility (ast : typed_program) =
           when String.equal name fn_name ->
             b
         | _ -> []) in
-  let rec check_fun (visited : String.Set.t) {name= fn_name; id_loc} =
+  let rec check_fun (visited : Set.M(String).t) {name= fn_name; id_loc} =
     if Set.mem visited fn_name then visited
     else
       let rec check_expr seen = function
@@ -654,7 +654,7 @@ let verify_second_order_derivative_compatibility (ast : typed_program) =
       let visited' = Set.add visited fn_name in
       List.fold ~f:check_stmt ~init:visited' (get_function_bodies fn_name) in
   ignore
-    (List.fold ~f:check_fun ~init:String.Set.empty
+    (List.fold ~f:check_fun ~init:(Set.empty (module String))
        !requires_higher_order_autodiff)
 
 (** Currently only used by the laplace functions, this checks that a function in
@@ -1049,7 +1049,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
                 (pp_indented_box Pretty_printing.pp_expression)
                 {expr; emeta}
                 (pp_indented_box_t
-                   (Format.dprintf "matrix_power(%a, %a)"
+                   (Stdlib.Format.dprintf "matrix_power(%a, %a)"
                       Pretty_printing.pp_expression e1
                       Pretty_printing.pp_expression e2)) in
             add_warning x.emeta.loc s
@@ -1068,9 +1068,9 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
                      (pp_indented_box Pretty_printing.pp_expression)
                      {expr; emeta}
                      (pp_indented_box_t
-                        (Format.dprintf "(%a) %a %a" pp_e le pp op pp_e re))
+                        (Stdlib.Format.dprintf "(%a) %a %a" pp_e le pp op pp_e re))
                      (pp_indented_box_t
-                        (Format.dprintf "%a %a %a && %a %a %a" pp_e e1 pp op2
+                        (Stdlib.Format.dprintf "%a %a %a && %a %a %a" pp_e e1 pp op2
                            pp_e e2 pp_e e2 pp op pp_e re)))
             | _ -> ())
         | _ -> () in
@@ -1082,7 +1082,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
       verify_identifier id;
       check_variable cf loc tenv id
   | IntNumeral s -> (
-      match float_of_string_opt s with
+      match Stdlib.float_of_string_opt s with
       | Some i when i < 2_147_483_648.0 ->
           mk_typed_expression ~expr:(IntNumeral s) ~ad_level:DataOnly
             ~type_:UInt ~loc
@@ -1386,18 +1386,18 @@ let variables_accessed_in lv =
      only the expressions inside of LIndexed *)
   let rec extract_indices lv =
     match lv.lval with
-    | LVariable _ -> String.Set.empty
+    | LVariable _ -> (Set.empty (module String))
     | LTupleProjection (lv, _) -> extract_indices lv
     | LIndexed (lv, es) ->
         List.concat_map ~f:exprs_in_index es
         |> List.concat_map ~f:extract_ids
         |> List.map ~f:(fun {name; _} -> name)
-        |> String.Set.of_list
+        |> Set.of_list (module String)
         |> Set.union (extract_indices lv) in
   let rec extract_indices_pack lv =
     match lv with
     | LTuplePack {lvals; _} ->
-        String.Set.union_list (List.map ~f:extract_indices_pack lvals)
+        Set.union_list (module String) (List.map ~f:extract_indices_pack lvals)
     | LValue lv -> extract_indices lv in
   extract_indices_pack lv
 
@@ -1421,7 +1421,7 @@ let verify_lvalue_unique (lv : Ast.typed_lval_pack) =
      much less refined than the above and forbids some cases that would be
      harmless, but this is also in general a very weird thing to try to do, so I
      think that is acceptable *)
-  let all_variables = List.map ~f:name_of_lval all_lvals |> String.Set.of_list in
+  let all_variables = List.map ~f:name_of_lval all_lvals |> Set.of_list (module String) in
   let accessed_lvals = variables_accessed_in lv in
   match Set.inter accessed_lvals all_variables |> Set.to_list with
   | [] -> ()

--- a/src/frontend/Typechecker.mli
+++ b/src/frontend/Typechecker.mli
@@ -18,7 +18,7 @@ open Ast
 val check_program :
      ?allow_undefined_functions:bool
   -> untyped_program
-  -> (typed_program * Warnings.t list, Semantic_error.t) result
+  -> (typed_program * Warnings.t list, Semantic_error.t) Result.t
 (** Type check a Stan program, returning a typed program and warnings or an
     error. When [allow_undefined_functions] is set to [true], the typechecker
     will not check that all functions have a definition. *)

--- a/src/frontend/Warnings.ml
+++ b/src/frontend/Warnings.ml
@@ -11,5 +11,5 @@ let pp ?printed_filename ppf (span, message) =
     span Fmt.text message
 
 let pp_warnings ?printed_filename ppf warnings =
-  if not (Core.List.is_empty warnings) then
+  if not (Base.List.is_empty warnings) then
     Fmt.(pf ppf "@[<v>%a@.@]" (list ~sep:cut (pp ?printed_filename)) warnings)

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -1,13 +1,21 @@
 (library
  (name frontend)
  (public_name stanc.frontend)
- (libraries core menhirLib yojson fmt middle stan_math_signatures)
+ (libraries base stdio menhirLib yojson fmt middle stan_math_signatures)
  (instrumentation
   (backend bisect_ppx))
  (modules :standard \ parser_messages_add_type parser_strip_redundant_state)
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test
+   ppx_deriving.fold
+   ppx_deriving.map)))
 
 (ocamllex lexer)
 
@@ -18,7 +26,7 @@
 (executable
  (name parser_messages_add_type)
  (modules parser_messages_add_type)
- (libraries str))
+ (libraries str stdio))
 
 (rule
  (progn
@@ -55,7 +63,7 @@
 (executable
  (name parser_strip_redundant_state)
  (modules parser_strip_redundant_state)
- (libraries str core))
+ (libraries str base stdio))
 
 (rule
  (with-stdin-from

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -1,8 +1,8 @@
 (** The lexer that will feed into the parser. An OCamllex file. *)
 
 {
-  module Stack = Core.Stack
-  module Queue = Core.Queue
+  module Stack = Base.Stack
+  module Queue = Base.Queue
   open Lexing
   open Debugging
   open Preprocessor

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -1,13 +1,18 @@
 (** The parser for Stan. A Menhir file. *)
 %{
-open Core
+open Base
+
+(* Menhir-generated code uses [Obj] directly; rebind it to avoid Base's
+   deprecation alert on the stdlib module *)
+module Obj = Stdlib.Obj
+
 open Middle
 open Ast
 open Debugging
 open Preprocessor
 
 let parse_error msg loc =
-  Syntax_error.parse_error (Scanf.format_from_string msg "") (location_span_of_positions loc)
+  Syntax_error.parse_error (Stdlib.Scanf.format_from_string msg "") (location_span_of_positions loc)
 
 (* Takes a sized_basic_type and a list of sizes and repeatedly applies then
    SArray constructor, taking sizes off the list *)
@@ -39,7 +44,7 @@ let rec iterate_n f x = function 0 -> x | n -> iterate_n f (f x) (n - 1)
 
 let parse_tuple_slot ix_str (start, stop) =
   let slot = String.drop_prefix ix_str 1 in
-  match int_of_string_opt slot with
+  match Stdlib.int_of_string_opt slot with
   | None ->
       parse_error
         ("@[@{<light_red>Ill-formed index.@} Failed to parse integer from string \

--- a/src/frontend/parser_messages_add_type.ml
+++ b/src/frontend/parser_messages_add_type.ml
@@ -1,5 +1,5 @@
 let () =
-  let code = In_channel.input_all In_channel.stdin in
+  let code = Stdio.In_channel.input_all Stdio.In_channel.stdin in
   let code =
     (* we modify the code to give it a type annotation. This forces the compiler
        to check the validitiy of our messages as Format strings at compile time,
@@ -9,4 +9,4 @@ let () =
   (* Strict newlines ('\n') can break things in formatting, we replace them with
      break hints *)
   let code = Str.global_replace (Str.regexp {|\\n|}) "@." code in
-  print_string code
+  Stdio.print_string code

--- a/src/frontend/parser_strip_redundant_state.ml
+++ b/src/frontend/parser_strip_redundant_state.ml
@@ -17,7 +17,7 @@ let strip_redundant_parser_states content =
   Str.global_replace pattern "\\1\n\\3\n\\5" content
 
 let strip_lines content =
-  let open Core.String in
+  let open Base.String in
   split_lines content |> List.map rstrip |> concat_lines
 
 let rec strip_until_fixed content =
@@ -25,6 +25,6 @@ let rec strip_until_fixed content =
   if String.equal content stripped then stripped else strip_until_fixed stripped
 
 let () =
-  let content = In_channel.input_all In_channel.stdin in
+  let content = Stdio.In_channel.input_all Stdio.In_channel.stdin in
   let result = strip_until_fixed content |> strip_lines in
-  print_string result
+  Stdio.print_string result

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Common
 
 module Pattern = struct
@@ -73,36 +73,51 @@ module Typed = struct
 
   type t = (Meta.t[@compare.ignore]) Fixed.t [@@deriving hash, sexp, compare]
 
+  let equal t1 t2 = compare t1 t2 = 0
+
   let type_of {meta= Meta.{type_; _}; _} = type_
   let adlevel_of {meta= Meta.{adlevel; _}; _} = adlevel
   let fun_arg {meta= Meta.{type_; adlevel; _}; _} = (adlevel, type_)
   let pp = pp
 
   (** Since the type [t] is now concrete (i.e. not a type _constructor_) we can
-      construct a [Comparable.S] giving us [Map] and [Set] specialized to the
-      type. *)
+      construct [Map] and [Set] modules specialized to the type. *)
 
-  module Comparator = Comparator.Make (struct
+  module Cmp = struct
     type nonrec t = t
 
     let compare = compare
     let sexp_of_t = sexp_of_t
-  end)
 
-  include Comparator
+    include Comparator.Make (struct
+      type nonrec t = t
 
-  include Comparable.Make_using_comparator (struct
-    type nonrec t = t
+      let compare = compare
+      let sexp_of_t = sexp_of_t
+    end)
+  end
 
-    let sexp_of_t = sexp_of_t
-    let t_of_sexp = t_of_sexp
+  include (
+    Cmp : Comparator.S with type t := t and type comparator_witness = Cmp.comparator_witness)
 
-    include Comparator
-  end)
+  module Set = struct
+    type t = Set.M(Cmp).t
+
+    let empty = Set.empty (module Cmp)
+    let singleton = Set.singleton (module Cmp)
+    let union_list = Set.union_list (module Cmp)
+  end
+
+  module Map = struct
+    type 'v t = 'v Map.M(Cmp).t
+
+    let empty = Map.empty (module Cmp)
+    let of_alist_exn l = Map.of_alist_exn (module Cmp) l
+  end
 end
 
 module Helpers = struct
-  let int i = {meta= Typed.Meta.empty; pattern= Lit (Int, string_of_int i)}
+  let int i = {meta= Typed.Meta.empty; pattern= Lit (Int, Int.to_string i)}
 
   let float i =
     { meta= {Typed.Meta.empty with type_= UReal}
@@ -290,7 +305,7 @@ module Helpers = struct
       , [Upfrom loop_bottom; Single loop_bottom; Single loop_bottom] ) ]
     |> List.map ~f:(fun (ut, idx) -> infer_type_of_indexed ut idx)
     |> Fmt.(str "@[<hov>%a@]" (list ~sep:comma UnsizedType.pp))
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
       vector, array[] matrix, matrix, array[] vector, real, array[] real |}]

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -41,17 +41,32 @@ module Typed : sig
 
   type nonrec t = (Meta.t[@compare.ignore]) t [@@deriving hash, sexp, compare]
 
+  val equal : t -> t -> bool
   val type_of : t -> UnsizedType.t
   val adlevel_of : t -> UnsizedType.autodifftype
   val fun_arg : t -> UnsizedType.autodifftype * UnsizedType.t
   val pp : t Fmt.t
 
-  include Core.Comparator.S with type t := t
+  include Base.Comparator.S with type t := t
 
-  include
-    Core.Comparable.S
-      with type t := t
-       and type comparator_witness := comparator_witness
+  (** [Set] and [Map] modules specialized to this type, replacing the ones
+      previously provided by [Core.Comparable.S] *)
+  module Set : sig
+    type expr := t
+    type nonrec t = (expr, comparator_witness) Base.Set.t
+
+    val empty : t
+    val singleton : expr -> t
+    val union_list : t list -> t
+  end
+
+  module Map : sig
+    type expr := t
+    type 'v t = (expr, 'v, comparator_witness) Base.Map.t
+
+    val empty : 'v t
+    val of_alist_exn : (expr * 'v) list -> 'v t
+  end
 end
 
 module Helpers : sig

--- a/src/middle/Fun_kind.ml
+++ b/src/middle/Fun_kind.ml
@@ -1,7 +1,7 @@
 (** Types for function kinds, e.g. [StanLib] or [UserDefined], and function
     suffix types, e.g. [foo_ldfp], [bar_lp] *)
 
-open Core
+open Base
 
 type 'propto suffix =
   | FnPlain
@@ -21,7 +21,7 @@ type 'e t =
 [@@deriving compare, sexp, hash, map, fold]
 
 let suffix_from_name fname =
-  let is_suffix suffix = Core.String.is_suffix ~suffix fname in
+  let is_suffix suffix = Base.String.is_suffix ~suffix fname in
   if is_suffix "_rng" then FnRng
   else if is_suffix "_lp" then FnTarget
   else if is_suffix "_jacobian" then FnJacobian

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -1,6 +1,6 @@
 (** Types of indexing operations *)
 
-open Core
+open Base
 
 type 'a t =
   | All

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -1,6 +1,6 @@
 (** Language functions defined internally by the compiler *)
 
-open Core
+open Base
 
 type 'expr t =
   | FnLength

--- a/src/middle/Location.ml
+++ b/src/middle/Location.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
 [@@deriving sexp, hash]
@@ -53,7 +53,7 @@ let rec pp ?(print_file = true) ?(print_line = true) printed_filename ppf loc =
   let incl, filename =
     match loc.included_from with
     | Some loc2 ->
-        ( Format.dprintf ", included from\n%a" (pp printed_filename) loc2
+        ( Stdlib.Format.dprintf ", included from\n%a" (pp printed_filename) loc2
         , loc.filename )
     | None -> (ignore, Option.value ~default:loc.filename printed_filename)
   in

--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 type t = {begin_loc: Location.t; end_loc: Location.t}
 [@@deriving sexp, hash, compare]

--- a/src/middle/Mem_pattern.ml
+++ b/src/middle/Mem_pattern.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 
 (** This type represents whether or not an autodiff type can be represented as
     an Array of Structs (AoS) or as a Struct of Arrays. This applies to

--- a/src/middle/Operator.ml
+++ b/src/middle/Operator.ml
@@ -1,6 +1,6 @@
 (** Utilities for Stan's built in operators *)
 
-open Core
+open Base
 
 type t =
   | Plus
@@ -59,7 +59,7 @@ let to_string x = Sexp.to_string (sexp_of_t x) ^ "__"
 
 let of_string_opt x =
   try
-    String.chop_suffix_exn ~suffix:"__" x |> Sexp.of_string |> t_of_sexp |> Some
+    Some (t_of_sexp (Sexp.Atom (String.chop_suffix_exn ~suffix:"__" x)))
   with
-  | Sexplib.Conv.Of_sexp_error _ -> None
+  | Sexplib0.Sexp_conv.Of_sexp_error _ -> None
   | Invalid_argument _ -> None

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -1,6 +1,6 @@
 (** Defines the core of the MIR *)
 
-open Core
+open Base
 
 type fun_arg_decl = (UnsizedType.autodifftype * string * UnsizedType.t) list
 [@@deriving sexp, hash, map]
@@ -122,7 +122,7 @@ let pp pp_e pp_s ppf
     ; transform_inits
     ; output_vars
     ; _ } =
-  Format.open_vbox 0;
+  Stdlib.Format.open_vbox 0;
   pp_functions_block (pp_fun_def pp_s) ppf functions_block;
   Fmt.cut ppf ();
   pp_input_vars pp_e ppf input_vars;
@@ -138,7 +138,7 @@ let pp pp_e pp_s ppf
   pp_transform_inits pp_s ppf transform_inits;
   Fmt.cut ppf ();
   pp_output_vars pp_e ppf output_vars;
-  Format.close_box ()
+  Stdlib.Format.close_box ()
 
 (** Programs with typed expressions and locations *)
 module Typed = struct
@@ -148,7 +148,7 @@ module Typed = struct
 
   let sexp_of_t : t -> Sexp.t =
     sexp_of_t Expr.Typed.sexp_of_t Stmt.Located.sexp_of_t
-      Sexplib.Conv.sexp_of_opaque
+      Sexplib0.Sexp_conv.sexp_of_opaque
 end
 
 module Numbered = struct

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -1,6 +1,6 @@
 (** Types which have a concrete size associated, e.g. [vector[n]] *)
 
-open Core
+open Base
 
 type 'a t =
   | SInt
@@ -161,7 +161,7 @@ let%expect_test "dims" =
              ( SMatrix
                  (Mem_pattern.AoS, Expr.Helpers.str "x", Expr.Helpers.str "y")
              , Expr.Helpers.str "z" ))))
-  |> print_endline;
+  |> Stdio.print_endline;
   [%expect {| z, x, y |}]
 
 let rec contains_tuple st =
@@ -242,5 +242,5 @@ let%expect_test "dims" =
   let sclr, dims = get_array_dims st in
   let st2 = build_sarray dims sclr in
   let open Fmt in
-  pf stdout "%a = %a" (pp Expr.Typed.pp) st (pp Expr.Typed.pp) st2;
+  pf Fmt.stdout "%a = %a" (pp Expr.Typed.pp) st (pp Expr.Typed.pp) st2;
   [%expect {| array[array[real, N], 1] = array[array[real, N], 1] |}]

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Common
 
 module Pattern = struct
@@ -309,7 +309,7 @@ module Helpers = struct
     match lval with
     | LVariable name, _ -> name
     | LTupleProjection (sub_lval, num), _ ->
-        get_lhs_name sub_lval ^ "." ^ string_of_int num
+        get_lhs_name sub_lval ^ "." ^ Int.to_string num
 
   (* Copied from AST's version in AST.ml *)
   let rec lvalue_of_expr_opt (expr : 'e Expr.t) :
@@ -388,10 +388,10 @@ module Helpers = struct
             ((LTupleProjection (lvariable "x", 3), [Index.Single 4]), 5)
         , [] ) ] in
     let pp = Fmt.(list ~sep:comma (Pattern.pp_lvalue int)) in
-    Fmt.(str "Before: @[<hov>%a@]" pp) lvals |> print_endline;
+    Fmt.(str "Before: @[<hov>%a@]" pp) lvals |> Stdio.print_endline;
     List.map ~f:lvalue_base_reference lvals
     |> Fmt.(str "After: @[<hov>%a@]" pp)
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
       Before: x[1, 2, 3], x.1, x.2[3], x.3[4].5

--- a/src/middle/Transformation.ml
+++ b/src/middle/Transformation.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 
 (** Transformations (constraints) for global variable declarations *)
 

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -1,7 +1,7 @@
 (** Types which have dimensionalities but not sizes, e.g. [array[,,]] *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 
 type t =
   | UInt
@@ -142,19 +142,19 @@ let lub_ad_type xs =
 let%expect_test "lub_ad_type1" =
   let ads = [DataOnly; DataOnly; DataOnly; AutoDiffable] in
   let lub = lub_ad_type ads in
-  print_s [%sexp (lub : autodifftype option)];
+  Stdio.print_s [%sexp (lub : autodifftype option)];
   [%expect "(AutoDiffable)"]
 
 let%expect_test "lub_ad_type2" =
   let ads = [DataOnly; DataOnly; DataOnly] in
   let lub = lub_ad_type ads in
-  print_s [%sexp (lub : autodifftype option)];
+  Stdio.print_s [%sexp (lub : autodifftype option)];
   [%expect "(DataOnly)"]
 
 let%expect_test "lub_ad_type3" =
   let ads = [AutoDiffable; DataOnly; DataOnly; DataOnly] in
   let lub = lub_ad_type ads in
-  print_s [%sexp (lub : autodifftype option)];
+  Stdio.print_s [%sexp (lub : autodifftype option)];
   [%expect "(AutoDiffable)"]
 
 (** Given two types find the minimal type both can convert to *)
@@ -306,7 +306,7 @@ let enumerate_tuple_names_io name (ut : t) =
     match ut with
     | UTuple ts ->
         List.concat_mapi ts ~f:(fun i t ->
-            loop (base ^ "." ^ string_of_int (i + 1)) t)
+            loop (base ^ "." ^ Int.to_string (i + 1)) t)
     | UArray _ when contains_tuple ut ->
         let scalar, _ = unwind_array_type ut in
         loop base scalar
@@ -316,7 +316,7 @@ let enumerate_tuple_names_io name (ut : t) =
 let%expect_test "tuple names" =
   let t = UArray (UTuple [UInt; UArray (UTuple [UReal; UComplex]); UVector]) in
   let res = enumerate_tuple_names_io "foo" t in
-  [%sexp (res : string list)] |> print_s;
+  [%sexp (res : string list)] |> Stdio.print_s;
   [%expect {|
       (foo.1 foo.2.1 foo.2.2 foo.3) |}]
 
@@ -333,7 +333,6 @@ include Comparable.Make_using_comparator (struct
   type nonrec t = t
 
   let sexp_of_t = sexp_of_t
-  let t_of_sexp = t_of_sexp
 
   include Comparator
 end)

--- a/src/middle/Utils.ml
+++ b/src/middle/Utils.ml
@@ -1,6 +1,6 @@
 (** Utilities, primarily surrounding distribution names and suffixes *)
 
-open Core
+open Base
 
 let option_or_else ~if_none x = Option.first_some x if_none
 
@@ -52,10 +52,10 @@ let normalized_name name =
   | x -> x
 
 let%expect_test "unnormalized name mangling" =
-  stdlib_distribution_name "bernoulli_logit_lupmf" |> print_string;
-  stdlib_distribution_name "normal_lupdf" |> ( ^ ) "; " |> print_string;
-  stdlib_distribution_name "normal_lpdf" |> ( ^ ) "; " |> print_string;
-  stdlib_distribution_name "normal" |> ( ^ ) "; " |> print_string;
+  stdlib_distribution_name "bernoulli_logit_lupmf" |> Stdio.print_string;
+  stdlib_distribution_name "normal_lupdf" |> ( ^ ) "; " |> Stdio.print_string;
+  stdlib_distribution_name "normal_lpdf" |> ( ^ ) "; " |> Stdio.print_string;
+  stdlib_distribution_name "normal" |> ( ^ ) "; " |> Stdio.print_string;
   [%expect {| bernoulli_logit_lpmf; normal_lpdf; normal_lpdf; normal |}]
 
 (* Utilities for using Tuples and Transformations together *)

--- a/src/middle/dune
+++ b/src/middle/dune
@@ -1,9 +1,18 @@
 (library
  (name middle)
  (public_name stanc.middle)
- (libraries core fmt common)
+ (libraries base stdio fmt common)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.map ppx_deriving.fold ppx_deriving.create)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test
+   ppx_deriving.map
+   ppx_deriving.fold
+   ppx_deriving.create)))

--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -1,6 +1,6 @@
 (** A set of data types representing the C++ we generate *)
 
-open Core
+open Base
 
 type identifier = string [@@deriving sexp]
 
@@ -776,7 +776,7 @@ module Tests = struct
       [ matrix (complex local_scalar); const_char_array 43
       ; std_vector ~dims:2 Double; const_ref (TemplateType "T0__") ] in
     let open Fmt in
-    pf stdout "@[<v>%a@]" (list ~sep:comma Printing.pp_type_) ts;
+    pf Fmt.stdout "@[<v>%a@]" (list ~sep:comma Printing.pp_type_) ts;
     [%expect
       {|
         Eigen::Matrix<std::complex<local_scalar_t__>,-1,-1>,
@@ -792,8 +792,8 @@ module Tests = struct
     let vector = (row_vector Double).:{Literal "3"} in
     let values = [Literal "1"; Var "a"; Literal "3"] in
     let e = (vector << values).@!("finished") in
-    print_s [%sexp (e : expr)];
-    print_endline "";
+    Stdio.print_s [%sexp (e : expr)];
+    Stdio.print_endline "";
     Printing.pp_expr Fmt.stdout e;
     [%expect
       {|
@@ -827,7 +827,7 @@ module Tests = struct
            ~name:"foobar" ~return_type:Void ~inline:true ~body:rethrow ()) ]
     in
     let open Fmt in
-    pf stdout "@[<v>%a@]" (list ~sep:cut Printing.pp_fun_defn) funs;
+    pf Fmt.stdout "@[<v>%a@]" (list ~sep:cut Printing.pp_fun_defn) funs;
     [%expect
       {|
               template <typename T0__,

--- a/src/stan_math_backend/Cpp_Json.ml
+++ b/src/stan_math_backend/Cpp_Json.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 
 let rec sizedtype_to_json (st : Expr.Typed.t SizedType.t) : Yojson.Basic.t =
@@ -31,7 +31,7 @@ let rec sizedtype_to_json (st : Expr.Typed.t SizedType.t) : Yojson.Basic.t =
   | STuple subtypes ->
       `Assoc
         [ ("name", `String "tuple")
-        ; ("num_elements", `String (string_of_int (List.length subtypes)))
+        ; ("num_elements", `String (Int.to_string (List.length subtypes)))
         ; ("element_types", `List (List.map ~f:sizedtype_to_json subtypes)) ]
 
 let out_var_json (name, st, block) : Yojson.Basic.t =
@@ -44,7 +44,7 @@ let%expect_test "outvar to json pretty" =
   let var x = {Expr.pattern= Var x; meta= Expr.Typed.Meta.empty} in
   (* the following is equivalent to: parameters { vector[N] var_one[K]; } *)
   ("var_one", SArray (SVector (Mem_pattern.AoS, var "N"), var "K"), Parameters)
-  |> out_var_json |> Yojson.Basic.pretty_to_string |> print_endline;
+  |> out_var_json |> Yojson.Basic.pretty_to_string |> Stdio.print_endline;
   [%expect
     {|
   {
@@ -77,7 +77,7 @@ let%expect_test "outvar to json" =
   [ ( "var_one"
     , SizedType.SArray (SVector (AoS, var "N"), var "K")
     , Program.Parameters ) ]
-  |> out_var_interpolated_json_str |> print_endline;
+  |> out_var_interpolated_json_str |> Stdio.print_endline;
   [%expect
     {|
     "[{\"name\":\"var_one\",\"type\":{\"name\":\"array\",\"length\":" + std::to_string(K) + ",\"element_type\":{\"name\":\"vector\",\"length\":" + std::to_string(N) + "}},\"block\":\"parameters\"}]" |}]

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -1,7 +1,7 @@
 (** Lowering of Stan expressions to C++ *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Cpp
 
@@ -37,7 +37,7 @@ let fn_renames =
     ; ("lower_upper_bound_jacobian", "stan::math::lub_constrain")
     ; ("lower_upper_bound_constrain", "stan::math::lub_constrain")
     ; ("lower_upper_bound_unconstrain", "stan::math::lub_free") ]
-  |> String.Map.of_alist_exn
+  |> Map.of_alist_exn (module String)
 
 let constraint_to_string = function
   | Transformation.Ordered -> Some "ordered"
@@ -64,7 +64,7 @@ let constraint_to_string = function
 
 let functor_suffix = "_functor__"
 let reduce_sum_functor_suffix = "_rsfunctor__"
-let variadic_functor_suffix x = sprintf "_variadic%d_functor__" x
+let variadic_functor_suffix x = Printf.sprintf "_variadic%d_functor__" x
 
 type variadic = FixedArgs | ReduceSum | VariadicHOF of int
 [@@deriving compare, hash]
@@ -226,7 +226,7 @@ and lower_binary_fun f es = Exprs.fun_call f (lower_exprs es)
 and vector_literal ?(column = false) scalar es =
   let open Cpp.DSL in
   let vec = if column then Types.vector scalar else Types.row_vector scalar in
-  let make_vector size = vec.:{Literal (string_of_int size)} in
+  let make_vector size = vec.:{Literal (Int.to_string size)} in
   if List.is_empty es then make_vector 0
   else
     let vector = make_vector (List.length es) in
@@ -616,34 +616,34 @@ module Testing = struct
     Fmt.str "%a" Cpp.Printing.pp_expr (lower_expr @@ dummy_locate e)
 
   let%expect_test "pp_expr1" =
-    printf "%s" (pp_unlocated (Var "a"));
+    Stdio.printf "%s" (pp_unlocated (Var "a"));
     [%expect {| a |}]
 
   let%expect_test "pp_expr2" =
-    printf "%s" (pp_unlocated (Lit (Str, "b")));
+    Stdio.printf "%s" (pp_unlocated (Lit (Str, "b")));
     [%expect {| "b" |}]
 
   let%expect_test "pp_expr3" =
-    printf "%s" (pp_unlocated (Lit (Int, "112")));
+    Stdio.printf "%s" (pp_unlocated (Lit (Int, "112")));
     [%expect {| 112 |}]
 
   let%expect_test "pp_expr4" =
-    printf "%s" (pp_unlocated (Lit (Int, "112")));
+    Stdio.printf "%s" (pp_unlocated (Lit (Int, "112")));
     [%expect {| 112 |}]
 
   let%expect_test "pp_expr5" =
-    printf "%s" (pp_unlocated (FunApp (StanLib ("pi", FnPlain, AoS), [])));
+    Stdio.printf "%s" (pp_unlocated (FunApp (StanLib ("pi", FnPlain, AoS), [])));
     [%expect {| stan::math::pi() |}]
 
   let%expect_test "pp_expr6" =
-    printf "%s"
+    Stdio.printf "%s"
       (pp_unlocated
          (FunApp
             (StanLib ("sqrt", FnPlain, AoS), [dummy_locate (Lit (Int, "123"))])));
     [%expect {| stan::math::sqrt(123) |}]
 
   let%expect_test "pp_expr7" =
-    printf "%s"
+    Stdio.printf "%s"
       (pp_unlocated
          (FunApp
             ( StanLib ("atan", FnPlain, AoS)
@@ -652,7 +652,7 @@ module Testing = struct
     [%expect {| stan::math::atan(123, 1.2) |}]
 
   let%expect_test "pp_expr9" =
-    printf "%s"
+    Stdio.printf "%s"
       (pp_unlocated
          (TernaryIf
             ( dummy_locate (Lit (Int, "1"))
@@ -661,11 +661,11 @@ module Testing = struct
     [%expect {| (1 ? 1.2 : 2.3) |}]
 
   let%expect_test "pp_expr10" =
-    printf "%s" (pp_unlocated (Indexed (dummy_locate (Var "a"), [All])));
+    Stdio.printf "%s" (pp_unlocated (Indexed (dummy_locate (Var "a"), [All])));
     [%expect {| stan::model::rvalue(a, "a", stan::model::index_omni()) |}]
 
   let%expect_test "pp_expr11" =
-    printf "%s"
+    Stdio.printf "%s"
       (pp_unlocated
          (FunApp
             ( UserDefined ("poisson_rng", FnRng)
@@ -673,9 +673,9 @@ module Testing = struct
     [%expect {| poisson_rng(123, base_rng__, pstream__) |}]
 
   let%expect_test "pp_expr12" =
-    printf "%s\n"
+    Stdio.printf "%s\n"
       (Fmt.str "%a" Cpp.Printing.pp_expr (vector_literal Cpp.Double []));
-    printf "%s"
+    Stdio.printf "%s"
       (Fmt.str "%a" Cpp.Printing.pp_expr
          (vector_literal ~column:true Cpp.Double []));
     [%expect

--- a/src/stan_math_backend/Lower_functions.ml
+++ b/src/stan_math_backend/Lower_functions.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Middle
 open Lower_expr
 open Lower_stmt
@@ -88,7 +88,7 @@ let return_optional_arg_types (args : Program.fun_arg_decl) =
         [Types.base_type t]
     | _ -> [t] in
   List.concat_mapi args ~f:(fun i (ad, _, ty) ->
-      template_p (TemplateType (sprintf "T%d__" i)) (ad, ty))
+      template_p (TemplateType (Printf.sprintf "T%d__" i)) (ad, ty))
 
 (** Print template arguments for C++ functions that need templates
     @param args
@@ -110,12 +110,12 @@ let template_parameters (args : Program.fun_arg_decl) =
       ([template], requires typ (TemplateType template), TemplateType template)
   in
   List.mapi args ~f:(fun i (ad, _, ty) ->
-      template_p (sprintf "T%d__" i) (ad, ty))
+      template_p (Printf.sprintf "T%d__" i) (ad, ty))
 
 let%expect_test "arg types templated correctly" =
   [(AutoDiffable, "xreal", UReal); (AutoDiffable, "yint", UInt)]
-  |> template_parameters |> List.map ~f:fst3 |> List.concat
-  |> String.concat ~sep:"," |> print_endline;
+  |> template_parameters |> List.map ~f:(fun (x, _, _) -> x) |> List.concat
+  |> String.concat ~sep:"," |> Stdio.print_endline;
   [%expect {| T0__,T1__ |}]
 
 let%expect_test "arg types tuple template" =
@@ -124,11 +124,11 @@ let%expect_test "arg types tuple template" =
       , "xreal"
       , UTuple [UReal; UMatrix; UInt] ) ]
     |> template_parameters |> List.unzip3 in
-  templates |> List.concat |> String.concat ~sep:"," |> print_endline;
-  reqs |> List.concat |> List.sexp_of_t sexp_of_template_parameter |> print_s;
+  templates |> List.concat |> String.concat ~sep:"," |> Stdio.print_endline;
+  reqs |> List.concat |> List.sexp_of_t sexp_of_template_parameter |> Stdio.print_s;
   type_
   |> Fmt.to_to_string (Fmt.list ~sep:Fmt.comma Cpp.Printing.pp_type_)
-  |> print_endline;
+  |> Stdio.print_endline;
   [%expect
     {|
     T0__
@@ -156,11 +156,11 @@ let%expect_test "arg types tuple template" =
   let templates, reqs, type_ =
     [(AutoDiffable, "xreal", UArray (UTuple [UArray UInt; UMatrix]))]
     |> template_parameters |> List.unzip3 in
-  templates |> List.concat |> String.concat ~sep:"," |> print_endline;
-  reqs |> List.concat |> List.sexp_of_t sexp_of_template_parameter |> print_s;
+  templates |> List.concat |> String.concat ~sep:"," |> Stdio.print_endline;
+  reqs |> List.concat |> List.sexp_of_t sexp_of_template_parameter |> Stdio.print_s;
   type_
   |> Fmt.to_to_string (Fmt.list ~sep:Fmt.comma Cpp.Printing.pp_type_)
-  |> print_endline;
+  |> Stdio.print_endline;
   [%expect
     {|
   T0__
@@ -365,12 +365,12 @@ let get_functor_requirements (p : Program.Numbered.t) =
   let rec find_functors_stmt accum stmt =
     Stmt.(Pattern.fold find_functors_expr find_functors_stmt accum stmt.pattern)
   in
-  Program.fold find_functors_expr find_functors_stmt Fn.const String.Map.empty p
+  Program.fold find_functors_expr find_functors_stmt Fn.const (Map.empty (module String)) p
 
 let collect_functors_functions (p : Program.Numbered.t) : defn list =
   let functor_required = get_functor_requirements p in
   (* overloaded functions generate only one functor struct per name *)
-  let structs = String.Table.create () in
+  let structs = Hashtbl.create (module String) in
   let register_functors (d : _ Program.fun_def) =
     let functors =
       Map.find_multi functor_required d.fdname
@@ -460,7 +460,7 @@ module Testing = struct
         |> Some
     ; fdloc= Location_span.empty }
     |> str "@[<v>%a" pp_fun_def_test
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
     template <typename T0__, typename T1__,
@@ -521,7 +521,7 @@ module Testing = struct
         |> Some
     ; fdloc= Location_span.empty }
     |> str "@[<v>%a" pp_fun_def_test
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
     template <typename T0__, typename T1__, typename T2__, typename T3__,

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Lower_expr
 open Lower_stmt
@@ -167,7 +167,7 @@ let lower_constructor
     @ Stmts.unused "base_rng__"
     @ gen_function__ prog_name prog_name
     @ Decls.dummy_var in
-  let data_idents = List.map ~f:fst3 input_vars |> String.Set.of_list in
+  let data_idents = List.map ~f:(fun (x, _, _) -> x) input_vars |> Set.of_list (module String) in
   let lower_data (Stmt.{pattern; meta} as s) =
     match pattern with
     | Decl {decl_id; decl_type; _} when decl_id <> "pos__" -> (
@@ -477,7 +477,7 @@ let rec gen_param_names ?(outer_idcs = []) (decl_id, st) =
     | SizedType.STuple subtypes ->
         let idxes_subtypes =
           List.mapi
-            ~f:(fun i typ -> ((`Tuple, string_of_int (i + 1)), (name, typ)))
+            ~f:(fun i typ -> ((`Tuple, Int.to_string (i + 1)), (name, typ)))
             subtypes in
         List.concat_map
           ~f:(fun (idx, sub) -> gen_param_names ~outer_idcs:(idcs @ [idx]) sub)
@@ -886,7 +886,7 @@ module Testing = struct
   let%expect_test "model public basics" =
     model_public_basics "foobar"
     |> str "%a" Cpp.Printing.pp_program
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
       inline std::string model_name() const final {
@@ -900,7 +900,7 @@ module Testing = struct
   let%expect_test "boilerplate" =
     new_model_boilerplate "foobar"
     |> str "%a" Cpp.Printing.pp_program
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
         using stan_model = foobar_namespace::foobar;
@@ -921,7 +921,7 @@ module Testing = struct
     gen_param_names
       ("foo", SizedType.SArray (SComplex, Middle.Expr.Helpers.variable "N"))
     |> str "@[<v>%a" (list ~sep:cut Cpp.Printing.pp_stmt)
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
           for (int sym1__ = 1; sym1__ <= N; ++sym1__) {
@@ -938,7 +938,7 @@ module Testing = struct
           STuple [SInt; SArray (SReal, Middle.Expr.Helpers.variable "nested")])
       )
     |> str "@[<v>%a" (list ~sep:cut Cpp.Printing.pp_stmt)
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
       param_names__.emplace_back(std::string() + "tuple" + ':' + std::to_string(1));
@@ -956,7 +956,7 @@ module Testing = struct
                 [SInt; SArray (SReal, Middle.Expr.Helpers.variable "nested")]
             , Middle.Expr.Helpers.variable "N" )) )
     |> str "@[<v>%a" (list ~sep:cut Cpp.Printing.pp_stmt)
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
         for (int sym1__ = 1; sym1__ <= N; ++sym1__) {

--- a/src/stan_math_backend/Lower_stmt.ml
+++ b/src/stan_math_backend/Lower_stmt.ml
@@ -1,7 +1,7 @@
 (** Lowering of Stan statements to C++ *)
 
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Cpp
 open Lower_expr
@@ -359,7 +359,7 @@ module Testing = struct
       (lower_assign_sized
          (SArray (SArray (SMatrix (AoS, int 2, int 3), int 4), int 5))
          DataOnly Stmt.Pattern.Uninit)
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect {| |}]
 
   let%expect_test "set size mat array" =
@@ -369,7 +369,7 @@ module Testing = struct
       (lower_assign_sized
          (SArray (SArray (SMatrix (AoS, int 2, int 3), int 4), int 5))
          DataOnly Stmt.Pattern.Default)
-    |> print_endline;
+    |> Stdio.print_endline;
     [%expect
       {|
     std::vector<std::vector<Eigen::Matrix<double,-1,-1>>>(5,

--- a/src/stan_math_backend/Mangle.ml
+++ b/src/stan_math_backend/Mangle.ml
@@ -8,7 +8,7 @@
     NB: the use of a leading _ is essential, because the lexer won't allow this
     in a user-created variable. *)
 
-open Core
+open Base
 
 let kwrds_prefix = "_stan_"
 let remove_prefix s = String.chop_prefix_if_exists ~prefix:kwrds_prefix s
@@ -16,7 +16,7 @@ let prepend_kwrd x = kwrds_prefix ^ x
 
 let cpp_kwrds =
   (* C++ keywords that are not stan keywords *)
-  String.Set.of_list
+  Set.of_list (module String)
     ([ "alignas"; "alignof"; "and"; "and_eq"; "asm"; "bitand"; "bitor"; "bool"
      ; "case"; "catch"; "char"; "char16_t"; "char32_t"; "class"; "compl"
      ; "const"; "constexpr"; "const_cast"; "decltype"; "default"; "delete"; "do"

--- a/src/stan_math_backend/Numbering.ml
+++ b/src/stan_math_backend/Numbering.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 
 type state_t = Location_span.t list
@@ -87,12 +87,12 @@ let assign_loc location_num =
   let open Cpp in
   let open Cpp.DSL in
   if location_num = no_span_num then []
-  else ["current_statement__" := Literal (string_of_int location_num)]
+  else ["current_statement__" := Literal (Int.to_string location_num)]
 
 let register_map_rect_functors namespace map_rect_calls =
   let register_functor (i, f) =
     Cpp.Preprocessor
       (MacroApply
-         ("STAN_REGISTER_MAP_RECT", [string_of_int i; namespace ^ "::" ^ f]))
+         ("STAN_REGISTER_MAP_RECT", [Int.to_string i; namespace ^ "::" ^ f]))
   in
   List.map ~f:register_functor map_rect_calls

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open Base
+open Base.Poly
 open Middle
 open Mangle
 
@@ -36,7 +36,7 @@ let rec change_kwrds_stmts s =
 (** A list of functions which return an Eigen block expression *)
 let eigen_block_expr_fns =
   ["head"; "tail"; "segment"; "col"; "row"; "block"; "sub_row"; "sub_col"]
-  |> String.Set.of_list
+  |> Set.of_list (module String)
 
 (** Eval indexed eigen types in UDF calls to prevent infinite template expansion
     if the call is recursive
@@ -52,7 +52,7 @@ let eigen_block_expr_fns =
     and this algorithm is O(n^3) so it's important to track only the function
     calls that really can propagate eigen templates. *)
 let break_eigen_cycles functions_block =
-  let callgraph = String.Table.create () in
+  let callgraph = Hashtbl.create (module String) in
   let eval_eigen_cycles fun_args calls (f : _ Program.fun_def) =
     let open Expr in
     let rec is_potentially_recursive = function
@@ -110,10 +110,10 @@ let break_eigen_cycles functions_block =
     let fun_args =
       List.filter_map fdargs ~f:(fun (_, n, t) ->
           if UnsizedType.is_eigen_type t then Some n else None)
-      |> String.Set.of_list in
+      |> Set.of_list (module String) in
     if Set.is_empty fun_args then fd
     else
-      let calls = String.Hash_set.create () in
+      let calls = Hash_set.create (module String) in
       let fndef = eval_eigen_cycles fun_args calls fd in
       if not (Hash_set.is_empty calls) then (
         (* update [callgraph] with the call paths going through the current
@@ -126,7 +126,7 @@ let break_eigen_cycles functions_block =
   List.map ~f:break_cycles functions_block
 
 let opencl_trigger_restrictions =
-  String.Map.of_alist_exn
+  Map.of_alist_exn (module String)
     [ ( "bernoulli_lpmf"
       , [ [ (0, UnsizedType.DataOnly, UnsizedType.UArray UnsizedType.UInt)
           ; (1, UnsizedType.DataOnly, UnsizedType.UReal) ] ] )
@@ -167,7 +167,7 @@ let opencl_supported_functions =
   ; "scaled_inv_chi_square_lpdf"; "skew_normal_lpdf"; "std_normal_lpdf"
   ; "student_t_lpdf"; "uniform_lpdf"; "weibull_lpdf"; "binomial_logit_lpmf"
   ; "binomial_logit_glm_lpmf" ]
-  |> String.Set.of_list
+  |> Set.of_list (module String)
 
 let opencl_suffix = "_opencl__"
 
@@ -292,7 +292,7 @@ let rec var_context_read_inside_tuple enclosing_tuple_name origin_type
           subtypes in
       let enclosing_names =
         List.mapi
-          ~f:(fun i _ -> enclosing_tuple_name ^ "." ^ string_of_int (i + 1))
+          ~f:(fun i _ -> enclosing_tuple_name ^ "." ^ Int.to_string (i + 1))
           subtypes in
       List.map2_exn
         ~f:(fun name projection ->
@@ -306,7 +306,7 @@ let rec var_context_read_inside_tuple enclosing_tuple_name origin_type
         | STuple subtypes ->
             ( List.mapi
                 ~f:(fun i _ ->
-                  enclosing_tuple_name ^ "." ^ string_of_int (i + 1))
+                  enclosing_tuple_name ^ "." ^ Int.to_string (i + 1))
                 subtypes
             , subtypes )
         | _ -> ([], []) in
@@ -502,7 +502,7 @@ let rec var_context_read_internal
         match tupl with
         | STuple subtypes ->
             ( List.mapi
-                ~f:(fun i _ -> decl_id ^ "." ^ string_of_int (i + 1))
+                ~f:(fun i _ -> decl_id ^ "." ^ Int.to_string (i + 1))
                 subtypes
             , subtypes )
         | _ -> (* impossible by above pattern patch *) ([], []) in
@@ -756,7 +756,7 @@ let%expect_test "Flatten slists" =
             |> s ]
         |> s ]
       |> flatten_slists_list) in
-  print_s [%sexp (stmt : (unit, unit) Stmt.t list)];
+  Stdio.print_s [%sexp (stmt : (unit, unit) Stmt.t list)];
   [%expect
     {|
     (((pattern
@@ -769,7 +769,7 @@ let%expect_test "Flatten slists" =
 
 let add_reads vars mkread stmts =
   let vars = List.map ~f:(fun (id, l, outvar) -> (id, (l, outvar))) vars in
-  let var_names = String.Map.of_alist_exn vars in
+  let var_names = Map.of_alist_exn (module String) vars in
   let add_read_to_decl (Stmt.{pattern; _} as stmt) =
     match pattern with
     | Decl ({decl_id; _} as decl_rec) when Map.mem var_names decl_id -> (
@@ -978,14 +978,14 @@ let is_opencl_var = String.is_suffix ~suffix:opencl_suffix
 let rec collect_vars_expr is_target accum Expr.{pattern; _} =
   Set.union accum
     (match pattern with
-    | Var s when is_target s -> String.Set.of_list [s]
-    | x -> Expr.Pattern.fold (collect_vars_expr is_target) String.Set.empty x)
+    | Var s when is_target s -> Set.of_list (module String) [s]
+    | x -> Expr.Pattern.fold (collect_vars_expr is_target) (Set.empty (module String)) x)
 
 let collect_opencl_vars s =
   let rec go accum s =
     Stmt.(Pattern.fold (collect_vars_expr is_opencl_var) go accum s.pattern)
   in
-  go String.Set.empty s
+  go (Set.empty (module String)) s
 
 let%expect_test "collect vars expr" =
   let mkvar s = Expr.{pattern= Var s; meta= Typed.Meta.empty} in
@@ -995,12 +995,12 @@ let%expect_test "collect vars expr" =
       { pattern= FunApp (StanLib ("print", FnPlain, AoS), args)
       ; meta= Typed.Meta.empty } in
   Stmt.{pattern= TargetPE fnapp; meta= Location_span.empty}
-  |> collect_opencl_vars |> String.Set.sexp_of_t |> print_s;
+  |> collect_opencl_vars |> [%sexp_of: Set.M(String).t] |> Stdio.print_s;
   [%expect {| (w_opencl__ x_opencl__) |}]
 
 let%expect_test "insert before" =
   let l = [1; 2; 3; 4; 5; 6] |> insert_before (( = ) 6) [999] in
-  [%sexp (l : int list)] |> print_s;
+  [%sexp (l : int list)] |> Stdio.print_s;
   [%expect {| (1 2 3 4 5 999 6) |}]
 
 let map_prog_stmt_lists f (p : ('a, 'b, 'c) Program.t) =
@@ -1124,7 +1124,7 @@ let trans_prog ?(use_opencl = false) (p : Program.Typed.t) =
     |> add_reads p.output_vars param_deserializer_read
     |> translate_to_open_cl in
   let opencl_vars =
-    String.Set.union_list
+    Set.union_list (module String)
       (List.concat_map
          ~f:(List.map ~f:collect_opencl_vars)
          [log_prob; generate_quantities])

--- a/src/stan_math_backend/dune
+++ b/src/stan_math_backend/dune
@@ -1,7 +1,7 @@
 (library
  (name stan_math_backend)
  (public_name stanc.stan_math_backend)
- (libraries core fmt yojson middle stan_math_signatures)
+ (libraries base stdio fmt yojson middle stan_math_signatures)
  (instrumentation
   (backend bisect_ppx))
  (private_modules
@@ -14,4 +14,11 @@
   numbering)
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.make)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test
+   ppx_deriving.make)))

--- a/src/stan_math_signatures/Generate.ml
+++ b/src/stan_math_signatures/Generate.ml
@@ -6,7 +6,7 @@
     combinations, so now it is done by the build system and just stored in the
     binary using the [Marshal] library. *)
 
-open Core
+open Base
 open Middle
 
 (** The "dimensionality" (bad name?) is supposed to help us represent the
@@ -99,14 +99,14 @@ let is_primitive = function
 
 (** The signatures hash table *)
 let (stan_math_signatures : (string, UnsizedType.signature list) Hashtbl.t) =
-  String.Table.create ()
+  Hashtbl.create (module String)
 
 (** The variadic signatures hash table
 
     These functions cannot be overloaded. *)
 let (stan_math_variadic_signatures :
       (string, UnsizedType.variadic_signature) Hashtbl.t) =
-  String.Table.create ()
+  Hashtbl.create (module String)
 
 (* XXX The correct word here isn't combination - what is it? *)
 let all_combinations xx =
@@ -115,7 +115,7 @@ let all_combinations xx =
           List.map ~f:(fun arg -> arg :: acc) x))
 
 let missing_math_functions =
-  String.Set.of_list ["beta_proportion_cdf"; "loglogistic_lcdf"]
+  Set.of_list (module String) ["beta_proportion_cdf"; "loglogistic_lcdf"]
 
 let rng_return_type t lt =
   if List.for_all ~f:is_primitive lt then t else UnsizedType.UArray t
@@ -419,12 +419,12 @@ let add_binary_vec name supports_soa =
     ~scalars:[UInt; UReal] name supports_soa
 
 let add_binary_vec_real_real name supports_soa =
-  add_binary_vec_general ~return_fn:Fun.id
+  add_binary_vec_general ~return_fn:Fn.id
     ~vectors:[UArray UReal; UVector; URowVector; UMatrix]
     ~scalars:[UReal] name supports_soa
 
 let add_binary_vec_complex_complex name supports_soa =
-  add_binary_vec_general ~return_fn:Fun.id
+  add_binary_vec_general ~return_fn:Fn.id
     ~vectors:[UArray UComplex; UComplexVector; UComplexRowVector; UComplexMatrix]
     ~scalars:[UComplex] name supports_soa
 
@@ -2618,7 +2618,7 @@ let variadic_dae_mandatory_fun_args =
 let variadic_ode_adjoint_fn = "ode_adjoint_tol_ctl"
 
 let variadic_ode_nonadjoint_fns =
-  String.Set.of_list
+  Set.of_list (module String)
     [ "ode_bdf_tol"; "ode_rk45_tol"; "ode_adams_tol"; "ode_bdf"; "ode_rk45"
     ; "ode_adams"; "ode_ckrk"; "ode_ckrk_tol" ]
 
@@ -2725,42 +2725,42 @@ let () =
 (** Print a module definition to [file] that contains the signatures computed
     above *)
 let generate_module () =
-  let marshal e = Marshal.to_string e [] in
-  (* Core's Hashtbl cannot be safely Marshal'd, so we round trip through an
+  let marshal e = Stdlib.Marshal.to_string e [] in
+  (* Base's Hashtbl cannot be safely Marshal'd, so we round trip through an
      associative list *)
-  let marshal_hashtbl (type value) (t : value String.Table.t) =
+  let marshal_hashtbl (type value) (t : (string, value) Hashtbl.t) =
     marshal (Hashtbl.to_alist t) in
   let distributions_simplified =
     distributions
     |> List.map ~f:(fun (kind, name, _, _) ->
         (name, List.map ~f:(Fn.compose String.lowercase show_fkind) kind))
       (* combine any common keys *)
-    |> String.Map.of_alist_reduce ~f:(fun v1 v2 ->
+    |> Map.of_alist_reduce (module String) ~f:(fun v1 v2 ->
         v1 @ v2 |> Set.Poly.of_list |> Set.to_list)
     |> Map.to_alist in
-  Printf.printf
+  Stdio.printf
     {|
-let unmarshal s = Marshal.from_string s 0
-let unmarshal_hashtbl s : 'a Core.String.Table.t =
-  unmarshal s |> Core.String.Table.of_alist_exn |};
-  Printf.printf
+let unmarshal s = Stdlib.Marshal.from_string s 0
+let unmarshal_hashtbl s : (string, 'a) Base.Hashtbl.t =
+  unmarshal s |> Base.Hashtbl.of_alist_exn (module Base.String) |};
+  Stdio.printf
     {|
 let stan_math_signatures :
-    Middle.UnsizedType.signature list Core.String.Table.t Lazy.t=
+    (string, Middle.UnsizedType.signature list) Base.Hashtbl.t Lazy.t=
   lazy (fst @@ Gc.ramp_up @@
         fun () -> unmarshal_hashtbl %S) |}
     (marshal_hashtbl stan_math_signatures);
-  Printf.printf
+  Stdio.printf
     {|
 let stan_math_variadic_signatures :
-    Middle.UnsizedType.variadic_signature Core.String.Table.t =
+    (string, Middle.UnsizedType.variadic_signature) Base.Hashtbl.t =
   unmarshal_hashtbl %S |}
     (marshal_hashtbl stan_math_variadic_signatures);
-  Printf.printf
+  Stdio.printf
     {|
 let distributions : (string * string list) list = unmarshal %S |}
     (marshal distributions_simplified);
-  Printf.eprintf
+  Stdio.eprintf
     "Generated signatures for %d functions, %d distributions, and %d variadic \
      functions.\n"
     (Hashtbl.length stan_math_signatures)

--- a/src/stan_math_signatures/Generated_signatures.mli
+++ b/src/stan_math_signatures/Generated_signatures.mli
@@ -3,12 +3,12 @@
 
     These values should only be used by the [Stan_math_signatures] module. *)
 
-open Core
+open Base
 open Middle
 
-val stan_math_signatures : UnsizedType.signature list String.Table.t Lazy.t
+val stan_math_signatures : (string, UnsizedType.signature list) Hashtbl.t Lazy.t
 
 val stan_math_variadic_signatures :
-  UnsizedType.variadic_signature String.Table.t
+  (string, UnsizedType.variadic_signature) Hashtbl.t
 
 val distributions : (string * string list) list

--- a/src/stan_math_signatures/Stan_math_signatures.ml
+++ b/src/stan_math_signatures/Stan_math_signatures.ml
@@ -1,7 +1,7 @@
 (** The signatures of the Stan Math library, which are used for type checking *)
-open Core
+open Base
 
-open Core.Poly
+open Base.Poly
 open Middle
 
 (** The [Generated_signatures] module is produced by the [Generate.ml]
@@ -71,7 +71,7 @@ let make_assignmentoperator_stan_math_signatures assop =
     | assop -> operator_to_stan_math_fns assop)
   |> List.concat_map ~f:get_sigs
   |> List.concat_map ~f:(function
-    | [(ad1, lhs); (ad2, rhs)], ReturnType rtype, _, _
+    | [(ad1, lhs); (ad2, rhs)], UnsizedType.ReturnType rtype, _, _
       when rtype = lhs
            && not
                 ((assop = Operator.EltTimes || assop = Operator.EltDivide)
@@ -119,7 +119,7 @@ let string_operator_to_stan_math_fns str =
 
 let pretty_print_all_math_sigs ppf () =
   let open Fmt in
-  Format.pp_set_margin ppf 180;
+  Stdlib.Format.pp_set_margin ppf 180;
   let pp_sig ppf (name, (args, rt, _, _)) =
     pf ppf "%s(@[<h>%a@]) => %a" name
       (list ~sep:comma UnsizedType.pp)
@@ -164,7 +164,7 @@ let embedded_laplace_functions =
   ; "laplace_latent_neg_binomial_2_log_rng"
   ; "laplace_latent_tol_neg_binomial_2_log_rng"
   ; "laplace_latent_poisson_log_rng"; "laplace_latent_tol_poisson_log_rng" ]
-  |> String.Set.of_list
+  |> Set.of_list (module String)
 
 let is_embedded_laplace_fn name =
   Set.mem embedded_laplace_functions (Utils.stdlib_distribution_name name)
@@ -179,7 +179,7 @@ let laplace_helper_lik_args =
   ; ( "poisson_log"
     , [ (AutoDiffable, UArray UInt); (AutoDiffable, UArray UInt)
       ; (AutoDiffable, UVector) ] ) ]
-  |> String.Map.of_alist_exn
+  |> Map.of_alist_exn (module String)
 
 let laplace_helper_param_types name =
   let without_prefix =
@@ -208,7 +208,7 @@ let disallowed_second_order =
   [ "algebra_solver"; "algebra_solver_newton"; "integrate_1d"; "integrate_ode"
   ; "integrate_ode_adams"; "integrate_ode_bdf"; "integrate_ode_rk45"; "map_rect"
   ; "hmm_marginal"; "hmm_hidden_state_prob" ]
-  |> String.Set.of_list
+  |> Set.of_list (module String)
 
 let lacks_higher_order_autodiff name =
   Set.mem disallowed_second_order name || is_special_function_name name

--- a/src/stan_math_signatures/dune
+++ b/src/stan_math_signatures/dune
@@ -1,21 +1,34 @@
 (library
  (name stan_math_signatures)
  (public_name stanc.stan_math_signatures)
- (libraries core fmt common middle)
+ (libraries base stdio fmt common middle)
  (instrumentation
   (backend bisect_ppx))
  (modules :standard \ generate)
  (private_modules generated_signatures)
  (inline_tests)
  (preprocess
-  (pps ppx_jane)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test)))
 
 (executable
  (name generate)
  (modules generate)
  (preprocess
-  (pps ppx_jane ppx_deriving.show))
- (libraries core common middle))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test
+   ppx_deriving.show))
+ (libraries base stdio common middle))
 
 (rule
  (with-stdout-to

--- a/src/stanc/CLI.ml
+++ b/src/stanc/CLI.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Frontend
 open Cmdliner
 
@@ -38,7 +38,7 @@ module Options = struct
         | 0 -> false
         | 1 -> true
         | _ ->
-            Printf.eprintf
+            Stdio.eprintf
               "Warning: Duplicated flag '--%s' ignored, consider updating your \
                call to stanc!"
               name;
@@ -243,7 +243,7 @@ module Debug_Options = struct
       (function
         | None -> `Ok None
         | Some file -> (
-            try `Ok (Some ("'" ^ file ^ "'", In_channel.read_all file))
+            try `Ok (Some ("'" ^ file ^ "'", Stdio.In_channel.read_all file))
             with _ ->
               `Error (true, "File '" ^ file ^ "' not found or cannot be opened.")
             ))

--- a/src/stanc/dune
+++ b/src/stanc/dune
@@ -3,14 +3,22 @@
  (modes
   (byte c)
   (best exe))
- (libraries core fmt cmdliner fmt.cli fmt.tty driver stan_math_signatures)
+ (libraries
+  base
+  stdio
+  fmt
+  cmdliner
+  fmt.cli
+  fmt.tty
+  driver
+  stan_math_signatures)
  (instrumentation
   (backend bisect_ppx))
  (modules Stanc CLI)
  (public_name stanc)
  (package stanc)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_base ppx_pipebang ppx_sexp_message ppx_sexp_value)))
 
 (rule
  (target

--- a/src/stanc/stanc.ml
+++ b/src/stanc/stanc.ml
@@ -1,5 +1,5 @@
 (** stanc console application *)
-open Core
+open Base
 
 open Frontend
 
@@ -7,24 +7,24 @@ let exit_ok = CLI.exit_ok
 let exit_err = CLI.exit_err
 
 let dump_math_sigs () =
-  Stan_math_signatures.pretty_print_all_math_sigs Format.std_formatter ();
+  Stan_math_signatures.pretty_print_all_math_sigs Stdlib.Format.std_formatter ();
   exit_ok
 
 let dump_math_dists () =
-  Stan_math_signatures.pretty_print_all_math_distributions Format.std_formatter
+  Stan_math_signatures.pretty_print_all_math_distributions Stdlib.Format.std_formatter
     ();
   exit_ok
 
 let write filename data =
   try
-    Out_channel.write_all filename ~data;
+    Stdio.Out_channel.write_all filename ~data;
     exit_ok
   with Sys_error msg ->
     Fmt.epr "Error writing to file '%s': %s@." filename msg;
     exit_err
 
 let print_and_exit data =
-  print_endline data;
+  Stdio.print_endline data;
   exit_ok
 
 let print_or_write_and_exit output_file data =
@@ -42,7 +42,7 @@ let output_callback break output_file printed_filename :
       break (print_or_write_and_exit output_file s)
   | DebugOutput s | Memory_patterns s ->
       (* historically, these flags didn't prevent you from continuing *)
-      print_string s
+      Stdio.print_string s
   | Warnings ws -> Warnings.pp_warnings Fmt.stderr ?printed_filename ws
 
 let stanc ?tty_colors ?(debug_lex : bool = false) ?(debug_parse : bool = false)
@@ -59,7 +59,7 @@ let stanc ?tty_colors ?(debug_lex : bool = false) ?(debug_parse : bool = false)
   let model_file_name, model_source, printed_filename =
     if String.equal model_file "-" then
       ( "stdin"
-      , `Code (In_channel.input_all In_channel.stdin)
+      , `Code (Stdio.In_channel.input_all Stdio.In_channel.stdin)
       , Option.first_some flags.filename_in_msg (Some "stdin") )
     else (model_file, `File model_file, flags.filename_in_msg) in
   With_return.with_return @@ fun {return} ->
@@ -70,7 +70,7 @@ let stanc ?tty_colors ?(debug_lex : bool = false) ?(debug_parse : bool = false)
       (output_callback return output_file printed_filename)
   with
   | Ok cpp_str ->
-      if print_cpp then print_endline cpp_str;
+      if print_cpp then Stdio.print_endline cpp_str;
       let out =
         if String.equal output_file "" then
           Common.Files.remove_dotstan model_file_name ^ ".hpp"
@@ -105,8 +105,8 @@ let dispatch_commands args =
   match Common.ICE.with_exn_message go with
   | Ok code -> code
   | Error internal_error ->
-      Out_channel.output_string stderr internal_error;
-      Out_channel.flush stderr;
+      Stdio.Out_channel.output_string Stdio.stderr internal_error;
+      Stdio.Out_channel.flush Stdio.stderr;
       CLI.exit_ice
 
 let main () =
@@ -125,4 +125,4 @@ let main () =
     | s -> s);
   Cmd.eval' ~argv ~catch:false stanc_cmd
 
-let () = if !Sys.interactive then () else exit (main ())
+let () = if !Sys.interactive then () else Stdlib.exit (main ())

--- a/src/stancjs/conversion.ml
+++ b/src/stancjs/conversion.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Frontend
 open Js_of_ocaml
 
@@ -28,13 +28,13 @@ let checked_to_array ~name value =
          (Js.typeof value |> Js.to_string))
   else Ok (Js.to_array value)
 
-let get_includes_lenient includes : string String.Map.t * string list =
+let get_includes_lenient includes : string Map.M(String).t * string list =
   let open Common.Let_syntax.Result in
   let map, warnings =
     match Js.Opt.to_option includes with
-    | None -> (String.Map.empty, [] (* normal use: argument not supplied *))
+    | None -> ((Map.empty (module String)), [] (* normal use: argument not supplied *))
     | Some includes when not (typecheck includes "object") ->
-        ( String.Map.empty
+        ( (Map.empty (module String))
         , [bad_arg_message ~name:"includes" ~expected:"object" includes] )
     | Some includes ->
         let keys = Js.object_keys includes |> Js.to_array |> List.of_array in
@@ -47,7 +47,7 @@ let get_includes_lenient includes : string String.Map.t * string list =
           (k_str, value_str) in
         let alist, warnings = List.map keys ~f:lookup |> List.partition_result in
         ( (* JS objects cannot have duplicate keys *)
-          String.Map.of_alist_exn alist
+          Map.of_alist_exn (module String) alist
         , warnings ) in
   ( map
   , List.map
@@ -60,7 +60,7 @@ type flags =
   {name: string; code: string; driver_flags: Driver.Flags.t; color_output: bool}
 
 let process_flags name code (flags : 'a Js.opt) includes :
-    (flags, string) result =
+    (flags, string) Result.t =
   let open Common.Let_syntax.Result in
   let* name = checked_to_string ~name:"name" name in
   let* code = checked_to_string ~name:"code" code in
@@ -72,7 +72,7 @@ let process_flags name code (flags : 'a Js.opt) includes :
         let+ ocaml_flags =
           let open Result in
           Array.mapi flags_array ~f:(fun i v ->
-              checked_to_string ~name:("flags[" ^ string_of_int i ^ "]") v)
+              checked_to_string ~name:("flags[" ^ Int.to_string i ^ "]") v)
           |> Array.to_list |> Result.all >>| Array.of_list in
         Driver.Flags.set_backend_args_list
           (ocaml_flags |> Array.to_list |> List.map ~f:(fun o -> "--" ^ o));
@@ -134,7 +134,7 @@ let process_flags name code (flags : 'a Js.opt) includes :
                   |> Option.map ~f:(fun s -> ("debug-data-json", s)) }
           ; line_length=
               flag_val "max-line-length"
-              |> Option.map ~f:int_of_string
+              |> Option.map ~f:Int.of_string
               |> Option.value ~default:78
           ; canonicalizer_settings=
               (if is_flag_set "print-canonical" then Canonicalize.legacy
@@ -160,14 +160,14 @@ let process_flags name code (flags : 'a Js.opt) includes :
 
 let str_color ~color_output =
   let buf = Buffer.create 64 in
-  let ppf = Format.formatter_of_buffer buf in
+  let ppf = Stdlib.Format.formatter_of_buffer buf in
   Fmt.set_style_renderer ppf (if color_output then `Ansi_tty else `None);
   let flush ppf =
-    Format.pp_print_flush ppf ();
+    Stdlib.Format.pp_print_flush ppf ();
     let s = Buffer.contents buf in
     Buffer.reset buf;
     s in
-  Format.kfprintf flush ppf
+  Stdlib.Format.kfprintf flush ppf
 
 class type stancReturn = object
   method result : Js.js_string Js.t Js.optdef_prop

--- a/src/stancjs/conversion.mli
+++ b/src/stancjs/conversion.mli
@@ -1,7 +1,7 @@
 open Js_of_ocaml
 
 val get_includes_lenient :
-  'a Js.t Js.opt -> string Core.String.Map.t * string list
+  'a Js.t Js.opt -> string Base.Map.M(Base.String).t * string list
 (** Converts from a [{ [s:string]:string }] JS object type to an OCaml map, with
     warnings for bad input. *)
 
@@ -12,12 +12,12 @@ val process_flags :
      Js.js_string Js.t
   -> Js.js_string Js.t
   -> Js.js_string Js.t Js.js_array Js.t Js.opt
-  -> string Core.String.Map.t
-  -> (flags, string) result
+  -> string Base.Map.M(Base.String).t
+  -> (flags, string) Result.t
 (** Turn function inputs into a [Driver.Flags.t] *)
 
 val str_color :
-  color_output:bool -> ('a, Format.formatter, unit, string) format4 -> 'a
+  color_output:bool -> ('a, Stdlib.Format.formatter, unit, string) format4 -> 'a
 (** similar to [Fmt.str_like] but directly sets style rendering rather than
     copying from another ppf *)
 
@@ -34,5 +34,5 @@ val wrap_result :
   -> code:string
   -> color_output:bool
   -> warnings:string list
-  -> (string, Frontend.Errors.t) result
+  -> (string, Frontend.Errors.t) Result.t
   -> stancReturn Js.t

--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -1,9 +1,9 @@
 (executable
  (name stancjs)
- (libraries core fmt js_of_ocaml driver stan_math_signatures)
+ (libraries base stdio fmt js_of_ocaml driver stan_math_signatures)
  (modules Stancjs Conversion)
  (preprocess
-  (pps ppx_jane js_of_ocaml-ppx))
+  (pps ppx_base ppx_pipebang ppx_sexp_message ppx_sexp_value js_of_ocaml-ppx))
  (modes js))
 
 (env

--- a/src/stancjs/stancjs.ml
+++ b/src/stancjs/stancjs.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Frontend
 open Conversion
 open Js_of_ocaml

--- a/stanc.opam
+++ b/stanc.opam
@@ -8,7 +8,15 @@ bug-reports: "https://github.com/stan-dev/stanc3/issues"
 depends: [
   "dune" {>= "3.5"}
   "ocaml" {= "5.5.0"}
-  "core" {= "v0.17.2"}
+  "base" {= "v0.17.3"}
+  "stdio" {= "v0.17.0"}
+  "sexplib0" {= "v0.17.0"}
+  "ppx_base" {= "v0.17.0"}
+  "ppx_pipebang" {= "v0.17.0"}
+  "ppx_sexp_message" {= "v0.17.0"}
+  "ppx_sexp_value" {= "v0.17.0"}
+  "ppx_expect" {= "v0.17.3"}
+  "ppx_inline_test" {= "v0.17.1"}
   "menhir" {= "20260209"}
   "ppx_deriving" {= "6.1.1"}
   "fmt" {= "0.11.0"}

--- a/test/integration/dune
+++ b/test/integration/dune
@@ -1,6 +1,6 @@
 (executable
  (name run_bin_on_args)
- (libraries core unix))
+ (libraries base stdio unix))
 
 (cram
  (applies_to :whole_subtree)

--- a/test/integration/run_bin_on_args.ml
+++ b/test/integration/run_bin_on_args.ml
@@ -1,16 +1,16 @@
 module Caml_unix = Unix
-open Core
+open Base
 
 let string_of_status = function
-  | Caml_unix.WEXITED i -> sprintf "[exit %n]" i
-  | WSIGNALED i -> sprintf "[signal %n]" i
-  | WSTOPPED i -> sprintf "[stopped %n]" i
+  | Caml_unix.WEXITED i -> Printf.sprintf "[exit %n]" i
+  | WSIGNALED i -> Printf.sprintf "[signal %n]" i
+  | WSTOPPED i -> Printf.sprintf "[stopped %n]" i
 
 let run_capturing_output cmd =
   let noflags = Array.create ~len:0 "" in
   let stdout, stdin, stderr = Caml_unix.open_process_full cmd noflags in
   let chns = [stdout; stderr] in
-  let out = List.map ~f:In_channel.input_lines chns |> List.concat in
+  let out = List.map ~f:Stdio.In_channel.input_lines chns |> List.concat in
   let status =
     string_of_status (Caml_unix.close_process_full (stdout, stdin, stderr))
   in
@@ -34,4 +34,4 @@ let () =
         let binary =
           String.substr_replace_first binary ~pattern:".exe" ~with_:"" in
         binary ^ " " ^ arg in
-      Printf.printf "  $ %s\n%s\n" short_cmd (run_capturing_output cmd))
+      Stdio.printf "  $ %s\n%s\n" short_cmd (run_capturing_output cmd))

--- a/test/stancjs/dune
+++ b/test/stancjs/dune
@@ -1,6 +1,6 @@
 (executable
  (name run_js_on_args)
- (libraries core unix)
+ (libraries base stdio unix)
  (modes exe))
 
 (rule

--- a/test/stancjs/run_js_on_args.ml
+++ b/test/stancjs/run_js_on_args.ml
@@ -1,11 +1,11 @@
 module Caml_unix = Unix
-open Core
+open Base
 
 let run_capturing_output cmd =
   let env = [| "PATH=" ^ (Sys.getenv "PATH" |> Option.value ~default:"") |] in
   let stdout, stdin, stderr = Caml_unix.open_process_full cmd env in
   let chns = [stdout; stderr] in
-  let out = List.map ~f:In_channel.input_lines chns in
+  let out = List.map ~f:Stdio.In_channel.input_lines chns in
   ignore (Caml_unix.close_process_full (stdout, stdin, stderr));
   String.concat ~sep:"\n" (List.concat out)
 
@@ -16,4 +16,4 @@ let () =
   Array.iter files ~f:(fun arg ->
       let arg = String.chop_prefix_if_exists arg ~prefix:"./" in
       let cmd = "node " ^ arg in
-      Printf.printf "$ %s\n%s\n" cmd (run_capturing_output cmd))
+      Stdio.printf "$ %s\n%s\n" cmd (run_capturing_output cmd))

--- a/test/unit/Ast_to_Mir_tests.ml
+++ b/test/unit/Ast_to_Mir_tests.ml
@@ -1,5 +1,5 @@
 open Middle
-open Core
+open Base
 
 let%expect_test "Operator-assign example" =
   Test_utils.mir_of_string
@@ -12,7 +12,7 @@ let%expect_test "Operator-assign example" =
       |}
   |> (fun Program.{log_prob; _} -> log_prob)
   |> Fmt.str "@[<v>%a@]" (Fmt.list ~sep:Fmt.cut Stmt.Located.pp)
-  |> print_endline;
+  |> Stdio.print_endline;
   [%expect
     {|
       {
@@ -33,7 +33,7 @@ let%expect_test "Prefix-Op-Example" =
       |}
   in
   let op = mir.log_prob in
-  print_s [%sexp (op : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (op : Stmt.Located.t list)];
   (* Perhaps this is producing too many nested lists. XXX *)
   [%expect
     {|
@@ -66,7 +66,7 @@ let%expect_test "Prefix-Op-Example" =
 
 let%expect_test "read data" =
   let m = Test_utils.mir_of_string "data { array[5] matrix[10, 20] mat; }" in
-  print_s [%sexp (m.prepare_data : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (m.prepare_data : Stmt.Located.t list)];
   [%expect
     {|
     (((pattern
@@ -88,7 +88,7 @@ let%expect_test "read param" =
   let m =
     Test_utils.mir_of_string
       "parameters { array[5] matrix<lower=0>[10, 20] mat; }" in
-  print_s [%sexp (m.log_prob : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (m.log_prob : Stmt.Located.t list)];
   [%expect
     {|
     (((pattern
@@ -110,7 +110,7 @@ let%expect_test "gen quant" =
   let m =
     Test_utils.mir_of_string
       "generated quantities { array[5] matrix<lower=0>[10, 20] mat; }" in
-  print_s [%sexp (m.generate_quantities : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (m.generate_quantities : Stmt.Located.t list)];
   [%expect
     {|
     (((pattern
@@ -168,7 +168,7 @@ let%expect_test "gen quant" =
 
 let%expect_test "read data - constraint " =
   let m = Test_utils.mir_of_string "data { array[5] real<lower=3.4> y; }" in
-  print_s [%sexp (m.prepare_data : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (m.prepare_data : Stmt.Located.t list)];
   [%expect
     {|
   (((pattern
@@ -200,7 +200,7 @@ let%expect_test "read data - tuple" =
   let m =
     Test_utils.mir_of_string "data { array[5] tuple(real, simplex[20]) x; }"
   in
-  print_s [%sexp (m.prepare_data : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (m.prepare_data : Stmt.Located.t list)];
   [%expect
     {|
     (((pattern

--- a/test/unit/Dataflow_utils.ml
+++ b/test/unit/Dataflow_utils.ml
@@ -1,7 +1,8 @@
 open Middle
 open Analysis_and_optimization.Dataflow_utils
-open Core
-open Core.Poly
+open Base
+open Common.Poly_containers
+open Base.Poly
 open Analysis_and_optimization.Dataflow_types
 
 (***********************************)
@@ -26,14 +27,14 @@ let%expect_test "Loop test" =
         (fun {meta; _} -> meta)
         {meta= Location_span.empty; pattern= block}) in
   let exits, preds = build_predecessor_graph statement_map in
-  print_s
+  Stdio.print_s
     [%sexp
       (statement_map
         : ( label
           , (Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t )
           Map.Poly.t)];
-  print_s [%sexp (exits : label Set.Poly.t)];
-  print_s [%sexp (preds : (label, label Set.Poly.t) Map.Poly.t)];
+  Stdio.print_s [%sexp (exits : label Set.Poly.t)];
+  Stdio.print_s [%sexp (preds : (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
     {|
       ((1
@@ -119,7 +120,7 @@ let%expect_test "Loop passthrough" =
         (fun {meta; _} -> meta)
         {meta= Location_span.empty; pattern= block}) in
   let exits, _ = build_predecessor_graph statement_map in
-  print_s [%sexp (exits : label Set.Poly.t)];
+  Stdio.print_s [%sexp (exits : label Set.Poly.t)];
   [%expect {|
       (1)
     |}]
@@ -171,7 +172,7 @@ let example1_statement_map =
       example1_program)
 
 let%expect_test "Statement label map example" =
-  print_s
+  Stdio.print_s
     [%sexp
       (Map.Poly.map example1_statement_map ~f:fst
         : (label, (Expr.Typed.t, label) Stmt.Pattern.t) Map.Poly.t)];
@@ -276,7 +277,7 @@ let%expect_test "Statement label map example" =
 
 let%expect_test "Predecessor graph example" =
   let exits, preds = build_predecessor_graph example1_statement_map in
-  print_s
+  Stdio.print_s
     [%sexp
       ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
@@ -290,7 +291,7 @@ let%expect_test "Predecessor graph example" =
 
 let%expect_test "Controlflow graph example" =
   let cf = build_cf_graph example1_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  Stdio.print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 ()) (6 (5)) (7 (5)) (8 (5)) (9 (5 13))
@@ -330,7 +331,7 @@ let example3_statement_map =
       example3_program)
 
 let%expect_test "Statement label map example 3" =
-  print_s
+  Stdio.print_s
     [%sexp
       (example3_statement_map
         : ( label
@@ -379,7 +380,7 @@ let%expect_test "Statement label map example 3" =
 
 let%expect_test "Controlflow graph example 3" =
   let cf = build_cf_graph example3_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  Stdio.print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
   [%expect {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 (4)) (6 ()))
     |}]
@@ -390,7 +391,7 @@ let%expect_test "Predecessor graph example 3" =
    * Similarly for for-loops.
    *)
   let exits, preds = build_predecessor_graph example3_statement_map in
-  print_s
+  Stdio.print_s
     [%sexp
       ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
@@ -424,7 +425,7 @@ let example4_statement_map =
       example4_program)
 
 let%expect_test "Statement label map example 4" =
-  print_s
+  Stdio.print_s
     [%sexp
       (example4_statement_map
         : ( label
@@ -478,7 +479,7 @@ let%expect_test "Statement label map example 4" =
 
 let%expect_test "Controlflow graph example 4" =
   let cf = build_cf_graph example4_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  Stdio.print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 (4)) (6 (4)) (7 (4 6)))
@@ -491,7 +492,7 @@ let%expect_test "Predecessor graph example 4" =
    * or a very conservative approximation
    * ( (7) ( (1 ()) (2 (1)) (3 (2)) (4 (3 6 7)) (5 (4)) (6 (5)) (7 (6)) ) )
    *)
-  print_s
+  Stdio.print_s
     [%sexp
       ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
@@ -526,7 +527,7 @@ let example5_statement_map =
       example5_program)
 
 let%expect_test "Statement label map example 5" =
-  print_s
+  Stdio.print_s
     [%sexp
       (example5_statement_map
         : ( label
@@ -585,7 +586,7 @@ let%expect_test "Statement label map example 5" =
 
 let%expect_test "Controlflow graph example 5" =
   let cf = build_cf_graph example5_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  Stdio.print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 (6)) (5 (4)) (6 (4)) (7 (4)) (8 ()))
@@ -596,7 +597,7 @@ let%expect_test "Predecessor graph example 5" =
   (* TODO: this is still very very conservative (e.g. I'd hope for (8) ((1 ()))
      (2 (1)) (3 (2)) (4 (3)) (5 (4)) (6 (5)) (7 ()) (8 (6)) but maybe that's too
      much to ask for ) *)
-  print_s
+  Stdio.print_s
     [%sexp
       ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
   [%expect

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -1,5 +1,5 @@
 open Analysis_and_optimization
-open Core
+open Base
 open Frontend
 open Debug_data_generation
 
@@ -20,7 +20,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -58,7 +58,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -108,7 +108,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -150,7 +150,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -329,7 +329,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -729,7 +729,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -862,7 +862,7 @@ let%expect_test "whole program data generation check" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {| { "K": 4, "N": 1, "player1": [ 2 ], "player0": [ 3 ], "y": [ 1 ] } |}]
 
@@ -880,7 +880,7 @@ let%expect_test "Complex numbers program" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {
@@ -927,7 +927,7 @@ let%expect_test "Tuples program" =
       |}
   in
   let str = print_data_prog ast in
-  print_string str;
+  Stdio.print_string str;
   [%expect
     {|
     {

--- a/test/unit/Dependence_analysis.ml
+++ b/test/unit/Dependence_analysis.ml
@@ -1,4 +1,5 @@
-open Core
+open Base
+open Common.Poly_containers
 open Analysis_and_optimization.Dependence_analysis
 open Middle
 open Analysis_and_optimization.Dataflow_types
@@ -40,7 +41,7 @@ let example1_program =
 
 let%expect_test "Dependency graph example" =
   let deps = log_prob_dependency_graph example1_program in
-  print_s [%sexp (deps : (label, label Set.Poly.t) Map.Poly.t)];
+  Stdio.print_s [%sexp (deps : (label, label Set.Poly.t) Map.Poly.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 (4)) (6 (4 5)) (7 (4 5)) (8 (4 5))
@@ -57,7 +58,7 @@ let%expect_test "Reaching defns example" =
       ~f:(fun (_, x) ->
         ( reaching_defn_lookup x.reaching_defn_entry (VVar "j")
         , reaching_defn_lookup x.reaching_defn_exit (VVar "j") )) in
-  print_s
+  Stdio.print_s
     [%sexp (deps : (label, label Set.Poly.t * label Set.Poly.t) Map.Poly.t)];
   [%expect
     {|
@@ -72,7 +73,7 @@ let%expect_test "Reaching defns example" =
   let deps =
     Map.Poly.map (log_prob_build_dep_info_map example1_program)
       ~f:(fun (_, x) -> (x.reaching_defn_entry, x.reaching_defn_exit)) in
-  print_s
+  Stdio.print_s
     [%sexp
       (deps
         : ( label
@@ -107,7 +108,7 @@ let%expect_test "Variable dependency example" =
       (log_prob_build_dep_info_map example1_program)
       (Set.Poly.singleton (VVar "j"))
       17 in
-  print_s [%sexp (deps : label Set.Poly.t)];
+  Stdio.print_s [%sexp (deps : label Set.Poly.t)];
   [%expect {|
       (4 5 9 11 13 14 16)
     |}]
@@ -161,7 +162,7 @@ let uninitialized_var_example =
 
 let%expect_test "Uninitialized variables example" =
   let deps = mir_uninitialized_variables uninitialized_var_example in
-  print_s [%sexp (deps : (Location_span.t * string) Set.Poly.t)];
+  Stdio.print_s [%sexp (deps : (Location_span.t * string) Set.Poly.t)];
   [%expect
     {|
       ((((begin_loc

--- a/test/unit/Desugar_test.ml
+++ b/test/unit/Desugar_test.ml
@@ -1,9 +1,9 @@
-open Core
+open! Base
 open Analysis_and_optimization
 
 let print_tdata Middle.Program.{prepare_data; _} =
   Fmt.(str "@[<v>%a@]@," (list ~sep:cut Middle.Stmt.Located.pp) prepare_data)
-  |> print_endline
+  |> Stdio.print_endline
 
 let%expect_test "matrix array multi indexing " =
   Test_utils.mir_of_string

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -1,11 +1,11 @@
-open Core
+open Base
 open Common
 
 let%expect_test "with_exn_message" =
-  Printexc.record_backtrace false;
+  Backtrace.Exn.set_recording false;
   ICE.with_exn_message (fun () -> failwith "oops!")
-  |> Result.error |> Option.value_exn |> print_endline;
-  Printexc.record_backtrace true;
+  |> Result.error |> Option.value_exn |> Stdio.print_endline;
+  Backtrace.Exn.set_recording true;
   [%expect
     {|
     Internal compiler error:
@@ -22,18 +22,18 @@ let%expect_test "backtrace indirect test" =
   |> Result.error |> Option.value_exn
   |> fun s ->
     if String.is_substring ~substring:"Called from Common" s then
-      print_endline "Backtrace found in message"
-    else print_endline "FAILED TO FIND BACKTRACE" );
+      Stdio.print_endline "Backtrace found in message"
+    else Stdio.print_endline "FAILED TO FIND BACKTRACE" );
   [%expect {| Backtrace found in message |}]
 
 let%expect_test "ICE triggered" =
-  Printexc.record_backtrace false;
+  Backtrace.Exn.set_recording false;
   ICE.with_exn_message (fun () ->
       Middle.(
         Expr.Helpers.infer_type_of_indexed UnsizedType.UReal
           [Index.Single Expr.Helpers.loop_bottom]))
-  |> Result.error |> Option.value_exn |> print_endline;
-  Printexc.record_backtrace true;
+  |> Result.error |> Option.value_exn |> Stdio.print_endline;
+  Backtrace.Exn.set_recording true;
   [%expect
     {|
     Internal compiler error:

--- a/test/unit/Factor_graph.ml
+++ b/test/unit/Factor_graph.ml
@@ -1,5 +1,6 @@
 open Analysis_and_optimization.Factor_graph
-open Core
+open Base
+open Common.Poly_containers
 open Analysis_and_optimization.Dataflow_types
 
 let reject_example =
@@ -42,7 +43,7 @@ let reject_example =
 
 let%expect_test "Factor graph reject example" =
   let deps = prog_factor_graph reject_example in
-  print_s [%sexp (deps : factor_graph)];
+  Stdio.print_s [%sexp (deps : factor_graph)];
   [%expect
     {|
       ((factor_map
@@ -90,7 +91,7 @@ let complex_example =
 
 let%expect_test "Factor graph complex example" =
   let deps = prog_factor_graph complex_example in
-  print_s [%sexp (deps : factor_graph)];
+  Stdio.print_s [%sexp (deps : factor_graph)];
   [%expect
     {|
 ((factor_map
@@ -383,7 +384,7 @@ let complex_example =
 
 let%expect_test "Priors complex example" =
   let priors = list_priors complex_example in
-  print_s
+  Stdio.print_s
     [%sexp
       (priors
         : ( vexpr

--- a/test/unit/In_memory_include_tests.ml
+++ b/test/unit/In_memory_include_tests.ml
@@ -1,11 +1,11 @@
-open Core
+open Base
 open Frontend
 
 let print_ast_or_error code =
   let () =
     match Test_utils.untyped_ast_of_string code with
-    | Result.Error e -> print_endline @@ Test_utils.error_to_string ~code e
-    | Result.Ok ast -> print_s [%sexp (ast : Ast.untyped_program)] in
+    | Result.Error e -> Stdio.print_endline @@ Test_utils.error_to_string ~code e
+    | Result.Ok ast -> Stdio.print_s [%sexp (ast : Ast.untyped_program)] in
   (* reset *) Include_files.include_provider := FileSystemPaths []
 
 let include_model = {|
@@ -17,7 +17,7 @@ data {
 
 (* TESTS *)
 let%expect_test "no includes" =
-  Include_files.include_provider := InMemory String.Map.empty;
+  Include_files.include_provider := InMemory (Map.empty (module String));
   print_ast_or_error include_model;
   [%expect
     {|
@@ -36,7 +36,7 @@ let%expect_test "no includes" =
 
 let%expect_test "wrong include" =
   Include_files.include_provider :=
-    InMemory (String.Map.of_alist_exn [("bar.stan", "functions { }")]);
+    InMemory (Map.of_alist_exn (module String) [("bar.stan", "functions { }")]);
   print_ast_or_error include_model;
   [%expect
     {|
@@ -66,7 +66,7 @@ let b = {|
 let%expect_test "recursive include" =
   Include_files.include_provider :=
     InMemory
-      (String.Map.of_alist_exn [("include/a.stan", a); ("include/b.stan", b)]);
+      (Map.of_alist_exn (module String) [("include/a.stan", a); ("include/b.stan", b)]);
   print_ast_or_error a;
   [%expect
     {|
@@ -93,7 +93,7 @@ functions {
 
 let%expect_test "good include" =
   Include_files.include_provider :=
-    InMemory (String.Map.of_alist_exn [("foo.stan", foo)]);
+    InMemory (Map.of_alist_exn (module String) [("foo.stan", foo)]);
   print_ast_or_error include_model;
   [%expect
     {|

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Analysis_and_optimization.Optimize
 open Middle
 open Common
@@ -28,7 +28,7 @@ let%expect_test "map_rec_stmt_loc" =
         Stmt.Pattern.NRFunApp (CompilerInternal FnPrint, [s; s])
     | x -> x in
   let mir = Program.map Fn.id (map_rec_stmt_loc f) Fn.id mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -72,8 +72,8 @@ let%expect_test "map_rec_state_stmt_loc" =
     (map_rec_state_stmt_loc f 0)
       Stmt.{pattern= SList mir.log_prob; meta= Location_span.empty} in
   let mir = {mir with log_prob= [mir_stmt]} in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
-  print_endline (string_of_int num);
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
+  Stdio.print_endline (Int.to_string num);
   [%expect
     {|
       log_prob {
@@ -118,7 +118,7 @@ let%expect_test "inline functions" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -180,7 +180,7 @@ let%expect_test "inline functions 2" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -234,7 +234,7 @@ let%expect_test "list collapsing" =
   in
   let mir = function_inlining mir in
   let mir = list_collapsing mir in
-  print_s [%sexp (mir : Middle.Program.Typed.t)];
+  Stdio.print_s [%sexp (mir : Middle.Program.Typed.t)];
   [%expect
     {|
 ((functions_block
@@ -415,7 +415,7 @@ let%expect_test "recursive functions" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -475,7 +475,7 @@ let%expect_test "do not try to inline extern functions" =
             |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
             functions {
@@ -519,7 +519,7 @@ let%expect_test "inline function in for loop" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -594,7 +594,7 @@ let%expect_test "inline function in for loop 2" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -677,7 +677,7 @@ let%expect_test "inline function in while loop" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -743,7 +743,7 @@ let%expect_test "inline function in if then else" =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -809,7 +809,7 @@ let%expect_test "inline function in ternary if " =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -888,7 +888,7 @@ let%expect_test "inline function multiple returns " =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -951,7 +951,7 @@ let%expect_test "inline function indices " =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -1008,7 +1008,7 @@ let%expect_test "inline function and " =
   in
   (* TODO: these declarations are still in the wrong place *)
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -1065,7 +1065,7 @@ let%expect_test "inline function or " =
       |}
   in
   let mir = function_inlining mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -1117,7 +1117,7 @@ let%expect_test "unroll nested loop" =
       |}
   in
   let mir = static_loop_unrolling mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1159,7 +1159,7 @@ let%expect_test "unroll nested loop 2" =
       |}
   in
   let mir = static_loop_unrolling mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1356,7 +1356,7 @@ let%expect_test "unroll nested loop 3" =
       |}
   in
   let mir = static_loop_unrolling mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1452,7 +1452,7 @@ let%expect_test "unroll nested loop with break" =
       |}
   in
   let mir = static_loop_unrolling mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1496,7 +1496,7 @@ let%expect_test "constant propagation" =
       |}
   in
   let mir = constant_propagation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
     prepare_data {
@@ -1541,7 +1541,7 @@ let%expect_test "constant propagation, local scope" =
       |}
   in
   let mir = constant_propagation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
     prepare_data {
@@ -1588,7 +1588,7 @@ let%expect_test "constant propagation, model block local scope" =
       |}
   in
   let mir = constant_propagation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
     log_prob {
@@ -1634,7 +1634,7 @@ let%expect_test "expression propagation" =
       |}
   in
   let mir = expression_propagation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       prepare_data {
@@ -1674,7 +1674,7 @@ let%expect_test "copy propagation" =
       |}
   in
   let mir = copy_propagation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1715,7 +1715,7 @@ let%expect_test "dead code elimination" =
       |}
   in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       prepare_data {
@@ -1757,7 +1757,7 @@ let%expect_test "dead code elimination decl" =
       |}
   in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1788,7 +1788,7 @@ let%expect_test "dead code elimination, for loop" =
       |}
   in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1820,7 +1820,7 @@ let%expect_test "dead code elimination, while loop" =
       |}
   in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1863,7 +1863,7 @@ let%expect_test "dead code elimination, if then" =
       |}
   in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1899,7 +1899,7 @@ let%expect_test "dead code elimination, nested" =
       |}
   in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1939,7 +1939,7 @@ let%expect_test "dead code elimination, real zero if (direct MIR)" =
             { pattern= IfElse (real_zero, print_hello, Some print_goodbye)
             ; meta= Location_span.empty } ] } in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -1968,7 +1968,7 @@ let%expect_test "dead code elimination, real zero while (direct MIR)" =
             {pattern= While (real_zero, print_hello); meta= Location_span.empty}
         ] } in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       generate_quantities {
@@ -1993,7 +1993,7 @@ let%expect_test "dead code elimination, real zero if no else (direct MIR)" =
             { pattern= IfElse (real_zero, print_hello, None)
             ; meta= Location_span.empty } ] } in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       generate_quantities {
@@ -2016,7 +2016,7 @@ let%expect_test "partial evaluation" =
       |}
   in
   let mir = partial_evaluation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2045,7 +2045,7 @@ let%expect_test "partial evaluate reject" =
       }
       |} in
   let mir = partial_evaluation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2076,7 +2076,7 @@ let%expect_test "try partially evaluate" =
       |}
   in
   let mir = partial_evaluation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2109,7 +2109,7 @@ let%expect_test "partially evaluate with equality check" =
       |}
   in
   let mir = partial_evaluation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2292,7 +2292,7 @@ model {
   in
   let mir = constant_propagation mir in
   let mir = partial_evaluation mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2497,7 +2497,7 @@ let%expect_test "lazy code motion" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
     log_prob {
@@ -2530,7 +2530,7 @@ let%expect_test "lazy code motion, 2" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2563,7 +2563,7 @@ let%expect_test "lazy code motion, 3" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2611,7 +2611,7 @@ let%expect_test "lazy code motion, 4" =
   let mir = list_collapsing mir in
   (* TODO: make sure that these temporaries do not get assigned level DataOnly
      unless appropriate *)
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2674,7 +2674,7 @@ let%expect_test "lazy code motion, 5" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2732,7 +2732,7 @@ let%expect_test "lazy code motion, 6" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2787,7 +2787,7 @@ let%expect_test "lazy code motion, 7" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2847,7 +2847,7 @@ let%expect_test "lazy code motion, 8, _lp functions not optimized" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       functions {
@@ -2897,7 +2897,7 @@ let%expect_test "lazy code motion, 9" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2931,7 +2931,7 @@ let%expect_test "lazy code motion, 10" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -2971,7 +2971,7 @@ let%expect_test "lazy code motion, 11" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -3011,7 +3011,7 @@ let%expect_test "lazy code motion, 12" =
   in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -3056,7 +3056,7 @@ let%expect_test "lazy code motion, 13" =
   let mir = one_step_loop_unrolling mir in
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -3124,7 +3124,7 @@ let%expect_test
   let mir = lazy_code_motion mir in
   let mir = list_collapsing mir in
   let mir = dead_code_elimination mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -3175,7 +3175,7 @@ let%expect_test "block fixing" =
                   , None )
             ; meta= Location_span.empty } ] } in
   let mir = block_fixing mir in
-  print_s [%sexp (mir : Program.Typed.t)];
+  Stdio.print_s [%sexp (mir : Program.Typed.t)];
   [%expect
     {|
       ((functions_block ()) (input_vars ()) (prepare_data ())
@@ -3233,7 +3233,7 @@ let%expect_test "one-step loop unrolling" =
       |}
   in
   let mir = one_step_loop_unrolling mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       prepare_data {
@@ -3301,7 +3301,7 @@ let%expect_test "adlevel_optimization" =
       |}
   in
   let mir = optimize_ad_levels mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -3370,7 +3370,7 @@ let%expect_test "adlevel_optimization expressions" =
       |}
   in
   let mir = optimize_ad_levels mir in
-  print_s [%sexp (mir.log_prob : Stmt.Located.t list)];
+  Stdio.print_s [%sexp (mir.log_prob : Stmt.Located.t list)];
   [%expect
     {|
       (((pattern
@@ -3506,7 +3506,7 @@ let%expect_test "adlevel_optimization 2" =
       |}
   in
   let mir = optimize_ad_levels mir in
-  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
+  Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> Stdio.print_endline;
   [%expect
     {|
       log_prob {
@@ -3562,5 +3562,5 @@ let%expect_test "Mapping acts recursively" =
       , [from] ) in
   let m = Expr.Typed.Map.of_alist_exn [(from, into)] in
   let s' = expr_subst_stmt_base m s in
-  Fmt.str "@[<v>%a@]" Stmt.Located.pp (unpattern s') |> print_endline;
+  Fmt.str "@[<v>%a@]" Stmt.Located.pp (unpattern s') |> Stdio.print_endline;
   [%expect {| (FnWriteParam(unconstrain_opt())(var y))__(y); |}]

--- a/test/unit/Parse_tests.ml
+++ b/test/unit/Parse_tests.ml
@@ -1,4 +1,4 @@
-open Core
+open Base
 open Frontend
 
 let print_ast_of_string code =
@@ -6,7 +6,7 @@ let print_ast_of_string code =
     Test_utils.untyped_ast_of_string code
     |> Result.map_error ~f:(Test_utils.error_to_string ~code)
     |> Result.ok_or_failwith in
-  print_s [%sexp (ast : Ast.untyped_program)]
+  Stdio.print_s [%sexp (ast : Ast.untyped_program)]
 
 (* TESTS *)
 let%expect_test "parse conditional" =

--- a/test/unit/Semantic_check_tests.ml
+++ b/test/unit/Semantic_check_tests.ml
@@ -1,4 +1,4 @@
-open Core
+open! Base
 open Frontend
 open Test_utils
 
@@ -11,7 +11,7 @@ transformed data {
 }
 |}
   |> typed_ast_of_string_exn |> Pretty_print_prog.pretty_print_typed_program
-  |> print_endline;
+  |> Stdio.print_endline;
   [%expect
     {|
     transformed data {

--- a/test/unit/Test_utils.ml
+++ b/test/unit/Test_utils.ml
@@ -1,5 +1,5 @@
 open Frontend
-open Core
+open Base
 
 let untyped_ast_of_string s =
   let res, warnings = Parse.parse_program (`Code s) in

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,7 +1,8 @@
 (library
  (name unit_tests)
  (libraries
-  core
+  common
+  base
   fmt
   frontend
   stan_math_backend
@@ -9,4 +10,10 @@
   analysis_and_optimization)
  (inline_tests)
  (preprocess
-  (pps ppx_jane)))
+  (pps
+   ppx_base
+   ppx_pipebang
+   ppx_sexp_message
+   ppx_sexp_value
+   ppx_expect
+   ppx_inline_test)))


### PR DESCRIPTION
## Summary

Removes the dependency on Jane Street's `core`, replacing it with the much lighter `base` + `stdio` (+ `sexplib0`). This shrinks the dependency footprint and build time, which is particularly relevant for the js_of_ocaml (`stancjs`) build.

- **Dependencies**: `core` → `base`, `stdio`, `sexplib0`. The `ppx_jane` bundle is replaced with only the rewriters actually used: `ppx_base`, `ppx_pipebang`, `ppx_sexp_message`, `ppx_sexp_value`, `ppx_expect`, `ppx_inline_test`.
- **Mechanical changes**: `open Base` instead of `open Core`; I/O goes through `Stdio`; stdlib modules that Base deprecates (`Format`, `Obj`, `Scanf`, `Marshal`, …) are qualified with `Stdlib`.
- **Core-only APIs replaced**:
  - `String.{Map,Set,Table,Hash_set}` → Base's comparator-passing style (`Map.M(String).t`, `Set.of_list (module String)`, `Hashtbl.create (module String)`, …)
  - `Expr.Typed`'s `Map`/`Set` submodules (previously from `Core.Comparable.S`, which Base does not provide) are now small explicit submodules exposing exactly the operations used.
  - `Map.Make_using_comparator`, `Set.of_map_keys`, `fst3` → Base equivalents.
- **New module** `Common.Poly_containers`: Base's `Set.Poly`/`Map.Poly` lack sexp converters, so this provides `sexp_of_t` for both in Core's exact output format — which is why no expect-test output changed.
- The `Generated_signatures` code generator now emits `Base.Hashtbl` instead of `Core.String.Table`.

## Notes for reviewers

- `ppx_jane` silently included **ppx_pipebang** (rewrites `x |> f` to `f x` at parse time), and the codebase depends on it: e.g. `|> UnsizedType.UArray` (constructor after pipe) and several places where record/constructor disambiguation only typechecks with the pipe inlined. It is kept as an explicit dependency.
- Two tiny semantic substitutions: `elt ** 2.` → `elt *. elt` (Base makes `**` integer exponentiation) and `Operator.of_string_opt` builds its `Sexp.Atom` directly instead of going through the deprecated `Sexp.of_string`.

## Testing

- `dune build @all` clean
- `dune runtest` (unit expect tests + integration cram suite): all pass **without a single expected-output change**
- `dune build @runjstest` (stancjs under node): passes
- Smoke-tested the `stanc` binary end-to-end on an integration model

🤖 Generated with [Claude Code](https://claude.com/claude-code)