### PR TITLE
Update ICE handling with new Format functions

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,6 @@
   ppx_inline_test
   ppx_pipebang
   ppx_sexp_value
-  ppx_sexp_message
   (ocamlformat
    (and
     :with-dev-setup

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -8,6 +8,6 @@ eval $(opam env)
 opam pin -y base v0.17.3 --no-action
 
 opam install -y dune base.v0.17.3 menhir.20260209 ppx_deriving.6.1.1 fmt.0.11.0 yojson.3.0.0 cmdliner.2.1.1\
-     ppx_hash ppx_compare ppx_sexp_conv ppx_expect ppx_inline_test ppx_pipebang ppx_sexp_value ppx_sexp_message
+     ppx_hash ppx_compare ppx_sexp_conv ppx_expect ppx_inline_test ppx_pipebang ppx_sexp_value
 
 eval $(opam env)

--- a/scripts/install_build_deps_windows.sh
+++ b/scripts/install_build_deps_windows.sh
@@ -17,6 +17,6 @@ opam install -y base.v0.17.3 base-windows.v0.17.3 menhir.20260209 menhir-windows
      fmt-windows.0.11.0 yojson.3.0.0 yojson-windows.3.0.0 cmdliner.2.1.1 cmdliner-windows.2.1.1\
      ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1 ppx_hash ppx_hash-windows ppx_compare ppx_compare-windows ppx_sexp_conv\
      ppx_sexp_conv-windows ppx_expect ppx_expect-windows ppx_inline_test ppx_inline_test-windows ppx_pipebang\
-     ppx_pipebang-windows ppx_sexp_value ppx_sexp_value-windows ppx_sexp_message ppx_sexp_message-windows
+     ppx_pipebang-windows ppx_sexp_value ppx_sexp_value-windows
 
 eval $(opam env)

--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -16,15 +16,15 @@ let dotproduct xs ys =
 let matprod x y =
   let y_T = transpose y in
   if List.length x <> List.length y_T then
-    Common.ICE.internal_compiler_error
-      [%message "Matrix multiplication dim. mismatch"] [@coverage off]
+    Common.ICE.internal_error "Matrix multiplication dim. mismatch"
+    [@coverage off]
   else List.map ~f:(fun row -> List.map ~f:(dotproduct row) y_T) x
 
 let rec vect_to_mat l m =
   let len = List.length l in
   if len % m <> 0 then
-    Common.ICE.internal_compiler_error
-      [%message "The length has to be a whole multiple of the partition size"]
+    Common.ICE.internal_error
+      "The length has to be a whole multiple of the partition size"
     [@coverage off]
   else if len = m then [l]
   else
@@ -48,6 +48,7 @@ let unwrap_num_exn m e =
         (Fmt.str "Cannot evaluate expression: %a" Expr.Typed.pp e)
 
 let unwrap_int_exn m e = Int.of_float (unwrap_num_exn m e)
+let dprint_transform t ppf = Transformation.pp Expr.Typed.pp ppf t
 
 let gen_num_int m t =
   let def_low, diff = (2, 4) in
@@ -61,10 +62,8 @@ let gen_num_int m t =
      |CholeskyCorr | CholeskyCov | Correlation | Covariance | StochasticRow
      |StochasticColumn | TupleTransformation _ | Offset _ | Multiplier _
      |OffsetMultiplier _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "Unknown transformation for int" (t : Expr.Typed.t Transformation.t)]
-        [@coverage off] in
+        Common.ICE.internal_errorf "Unknown transformation for int: %t"
+          [dprint_transform t] [@coverage off] in
   let low = if low = 0 && up <> 1 then low + 1 else low in
   Random.int (up - low + 1) + low
 
@@ -80,10 +79,8 @@ let gen_num_real m t =
     | Ordered | PositiveOrdered | Simplex | UnitVector | SumToZero
      |CholeskyCorr | CholeskyCov | Correlation | Covariance | StochasticRow
      |StochasticColumn | TupleTransformation _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "Unknown transformation for real"
-              (t : Expr.Typed.t Transformation.t)] [@coverage off] in
+        Common.ICE.internal_errorf "Unknown transformation for real: %t"
+          [dprint_transform t] [@coverage off] in
   Random.float_range low up
 
 let repeat n e = List.init n ~f:(Fn.const e)
@@ -126,10 +123,8 @@ let gen_row_vector m n t =
   | Ordered | PositiveOrdered | Simplex | UnitVector | SumToZero
    |CholeskyCorr | CholeskyCov | Correlation | Covariance | StochasticRow
    |StochasticColumn | TupleTransformation _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Unknown transformation for row_vector"
-            (t : Expr.Typed.t Transformation.t)] [@coverage off]
+      Common.ICE.internal_errorf "Unknown transformation for row_vector: %t"
+        [dprint_transform t] [@coverage off]
 
 let sum_to_zero_floats n =
   let l = random_floats n in
@@ -174,10 +169,8 @@ let gen_vector m n t =
       Expr.Helpers.transpose (gen_row_vector m n t)
   | CholeskyCorr | CholeskyCov | Correlation | Covariance | StochasticRow
    |StochasticColumn | TupleTransformation _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Unknown transformation for vector"
-            (t : Expr.Typed.t Transformation.t)] [@coverage off]
+      Common.ICE.internal_errorf "Unknown transformation for vector: %t"
+        [dprint_transform t] [@coverage off]
 
 let gen_cov_unwrapped n =
   let l = random_floats (n * n) in
@@ -266,10 +259,8 @@ let gen_matrix mm m n t =
       Expr.Helpers.matrix_from_rows
         (repeat_th m (fun () -> gen_row_vector mm n t))
   | Ordered | PositiveOrdered | Simplex | UnitVector | TupleTransformation _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Unknown transformation for matrix"
-            (t : Expr.Typed.t Transformation.t)] [@coverage off]
+      Common.ICE.internal_errorf "Unknown transformation for matrix: %t"
+        [dprint_transform t] [@coverage off]
 
 let gen_complex_unwrapped () =
   ( gen_num_real Map.Poly.empty Transformation.Identity

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -225,8 +225,8 @@ let vexpr_of_expr_exn Expr.{pattern; _} =
   match pattern with
   | Var s -> VVar s
   | _ ->
-      Common.ICE.internal_compiler_error
-        [%message "Non-var expression found, but var expected"] [@coverage off]
+      Common.ICE.internal_error "Non-var expression found, but var expected"
+      [@coverage off]
 
 (** See interface file *)
 let rec expr_var_set Expr.{pattern; meta} =
@@ -282,9 +282,8 @@ let expr_assigned_var Expr.{pattern; _} =
   | Var s -> VVar s
   | Indexed ({pattern= Var s; _}, _) -> VVar s
   | _ ->
-      Common.ICE.internal_compiler_error
-        [%message "Unimplemented: analysis of assigning to non-var"]
-      [@coverage off]
+      Common.ICE.internal_error
+        "Unimplemented: analysis of assigning to non-var" [@coverage off]
 
 (** See interface file *)
 let rec summation_terms (Expr.{pattern; _} as rhs) =
@@ -480,11 +479,9 @@ let unsafe_unsized_to_sized_type (rt : Expr.Typed.t Type.t) =
         | UTuple ts -> STuple (List.map ~f:to_sized ts)
         | UFun (_, UnsizedType.ReturnType inner_ut, _, _) -> to_sized inner_ut
         | UFun (_, Void, _, _) | UMathLibraryFunction ->
-            Common.ICE.internal_compiler_error
-              [%message
-                ("return type of a function was a void user defined function \
-                  or math library function."
-                  : string)] [@coverage off] in
+            Common.ICE.internal_error
+              "return type of a function was a void user defined function or \
+               math library function." [@coverage off] in
       Type.Sized (to_sized ut)
 
 let%expect_test "cleanup" =
@@ -495,6 +492,5 @@ let%expect_test "cleanup" =
   let body = Block [Skip |> swrap] |> swrap in
   let s = For {loopvar= "i"; lower= loop_bottom; upper= loop_bottom; body} in
   let res = [s |> swrap] |> cleanup_empty_stmts in
-  [%sexp (res : Stmt.Located.t list)] |> print_s;
-  [%expect {|
-    () |}]
+  Fmt.list Stmt.Located.pp Format.std_formatter res;
+  [%expect {| |}]

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -14,20 +14,6 @@ module Expr_set = struct
   let union_list = Set.union_list (module Expr.Typed)
 end
 
-(** Debugging tool to print out MFP sets **)
-let print_mfp to_string (mfp : (int, 'a entry_exit) Map.Poly.t)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) : unit =
-  let print_set s =
-    [%sexp (Set.Poly.map ~f:to_string s : string Set.Poly.t)]
-    |> Sexp.to_string_hum in
-  let print_stmt s =
-    [%sexp (s : Stmt.Located.Non_recursive.t)] |> Sexp.to_string_hum in
-  Map.iteri mfp ~f:(fun ~key ~data ->
-      print_endline
-        (Int.to_string key ^ ":\n "
-        ^ print_stmt (Map.Poly.find_exn flowgraph_to_mir key)
-        ^ ":\n " ^ print_set data.entry ^ " \t-> " ^ print_set data.exit))
-
 (** Calculate the free (non-bound) variables in an expression *)
 let rec free_vars_expr (e : Expr.Typed.t) =
   match e.pattern with

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -39,8 +39,8 @@ let transform_program (mir : Program.Typed.t)
       ; reverse_mode_log_prob= reverse_mode_log_prob'
       ; generate_quantities= generate_quantities' }
   | _ ->
-      ICE.internal_compiler_error
-        [%message "Something went wrong with program transformation packing!"]
+      ICE.internal_error
+        "Something went wrong with program transformation packing!"
       [@coverage off]
 
 (** Apply the transformation to each function body and to each program block
@@ -53,8 +53,8 @@ let transform_program_blockwise (mir : Program.Typed.t)
     match transform fd {pattern= SList s; meta= Location_span.empty} with
     | {pattern= SList l; _} -> l
     | _ ->
-        ICE.internal_compiler_error
-          [%message "Something went wrong with program transformation packing!"]
+        ICE.internal_error
+          "Something went wrong with program transformation packing!"
         [@coverage off] in
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
@@ -158,17 +158,13 @@ let handle_early_returns (fname : string) opt_var stmt =
         | Some name, Some e ->
             Assignment (Stmt.Helpers.lvariable name, Expr.Typed.type_of e, e)
         | Some _, None ->
-            ICE.internal_compiler_error
-              [%message
-                ("Function should return a value but found an empty return \
-                  statement."
-                  : string)] [@coverage off]
+            ICE.internal_error
+              "Function should return a value but found an empty return \
+               statement." [@coverage off]
         | None, Some _ ->
-            ICE.internal_compiler_error
-              [%message
-                ("Expected a void function but found a non-empty return \
-                  statement."
-                  : string)] [@coverage off])
+            ICE.internal_error
+              "Expected a void function but found a non-empty return statement."
+            [@coverage off])
     | Stmt.Pattern.For _ as loop when num_returns > 1 ->
         Stmt.Pattern.SList
           [ Stmt.{pattern= loop; meta= Location_span.empty}
@@ -1235,8 +1231,8 @@ let optimize_soa (mir : Program.Typed.t) =
     match transform {pattern= SList s; meta= Location_span.empty} with
     | {pattern= SList (l : Stmt.Located.t list); _} -> l
     | _ ->
-        ICE.internal_compiler_error
-          [%message "Something went wrong with program transformation packing!"]
+        ICE.internal_error
+          "Something went wrong with program transformation packing!"
         [@coverage off] in
   {mir with reverse_mode_log_prob= transform' mir.reverse_mode_log_prob}
 

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -21,8 +21,8 @@ let apply_prefix_operator_int (op : string) i =
         | "PMinus__" -> -i
         | "PNot__" -> if i = 0 then 1 else 0
         | s ->
-            Common.ICE.internal_compiler_error
-              [%message "Not an int prefix operator: " s] [@coverage off]) )
+            Common.ICE.internal_errorf "Not an int prefix operator: %s" [s]
+            [@coverage off]) )
 
 let apply_prefix_operator_real (op : string) i =
   Expr.Pattern.Lit
@@ -32,8 +32,8 @@ let apply_prefix_operator_real (op : string) i =
         | "PPlus__" -> i
         | "PMinus__" -> -.i
         | s ->
-            Common.ICE.internal_compiler_error
-              [%message "Not a real prefix operator: " s] [@coverage off]) )
+            Common.ICE.internal_errorf "Not a real prefix operator: %s" [s]
+            [@coverage off]) )
 
 let apply_operator_int (op : string) i1 i2 =
   Expr.Pattern.Lit
@@ -52,8 +52,8 @@ let apply_operator_int (op : string) i1 i2 =
         | "Greater__" -> Bool.to_int (i1 > i2)
         | "Geq__" -> Bool.to_int (i1 >= i2)
         | s ->
-            Common.ICE.internal_compiler_error
-              [%message "Not an int operator: " s] [@coverage off]) )
+            Common.ICE.internal_errorf "Not an int operator: %s" [s]
+            [@coverage off]) )
 
 let apply_arithmetic_operator_real (op : string) r1 r2 =
   Expr.Pattern.Lit
@@ -65,8 +65,8 @@ let apply_arithmetic_operator_real (op : string) r1 r2 =
         | "Times__" -> r1 *. r2
         | "Divide__" -> r1 /. r2
         | s ->
-            Common.ICE.internal_compiler_error
-              [%message "Not a real operator: " s] [@coverage off]) )
+            Common.ICE.internal_errorf "Not a real operator: %s" [s]
+            [@coverage off]) )
 
 let apply_logical_operator_real (op : string) r1 r2 =
   Expr.Pattern.Lit
@@ -80,8 +80,8 @@ let apply_logical_operator_real (op : string) r1 r2 =
         | "Greater__" -> Bool.to_int (r1 > r2)
         | "Geq__" -> Bool.to_int (r1 >= r2)
         | s ->
-            Common.ICE.internal_compiler_error
-              [%message "Not a logical operator: " s] [@coverage off]) )
+            Common.ICE.internal_errorf "Not a logical operator: %s" [s]
+            [@coverage off]) )
 
 let is_multi_index = function
   | Index.MultiIndex _ | Upfrom _ | Between _ | All -> true
@@ -1113,11 +1113,11 @@ let rec simplify_index_expr pattern =
                    ; meta }
                  , outer_tl ))
         | inner_singles, (([] | Single _ :: _) as multis) ->
-            Common.ICE.internal_compiler_error
-              [%message
-                " There must be a multi-index."
-                  (inner_singles : Expr.Typed.t Index.t list)
-                  (multis : Expr.Typed.t Index.t list)] [@coverage off])
+            Common.ICE.(
+              let pp = Fmt.list (Index.pp Expr.Typed.pp) in
+              internal_errorf
+                "There must be a multi-index. singles %t multis %t "
+                [pp $ inner_singles; pp $ multis]) [@coverage off])
     | e -> e)
 
 let remove_trailing_alls_expr = function

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -239,10 +239,9 @@ let list_param_dependant_fundef_cf (mir : Program.Typed.t)
         Set.Poly.map dep_args ~f:(fun (loc, ix, arg_name) ->
             (loc, List.nth_exn arg_exprs ix, arg_name))
     | _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "In finding searching for parameter dependent function arguments, \
-             mismatched function."] [@coverage off] in
+        Common.ICE.internal_error
+          "In finding searching for parameter dependent function arguments, \
+           mismatched function." [@coverage off] in
   let arg_param_deps label arg_expr =
     var_deps info_map ~expr:(Some arg_expr) label (parameter_names_set mir)
   in

--- a/src/analysis_and_optimization/Pedantic_dist_warnings.ml
+++ b/src/analysis_and_optimization/Pedantic_dist_warnings.ml
@@ -157,11 +157,9 @@ let constr_mismatch_warning (constr : var_constraint_named) (arg : arg_info)
     match List.nth args (arg_number arg) with
     | Some v -> v
     | None ->
-        let arg_fail_msg =
-          Printf.sprintf "Distribution %s at %s expects more arguments." name
-            (Location_span.to_string loc) in
-        (Common.ICE.internal_compiler_error [%message arg_fail_msg]
-         [@coverage off]) in
+        Common.ICE.(
+          internal_errorf "Distribution %s at %t expects more arguments."
+            [name; Location_span.pp $ loc]) [@coverage off] in
   match v with
   | Param (pname, trans), meta
     when transform_mismatch_constraint constr.constr trans ->

--- a/src/analysis_and_optimization/dune
+++ b/src/analysis_and_optimization/dune
@@ -7,4 +7,4 @@
  (inline_tests)
  (modules_without_implementation monotone_framework_sigs)
  (preprocess
-  (pps ppx_compare ppx_sexp_conv ppx_expect ppx_sexp_value ppx_sexp_message)))
+  (pps ppx_compare ppx_sexp_conv ppx_expect)))

--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -1,25 +1,19 @@
-(** Internal compiler errors *)
+let internal_error = failwith
+let internal_errorf s a = failwith (Format.lasprintf s a)
+let ( $ ) pp x ppf = pp ppf x
 
-open Core
-
-(** An alias of [Core.raise_s]. This used to do more processing, for now it is
-    preserved just as a nicer marker in the code *)
-let internal_compiler_error = raise_s
-
-(** Catch all exceptions at the top-level and convert them into a
-    ['a, string result] where the string contains the exception and a backtrace
-    if present, followed by a link to our bugtracker. *)
 let with_exn_message f =
   try Ok (f ())
   with e ->
     let bt =
       if Printexc.backtrace_status () then Printexc.get_backtrace ()
       else "Backtrace missing." in
+    let msg = match e with Failure msg -> msg | _ -> Printexc.to_string e in
     Error
       (Fmt.str
-         "Internal compiler error:@ @[%a@]@\n\
+         "Internal compiler error:@ @[%s@]@\n\
           %s@\n\
           @\n\
           This should never happen. Please file a bug at %%PKG_ISSUES%%@ and \
           include this message and the model that caused this issue.@\n"
-         Exn.pp e bt)
+         msg bt)

--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -1,4 +1,4 @@
-let internal_error = failwith
+let internal_error s = failwith s
 let internal_errorf s a = failwith (Format.lasprintf s a)
 let ( $ ) pp x ppf = pp ppf x
 

--- a/src/common/ICE.mli
+++ b/src/common/ICE.mli
@@ -1,0 +1,25 @@
+(** Internal compiler errors *)
+
+val internal_error : string -> 'a
+(** Alias for [failwith] *)
+
+val internal_errorf :
+     ('a, Format.formatter, unit, string) format4
+  -> ('a, string) Format.Args.t
+  -> 'b
+(** Failwith but with pretty-printing *)
+
+val ( $ ) : 'a Fmt.t -> 'a -> Format.formatter -> unit
+(** [$] is [Fun.flip]; useful in internal_errorf for pairing pretty printers and
+    values into something %t can format:
+    [internal_errorf "Foo: %t" [pp_foo $ foo] ] is equivalent to
+    [internal_error (Format.asprintf "Foo: %a" pp_foo foo)]
+
+    A similar operator was suggested in the
+    {{:https://github.com/ocaml/ocaml/pull/13372#issuecomment-2325194034}PR}
+    which introduced the [Format.Args.t] type *)
+
+val with_exn_message : (unit -> 'a) -> ('a, string) result
+(** Catch all exceptions at the top-level and convert them into a
+    ['a, string result] where the string contains the exception and a backtrace
+    if present, followed by a link to our bugtracker. *)

--- a/src/common/Nonempty_list.ml
+++ b/src/common/Nonempty_list.ml
@@ -1,5 +1,3 @@
-open Core
-
 type 'a t = ( :: ) of 'a * 'a list
 
 let to_list (hd :: tl) : _ list = hd :: tl
@@ -10,17 +8,10 @@ let of_list : _ list -> _ t option = function
 
 let of_list_exn : _ list -> _ t = function
   | [] ->
-      ICE.internal_compiler_error
-        [%message "Nonempty_list.of_list_exn: empty list"] [@coverage off]
+      ICE.internal_error "Nonempty_list.of_list_exn: empty list" [@coverage off]
   | hd :: tl -> hd :: tl
 
 (** [@@deriving sexp] doesn't like this type, so we do it manually *)
-include
-  Sexpable.Of_sexpable1
-    (List)
-    (struct
-      type nonrec 'a t = 'a t
 
-      let to_sexpable = to_list
-      let of_sexpable = of_list_exn
-    end)
+let sexp_of_t f l = Sexplib0.Sexp_conv.sexp_of_list f (to_list l)
+let t_of_sexp f s = Sexplib0.Sexp_conv.list_of_sexp f s |> of_list_exn

--- a/src/common/Nonempty_list.ml
+++ b/src/common/Nonempty_list.ml
@@ -10,8 +10,3 @@ let of_list_exn : _ list -> _ t = function
   | [] ->
       ICE.internal_error "Nonempty_list.of_list_exn: empty list" [@coverage off]
   | hd :: tl -> hd :: tl
-
-(** [@@deriving sexp] doesn't like this type, so we do it manually *)
-
-let sexp_of_t f l = Sexplib0.Sexp_conv.sexp_of_list f (to_list l)
-let t_of_sexp f s = Sexplib0.Sexp_conv.list_of_sexp f s |> of_list_exn

--- a/src/common/Nonempty_list.mli
+++ b/src/common/Nonempty_list.mli
@@ -1,11 +1,9 @@
 (** A non-empty list type. This can be constructed with the usual list syntax
     when the compiler is inferring the type, e.g.
 
-    [let x : _ Nonempty_list.t = [1;2;3]]
+    [let x : _ Nonempty_list.t = [1;2;3]] *)
 
-    In Core v0.18, we can replace this with [Core.Nonempty_list] *)
-
-type 'a t = ( :: ) of 'a * 'a list [@@deriving sexp]
+type 'a t = ( :: ) of 'a * 'a list
 
 val to_list : 'a t -> 'a list
 val of_list : 'a list -> 'a t option

--- a/src/common/dune
+++ b/src/common/dune
@@ -2,7 +2,5 @@
  (name common)
  (public_name stanc.common)
  (libraries core fmt)
- (preprocess
-  (pps ppx_sexp_conv ppx_deriving.fold ppx_deriving.map))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/common/dune
+++ b/src/common/dune
@@ -3,6 +3,6 @@
  (public_name stanc.common)
  (libraries core fmt)
  (preprocess
-  (pps ppx_sexp_conv ppx_sexp_message ppx_deriving.fold ppx_deriving.map))
+  (pps ppx_sexp_conv ppx_deriving.fold ppx_deriving.map))
  (instrumentation
   (backend bisect_ppx)))

--- a/src/driver/Entry.ml
+++ b/src/driver/Entry.ml
@@ -50,7 +50,7 @@ type compilation_result = (string, Errors.t) result
 let debug_output_mir output mir = function
   | Flags.Off -> ()
   | Basic ->
-      output (DebugOutput (fmt_sexp [%sexp (mir : Middle.Program.Typed.t)]))
+      output (DebugOutput (fmt_sexp (Middle.Program.Typed.sexp_of_t mir)))
   | Pretty -> output (DebugOutput (Fmt.str "%a" Program.Typed.pp mir))
 
 let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
@@ -64,13 +64,13 @@ let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
   output (Warnings parser_warnings);
   let* ast in
   if flags.debug_settings.print_ast then
-    output (DebugOutput (fmt_sexp [%sexp (ast : Ast.untyped_program)]));
+    output (DebugOutput (fmt_sexp (Ast.sexp_of_untyped_program ast)));
   let* typed_ast, type_warnings =
     Typechecker.check_program ~allow_undefined_functions:flags.allow_undefined
       ast
     |> Result.map_error ~f:(fun e -> Errors.Semantic_error e) in
   if flags.debug_settings.print_typed_ast then
-    output (DebugOutput (fmt_sexp [%sexp (typed_ast : Ast.typed_program)]));
+    output (DebugOutput (fmt_sexp (Ast.sexp_of_typed_program typed_ast)));
   output (Warnings type_warnings);
   if flags.info then output (Info (Info.info typed_ast));
   let deprecation_warnings =
@@ -141,5 +141,5 @@ let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
       ~standalone_functions:(flags.functions_only || flags.standalone_functions)
       ?printed_filename:flags.filename_in_msg opt_mir in
   if flags.debug_settings.print_lir then
-    output (DebugOutput (fmt_sexp [%sexp (cpp : Cpp.program)]));
+    output (DebugOutput (fmt_sexp (Cpp.sexp_of_program cpp)));
   Fmt.(to_to_string Cpp.Printing.pp_program) cpp

--- a/src/driver/Flags.ml
+++ b/src/driver/Flags.ml
@@ -1,4 +1,4 @@
-open Core
+open StdLabels
 
 type t =
   { optimization_level: Analysis_and_optimization.Optimize.optimization_level
@@ -75,9 +75,9 @@ let set_backend_args_list flags =
   let sans_model_and_hpp_paths x =
     not
       String.(
-        is_suffix ~suffix:".stan" x
-        && not (is_prefix ~prefix:"--filename-in-msg" x)
-        || is_prefix ~prefix:"--o" x) in
+        ends_with ~suffix:".stan" x
+        && not (starts_with ~prefix:"--filename-in-msg" x)
+        || starts_with ~prefix:"--o" x) in
   let stanc_args_to_print =
     flags |> List.filter ~f:sans_model_and_hpp_paths |> String.concat ~sep:" "
   in

--- a/src/driver/dune
+++ b/src/driver/dune
@@ -12,4 +12,4 @@
   (backend bisect_ppx))
  (inline_tests)
  (preprocess
-  (pps ppx_inline_test ppx_sexp_value)))
+  (pps ppx_inline_test)))

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -275,8 +275,8 @@ let rec untyped_expression_of_typed_expression
       { expr=
           map_expression untyped_expression_of_typed_expression ignore
             (fun _ ->
-              (Common.ICE.internal_compiler_error
-                 [%message "Promotion snuck through!"] [@coverage off]))
+              (Common.ICE.internal_error "Promotion snuck through!"
+               [@coverage off]))
             expr
       ; emeta= {loc= emeta.loc} }
 

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -85,9 +85,9 @@ and trans_idx = function
       | UInt -> Single (trans_expr e)
       | UArray _ -> MultiIndex (trans_expr e)
       | _ ->
-          Common.ICE.internal_compiler_error
-            [%message "Expecting int or array" (e.emeta.type_ : UnsizedType.t)]
-          [@coverage off])
+          Common.ICE.(
+            internal_errorf "Expecting int or array, got %t"
+              [UnsizedType.pp $ e.emeta.type_]) [@coverage off])
 
 and trans_exprs exprs = List.map ~f:trans_expr exprs
 
@@ -317,11 +317,11 @@ let rec shrink_helper (f : size_change) f_d2 st =
     match f with
     | Univariate f -> f d
     | Multivariate _ ->
-        Common.ICE.internal_compiler_error
-          [%message
+        Common.ICE.(
+          internal_errorf
             "To shrink a vector, the first argument must be a univariate \
-             function "
-              (st : Expr.Typed.t SizedType.t)] [@coverage off] in
+             function, got: %t"
+            [SizedType.pp Expr.Typed.pp $ st]) [@coverage off] in
   match st with
   | SizedType.SArray (t, d) -> SizedType.SArray (shrink_helper f f_d2 t, d)
   | SVector (mem_pattern, d) -> SVector (mem_pattern, f_assert_univariate d)
@@ -333,10 +333,9 @@ let rec shrink_helper (f : size_change) f_d2 st =
       | Multivariate f -> SVector (mem_pattern, f d1 d2))
   | SInt | SReal | SComplex | STuple _ | SComplexRowVector _
    |SComplexVector _ | SComplexMatrix _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Expecting SVector or SMatrix, got " (st : Expr.Typed.t SizedType.t)]
-      [@coverage off]
+      Common.ICE.(
+        internal_errorf "Expecting SVector or SMatrix, got %t"
+          [SizedType.pp Expr.Typed.pp $ st]) [@coverage off]
 
 let rec transform_sizedtype transformation sizedtype =
   (* Functions for computing the new sizetype after some transformation *)
@@ -513,9 +512,9 @@ let unwrap_block_or_skip = function
   | [({Stmt.pattern= Block _; _} as b)] -> Some b
   | [{pattern= Skip; _}] -> None
   | x ->
-      Common.ICE.internal_compiler_error
-        [%message "Expecting a block or skip, not" (x : Stmt.Located.t list)]
-      [@coverage off]
+      Common.ICE.(
+        internal_errorf "Expecting a block or skip, not %t"
+          [Fmt.list Stmt.Located.pp $ x]) [@coverage off]
 
 let index_tuple (e : Ast.typed_expression) i =
   let emeta =
@@ -526,10 +525,10 @@ let index_tuple (e : Ast.typed_expression) i =
           ; ad_level= List.nth_exn ads i
           ; loc= e.emeta.loc }
     | _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "Attempted to index into a non-tuple during lowering"
-              (e : Ast.typed_expression)] [@coverage off] in
+        Common.ICE.(
+          internal_errorf
+            "Attempted to index into a non-tuple %t during lowering"
+            [Pretty_printing.pp_typed_expression $ e]) [@coverage off] in
   Ast.{expr= TupleProjection (e, i + 1); emeta}
 
 let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
@@ -557,11 +556,12 @@ let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
         | UserDefined (FnLpdf _) | StanLib (FnLpdf _) -> "_lpdf"
         | UserDefined (FnLpmf _) | StanLib (FnLpmf _) -> "_lpmf"
         | _ ->
-            Common.ICE.internal_compiler_error
-              [%message
-                "Impossible: tilde with non-distribution after typechecking"
-                  (distribution : Ast.identifier)
-                  (kind : Ast.fun_kind)] [@coverage off] in
+            Common.ICE.internal_errorf
+              "Impossible: tilde with non-distribution after typechecking, \
+               dist %s kind %s"
+              [ distribution.name
+              ; Ast.sexp_of_fun_kind kind |> Sexp.to_string_hum ]
+            [@coverage off] in
       let name = distribution.name ^ sfx in
       let add_dist =
         let adlevel =
@@ -633,9 +633,8 @@ let rec trans_stmt ud_dists (declc : decl_context) (ts : Ast.typed_statement) =
           ; meta= smeta } in
       Stmt.Helpers.[ensure_var (for_each bodyfn) iteratee' smeta]
   | Ast.FunDef _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Found function definition statement outside of function block"]
+      Common.ICE.internal_error
+        "Found function definition statement outside of function block"
       [@coverage off]
   | Ast.VarDecl {decl_type; transformation; variables; is_global= _} ->
       List.concat_map
@@ -745,8 +744,8 @@ let trans_fun_def ud_dists (ts : Ast.typed_statement) =
               |> unwrap_block_or_skip
           ; fdloc= ts.smeta.loc } ]
   | _ ->
-      Common.ICE.internal_compiler_error
-        [%message "Found non-function definition statement in function block"]
+      Common.ICE.internal_error
+        "Found non-function definition statement in function block"
       [@coverage off]
 
 let get_block block prog =

--- a/src/frontend/Info.ml
+++ b/src/frontend/Info.ml
@@ -20,10 +20,9 @@ let rec unsized_basetype_json t =
         [ ("type", `List (List.map ~f:unsized_basetype_json internals))
         ; ("dimensions", `Int dims) ]
   | (UMathLibraryFunction | UFun _ | UArray _) as t ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Unexpected unsized type in unsized_basetype_json" (t : UnsizedType.t)]
-      [@coverage off]
+      Common.ICE.(
+        internal_errorf "Unexpected unsized type in unsized_basetype_json: %t"
+          [UnsizedType.pp $ t]) [@coverage off]
 
 let basetype_dims t = SizedType.to_unsized t |> unsized_basetype_json
 

--- a/src/frontend/Parse.ml
+++ b/src/frontend/Parse.ml
@@ -1,7 +1,6 @@
 (** Some complicated stuff to get the custom syntax errors out of Menhir's
     Incremental API *)
 
-open Core
 open Stdlib.Result.Syntax
 module Interp = Parser.MenhirInterpreter
 
@@ -21,8 +20,7 @@ let drive_parser parse_fun =
       match error_state with
       | Interp.HandlingError env -> env
       | _ ->
-          Common.ICE.internal_compiler_error
-            [%message "Parser failed but is not in an error state "]
+          Common.ICE.internal_error "Parser failed but is not in an error state"
           [@coverage off] in
     let message =
       let state = Interp.current_state_number env in
@@ -35,10 +33,8 @@ let drive_parser parse_fun =
             ""
         else ""
       with _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "Failed to find error for parser error state " (state : int)]
-        [@coverage off] in
+        Common.ICE.internal_errorf "Failed to find error for parser state %d"
+          [state] [@coverage off] in
     let location =
       let env =
         match prev with
@@ -70,8 +66,8 @@ let parse parse_fun file_or_code =
   let result =
     let* lexbuf, name = to_lexbuf file_or_code in
     Preprocessor.init lexbuf name;
-    drive_parser parse_fun
-    |> Result.map_error ~f:(fun e -> Errors.Syntax_error e) in
+    drive_parser parse_fun |> Result.map_error (fun e -> Errors.Syntax_error e)
+  in
   (result, Input_warnings.collect ())
 
 let parse_stanfunctions file_or_code =

--- a/src/frontend/Pretty_print_prog.ml
+++ b/src/frontend/Pretty_print_prog.ml
@@ -57,7 +57,7 @@ let check_correctness ?(bare_functions = false) prog pretty =
         let error =
           Fmt.str "%a" (Errors.pp ?printed_filename:None ~code:pretty) e in
         (Common.ICE.internal_errorf
-           "Pretty-printed program failed to parse! Error %s@\n%s@\n%s"
+           "Pretty-printed program failed to parse!@\nError %s@\n%s@\n%s"
            [ error; Ast.sexp_of_untyped_program prog |> Sexp.to_string_hum
            ; pretty ] [@coverage off]) in
   if compare_untyped_program prog result_ast <> 0 then

--- a/src/frontend/Pretty_print_prog.ml
+++ b/src/frontend/Pretty_print_prog.ml
@@ -56,17 +56,16 @@ let check_correctness ?(bare_functions = false) prog pretty =
     | Error e ->
         let error =
           Fmt.str "%a" (Errors.pp ?printed_filename:None ~code:pretty) e in
-        (Common.ICE.internal_compiler_error
-           [%message
-             "Pretty-printed program failed to parse" error
-               (prog : Ast.untyped_program)
-               pretty] [@coverage off]) in
+        (Common.ICE.internal_errorf
+           "Pretty-printed program failed to parse! Error %s@\n%s@\n%s"
+           [ error; Ast.sexp_of_untyped_program prog |> Sexp.to_string_hum
+           ; pretty ] [@coverage off]) in
   if compare_untyped_program prog result_ast <> 0 then
-    Common.ICE.internal_compiler_error
-      [%message
-        "Pretty-printed program does match the original!"
-          (prog : Ast.untyped_program)
-          (result_ast : Ast.untyped_program)] [@coverage off]
+    Common.ICE.internal_errorf
+      "Pretty-printed program does not match the original!@\n%s@\n%s"
+      [ Ast.sexp_of_untyped_program prog |> Sexp.to_string_hum
+      ; Ast.sexp_of_untyped_program result_ast |> Sexp.to_string_hum ]
+    [@coverage off]
 
 let pretty_print_program ?(bare_functions = false) ?(line_length = 78)
     ?(inline_includes = false) ?(strip_comments = false) p =

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -82,11 +82,11 @@ let skip_comments loc =
              technically allowed things fail For example, an if statement where
              the 'else' is entirely inside the include. This makes the failure
              noisy rather than ever producing anything invalid for these. *)
-          Common.ICE.internal_compiler_error
-            [%message
-              "Unable to format #include in this position!"
-                (l : string list)
-                (loc : Middle.Location_span.t)] [@coverage off]
+          Common.ICE.(
+            internal_errorf
+              "Unable to format #include in this position! Lines: %t Loc: %t"
+              [Fmt.list Fmt.string $ l; Middle.Location_span.pp $ loc])
+          [@coverage off]
       | x, s :: l, loc -> Some (x, (" ^^^:" ^ s) :: l, loc)
       | _, [], _ -> None)
 
@@ -274,8 +274,8 @@ and pp_expression ppf ({expr= e_content; emeta= {loc; _}} : untyped_expression)
   | CondDistApp (_, id, es) -> (
       match es with
       | [] ->
-          Common.ICE.internal_compiler_error
-            [%message "CondDistApp with no arguments: " id.name] [@coverage off]
+          Common.ICE.internal_errorf "CondDistApp with no arguments: %s"
+            [id.name] [@coverage off]
       | [e] ->
           pf ppf "%a(@,%a%a)@]" pp_start_funapp id pp_expression e
             (pp_comments_spacing ~before:sp get_comments)

--- a/src/frontend/Pretty_printing.ml
+++ b/src/frontend/Pretty_printing.ml
@@ -83,9 +83,8 @@ let skip_comments loc =
              the 'else' is entirely inside the include. This makes the failure
              noisy rather than ever producing anything invalid for these. *)
           Common.ICE.(
-            internal_errorf
-              "Unable to format #include in this position! Lines: %t Loc: %t"
-              [Fmt.list Fmt.string $ l; Middle.Location_span.pp $ loc])
+            internal_errorf "%t: Unable to format #include of %t!"
+              [Middle.Location_span.pp $ loc; Fmt.list Fmt.string $ l])
           [@coverage off]
       | x, s :: l, loc -> Some (x, (" ^^^:" ^ s) :: l, loc)
       | _, [], _ -> None)

--- a/src/frontend/Promotion.ml
+++ b/src/frontend/Promotion.ml
@@ -12,7 +12,7 @@ type t =
   | IntToComplex
   | RealToComplex
   | TuplePromotion of t list
-[@@deriving sexp]
+[@@deriving sexp, show]
 
 (** Our promotion nodes only store the scalar type to promote, e.g to promote a
     [tuple(array int)] to a [tuple(array real)], we store [tuple(real)], not
@@ -54,26 +54,21 @@ let rec promote_unsized_type (typ : UnsizedType.t)
       (UnsizedType.promote_container typ UComplex, AutoDiffable)
   | NoPromotion, _, _ -> (typ, ad)
   | (IntToReal | ToVar | ToComplexVar | IntToComplex), _, _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Failed to promote type, unexpected type:"
-            (prom : t)
-            (typ : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Failed to promote type with %s, unexpected type: %t %t"
+          UnsizedType.[show prom; pp $ typ; pp_autodifftype $ ad])
+      [@coverage off]
   | TuplePromotion _, _, _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Found Tuple Promotion for a non-tuple type:"
-            (prom : t)
-            (typ : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Found Tuple Promotion %s for a non-tuple type: %t %t"
+          UnsizedType.[show prom; pp $ typ; pp_autodifftype $ ad])
+      [@coverage off]
   | _, _, TupleAD _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Found Tuple Autodiff in promotion for a non-tuple type:"
-            (prom : t)
-            (typ : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf
+          "Found Tuple Autodiff in promotion %s for a non-tuple type: %t %t"
+          UnsizedType.[show prom; pp $ typ; pp_autodifftype $ ad])
+      [@coverage off]
   | _, _, _ -> (typ, ad)
 
 let promote_inner (exp : Ast.typed_expression) prom =
@@ -118,11 +113,10 @@ let promote_inner (exp : Ast.typed_expression) prom =
           { expr= Promotion (exp, (prom_type, ad_level))
           ; emeta= {emeta with type_; ad_level} }
       | _ ->
-          Common.ICE.internal_compiler_error
-            [%message
-              "Tuple promotion on non-tuple"
-                (exp : Ast.typed_expression)
-                (prom : t)] [@coverage off])
+          Common.ICE.(
+            internal_errorf "Tuple promotion %s for a non-tuple: %t"
+              [show prom; Pretty_printing.pp_typed_expression $ exp])
+          [@coverage off])
   | _ -> exp
 
 let rec promote (exp : Ast.typed_expression) prom =
@@ -205,21 +199,21 @@ let rec get_type_promotion_exn (ad_requested, ty_requested)
     | UInt, UInt -> NoPromotion
     | t1, t2 when t1 = t2 && ad_requested = ad_current -> NoPromotion
     | _, _ ->
-        Common.ICE.internal_compiler_error
-          [%message
-            "Tried to get promotion of mismatched types!"
-              (ty_current : UnsizedType.t)
-              (ad_current : UnsizedType.autodifftype)
-              "cannot be promoted to "
-              (ty_requested : UnsizedType.t)
-              (ad_requested : UnsizedType.autodifftype)] [@coverage off]
+        Common.ICE.(
+          internal_errorf
+            "Tried to get promotion of mismatched types! %t %t cannot be \
+             promoted to %t %t"
+            UnsizedType.
+              [ pp $ ty_current; pp_autodifftype $ ad_current; pp $ ty_requested
+              ; pp_autodifftype $ ad_requested ]) [@coverage off]
   else
-    Common.ICE.internal_compiler_error
-      [%message
-        "Tried to get promotion of incompatible autodifftypes!"
-          (ad_current : UnsizedType.autodifftype)
-          "cannot be promoted to "
-          (ad_requested : UnsizedType.autodifftype)] [@coverage off]
+    Common.ICE.(
+      internal_errorf
+        "Tried to get promotion of incompatible autodifftypes! %t cannot be \
+         promoted to %t"
+        UnsizedType.
+          [pp_autodifftype $ ad_current; pp_autodifftype $ ad_requested])
+    [@coverage off]
 
 (** Calculate the "cost"/number of promotions performed. Used to disambiguate
     function signatures *)

--- a/src/frontend/Semantic_error.ml
+++ b/src/frontend/Semantic_error.ml
@@ -378,8 +378,8 @@ module TypeError = struct
           | "lpmf" -> "lpdf"
           | "lupmf" -> "lupdf"
           | _ ->
-              Common.ICE.internal_compiler_error
-                [%message "Bad suffix:" (suffix : string)] [@coverage off] in
+              Common.ICE.internal_errorf "Bad suffix: %s" [suffix]
+              [@coverage off] in
         Fmt.pf ppf
           "Function %a is not implemented for distribution %a, use %a instead."
           quoted

--- a/src/frontend/Typechecker.ml
+++ b/src/frontend/Typechecker.ml
@@ -608,10 +608,9 @@ let make_function_variable cf loc id = function
         ~ad_level:(calculate_autodifftype cf Functions type_)
         ~type_ ~loc
   | type_ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Attempting to create function variable out of "
-            (type_ : UnsizedType.t)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Attempting to create function variable out of %t"
+          [UnsizedType.pp $ type_]) [@coverage off]
 
 (** Check that the functions in the list [requires_higher_order_autodiff] cannot
     {b transitively} call stan math functions that don't have second derivative
@@ -1126,15 +1125,15 @@ and check_expression cf tenv ({emeta; expr} : Ast.untyped_expression) :
                 (List.length ts) i
               |> error
           | _ ->
-              Common.ICE.internal_compiler_error
-                [%message
-                  "Error in internal representation: tuple types don't match AD"]
+              Common.ICE.internal_error
+                "Error in internal representation: tuple types don't match AD"
               [@coverage off])
       | UTuple _, ad ->
-          Common.ICE.internal_compiler_error
-            [%message
-              "Error in internal representation: tuple doesn't have tupleAD"
-                (ad : UnsizedType.autodifftype)] [@coverage off]
+          Common.ICE.(
+            internal_errorf
+              "Error in internal representation: tuple doesn't have tupleAD, \
+               had %t"
+              [UnsizedType.pp_autodifftype $ ad]) [@coverage off]
       | _, _ ->
           Semantic_error.tuple_index_not_tuple emeta.loc te.emeta.type_ |> error
       )
@@ -1462,9 +1461,8 @@ let rec check_lvalue cf tenv {lval; lmeta= ({loc} : located_meta)} =
                 idx
               |> error
           | _ ->
-              Common.ICE.internal_compiler_error
-                [%message
-                  "Error in internal representation: tuple types don't match AD"]
+              Common.ICE.internal_error
+                "Error in internal representation: tuple types don't match AD"
               [@coverage off])
       | _, _ ->
           Semantic_error.tuple_index_not_tuple loc tlval.lmeta.type_ |> error)
@@ -1556,10 +1554,11 @@ let check_tilde_distribution loc cf tenv id arguments =
         match fn_expr.expr with
         | CondDistApp (kind, _, args) -> (args, kind)
         | _ ->
-            Common.ICE.internal_compiler_error
-              [%message
-                "Typechecking a laplace marginal did not return a distribution "
-                  (fn_expr : Ast.typed_expression)] [@coverage off]
+            Common.ICE.(
+              internal_errorf
+                "Typechecking a laplace marginal did not return a \
+                 distribution, got %t"
+                [Pretty_printing.pp_typed_expression $ fn_expr]) [@coverage off]
       else
         (* Otherwise, the function is non existent *)
         Semantic_error.invalid_tilde_no_such_dist id.id_loc name
@@ -2084,8 +2083,8 @@ and check_fundef loc cf tenv return_ty id args body =
         | UnsizedType.DataOnly, ut -> (Env.Data, ut)
         | AutoDiffable, ut -> (Param, ut)
         | TupleAD _, _ ->
-            Common.ICE.internal_compiler_error
-              [%message "TupleAD in function definition, this is unexpected!"]
+            Common.ICE.internal_error
+              "TupleAD in function definition, this is unexpected!"
             [@coverage off])
       arg_types in
   let tenv_body =
@@ -2196,11 +2195,10 @@ let verify_correctness_invariant (ast : untyped_program)
   let detyped = untyped_program_of_typed_program decorated_ast in
   if compare_untyped_program ast detyped = 0 then ()
   else
-    Common.ICE.internal_compiler_error
-      [%message
-        "Type checked AST does not match original AST. "
-          (detyped : untyped_program)
-          (ast : untyped_program)] [@coverage off]
+    Common.ICE.internal_errorf
+      "Type checked AST does not match original AST.@\n%s@\n%s"
+      [ Ast.sexp_of_untyped_program detyped |> Sexp.to_string_hum
+      ; Ast.sexp_of_untyped_program ast |> Sexp.to_string_hum ] [@coverage off]
 
 let check_program_exn ~allow_undefined_functions
     ({ functionblock= fb

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -14,8 +14,8 @@
    ppx_pipebang
    ppx_expect
    ppx_sexp_value
-   ppx_sexp_message
    ppx_deriving.fold
+   ppx_deriving.show
    ppx_deriving.map)))
 
 (ocamllex lexer)

--- a/src/frontend/parser.mly
+++ b/src/frontend/parser.mly
@@ -377,8 +377,8 @@ unsized_type:
   | basic_type LBRACK UNREACHABLE
     {
       (* This code will never be reached *)
-      Common.ICE.internal_compiler_error
-        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+      Common.ICE.internal_error "the UNREACHABLE token should never be produced"
+      [@coverage off]
     }
   | bt = basic_type { grammar_logger "unsized_type"; bt }
   | t = unsized_tuple_type { t }
@@ -421,8 +421,8 @@ basic_type:
     {
       (* This code will never be reached. The parser state exists to make the error
          more specific. *)
-      Common.ICE.internal_compiler_error
-        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+      Common.ICE.internal_error "the UNREACHABLE token should never be produced"
+      [@coverage off]
     }
 
 unsized_dims:
@@ -434,8 +434,8 @@ no_assign:
   | UNREACHABLE
     {
       (* This code will never be reached *)
-      Common.ICE.internal_compiler_error
-        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+      Common.ICE.internal_error "the UNREACHABLE token should never be produced"
+      [@coverage off]
     }
 
 optional_assignment(rhs):
@@ -489,8 +489,8 @@ decl(type_rule, rhs):
     }
   | DATABLOCK UNREACHABLE
     {
-      Common.ICE.internal_compiler_error
-        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+      Common.ICE.internal_error "the UNREACHABLE token should never be produced"
+      [@coverage off]
     }
   | ty = higher_type(type_rule)
     (* additional indirection only for better error messaging *)
@@ -601,8 +601,8 @@ sized_basic_type:
     {
       (* This code will never be reached. The parser state exists to make the error
          more specific. *)
-      Common.ICE.internal_compiler_error
-        [%message "the UNREACHABLE token should never be produced"] [@coverage off]
+      Common.ICE.internal_error "the UNREACHABLE token should never be produced"
+      [@coverage off]
     }
 
 top_var_type:

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -178,9 +178,9 @@ module Helpers = struct
       | UComplexVector -> UComplexRowVector
       | (UMatrix | UComplexMatrix) as t -> t
       | t ->
-          Common.ICE.internal_compiler_error
-            [%message "Cannot transpose " (t : UnsizedType.t)] [@coverage off]
-    in
+          Common.ICE.(
+            internal_errorf "Cannot transpose %t" [UnsizedType.pp $ t])
+          [@coverage off] in
     let expr = unary_op Transpose e in
     {expr with meta= {expr.meta with type_= new_type}}
 
@@ -228,8 +228,8 @@ module Helpers = struct
      |UComplexRowVector, [_] ->
         UComplex
     | _ ->
-        ICE.internal_compiler_error
-          [%message "Can't index" (ut : UnsizedType.t)] [@coverage off]
+        ICE.(internal_errorf "Can't index %t" [UnsizedType.pp $ ut])
+        [@coverage off]
 
   (** [add_index expression index] returns an expression that (additionally)
       indexes into the input [expression] by [index].*)
@@ -241,8 +241,7 @@ module Helpers = struct
       | Var _ | TupleProjection _ -> Pattern.Indexed (e, [i])
       | Indexed (e, indices) -> Indexed (e, indices @ [i])
       | _ ->
-          ICE.internal_compiler_error
-            [%message "Expected Var or Indexed but found " (e : Typed.t)]
+          ICE.(internal_errorf "Expected Var or Indexed but found %t" [pp $ e])
           [@coverage off] in
     {meta; pattern}
 
@@ -255,11 +254,11 @@ module Helpers = struct
       match Typed.(type_of e) with
       | UTuple ts -> List.nth_exn ts (i - 1)
       | t ->
-          ICE.internal_compiler_error
-            [%message
+          ICE.(
+            internal_errorf
               "Internal error: Attempted to apply tuple index to a non-tuple \
-               type:"
-                (t : UnsizedType.t)] [@coverage off] in
+               type: %t"
+              [UnsizedType.pp $ t]) [@coverage off] in
     let meta = Typed.Meta.{e.meta with type_= mtype} in
     let pattern = Pattern.TupleProjection (e, i) in
     {meta; pattern}

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -33,9 +33,8 @@ type 'expr t =
 let to_string
     ?(expr_to_string =
       fun _ ->
-        (Common.ICE.internal_compiler_error
-           [%message
-             "Should not be parsing expression from string in function renaming"]
+        (Common.ICE.internal_error
+           "Should not be parsing expression from string in function renaming"
          [@coverage off])) x =
   Sexp.to_string (sexp_of_t expr_to_string x) ^ "__"
 

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -70,10 +70,10 @@ let rec get_dims_io st =
   | SComplexMatrix (dim1, dim2) -> [dim1; dim2; two]
   | SArray (t, dim) -> dim :: get_dims_io t
   | STuple _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Tried to get IO dims of a tuple, which is not rectangular"
-            (st : Expr.Typed.t t)] [@coverage off]
+      Common.ICE.(
+        internal_errorf
+          "Tried to get IO dims of a tuple, which is not rectangular: %t"
+          [pp Expr.Typed.pp $ st]) [@coverage off]
 
 let rec io_size st =
   let two = Expr.Helpers.int 2 in

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -233,8 +233,7 @@ module Helpers = struct
         mk_for_iteratee rows (fun e -> for_each bodyfn e smeta) iteratee smeta
     | UArray _ -> mk_for_iteratee (len iteratee) bodyfn iteratee smeta
     | UMathLibraryFunction | UFun _ | UTuple _ ->
-        ICE.internal_compiler_error
-          [%message "Can't iterate over " (iteratee : Expr.Typed.t)]
+        ICE.(internal_errorf "Can't iterate over %t" [Expr.Typed.pp $ iteratee])
         [@coverage off]
 
   let contains_fn_kind is_fn_kind ?(init = false) stmt =

--- a/src/middle/Transformation.ml
+++ b/src/middle/Transformation.ml
@@ -24,7 +24,7 @@ type 'e t =
   | StochasticRow
   | StochasticColumn
   | TupleTransformation of 'e t list
-[@@deriving sexp, compare, map, hash, fold]
+[@@deriving sexp, compare, map, hash, fold, show]
 
 let rec has_check = function
   | Identity | Offset _ | Multiplier _ | OffsetMultiplier _ -> false

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -292,11 +292,10 @@ let rec fill_adtype_for_type ad ut =
       TupleAD (List.map2_exn ~f:fill_adtype_for_type ads ts)
   | _, UTuple ts -> TupleAD (List.map ~f:(fill_adtype_for_type ad) ts)
   | TupleAD _, _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Attempting to give a non-tuple a TupleAD type"
-            (ut : t)
-            (ad : autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf
+          "Attempting to give a non-tuple a TupleAD type: type %t ad %t"
+          [pp $ ut; pp_autodifftype $ ad]) [@coverage off]
   | _, _ -> ad
 
 (** List all possible tuple sub-names for IO purposes. E.g, the decl

--- a/src/middle/Utils.ml
+++ b/src/middle/Utils.ml
@@ -60,10 +60,9 @@ let%expect_test "unnormalized name mangling" =
 let tuple_trans_exn = function
   | Transformation.TupleTransformation transforms -> transforms
   | t ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Expected TupleTransformation but got"
-            (t : Expr.Typed.t Transformation.t)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Expected TupleTransformation but got %t"
+          [Transformation.pp Expr.Typed.pp $ t]) [@coverage off]
 
 let zip_stuple_trans_exn pst tms =
   let rec tuple_subtypes pst =
@@ -71,8 +70,8 @@ let zip_stuple_trans_exn pst tms =
     | SizedType.STuple subtypes -> subtypes
     | SArray (st, _) -> tuple_subtypes st
     | _ ->
-        Common.ICE.internal_compiler_error
-          [%message "Internal error: expected Tuple with TupleTransformation"]
+        Common.ICE.internal_error
+          "Internal error: expected Tuple with TupleTransformation"
         [@coverage off] in
   let psts = tuple_subtypes pst in
   List.zip_exn psts tms
@@ -83,8 +82,8 @@ let zip_utuple_trans_exn pst tms =
     | UnsizedType.UTuple uts -> uts
     | UArray ut -> tuple_psts ut
     | _ ->
-        Common.ICE.internal_compiler_error
-          [%message "Internal error: expected Tuple with TupleTransformation"]
+        Common.ICE.internal_error
+          "Internal error: expected Tuple with TupleTransformation"
         [@coverage off] in
   let psts = tuple_psts pst in
   List.zip_exn psts tms

--- a/src/middle/dune
+++ b/src/middle/dune
@@ -12,7 +12,7 @@
    ppx_hash
    ppx_expect
    ppx_sexp_value
-   ppx_sexp_message
    ppx_deriving.map
    ppx_deriving.fold
-   ppx_deriving.create)))
+   ppx_deriving.create
+   ppx_deriving.show)))

--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -2,7 +2,7 @@
 
 open Core
 
-type identifier = string [@@deriving sexp]
+type identifier = string [@@deriving sexp, show]
 
 (** C++ types *)
 type type_ =
@@ -25,7 +25,7 @@ type type_ =
   | Pointer of type_
   | TypeTrait of identifier * type_ list
       (** e.g. stan::promote_scalar, stan:base_type *)
-[@@deriving sexp]
+[@@deriving sexp, show]
 
 module Types = struct
   (** Helpers for constructing types *)
@@ -62,8 +62,8 @@ module Types = struct
     match t with
     | Matrix _ -> TypeTrait ("Eigen::Map", [t])
     | _ ->
-        Common.ICE.internal_compiler_error
-          [%message "Tried to make an Eigen::Map of" (t : type_)]
+        Common.ICE.(
+          internal_errorf "Tried to make an Eigen::Map of %s" [show_type_ t])
         [@coverage off]
 
   let var_context = TypeLiteral "stan::io::var_context"

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -57,9 +57,8 @@ let constraint_to_string = function
   | StochasticColumn -> Some "stochastic_column"
   | Identity -> None
   | TupleTransformation _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Cannot generate tuple transformation directly; should not be called"]
+      Common.ICE.internal_error
+        "Cannot generate tuple transformation directly; should not be called"
       [@coverage off]
 
 let functor_suffix = "_functor__"
@@ -148,11 +147,9 @@ let rec local_scalar ut ad =
   | _, UnsizedType.DataOnly | UInt, AutoDiffable -> stantype_prim ut
   | _, AutoDiffable -> Types.local_scalar
   | _, TupleAD _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Attempting to make a local scalar tuple"
-            (ut : UnsizedType.t)
-            (ad : UnsizedType.autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Attempting to make a local scalar tuple: type %t ad %t"
+          UnsizedType.[pp $ ut; pp_autodifftype $ ad]) [@coverage off]
 
 let minus_one e =
   let open Cpp.DSL in
@@ -177,8 +174,7 @@ let rec lower_type ?(mem_pattern = Mem_pattern.AoS) (t : UnsizedType.t)
   | UComplexRowVector -> Types.row_vector (Types.complex scalar)
   | UComplexMatrix -> Types.matrix (Types.complex scalar)
   | UMathLibraryFunction | UFun _ ->
-      Common.ICE.internal_compiler_error
-        [%message "Function types not implemented"] [@coverage off]
+      Common.ICE.internal_error "Function types not implemented" [@coverage off]
 
 let rec lower_unsizedtype_local ?(mem_pattern = Mem_pattern.AoS) adtype ut =
   match (adtype, ut) with
@@ -187,11 +183,9 @@ let rec lower_unsizedtype_local ?(mem_pattern = Mem_pattern.AoS) adtype ut =
   | UnsizedType.TupleAD _, UnsizedType.UArray t ->
       Types.std_vector (lower_unsizedtype_local ~mem_pattern adtype t)
   | _, UnsizedType.UTuple _ | TupleAD _, _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Tuple and Tuple AD type not matching!"
-            (ut : UnsizedType.t)
-            (adtype : UnsizedType.autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Tuple %t and Tuple AD type %t not matching!"
+          UnsizedType.[pp $ ut; pp_autodifftype $ adtype]) [@coverage off]
   | _, _ ->
       let s = local_scalar ut adtype in
       lower_type ~mem_pattern ut s
@@ -212,10 +206,9 @@ let rec lower_possibly_var_decl adtype ut mem_pattern =
            ~f:(fun ad t -> lower_possibly_var_decl ad t mem_pattern)
            ads t_lst)
   | x, ad ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Cannot lower" (x : UnsizedType.t) (ad : UnsizedType.autodifftype)]
-      [@coverage off]
+      Common.ICE.(
+        internal_errorf "Cannot lower %t %t"
+          UnsizedType.[pp $ x; pp_autodifftype $ ad]) [@coverage off]
 
 let rec lower_logical_op op e1 e2 =
   let prim e = Exprs.fun_call "stan::math::primitive_value" [lower_expr e] in
@@ -242,9 +235,9 @@ and read_data ut es =
     | UInt | UReal | UComplex | UVector | URowVector | UMatrix | UTuple _
      |UComplexMatrix | UComplexRowVector | UComplexVector | UArray _ | UFun _
      |UMathLibraryFunction ->
-        Common.ICE.internal_compiler_error
-          [%message "Can't ReadData of " (ut : UnsizedType.t)] [@coverage off]
-  in
+        Common.ICE.(
+          internal_errorf "Can't ReadData of %t" [UnsizedType.pp $ ut])
+        [@coverage off] in
   let open Cpp.DSL in
   let data_context = Var "context__" in
   data_context.@?(val_method, [lower_expr (List.hd_exn es)])
@@ -291,9 +284,8 @@ and lower_operator_app op es_in =
   | Modulo -> lower_binary_fun "stan::math::modulus" es
   | LDivide -> lower_binary_fun "stan::math::mdivide_left" es
   | And | Or ->
-      Common.ICE.internal_compiler_error
-        [%message "And/Or should have been converted to an expression"]
-      [@coverage off]
+      Common.ICE.internal_error
+        "And/Or should have been converted to an expression" [@coverage off]
   | EltTimes -> lower_binary_op Multiply "stan::math::elt_multiply" es
   | EltDivide -> lower_binary_op Divide "stan::math::elt_divide" es
   | Pow -> lower_binary_fun "stan::math::pow" es
@@ -449,10 +441,9 @@ and lower_compiler_internal ad ut f es =
         match ut with
         | UnsizedType.UArray ut -> ut
         | _ ->
-            Common.ICE.internal_compiler_error
-              [%message
-                "Array literal must have array type but found "
-                  (ut : UnsizedType.t)] [@coverage off] in
+            Common.ICE.(
+              internal_errorf "Array literal must have array type but found %t"
+                [UnsizedType.pp $ ut]) [@coverage off] in
       Exprs.std_vector_init_expr
         (lower_unsizedtype_local ad ut)
         (lower_exprs es)
@@ -475,10 +466,9 @@ and lower_compiler_internal ad ut f es =
                 (lower_unsizedtype_local ad UComplexRowVector)
                 (lower_exprs es) ]
       | _ ->
-          Common.ICE.internal_compiler_error
-            [%message
-              "Unexpected type for row vector literal" (ut : UnsizedType.t)]
-          [@coverage off])
+          Common.ICE.(
+            internal_errorf "Unexpected type for row vector literal %t"
+              [UnsizedType.pp $ ut]) [@coverage off])
   | FnReadData -> read_data ut es
   | FnReadDeserializer ->
       deserializer.@<>(( "read"
@@ -526,17 +516,15 @@ and lower_indexed_simple (e : expr) idcs =
   let idx_minus_one = function
     | Index.Single e -> minus_one e
     | MultiIndex e | Between (e, _) | Upfrom e -> (
-        Common.ICE.internal_compiler_error
-          [%message
-            "No non-Single indices allowed"
-              (e : expr)
-              (idcs : Expr.Typed.t Index.t list)] [@coverage off])
+        Common.ICE.(
+          internal_errorf "No non-Single indices allowed %t %t"
+            [Cpp.Printing.pp_expr $ e; Fmt.list (Index.pp Expr.Typed.pp) $ idcs])
+        [@coverage off])
     | All -> (
-        Common.ICE.internal_compiler_error
-          [%message
-            "No non-Single indices allowed"
-              (e : expr)
-              (idcs : Expr.Typed.t Index.t list)] [@coverage off]) in
+        Common.ICE.(
+          internal_errorf "No non-Single indices allowed %t %t"
+            [Cpp.Printing.pp_expr $ e; Fmt.list (Index.pp Expr.Typed.pp) $ idcs])
+        [@coverage off]) in
   List.fold idcs ~init:e ~f:(fun e id ->
       Subscript (e, idx_minus_one (Index.map lower_expr id)))
 

--- a/src/stan_math_backend/Lower_functions.ml
+++ b/src/stan_math_backend/Lower_functions.ml
@@ -49,10 +49,9 @@ let rec requires ut t =
         ("stan::is_tuple_of_size", [t; NonTypeTemplateInt (List.length ts)])
       :: List.concat_mapi ts ~f:(fun i ty -> requires ty (Types.tuple_elt t i))
   | UMathLibraryFunction | UFun _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Cannot formulate require templates for type " (ut : UnsizedType.t)]
-      [@coverage off]
+      Common.ICE.(
+        internal_errorf "Cannot formulate require templates for type %t"
+          [UnsizedType.pp $ ut]) [@coverage off]
 
 (** Identify the templates which need to be considered in the return type of the
     function (i.e., the scalar types) *)
@@ -74,13 +73,12 @@ let return_optional_arg_types (args : Program.fun_arg_decl) =
             let templates = List.concat temps in
             templates
         | _ ->
-            Common.ICE.internal_compiler_error
-              [%message
-                "Impossible: type passes UnsizedType.contains_tuple but \
-                 unwrapped scalar is not tuple"
-                  (typ : UnsizedType.t)
-                  (internal : UnsizedType.t)
-                  (ad : UnsizedType.autodifftype)] [@coverage off])
+            Common.ICE.(
+              internal_errorf
+                "Impossible: type %t passes UnsizedType.contains_tuple but \
+                 unwrapped scalar %t is not tuple %t"
+                UnsizedType.[pp $ typ; pp $ internal; pp_autodifftype $ ad])
+            [@coverage off])
     | UnsizedType.DataOnly, ut when not (UnsizedType.is_eigen_type ut) -> []
     | ( _
       , ( UnsizedType.UArray _ | UComplex | UVector | URowVector | UMatrix

--- a/src/stan_math_backend/Lower_program.ml
+++ b/src/stan_math_backend/Lower_program.ml
@@ -60,10 +60,9 @@ let lower_map_decl (vident, ut) : defn =
   | UComplexRowVector -> eigen_map_def (row_vector (complex scalar)) 1
   | UComplexVector -> eigen_map_def (vector (complex scalar)) 1
   | x ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Error during Map data construction for " vident " of type "
-            (x : UnsizedType.t)] [@coverage off]
+      Common.ICE.(
+        internal_errorf "Error during Map data construction for %s of type %t"
+          [vident; UnsizedType.pp $ x]) [@coverage off]
 
 let rec top_level_decls Stmt.{pattern; _} =
   match pattern with

--- a/src/stan_math_backend/Lower_stmt.ml
+++ b/src/stan_math_backend/Lower_stmt.ml
@@ -14,12 +14,11 @@ let check_to_string = function
   | Upper _ -> Some "less_or_equal"
   | CholeskyCov -> Some "cholesky_factor"
   | LowerUpper _ ->
-      Common.ICE.internal_compiler_error
-        [%message "LowerUpper is really two other checks tied together"]
-      [@coverage off]
+      Common.ICE.internal_error
+        "LowerUpper is really two other checks tied together" [@coverage off]
   | Offset _ | Multiplier _ | OffsetMultiplier _ ->
-      Common.ICE.internal_compiler_error
-        [%message "Offset and multiplier don't have a check"] [@coverage off]
+      Common.ICE.internal_error "Offset and multiplier don't have a check"
+      [@coverage off]
   | t -> constraint_to_string t
 
 let math_fn_translations = function
@@ -91,11 +90,11 @@ let rec initialize_value st adtype =
       let tupl = lower_st st adtype in
       InitializerExpr (tupl, List.map2_exn ~f:initialize_value subts ads)
   | _, STuple _ | TupleAD _, _ ->
-      Common.ICE.internal_compiler_error
-        [%message
-          "Mismatch between Tuple type and Tuple AD in code gen"
-            (st : Expr.Typed.t SizedType.t)
-            (adtype : UnsizedType.autodifftype)] [@coverage off]
+      Common.ICE.(
+        internal_errorf
+          "Mismatch between Tuple type %t and Tuple AD %t in code gen"
+          [SizedType.pp Expr.Typed.pp $ st; UnsizedType.pp_autodifftype $ adtype])
+      [@coverage off]
 
 (** Initialize an object of a given size.*)
 let lower_assign_sized st adtype (initialize : 'a Stmt.Pattern.decl_init) =
@@ -168,9 +167,8 @@ let rec lower_nonrange_lvalue lvalue =
   | lv, idcs when List.for_all ~f:is_single_index idcs ->
       lower_indexed_simple (lower_nonrange_lbase lv) idcs
   | _, _ ->
-      Common.ICE.internal_compiler_error
-        [%message "Multi-index must be the last (rightmost) index."]
-      [@coverage off]
+      Common.ICE.internal_error
+        "Multi-index must be the last (rightmost) index." [@coverage off]
 
 and lower_nonrange_lbase = function
   | Stmt.Pattern.LVariable v -> Var v

--- a/src/stan_math_backend/dune
+++ b/src/stan_math_backend/dune
@@ -21,5 +21,5 @@
    ppx_pipebang
    ppx_expect
    ppx_sexp_value
-   ppx_sexp_message
-   ppx_deriving.make)))
+   ppx_deriving.make
+   ppx_deriving.show)))

--- a/stanc.opam
+++ b/stanc.opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/stan-dev/stanc3"
 doc: "https://mc-stan.org/stanc3/stanc/"
 bug-reports: "https://github.com/stan-dev/stanc3/issues"
 depends: [
-  "dune" {>= "3.5"}
+  "dune" {>= "3.12"}
   "ocaml" {= "5.5.0"}
   "base" {= "v0.17.3"}
   "menhir" {= "20260209"}
@@ -22,8 +22,10 @@ depends: [
   "ppx_pipebang"
   "ppx_sexp_value"
   "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "menhirformat" {with-dev-setup}
   "bisect_ppx" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
+  "menhir-lsp" {with-dev-setup}
   "odoc" {with-doc}
   "sherlodoc" {with-doc}
 ]

--- a/stanc.opam
+++ b/stanc.opam
@@ -21,7 +21,6 @@ depends: [
   "ppx_inline_test"
   "ppx_pipebang"
   "ppx_sexp_value"
-  "ppx_sexp_message"
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "bisect_ppx" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -9,11 +9,12 @@ let%expect_test "with_exn_message" =
   [%expect
     {|
     Internal compiler error:
-    (Failure oops!)
+    oops!
     Backtrace missing.
 
     This should never happen. Please file a bug at %PKG_ISSUES%
-    and include this message and the model that caused this issue. |}]
+    and include this message and the model that caused this issue.
+    |}]
 
 (* expect_tests warn against directly including a backtrace for fragility
    reasons *)
@@ -37,8 +38,9 @@ let%expect_test "ICE triggered" =
   [%expect
     {|
     Internal compiler error:
-    ("Can't index" (ut UReal))
+    Can't index real
     Backtrace missing.
 
     This should never happen. Please file a bug at %PKG_ISSUES%
-    and include this message and the model that caused this issue. |}]
+    and include this message and the model that caused this issue.
+    |}]

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -3,7 +3,7 @@ open Common
 
 let%expect_test "with_exn_message" =
   Printexc.record_backtrace false;
-  ICE.with_exn_message (fun () -> failwith "oops!")
+  ICE.with_exn_message (fun () -> ICE.internal_error "oops!")
   |> Result.error |> Option.value_exn |> print_endline;
   Printexc.record_backtrace true;
   [%expect
@@ -19,7 +19,7 @@ let%expect_test "with_exn_message" =
 (* expect_tests warn against directly including a backtrace for fragility
    reasons *)
 let%expect_test "backtrace indirect test" =
-  ( ICE.with_exn_message (fun () -> failwith "oops!")
+  ( ICE.with_exn_message (fun () -> assert false)
   |> Result.error |> Option.value_exn
   |> fun s ->
     if String.is_substring ~substring:"Called from Common" s then


### PR DESCRIPTION
One of the more interesting additions in 5.5 is the `l*printf` family of functions (https://github.com/ocaml/ocaml/pull/13372). These make it much easier to create functions that "act like" pretty-printers that would have previously required continuations or been impossible to provide a type for. 

This PR replaces `Common.ICE.internal_compiler_error` with two functions, one that just accepts a string, and the other that uses `Format.lasprintf` to allow additional formatting. This is more flexible than the existing sexp-based function, and doesn't require the use of any PPX to invoke

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes



## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
