### PR TITLE
Remove dependency on Core in favor of small wrapper around Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-# rust
-/rust/target
-/bindgen_test/target
-**/*.rs.bk
-Cargo.lock
-math_iface/gen/*
-*.a
-
 # ocaml
 _opam
 _build
@@ -39,5 +31,4 @@ test/*.log
 # .hpp files in test folder
 test/**/*.hpp
 
-# .omir files in test folder
-test/**/*.omir
+compile_flags.txt

--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -12,7 +12,7 @@ These are automatically installed through the [scripts/install_ocaml.sh] and
 
 - OCaml 5.5.0
 - Dune 3.5+
-- {{:https://v3.ocaml.org/p/base/latest/doc/index.html}Base} v0.17.0 (a standard library replacement/supplement)
+- {{:https://ocaml.org/p/base/v0.17.3/doc/index.html}Base} v0.17.3 (a standard library replacement)
 - {{:http://gallium.inria.fr/~fpottier/menhir/manual.html}Menhir} 20260209 (a parser generator and parsing library)
 - {{:https://github.com/ocaml-ppx/ppx_deriving}ppx_deriving} 6.1.1 (a tool for generating boilerplate code)
 - {{:https://erratique.ch/software/fmt}fmt} 0.11.0 (a library for pretty-printing of formatted text)

--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -12,7 +12,7 @@ These are automatically installed through the [scripts/install_ocaml.sh] and
 
 - OCaml 5.5.0
 - Dune 3.5+
-- {{:https://v3.ocaml.org/p/core/latest/doc/index.html}Core} v0.17.2 (a standard library replacement)
+- {{:https://v3.ocaml.org/p/base/latest/doc/index.html}Base} v0.17.0 (a standard library replacement/supplement)
 - {{:http://gallium.inria.fr/~fpottier/menhir/manual.html}Menhir} 20260209 (a parser generator and parsing library)
 - {{:https://github.com/ocaml-ppx/ppx_deriving}ppx_deriving} 6.1.1 (a tool for generating boilerplate code)
 - {{:https://erratique.ch/software/fmt}fmt} 0.11.0 (a library for pretty-printing of formatted text)

--- a/dune-project
+++ b/dune-project
@@ -15,8 +15,10 @@
  (depends
   (ocaml
    (= 5.5.0))
-  (core
-   (= v0.17.2))
+  (base
+   (= v0.17.3))
+  (stdio
+   (= v0.17.0))
   (menhir
    (= 20260209))
   (ppx_deriving

--- a/dune-project
+++ b/dune-project
@@ -21,14 +21,22 @@
    (= v0.17.0))
   (menhir
    (= 20260209))
-  (ppx_deriving
-   (= 6.1.1))
   (fmt
    (= 0.11.0))
   (yojson
    (= 3.0.0))
   (cmdliner
    (= 2.1.1))
+  (ppx_deriving
+   (= 6.1.1))
+  ppx_hash
+  ppx_compare
+  ppx_sexp_conv
+  ppx_expect
+  ppx_inline_test
+  ppx_pipebang
+  ppx_sexp_value
+  ppx_sexp_message
   (ocamlformat
    (and
     :with-dev-setup

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -7,6 +7,7 @@ eval $(opam env)
 
 opam pin -y base v0.17.3 --no-action
 
-opam install -y dune base.v0.17.3 stdio.v0.17.0 menhir.20260209 ppx_deriving.6.1.1 fmt.0.11.0 yojson.3.0.0 cmdliner.2.1.1
+opam install -y dune base.v0.17.3 stdio.v0.17.0 menhir.20260209 ppx_deriving.6.1.1 fmt.0.11.0 yojson.3.0.0 cmdliner.2.1.1\
+     ppx_hash ppx_compare ppx_sexp_conv ppx_expect ppx_inline_test ppx_pipebang ppx_sexp_value ppx_sexp_message
 
 eval $(opam env)

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -5,8 +5,8 @@ set -e
 
 eval $(opam env)
 
-opam pin -y core v0.17.2 --no-action
+opam pin -y base v0.17.3 --no-action
 
-opam install -y dune core.v0.17.2 menhir.20260209 ppx_deriving.6.1.1 fmt.0.11.0 yojson.3.0.0 cmdliner.2.1.1
+opam install -y dune base.v0.17.3 stdio.v0.17.0 menhir.20260209 ppx_deriving.6.1.1 fmt.0.11.0 yojson.3.0.0 cmdliner.2.1.1
 
 eval $(opam env)

--- a/scripts/install_build_deps_windows.sh
+++ b/scripts/install_build_deps_windows.sh
@@ -14,7 +14,9 @@ opam pin add -y ocaml-windows 5.5.0
 
 # Install dependencies
 opam install -y base.v0.17.3 base-windows.v0.17.3 stdio.v0.17.0 stdio-windows.v0.17.0 menhir.20260209 menhir-windows.20260209\
-     ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1 fmt.0.11.0 fmt-windows.0.11.0 yojson.3.0.0 yojson-windows.3.0.0\
-     cmdliner.2.1.1 cmdliner-windows.2.1.1
+     fmt.0.11.0 fmt-windows.0.11.0 yojson.3.0.0 yojson-windows.3.0.0 cmdliner.2.1.1 cmdliner-windows.2.1.1\
+     ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1 ppx_hash ppx_hash-windows ppx_compare ppx_compare-windows ppx_sexp_conv\
+     ppx_sexp_conv-windows ppx_expect ppx_expect-windows ppx_inline_test ppx_inline_test-windows ppx_pipebang\
+     ppx_pipebang-windows ppx_sexp_value ppx_sexp_value-windows ppx_sexp_message ppx_sexp_message-windows
 
 eval $(opam env)

--- a/scripts/install_build_deps_windows.sh
+++ b/scripts/install_build_deps_windows.sh
@@ -13,7 +13,8 @@ opam repository add windows http://github.com/ocaml-cross/opam-cross-windows.git
 opam pin add -y ocaml-windows 5.5.0
 
 # Install dependencies
-opam install -y core.v0.17.2 core-windows.v0.17.2 menhir.20260209 menhir-windows.20260209 ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1\
- fmt.0.11.0 fmt-windows.0.11.0 yojson.3.0.0 yojson-windows.3.0.0 cmdliner.2.1.1 cmdliner-windows.2.1.1
+opam install -y base.v0.17.3 base-windows.v0.17.3 stdio.v0.17.0 stdio-windows.v0.17.0 menhir.20260209 menhir-windows.20260209\
+     ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1 fmt.0.11.0 fmt-windows.0.11.0 yojson.3.0.0 yojson-windows.3.0.0\
+     cmdliner.2.1.1 cmdliner-windows.2.1.1
 
 eval $(opam env)

--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -134,7 +134,7 @@ let gen_row_vector m n t =
 let sum_to_zero_floats n =
   let l = random_floats n in
   let sum = List.fold l ~init:0. ~f:( +. ) in
-  List.map l ~f:(fun x -> x -. (sum /. float_of_int n))
+  List.map l ~f:(fun x -> x -. (sum /. Float.of_int n))
 
 let simplex_floats n =
   let l = random_floats n in
@@ -337,9 +337,9 @@ open Yojson
 let json_to_mir (decls : (Expr.Typed.t SizedType.t * 'a * string) list)
     (json : Yojson.Basic.t) =
   let rec create_expr (type_ : UnsizedType.t) (json : Basic.t) =
-    let as_float = function `Int i -> float_of_int i | `Float f -> f in
+    let as_float = function `Int i -> Float.of_int i | `Float f -> f in
     let try_float = function
-      | `Int i -> Some (float_of_int i)
+      | `Int i -> Some (Float.of_int i)
       | `Float f -> Some f
       | _ -> None in
     let try_complex = function
@@ -371,7 +371,7 @@ let json_to_mir (decls : (Expr.Typed.t SizedType.t * 'a * string) list)
     | `Assoc l, UTuple ts ->
         l
         |> List.sort ~compare:(fun (x, _) (y, _) ->
-            Int.compare (int_of_string x) (int_of_string y))
+            Int.compare (Int.of_string x) (Int.of_string y))
         |> List.map2_exn ~f:(fun typ_ (_, json) -> create_expr typ_ json) ts
         |> Option.all
         |> Option.map ~f:(fun l -> Expr.Helpers.tuple_expr l)
@@ -398,7 +398,7 @@ let generate_json_entries (name, expr) : string * t =
         `List (List.map ~f:expr_to_json l)
     | FunApp (CompilerInternal FnMakeTuple, l) ->
         `Assoc
-          (List.mapi ~f:(fun i t -> (string_of_int (i + 1), expr_to_json t)) l)
+          (List.mapi ~f:(fun i t -> (Int.to_string (i + 1), expr_to_json t)) l)
     | FunApp (StanLib (transpose, _, _), [e])
       when String.equal transpose (Operator.to_string Transpose) ->
         expr_to_json e

--- a/src/analysis_and_optimization/Factor_graph.ml
+++ b/src/analysis_and_optimization/Factor_graph.ml
@@ -14,7 +14,7 @@ type factor =
 type factor_graph =
   { factor_map: (factor * label, vexpr Set.Poly.t) Map.Poly.t
   ; var_map: (vexpr, (factor * label) Set.Poly.t) Map.Poly.t }
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 let extract_factors_statement stmt =
   match stmt with

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -24,7 +24,7 @@ let rec num_expr_value (v : Expr.Typed.t) : (float * string) option =
   (* internal type promotions should be ignored *)
   | {pattern= Pattern.Promotion (e, _, _); _} -> num_expr_value e
   | {pattern= Pattern.Lit ((Real | Int), str); _} ->
-      Some (float_of_string str, str)
+      Some (Float.of_string str, str)
   | {pattern= Pattern.FunApp (StanLib ("PMinus__", FnPlain, _), [v]); _} -> (
       match num_expr_value v with
       | Some (v, s) -> Some (-.v, "-" ^ s)

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -271,7 +271,7 @@ let stmt_rhs stmt =
    |Break | Continue | Skip | Decl _ | Profile _ | Block _ | SList _ ->
       Set.Poly.empty
 
-let union_map (set : ('a, 'c) Set_intf.Set.t) ~(f : 'a -> 'b Set.Poly.t) =
+let union_map (set : ('a, 'c) Set.t) ~(f : 'a -> 'b Set.Poly.t) =
   Set.fold set ~init:Set.Poly.empty ~f:(fun s a -> Set.union s (f a))
 
 let stmt_rhs_var_set stmt = union_map (stmt_rhs stmt) ~f:expr_var_set

--- a/src/analysis_and_optimization/Mir_utils.mli
+++ b/src/analysis_and_optimization/Mir_utils.mli
@@ -160,12 +160,12 @@ val name_subst_stmt :
     provided Map. *)
 
 val expr_subst_expr :
-  Expr.Typed.t Expr.Typed.Map.t -> Expr.Typed.t -> Expr.Typed.t
+  Expr.Typed.t Map.M(Expr.Typed).t -> Expr.Typed.t -> Expr.Typed.t
 (** Substitute subexpressions in an expression according to the provided Map,
     trying to match on larger subexpressions before smaller ones. *)
 
 val expr_subst_stmt_base :
-     Expr.Typed.t Expr.Typed.Map.t
+     Expr.Typed.t Map.M(Expr.Typed).t
   -> (Expr.Typed.t, 'a) Stmt.Pattern.t
   -> (Expr.Typed.t, 'a) Stmt.Pattern.t
 (** Substitute subexpressions occurring at the top level in statements according

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -24,7 +24,7 @@ let print_mfp to_string (mfp : (int, 'a entry_exit) Map.Poly.t)
     [%sexp (s : Stmt.Located.Non_recursive.t)] |> Sexp.to_string_hum in
   Map.iteri mfp ~f:(fun ~key ~data ->
       print_endline
-        (string_of_int key ^ ":\n "
+        (Int.to_string key ^ ":\n "
         ^ print_stmt (Map.Poly.find_exn flowgraph_to_mir key)
         ^ ":\n " ^ print_set data.entry ^ " \t-> " ^ print_set data.exit))
 

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -6,6 +6,14 @@ open Monotone_framework_sigs
 open Mir_utils
 open Middle
 
+module Expr_set = struct
+  type t = Set.M(Expr.Typed).t
+
+  let empty = Set.empty (module Expr.Typed)
+  let singleton = Set.singleton (module Expr.Typed)
+  let union_list = Set.union_list (module Expr.Typed)
+end
+
 (** Debugging tool to print out MFP sets **)
 let print_mfp to_string (mfp : (int, 'a entry_exit) Map.Poly.t)
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) : unit =
@@ -204,28 +212,28 @@ let dual_powerset_lattice (type v)
   end : LATTICE
     with type properties = v Set.Poly.t)
 
-let powerset_lattice_expressions (initial : Expr.Typed.Set.t) =
+let powerset_lattice_expressions (initial : Expr_set.t) =
   (module struct
-    type properties = Expr.Typed.Set.t
+    type properties = Expr_set.t
 
-    let bottom = Expr.Typed.Set.empty
+    let bottom = Expr_set.empty
     let lub s1 s2 = Set.union s1 s2
     let leq s1 s2 = Set.is_subset s1 ~of_:s2
     let initial = initial
   end : LATTICE
-    with type properties = Expr.Typed.Set.t)
+    with type properties = Expr_set.t)
 
-let dual_powerset_lattice_expressions (initial : Expr.Typed.Set.t)
-    (total : Expr.Typed.Set.t) =
+let dual_powerset_lattice_expressions (initial : Expr_set.t)
+    (total : Expr_set.t) =
   (module struct
-    type properties = Expr.Typed.Set.t
+    type properties = Expr_set.t
 
     let bottom = total
     let lub s1 s2 = Set.inter s1 s2
     let leq s1 s2 = Set.is_subset s2 ~of_:s1
     let initial = initial
   end : LATTICE
-    with type properties = Expr.Typed.Set.t)
+    with type properties = Expr_set.t)
 
 (** Add a fresh bottom element to a lattice (possibly without bottom) *)
 let new_bot (type p) (module L : LATTICE_NO_BOT with type properties = p) =
@@ -578,45 +586,43 @@ let live_variables_transfer (never_kill : string Set.Poly.t)
 
 (** Calculate the set of sub-expressions of an expression *)
 let rec used_subexpressions_expr (e : Expr.Typed.t) =
-  Set.union
-    (Expr.Typed.Set.singleton e)
+  Set.union (Expr_set.singleton e)
     (match e.pattern with
-    | Var _ | Lit (_, _) -> Expr.Typed.Set.empty
+    | Var _ | Lit (_, _) -> Expr_set.empty
     | Promotion (expr, _, _) -> used_subexpressions_expr expr
     | FunApp (k, l) ->
-        Expr.Typed.Set.union_list
+        Expr_set.union_list
           (List.map ~f:used_subexpressions_expr (l @ Fun_kind.collect_exprs k))
     | TernaryIf (e1, e2, e3) ->
-        Expr.Typed.Set.union_list
+        Expr_set.union_list
           [ used_subexpressions_expr e1; used_subexpressions_expr e2
           ; used_subexpressions_expr e3 ]
     | Indexed (e, l) ->
-        Expr.Typed.Set.union_list
+        Expr_set.union_list
           (used_subexpressions_expr e
           :: List.map ~f:(used_expressions_idx_help used_subexpressions_expr) l
           )
     | TupleProjection (e, _) -> used_subexpressions_expr e
     | EAnd (e1, e2) | EOr (e1, e2) ->
-        Expr.Typed.Set.union_list
+        Expr_set.union_list
           [used_subexpressions_expr e1; used_subexpressions_expr e2])
 
 and used_expressions_idx_help f (i : Expr.Typed.t Index.t) =
   match i with
-  | All -> Expr.Typed.Set.empty
+  | All -> Expr_set.empty
   | Single e | Upfrom e | MultiIndex e -> f e
   | Between (e1, e2) -> Set.union (f e1) (f e2)
 
 let rec used_expressions_lval f
     ((lval, idxs) : Expr.Typed.t Stmt.Pattern.lvalue) =
   let used_idx =
-    Expr.Typed.Set.union_list (List.map ~f:(used_expressions_idx_help f) idxs)
-  in
+    Expr_set.union_list (List.map ~f:(used_expressions_idx_help f) idxs) in
   match lval with
   | LVariable _ -> used_idx
   | LTupleProjection (e, _) -> Set.union used_idx (used_expressions_lval f e)
 
 (** Calculate the set of expressions of an expression *)
-let used_expressions_expr e = Expr.Typed.Set.singleton e
+let used_expressions_expr e = Expr_set.singleton e
 
 let rec used_expressions_stmt_help f
     (s : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t) =
@@ -626,25 +632,25 @@ let rec used_expressions_stmt_help f
       f e
   | Assignment (l, _, e) -> Set.union (f e) (used_expressions_lval f l)
   | IfElse (e, b1, Some b2) ->
-      Expr.Typed.Set.union_list
+      Expr_set.union_list
         [ f e; used_expressions_stmt_help f b1.pattern
         ; used_expressions_stmt_help f b2.pattern ]
   | NRFunApp (k, l) ->
-      Expr.Typed.Set.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
-  | Decl _ | Return None | Break | Continue | Skip -> Expr.Typed.Set.empty
+      Expr_set.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
+  | Decl _ | Return None | Break | Continue | Skip -> Expr_set.empty
   | IfElse (e, b, None) | While (e, b) ->
       Set.union (f e) (used_expressions_stmt_help f b.pattern)
   | For {lower= e1; upper= e2; body= b; loopvar= s} ->
-      Expr.Typed.Set.union_list
+      Expr_set.union_list
         [ f e1; f e2; used_expressions_stmt_help f b.pattern
-        ; Expr.Typed.Set.singleton
+        ; Expr_set.singleton
             { pattern= Var s
             ; meta=
                 Expr.Typed.Meta.
                   {type_= UInt; adlevel= DataOnly; loc= Location_span.empty} }
         ]
   | Profile (_, l) | Block l | SList l ->
-      Expr.Typed.Set.union_list
+      Expr_set.union_list
         (List.map ~f:(fun s -> used_expressions_stmt_help f s.pattern) l)
 
 (** Calculate the set of sub-expressions in a statement *)
@@ -662,12 +668,12 @@ let top_used_expressions_stmt_help f (s : (Expr.Typed.t, int) Stmt.Pattern.t) =
   | Assignment (l, _, e) -> Set.union (f e) (used_expressions_lval f l)
   | While (e, _) | IfElse (e, _, _) -> f e
   | NRFunApp (k, l) ->
-      Expr.Typed.Set.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
+      Expr_set.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
   | Profile _ | Block _ | SList _ | Decl _
    |Return None
    |Break | Continue | Skip ->
-      Expr.Typed.Set.empty
-  | For {lower= e1; upper= e2; _} -> Expr.Typed.Set.union_list [f e1; f e2]
+      Expr_set.empty
+  | For {lower= e1; upper= e2; _} -> Expr_set.union_list [f e1; f e2]
 
 (** Calculate the set of sub-expressions at the top level in a statement *)
 let top_used_subexpressions_stmt =
@@ -680,7 +686,7 @@ let top_used_expressions_stmt =
 (** Calculate the subset (of p) of expressions that will need to be recomputed
     as a consequence of evaluating the statement s (because of writes to
     variables performed by s) *)
-let killed_expressions_stmt (p : Expr.Typed.Set.t)
+let killed_expressions_stmt (p : Expr_set.t)
     (s : (Expr.Typed.t, int) Stmt.Pattern.t) =
   Set.filter p ~f:(fun e ->
       let free_vars = free_vars_expr e in
@@ -703,10 +709,10 @@ let used (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
     lazy code motion) *)
 let anticipated_expressions_transfer
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
-    (used : (int, Expr.Typed.Set.t) Map.Poly.t) =
+    (used : (int, Expr_set.t) Map.Poly.t) =
   (module struct
     type labels = int
-    type properties = Expr.Typed.Set.t
+    type properties = Expr_set.t
 
     let transfer_function l p =
       let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
@@ -715,7 +721,7 @@ let anticipated_expressions_transfer
       transfer_gen_kill p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr.Typed.Set.t)
+     and type properties = Expr_set.t)
 
 (** A helper function for defining transfer functions in terms of gen and kill
     sets in an alternative way, that is used in some of the subanalyses of lazy
@@ -730,10 +736,10 @@ let transfer_gen_kill_alt p gen kill = Set.diff (Set.union p gen) kill
 (** An available expressions analysis, to be used in lazy code motion *)
 let available_expressions_transfer
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
-    (anticipated_expressions : (int, Expr.Typed.Set.t entry_exit) Map.Poly.t) =
+    (anticipated_expressions : (int, Expr_set.t entry_exit) Map.Poly.t) =
   (module struct
     type labels = int
-    type properties = Expr.Typed.Set.t
+    type properties = Expr_set.t
 
     let transfer_function l p =
       let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
@@ -742,13 +748,12 @@ let available_expressions_transfer
       transfer_gen_kill_alt p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr.Typed.Set.t)
+     and type properties = Expr_set.t)
 
 (** Calculates the set of expressions that can be calculated for the first time
     at each node in the flow graph *)
-let earliest
-    (anticipated_expressions : (int, Expr.Typed.Set.t entry_exit) Map.Poly.t)
-    (available_expressions : (int, Expr.Typed.Set.t entry_exit) Map.Poly.t) =
+let earliest (anticipated_expressions : (int, Expr_set.t entry_exit) Map.Poly.t)
+    (available_expressions : (int, Expr_set.t entry_exit) Map.Poly.t) =
   Map.fold anticipated_expressions ~init:Map.Poly.empty
     ~f:(fun ~key ~data accum ->
       Map.set accum ~key
@@ -757,12 +762,11 @@ let earliest
 
 (** The transfer function for a postponable expressions analysis (as a part of
     lazy code motion) *)
-let postponable_expressions_transfer
-    (earliest : (int, Expr.Typed.Set.t) Map.Poly.t)
-    (used : (int, Expr.Typed.Set.t) Map.Poly.t) =
+let postponable_expressions_transfer (earliest : (int, Expr_set.t) Map.Poly.t)
+    (used : (int, Expr_set.t) Map.Poly.t) =
   (module struct
     type labels = int
-    type properties = Expr.Typed.Set.t
+    type properties = Expr_set.t
 
     let transfer_function l p =
       let gen = Map.find_exn earliest l in
@@ -770,14 +774,14 @@ let postponable_expressions_transfer
       transfer_gen_kill_alt p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr.Typed.Set.t)
+     and type properties = Expr_set.t)
 
 (** Calculates the set of expressions that can be computed at the latest at each
     node *)
 let latest (successors : (int, int Set.Poly.t) Map.Poly.t)
-    (earliest : (int, Expr.Typed.Set.t) Map.Poly.t)
-    (postponable_expressions : (int, Expr.Typed.Set.t entry_exit) Map.Poly.t)
-    (used : (int, Expr.Typed.Set.t) Map.Poly.t) =
+    (earliest : (int, Expr_set.t) Map.Poly.t)
+    (postponable_expressions : (int, Expr_set.t entry_exit) Map.Poly.t)
+    (used : (int, Expr_set.t) Map.Poly.t) =
   let earliest_or_postponable key =
     Set.union
       (Map.Poly.find_exn earliest key)
@@ -792,12 +796,11 @@ let latest (successors : (int, int Set.Poly.t) Map.Poly.t)
 
 (** The transfer function for a used-not-latest expressions analysis, as a part
     of lazy code motion *)
-let used_not_latest_expressions_transfer
-    (used : (int, Expr.Typed.Set.t) Map.Poly.t)
-    (latest : (int, Expr.Typed.Set.t) Map.Poly.t) =
+let used_not_latest_expressions_transfer (used : (int, Expr_set.t) Map.Poly.t)
+    (latest : (int, Expr_set.t) Map.Poly.t) =
   (module struct
     type labels = int
-    type properties = Expr.Typed.Set.t
+    type properties = Expr_set.t
 
     let transfer_function l p =
       let gen = Map.find_exn used l in
@@ -805,7 +808,7 @@ let used_not_latest_expressions_transfer
       transfer_gen_kill_alt p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr.Typed.Set.t)
+     and type properties = Expr_set.t)
 
 (** The transfer function for the first forward analysis part of determining
     optimal ad-levels for variables *)
@@ -1038,8 +1041,8 @@ let lazy_expressions_mfp
   (* TODO: this could probably be done in a nicer way *)
   let used_expr = used flowgraph_to_mir in
   let (module Lattice1) =
-    dual_powerset_lattice_expressions Expr.Typed.Set.empty all_expressions in
-  let (module Lattice2) = powerset_lattice_expressions Expr.Typed.Set.empty in
+    dual_powerset_lattice_expressions Expr_set.empty all_expressions in
+  let (module Lattice2) = powerset_lattice_expressions Expr_set.empty in
   let (module Transfer1) =
     anticipated_expressions_transfer flowgraph_to_mir used_expr in
   let (module Mf1) =

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -967,7 +967,8 @@ let lazy_code_motion ?(preserve_stability = false) (mir : Program.Typed.t) =
       in
       Set.fold
         (Monotone_framework.used_expressions_stmt s.pattern)
-        ~init:Expr.Typed.Map.empty ~f:collect_expressions in
+        ~init:(Map.empty (module Expr.Typed))
+        ~f:collect_expressions in
     (* TODO: it'd be more efficient to just not accumulate constants in the
        static analysis *)
     let declarations_list =

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -8,7 +8,7 @@ exception Rejected of Location_span.t * string
 
 let rec is_int query Expr.{pattern; _} =
   match pattern with
-  | Lit (Int, i) | Lit (Real, i) -> float_of_string i = float_of_int query
+  | Lit (Int, i) | Lit (Real, i) -> Float.of_string i = Float.of_int query
   | Promotion (e, _, _) -> is_int query e
   | _ -> false
 

--- a/src/analysis_and_optimization/dune
+++ b/src/analysis_and_optimization/dune
@@ -7,4 +7,4 @@
  (inline_tests)
  (modules_without_implementation monotone_framework_sigs)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_compare ppx_sexp_conv ppx_expect ppx_sexp_value ppx_sexp_message)))

--- a/src/common/dune
+++ b/src/common/dune
@@ -3,6 +3,6 @@
  (public_name stanc.common)
  (libraries core fmt)
  (preprocess
-  (pps ppx_jane ppx_deriving.fold ppx_deriving.map))
+  (pps ppx_sexp_conv ppx_sexp_message ppx_deriving.fold ppx_deriving.map))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/core/Core.ml
+++ b/src/core/Core.ml
@@ -1,5 +1,6 @@
-(** This module shadows [core] from Jane Street with a more lightweight version
-    that only depends on Base, Sexplib0, and Stdio. *)
+(** This module is intended to be a drop-in replacement for our previous use of
+    [core] from Jane Street. This lightweight module only depends on Base,
+    Sexplib0, and Stdio. *)
 
 include Base
 include Stdio

--- a/src/core/Core.ml
+++ b/src/core/Core.ml
@@ -1,0 +1,100 @@
+(** This module shadows [core] from Jane Street with a more lightweight version
+    that only depends on Base, Sexplib0, and Stdio. *)
+
+include Base
+include Stdio
+
+(** We make a few modules look more like their Core equivalents *)
+
+module Set = struct
+  include Set
+
+  let of_map_keys m = Set.Poly.of_list (Map.keys m)
+
+  module Poly = struct
+    include Set.Poly
+
+    let sexp_of_t sexp_of_elt s =
+      List.sexp_of_t sexp_of_elt (Base.Set.to_list s)
+  end
+end
+
+module Map = struct
+  include Map
+
+  module Poly = struct
+    include Map.Poly
+
+    let sexp_of_t sexp_of_key sexp_of_data m =
+      List.sexp_of_t
+        (fun (k, v) -> Sexp.List [sexp_of_key k; sexp_of_data v])
+        (Base.Map.to_alist m)
+  end
+end
+
+module String = struct
+  include Base.String
+
+  module Table = struct
+    include Base.Hashtbl.M (Base.String)
+
+    let create () = Base.Hashtbl.create (module Base.String)
+    let of_alist_exn l = Base.Hashtbl.of_alist_exn (module Base.String) l
+  end
+
+  module Hash_set = struct
+    include Base.Hash_set.M (Base.String)
+
+    let create () = Base.Hash_set.create (module Base.String)
+  end
+
+  module Set = struct
+    include Base.Set.M (Base.String)
+
+    let of_list l = Base.Set.of_list (module Base.String) l
+    let empty = Base.Set.empty (module Base.String)
+    let sexp_of_t t = Base.Set.sexp_of_m__t (module Base.String) t
+    let union_list l = Base.Set.union_list (module Base.String) l
+  end
+
+  module Map = struct
+    include Base.Map.M (Base.String)
+
+    let empty = Base.Map.empty (module Base.String)
+    let of_alist_exn l = Base.Map.of_alist_exn (module Base.String) l
+    let of_alist_reduce l = Base.Map.of_alist_reduce (module Base.String) l
+  end
+end
+
+module Sexp = struct
+  include Base.Sexp
+
+  let of_string = Sexplib0.Sexp_conv.sexp_of_string
+end
+
+(** And declare some free functions that Core does *)
+
+let fst3 (v, _, _) = v
+let sprintf = Printf.sprintf
+
+(** Finally, we re-export a bunch of stuff from Stdlib that Base shadowed *)
+
+module Format = Stdlib.Format
+module Printexc = Stdlib.Printexc
+module Fun = Stdlib.Fun
+module Marshal = Stdlib.Marshal
+module Printf = Stdlib.Printf
+module Scanf = Stdlib.Scanf
+module Obj = Stdlib.Obj
+
+let ( ^^ ) = Stdlib.( ^^ )
+let ( ** ) = Stdlib.( ** )
+let string_of_int = Stdlib.string_of_int
+let int_of_string = Stdlib.int_of_string
+let int_of_string_opt = Stdlib.int_of_string_opt
+let float_of_string = Stdlib.float_of_string
+let float_of_string_opt = Stdlib.float_of_string_opt
+let float_of_int = Stdlib.float_of_int
+let exit = Stdlib.exit
+
+type ('a, 'b) result = ('a, 'b) Stdlib.result

--- a/src/core/Core.ml
+++ b/src/core/Core.ml
@@ -89,12 +89,6 @@ module Obj = Stdlib.Obj
 
 let ( ^^ ) = Stdlib.( ^^ )
 let ( ** ) = Stdlib.( ** )
-let string_of_int = Stdlib.string_of_int
-let int_of_string = Stdlib.int_of_string
-let int_of_string_opt = Stdlib.int_of_string_opt
-let float_of_string = Stdlib.float_of_string
-let float_of_string_opt = Stdlib.float_of_string_opt
-let float_of_int = Stdlib.float_of_int
 let exit = Stdlib.exit
 
 type ('a, 'b) result = ('a, 'b) Stdlib.result

--- a/src/core/dune
+++ b/src/core/dune
@@ -1,0 +1,6 @@
+(library
+ (name core)
+ (public_name stanc.core)
+ (libraries base stdio sexplib0)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -12,4 +12,4 @@
   (backend bisect_ppx))
  (inline_tests)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_inline_test ppx_sexp_value)))

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -428,7 +428,7 @@ let rec check_decl var decl_type' decl_trans smeta adlevel =
 
 let check_sizedtype name st =
   let check x = function
-    | {Expr.pattern= Lit (Int, i); _} when float_of_string i >= 0. -> []
+    | {Expr.pattern= Lit (Int, i); _} when Float.of_string i >= 0. -> []
     | n ->
         [ Stmt.Helpers.internal_nrfunapp FnValidateSize
             Expr.Helpers.
@@ -762,7 +762,7 @@ let rec trans_sizedtype_decl declc tr name st =
         [str name; str (Fmt.str "%a" Pretty_printing.pp_typed_expression x); n]
       n.meta.loc in
   let grab_size fn n = function
-    | Ast.{expr= IntNumeral i; _} as s when float_of_string i >= 2. ->
+    | Ast.{expr= IntNumeral i; _} as s when Float.of_string i >= 2. ->
         ([], trans_expr s)
     | Ast.({expr= IntNumeral _; _} | {expr= Variable _; _}) as s ->
         let e = trans_expr s in
@@ -857,7 +857,7 @@ let rec trans_sizedtype_decl declc tr name st =
                (List.zip_exn subtypes Utils.(tuple_trans_exn tr))
                ~f:(fun ix (st, trans) ->
                  trans_sizedtype_decl declc trans
-                   (name ^ former_array_indices ^ "." ^ string_of_int (ix + 1))
+                   (name ^ former_array_indices ^ "." ^ Int.to_string (ix + 1))
                    st)) in
         (List.concat stmts, SizedType.STuple subtypes') in
   go 1 st

--- a/src/frontend/Deprecation_analysis.ml
+++ b/src/frontend/Deprecation_analysis.ml
@@ -49,7 +49,7 @@ let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
       let w =
         match Map.find stan_lib_deprecations name with
         | Some (rename, (major, minor)) when not (expired (major, minor)) ->
-            let version = string_of_int major ^ "." ^ string_of_int minor in
+            let version = Int.to_string major ^ "." ^ Int.to_string minor in
             [ ( id_loc
               , name ^ " is deprecated and will be removed in Stan " ^ version
                 ^ ". Use " ^ rename
@@ -58,7 +58,7 @@ let rec collect_deprecated_expr (acc : (Location_span.t * string) list)
         | _ -> (
             match Map.find deprecated_odes name with
             | Some (rename, (major, minor)) ->
-                let version = string_of_int major ^ "." ^ string_of_int minor in
+                let version = Int.to_string major ^ "." ^ Int.to_string minor in
                 [ ( id_loc
                   , name ^ " is deprecated and will be removed in Stan "
                     ^ version ^ ". Use " ^ rename

--- a/src/frontend/Parse.ml
+++ b/src/frontend/Parse.ml
@@ -31,7 +31,7 @@ let drive_parser parse_fun =
         ^^
         if !Debugging.grammar_logging then
           Scanf.format_from_string
-            ("(Parse error state " ^ string_of_int state ^ ")\n")
+            ("(Parse error state " ^ Int.to_string state ^ ")\n")
             ""
         else ""
       with _ ->

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -29,7 +29,7 @@ let new_file_start_position buf filename included_from =
     if Option.is_none included_from then
       {Lexing.pos_fname= filename; pos_lnum= 1; pos_bol= 0; pos_cnum= 0}
     else
-      let key = "\u{0}" ^ string_of_int (Hashtbl.length locations_map) in
+      let key = "\u{0}" ^ Int.to_string (Hashtbl.length locations_map) in
       Hashtbl.add_exn locations_map ~key ~data:(filename, included_from);
       {Lexing.pos_fname= key; pos_lnum= 1; pos_bol= 0; pos_cnum= 0} in
   buf.lex_start_p <- pos;

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -1,7 +1,6 @@
 open Core
 open Core.Poly
 open Middle
-module TypeMap = Core.Map.Make_using_comparator (UnsizedType)
 
 let set ctx key data = ctx := Map.set !ctx ~key ~data
 
@@ -358,7 +357,7 @@ let quoted = Fmt.styled (`Fg `Green) Fmt.(quote string)
 
 let pp_mismatch_details ~skipped ppf details =
   let open Fmt in
-  let ctx = ref TypeMap.empty in
+  let ctx = ref (Map.empty (module UnsizedType)) in
   let n_skipped = List.length skipped in
   let pp_excluded_message =
     Fmt.if' (n_skipped > 0)
@@ -410,7 +409,7 @@ let pp_mismatch_details ~skipped ppf details =
 
 let pp_signature_mismatch ppf (name, arg_tys, (sigs, omitted)) =
   let open Fmt in
-  let ctx = ref TypeMap.empty in
+  let ctx = ref (Map.empty (module UnsizedType)) in
   let rec pp_explain_rec ppf = function
     | ArgError (n, DataOnlyError) ->
         pf ppf "@[<hov>The@ %s@ argument%a@]" (index_str n) text

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -1082,7 +1082,7 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
       verify_identifier id;
       check_variable cf loc tenv id
   | IntNumeral s -> (
-      match float_of_string_opt s with
+      match Float.of_string_opt s with
       | Some i when i < 2_147_483_648.0 ->
           mk_typed_expression ~expr:(IntNumeral s) ~ad_level:DataOnly
             ~type_:UInt ~loc

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -7,7 +7,16 @@
  (modules :standard \ parser_messages_add_type parser_strip_redundant_state)
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.fold ppx_deriving.map)))
+  (pps
+   ppx_hash
+   ppx_compare
+   ppx_sexp_conv
+   ppx_pipebang
+   ppx_expect
+   ppx_sexp_value
+   ppx_sexp_message
+   ppx_deriving.fold
+   ppx_deriving.map)))
 
 (ocamllex lexer)
 

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -39,7 +39,7 @@ let rec iterate_n f x = function 0 -> x | n -> iterate_n f (f x) (n - 1)
 
 let parse_tuple_slot ix_str (start, stop) =
   let slot = String.drop_prefix ix_str 1 in
-  match int_of_string_opt slot with
+  match Int.of_string_opt slot with
   | None ->
       parse_error
         ("@[@{<light_red>Ill-formed index.@} Failed to parse integer from string \

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -94,7 +94,7 @@ module Typed = struct
 end
 
 module Helpers = struct
-  let int i = {meta= Typed.Meta.empty; pattern= Lit (Int, string_of_int i)}
+  let int i = {meta= Typed.Meta.empty; pattern= Lit (Int, Int.to_string i)}
 
   let float i =
     { meta= {Typed.Meta.empty with type_= UReal}

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -73,6 +73,7 @@ module Typed = struct
 
   type t = (Meta.t[@compare.ignore]) Fixed.t [@@deriving hash, sexp, compare]
 
+  let equal t1 t2 = compare t1 t2 = 0
   let type_of {meta= Meta.{type_; _}; _} = type_
   let adlevel_of {meta= Meta.{adlevel; _}; _} = adlevel
   let fun_arg {meta= Meta.{type_; adlevel; _}; _} = (adlevel, type_)
@@ -90,15 +91,6 @@ module Typed = struct
   end)
 
   include Comparator
-
-  include Comparable.Make_using_comparator (struct
-    type nonrec t = t
-
-    let sexp_of_t = sexp_of_t
-    let t_of_sexp = t_of_sexp
-
-    include Comparator
-  end)
 end
 
 module Helpers = struct

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -41,17 +41,13 @@ module Typed : sig
 
   type nonrec t = (Meta.t[@compare.ignore]) t [@@deriving hash, sexp, compare]
 
+  val equal : t -> t -> bool
   val type_of : t -> UnsizedType.t
   val adlevel_of : t -> UnsizedType.autodifftype
   val fun_arg : t -> UnsizedType.autodifftype * UnsizedType.t
   val pp : t Fmt.t
 
   include Core.Comparator.S with type t := t
-
-  include
-    Core.Comparable.S
-      with type t := t
-       and type comparator_witness := comparator_witness
 end
 
 module Helpers : sig

--- a/src/middle/Operator.ml
+++ b/src/middle/Operator.ml
@@ -59,7 +59,8 @@ let to_string x = Sexp.to_string (sexp_of_t x) ^ "__"
 
 let of_string_opt x =
   try
-    String.chop_suffix_exn ~suffix:"__" x |> Sexp.of_string |> t_of_sexp |> Some
+    String.chop_suffix_exn ~suffix:"__" x
+    |> Sexp.of_string |> t_of_sexp |> Option.some
   with
-  | Sexplib.Conv.Of_sexp_error _ -> None
+  | Sexp.Of_sexp_error _ -> None
   | Invalid_argument _ -> None

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -148,7 +148,7 @@ module Typed = struct
 
   let sexp_of_t : t -> Sexp.t =
     sexp_of_t Expr.Typed.sexp_of_t Stmt.Located.sexp_of_t
-      Sexplib.Conv.sexp_of_opaque
+      Sexplib0.Sexp_conv.sexp_of_opaque
 end
 
 module Numbered = struct

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -309,7 +309,7 @@ module Helpers = struct
     match lval with
     | LVariable name, _ -> name
     | LTupleProjection (sub_lval, num), _ ->
-        get_lhs_name sub_lval ^ "." ^ string_of_int num
+        get_lhs_name sub_lval ^ "." ^ Int.to_string num
 
   (* Copied from AST's version in AST.ml *)
   let rec lvalue_of_expr_opt (expr : 'e Expr.t) :

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -306,7 +306,7 @@ let enumerate_tuple_names_io name (ut : t) =
     match ut with
     | UTuple ts ->
         List.concat_mapi ts ~f:(fun i t ->
-            loop (base ^ "." ^ string_of_int (i + 1)) t)
+            loop (base ^ "." ^ Int.to_string (i + 1)) t)
     | UArray _ when contains_tuple ut ->
         let scalar, _ = unwind_array_type ut in
         loop base scalar

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -333,7 +333,6 @@ include Comparable.Make_using_comparator (struct
   type nonrec t = t
 
   let sexp_of_t = sexp_of_t
-  let t_of_sexp = t_of_sexp
 
   include Comparator
 end)

--- a/src/middle/dune
+++ b/src/middle/dune
@@ -6,4 +6,13 @@
   (backend bisect_ppx))
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.map ppx_deriving.fold ppx_deriving.create)))
+  (pps
+   ppx_compare
+   ppx_sexp_conv
+   ppx_hash
+   ppx_expect
+   ppx_sexp_value
+   ppx_sexp_message
+   ppx_deriving.map
+   ppx_deriving.fold
+   ppx_deriving.create)))

--- a/src/stan_math_backend/Cpp_Json.ml
+++ b/src/stan_math_backend/Cpp_Json.ml
@@ -31,7 +31,7 @@ let rec sizedtype_to_json (st : Expr.Typed.t SizedType.t) : Yojson.Basic.t =
   | STuple subtypes ->
       `Assoc
         [ ("name", `String "tuple")
-        ; ("num_elements", `String (string_of_int (List.length subtypes)))
+        ; ("num_elements", `String (Int.to_string (List.length subtypes)))
         ; ("element_types", `List (List.map ~f:sizedtype_to_json subtypes)) ]
 
 let out_var_json (name, st, block) : Yojson.Basic.t =

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -226,7 +226,7 @@ and lower_binary_fun f es = Exprs.fun_call f (lower_exprs es)
 and vector_literal ?(column = false) scalar es =
   let open Cpp.DSL in
   let vec = if column then Types.vector scalar else Types.row_vector scalar in
-  let make_vector size = vec.:{Literal (string_of_int size)} in
+  let make_vector size = vec.:{Literal (Int.to_string size)} in
   if List.is_empty es then make_vector 0
   else
     let vector = make_vector (List.length es) in

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -477,7 +477,7 @@ let rec gen_param_names ?(outer_idcs = []) (decl_id, st) =
     | SizedType.STuple subtypes ->
         let idxes_subtypes =
           List.mapi
-            ~f:(fun i typ -> ((`Tuple, string_of_int (i + 1)), (name, typ)))
+            ~f:(fun i typ -> ((`Tuple, Int.to_string (i + 1)), (name, typ)))
             subtypes in
         List.concat_map
           ~f:(fun (idx, sub) -> gen_param_names ~outer_idcs:(idcs @ [idx]) sub)

--- a/src/stan_math_backend/Numbering.ml
+++ b/src/stan_math_backend/Numbering.ml
@@ -87,12 +87,12 @@ let assign_loc location_num =
   let open Cpp in
   let open Cpp.DSL in
   if location_num = no_span_num then []
-  else ["current_statement__" := Literal (string_of_int location_num)]
+  else ["current_statement__" := Literal (Int.to_string location_num)]
 
 let register_map_rect_functors namespace map_rect_calls =
   let register_functor (i, f) =
     Cpp.Preprocessor
       (MacroApply
-         ("STAN_REGISTER_MAP_RECT", [string_of_int i; namespace ^ "::" ^ f]))
+         ("STAN_REGISTER_MAP_RECT", [Int.to_string i; namespace ^ "::" ^ f]))
   in
   List.map ~f:register_functor map_rect_calls

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -292,7 +292,7 @@ let rec var_context_read_inside_tuple enclosing_tuple_name origin_type
           subtypes in
       let enclosing_names =
         List.mapi
-          ~f:(fun i _ -> enclosing_tuple_name ^ "." ^ string_of_int (i + 1))
+          ~f:(fun i _ -> enclosing_tuple_name ^ "." ^ Int.to_string (i + 1))
           subtypes in
       List.map2_exn
         ~f:(fun name projection ->
@@ -306,7 +306,7 @@ let rec var_context_read_inside_tuple enclosing_tuple_name origin_type
         | STuple subtypes ->
             ( List.mapi
                 ~f:(fun i _ ->
-                  enclosing_tuple_name ^ "." ^ string_of_int (i + 1))
+                  enclosing_tuple_name ^ "." ^ Int.to_string (i + 1))
                 subtypes
             , subtypes )
         | _ -> ([], []) in
@@ -502,7 +502,7 @@ let rec var_context_read_internal
         match tupl with
         | STuple subtypes ->
             ( List.mapi
-                ~f:(fun i _ -> decl_id ^ "." ^ string_of_int (i + 1))
+                ~f:(fun i _ -> decl_id ^ "." ^ Int.to_string (i + 1))
                 subtypes
             , subtypes )
         | _ -> (* impossible by above pattern patch *) ([], []) in

--- a/src/stan_math_backend/dune
+++ b/src/stan_math_backend/dune
@@ -14,4 +14,12 @@
   numbering)
  (inline_tests)
  (preprocess
-  (pps ppx_jane ppx_deriving.make)))
+  (pps
+   ppx_compare
+   ppx_sexp_conv
+   ppx_hash
+   ppx_pipebang
+   ppx_expect
+   ppx_sexp_value
+   ppx_sexp_message
+   ppx_deriving.make)))

--- a/src/stan_math_signatures/dune
+++ b/src/stan_math_signatures/dune
@@ -8,13 +8,13 @@
  (private_modules generated_signatures)
  (inline_tests)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_inline_test ppx_pipebang)))
 
 (executable
  (name generate)
  (modules generate)
  (preprocess
-  (pps ppx_jane ppx_deriving.show))
+  (pps ppx_deriving.show))
  (libraries core common middle))
 
 (rule

--- a/src/stanc/dune
+++ b/src/stanc/dune
@@ -8,9 +8,7 @@
   (backend bisect_ppx))
  (modules Stanc CLI)
  (public_name stanc)
- (package stanc)
- (preprocess
-  (pps ppx_jane)))
+ (package stanc))
 
 (rule
  (target

--- a/src/stancjs/conversion.ml
+++ b/src/stancjs/conversion.ml
@@ -72,7 +72,7 @@ let process_flags name code (flags : 'a Js.opt) includes :
         let+ ocaml_flags =
           let open Result in
           Array.mapi flags_array ~f:(fun i v ->
-              checked_to_string ~name:("flags[" ^ string_of_int i ^ "]") v)
+              checked_to_string ~name:("flags[" ^ Int.to_string i ^ "]") v)
           |> Array.to_list |> Result.all >>| Array.of_list in
         Driver.Flags.set_backend_args_list
           (ocaml_flags |> Array.to_list |> List.map ~f:(fun o -> "--" ^ o));
@@ -134,7 +134,7 @@ let process_flags name code (flags : 'a Js.opt) includes :
                   |> Option.map ~f:(fun s -> ("debug-data-json", s)) }
           ; line_length=
               flag_val "max-line-length"
-              |> Option.map ~f:int_of_string
+              |> Option.map ~f:Int.of_string
               |> Option.value ~default:78
           ; canonicalizer_settings=
               (if is_flag_set "print-canonical" then Canonicalize.legacy

--- a/src/stancjs/dune
+++ b/src/stancjs/dune
@@ -3,7 +3,7 @@
  (libraries core fmt js_of_ocaml driver stan_math_signatures)
  (modules Stancjs Conversion)
  (preprocess
-  (pps ppx_jane js_of_ocaml-ppx))
+  (pps js_of_ocaml-ppx))
  (modes js))
 
 (env

--- a/stanc.opam
+++ b/stanc.opam
@@ -8,12 +8,21 @@ bug-reports: "https://github.com/stan-dev/stanc3/issues"
 depends: [
   "dune" {>= "3.5"}
   "ocaml" {= "5.5.0"}
-  "core" {= "v0.17.2"}
+  "base" {= "v0.17.3"}
+  "stdio" {= "v0.17.0"}
   "menhir" {= "20260209"}
-  "ppx_deriving" {= "6.1.1"}
   "fmt" {= "0.11.0"}
   "yojson" {= "3.0.0"}
   "cmdliner" {= "2.1.1"}
+  "ppx_deriving" {= "6.1.1"}
+  "ppx_hash"
+  "ppx_compare"
+  "ppx_sexp_conv"
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_pipebang"
+  "ppx_sexp_value"
+  "ppx_sexp_message"
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "bisect_ppx" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -73,7 +73,7 @@ let%expect_test "map_rec_state_stmt_loc" =
       Stmt.{pattern= SList mir.log_prob; meta= Location_span.empty} in
   let mir = {mir with log_prob= [mir_stmt]} in
   Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
-  print_endline (string_of_int num);
+  print_endline (Int.to_string num);
   [%expect
     {|
       log_prob {

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -3560,7 +3560,7 @@ let%expect_test "Mapping acts recursively" =
     Stmt.Pattern.NRFunApp
       ( CompilerInternal (FnWriteParam {var= from; unconstrain_opt= None})
       , [from] ) in
-  let m = Expr.Typed.Map.of_alist_exn [(from, into)] in
+  let m = Map.of_alist_exn (module Expr.Typed) [(from, into)] in
   let s' = expr_subst_stmt_base m s in
   Fmt.str "@[<v>%a@]" Stmt.Located.pp (unpattern s') |> print_endline;
   [%expect {| (FnWriteParam(unconstrain_opt())(var y))__(y); |}]

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -9,4 +9,4 @@
   analysis_and_optimization)
  (inline_tests)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_expect ppx_inline_test ppx_sexp_value)))


### PR DESCRIPTION
This should resolve #1640. 

To make the patch as minimal as possible, I added our own `Core.ml` module which shadows all the `open Core`s we have, which just uses base and a few other small changes for compatibility. This means we could rather seamlessly return to using core once 0.18 (which removed the weird Temporal polyfill) is released, if we wished

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Replace this text with a short note on what will change if this pull request is merged. This will be included in the release notes.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
