### PR TITLE
Use a Dynarray instead of a hashtable for the preprocessor locations

### DIFF
--- a/src/core/Core.ml
+++ b/src/core/Core.ml
@@ -87,6 +87,7 @@ module Marshal = Stdlib.Marshal
 module Printf = Stdlib.Printf
 module Scanf = Stdlib.Scanf
 module Obj = Stdlib.Obj
+module Dynarray = Stdlib.Dynarray
 
 let ( ^^ ) = Stdlib.( ^^ )
 let ( ** ) = Stdlib.( ** )

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -11,26 +11,26 @@ let include_stack = Stack.create ()
 let included_files : string list ref = ref []
 let size () = Stack.length include_stack
 
-let locations_map : (string * Middle.Location.t option) String.Table.t =
-  String.Table.create ()
+let locations_map : (string * Middle.Location.t option) Dynarray.t =
+  Dynarray.create ()
 
 let new_file_start_position buf filename included_from =
   (* Lexing.position does not have a field to store `included_from` so we store
-     it in a global hashmap instead and put the hashmap key in `pos_fname`. The
-     keys are arbitrary unique strings. (Filenames are not good keys because the
-     same file could be included multiple times.)
+     it in a global array and put the key in `pos_fname`. The keys simply count
+     up. (Filenames are not good keys because the same file could be included
+     multiple times.)
 
      Prefixing the key with NUL allows us to do a little optimization: when
-     `included_from` is None we don't need to access the hashmap and can store
-     the filename directly in `pos_fname`. Filenames never begin with NUL so
+     `included_from` is None we don't need to access the array and can store the
+     filename directly in `pos_fname`. Filenames never begin with NUL so
      `location_of_position` only needs to check the first character to know
-     whether to do a hashmap lookup. *)
+     whether to do a lookup. *)
   let pos =
     if Option.is_none included_from then
       {Lexing.pos_fname= filename; pos_lnum= 1; pos_bol= 0; pos_cnum= 0}
     else
-      let key = "\u{0}" ^ Int.to_string (Hashtbl.length locations_map) in
-      Hashtbl.add_exn locations_map ~key ~data:(filename, included_from);
+      let key = "\u{0}" ^ Int.to_string (Dynarray.length locations_map) in
+      Dynarray.add_last locations_map (filename, included_from);
       {Lexing.pos_fname= key; pos_lnum= 1; pos_bol= 0; pos_cnum= 0} in
   buf.lex_start_p <- pos;
   buf.lex_curr_p <- pos
@@ -38,7 +38,7 @@ let new_file_start_position buf filename included_from =
 let location_of_position {Lexing.pos_fname; pos_lnum; pos_cnum; pos_bol} =
   let filename, included_from =
     if Char.equal (String.get pos_fname 0) (Char.of_string "\u{0}") then
-      Hashtbl.find_exn locations_map pos_fname
+      Dynarray.get locations_map (Int.of_string (String.subo ~pos:1 pos_fname))
     else (pos_fname, None) in
   { Middle.Location.line_num= pos_lnum
   ; col_num= pos_cnum - pos_bol
@@ -57,7 +57,7 @@ let location_span_of_positions (start_pos, end_pos) : Middle.Location_span.t =
   {begin_loc; end_loc}
 
 let init buf filename =
-  Hashtbl.clear locations_map;
+  Dynarray.clear locations_map;
   Queue.clear comments;
   included_files := [];
   Stack.clear include_stack;

--- a/src/frontend/Preprocessor.ml
+++ b/src/frontend/Preprocessor.ml
@@ -1,12 +1,11 @@
 (** Preprocessor for handling include directives *)
 
-open Core
 open Lexing
 open Debugging
 
 let comments = Queue.create ()
-let add_comment = Queue.enqueue comments
-let get_comments () = Queue.to_list comments
+let add_comment c = Queue.push c comments
+let get_comments () = Queue.to_seq comments |> List.of_seq
 let include_stack = Stack.create ()
 let included_files : string list ref = ref []
 let size () = Stack.length include_stack
@@ -16,9 +15,7 @@ let locations_map : (string * Middle.Location.t option) Dynarray.t =
 
 let new_file_start_position buf filename included_from =
   (* Lexing.position does not have a field to store `included_from` so we store
-     it in a global array and put the key in `pos_fname`. The keys simply count
-     up. (Filenames are not good keys because the same file could be included
-     multiple times.)
+     it in a global array and put its index in `pos_fname`.
 
      Prefixing the key with NUL allows us to do a little optimization: when
      `included_from` is None we don't need to access the array and can store the
@@ -29,7 +26,12 @@ let new_file_start_position buf filename included_from =
     if Option.is_none included_from then
       {Lexing.pos_fname= filename; pos_lnum= 1; pos_bol= 0; pos_cnum= 0}
     else
-      let key = "\u{0}" ^ Int.to_string (Dynarray.length locations_map) in
+      let encode i =
+        let buf = Bytes.create 5 in
+        Bytes.set buf 0 Char.Ascii.min;
+        Bytes.set_int32_ne buf 1 (Int32.of_int i);
+        Bytes.to_string buf in
+      let key = encode (Dynarray.length locations_map) in
       Dynarray.add_last locations_map (filename, included_from);
       {Lexing.pos_fname= key; pos_lnum= 1; pos_bol= 0; pos_cnum= 0} in
   buf.lex_start_p <- pos;
@@ -37,8 +39,9 @@ let new_file_start_position buf filename included_from =
 
 let location_of_position {Lexing.pos_fname; pos_lnum; pos_cnum; pos_bol} =
   let filename, included_from =
-    if Char.equal (String.get pos_fname 0) (Char.of_string "\u{0}") then
-      Dynarray.get locations_map (Int.of_string (String.subo ~pos:1 pos_fname))
+    if Char.equal (String.get pos_fname 0) Char.Ascii.min then
+      let decode s = Int32.to_int (Bytes.get_int32_ne (Bytes.of_string s) 1) in
+      Dynarray.get locations_map (decode pos_fname)
     else (pos_fname, None) in
   { Middle.Location.line_num= pos_lnum
   ; col_num= pos_cnum - pos_bol
@@ -61,18 +64,18 @@ let init buf filename =
   Queue.clear comments;
   included_files := [];
   Stack.clear include_stack;
-  Stack.push include_stack buf;
+  Stack.push buf include_stack;
   new_file_start_position buf filename None
 
 let current_buffer () =
-  let buf = Stack.top_exn include_stack in
+  let buf = Stack.top include_stack in
   buf
 
 let current_location () =
   let buf = current_buffer () in
   location_span_of_positions (Lexing.lexeme_start_p buf, Lexing.lexeme_end_p buf)
 
-let pop_buffer () = Stack.pop_exn include_stack
+let pop_buffer () = Stack.pop include_stack
 
 let restore_prior_lexbuf () =
   ignore (pop_buffer ());
@@ -101,17 +104,17 @@ let find_include_fs lookup_paths fname =
           let full_path = path ^ "/" ^ fname in
           let ic = In_channel.open_bin full_path in
           let lexbuf = Lexing.from_channel ic in
-          Stdlib.Gc.finalise (fun _ -> In_channel.close_noerr ic) lexbuf;
+          Gc.finalise (fun _ -> In_channel.close_noerr ic) lexbuf;
           (lexbuf, full_path)
         with _ -> loop rest_of_paths) in
   loop lookup_paths
 
 let find_include_inmemory map fname =
-  match Map.find map fname with
+  match Core.Map.find map fname with
   | None ->
       let message =
         let pp_list ppf l =
-          let keys = Map.keys l in
+          let keys = Core.Map.keys l in
           if List.is_empty keys then Fmt.string ppf "None"
           else Fmt.(list ~sep:comma string) ppf keys in
         Fmt.str
@@ -128,14 +131,12 @@ let find_include fname =
 
 let try_get_new_lexbuf fname =
   let prior_loc =
-    let lexbuf = Stack.top_exn include_stack in
+    let lexbuf = Stack.top include_stack in
     location_of_position lexbuf.lex_start_p in
   let new_lexbuf =
     let buf, file = find_include fname in
     let buf =
-      if
-        Common.Files.is_stanfunctions file
-        && List.mem !included_files file ~equal:String.equal
+      if Common.Files.is_stanfunctions file && List.mem file !included_files
       then (
         lexer_logger ("ignoring duplicated include  " ^ file);
         Lexing.from_string "")
@@ -154,7 +155,7 @@ let try_get_new_lexbuf fname =
     go included_from in
   if dup_exists prior_loc then
     include_error (Printf.sprintf "File %s recursively included itself." fname);
-  Stack.push include_stack new_lexbuf;
+  Stack.push new_lexbuf include_stack;
   new_lexbuf
 
 let included_files () = List.rev !included_files

--- a/src/frontend/lexer.mll
+++ b/src/frontend/lexer.mll
@@ -1,8 +1,6 @@
 (** The lexer that will feed into the parser. An OCamllex file. *)
 
 {
-  module Stack = Core.Stack
-  module Queue = Core.Queue
   open Lexing
   open Debugging
   open Preprocessor


### PR DESCRIPTION
This hashtable only ever had keys that were numeric and growing, which means it was essentially just a growable array in a language without good support for those. Now that the standard library has a `Dynarray` module, we can use that and save on some storage

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
