### PR TITLE
Remove unnecessary ppx_hash

### DIFF
--- a/docs/core_ideas.mld
+++ b/docs/core_ideas.mld
@@ -34,7 +34,7 @@ If you look at a type declaration of something like [Ast.typed_expression], you'
 
 {[
 type typed_expression = (typed_expr_meta, fun_kind) expr_with
-[@@deriving sexp, compare, map, hash, fold]
+[@@deriving sexp, compare, map, fold]
 ]}
 
 When using an editor that supports code completion, you may notice that the [Ast] module suggests functions

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,6 @@
    (= 2.1.1))
   (ppx_deriving
    (= 6.1.1))
-  ppx_hash
   ppx_compare
   ppx_sexp_conv
   ppx_expect

--- a/scripts/install_build_deps.sh
+++ b/scripts/install_build_deps.sh
@@ -8,6 +8,6 @@ eval $(opam env)
 opam pin -y base v0.17.3 --no-action
 
 opam install -y dune base.v0.17.3 menhir.20260209 ppx_deriving.6.1.1 fmt.0.11.0 yojson.3.0.0 cmdliner.2.1.1\
-     ppx_hash ppx_compare ppx_sexp_conv ppx_expect ppx_inline_test ppx_pipebang ppx_sexp_value
+     ppx_compare ppx_sexp_conv ppx_expect ppx_inline_test ppx_pipebang ppx_sexp_value
 
 eval $(opam env)

--- a/scripts/install_build_deps_windows.sh
+++ b/scripts/install_build_deps_windows.sh
@@ -15,7 +15,7 @@ opam pin add -y ocaml-windows 5.5.0
 # Install dependencies
 opam install -y base.v0.17.3 base-windows.v0.17.3 menhir.20260209 menhir-windows.20260209 fmt.0.11.0\
      fmt-windows.0.11.0 yojson.3.0.0 yojson-windows.3.0.0 cmdliner.2.1.1 cmdliner-windows.2.1.1\
-     ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1 ppx_hash ppx_hash-windows ppx_compare ppx_compare-windows ppx_sexp_conv\
+     ppx_deriving.6.1.1 ppx_deriving-windows.6.1.1 ppx_compare ppx_compare-windows ppx_sexp_conv\
      ppx_sexp_conv-windows ppx_expect ppx_expect-windows ppx_inline_test ppx_inline_test-windows ppx_pipebang\
      ppx_pipebang-windows ppx_sexp_value ppx_sexp_value-windows
 

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -14,7 +14,7 @@ open Middle
 (** Our type for identifiers, on which we record a location *)
 type identifier =
   {name: string; id_loc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
-[@@deriving sexp, hash, compare]
+[@@deriving sexp, compare]
 
 (** Indices for array access *)
 type 'e index =
@@ -23,13 +23,13 @@ type 'e index =
   | Upfrom of 'e
   | Downfrom of 'e
   | Between of 'e * 'e
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 (** Front-end function kinds *)
 type fun_kind =
   | StanLib of bool Fun_kind.suffix
   | UserDefined of bool Fun_kind.suffix
-[@@deriving compare, sexp, hash]
+[@@deriving compare, sexp]
 
 (** Expression shapes (used for both typed and untyped expressions, where we
     substitute untyped_expression or typed_expression for 'e *)
@@ -52,18 +52,18 @@ type ('e, 'f, 'p) expression =
   | Indexed of 'e * 'e index list
   | TupleProjection of 'e * int
   | TupleExpr of 'e list
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type ('m, 'f, 'p) expr_with =
   {expr: (('m, 'f, 'p) expr_with, 'f, 'p) expression; emeta: 'm}
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 (** Untyped expressions, which have location_spans as meta-data *)
 type located_meta = {loc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 type untyped_expression = (located_meta, unit, Core.Nothing.t) expr_with
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 (** Typed expressions also have meta-data after type checking: a location_span,
     as well as a type and an origin block (lub of the origin blocks of the
@@ -72,14 +72,14 @@ type typed_expr_meta =
   { loc: (Location_span.t[@sexp.opaque] [@compare.ignore])
   ; ad_level: UnsizedType.autodifftype
   ; type_: UnsizedType.t }
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 type typed_expression =
   ( typed_expr_meta
   , fun_kind
   , UnsizedType.t * UnsizedType.autodifftype )
   expr_with
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 let expr_loc_lub exprs =
   match List.map ~f:(fun e -> e.emeta.loc) exprs with
@@ -93,7 +93,7 @@ let expr_ad_lub exprs =
 
 (** Assignment operators *)
 type assignmentoperator = Assign | OperatorAssign of Operator.t
-[@@deriving sexp, hash, compare]
+[@@deriving sexp, compare]
 
 (** Truncations *)
 type 'e truncation =
@@ -101,40 +101,40 @@ type 'e truncation =
   | TruncateUpFrom of 'e
   | TruncateDownFrom of 'e
   | TruncateBetween of 'e * 'e
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 (** Things that can be printed *)
 type 'e printable = PString of string | PExpr of 'e
-[@@deriving sexp, compare, map, hash, fold]
+[@@deriving sexp, compare, map, fold]
 
 type ('l, 'e) lvalue =
   | LVariable of identifier
   | LIndexed of 'l * 'e index list
   | LTupleProjection of 'l * int
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type 'l lvalue_pack =
   | LValue of 'l
   | LTuplePack of
       { lvals: 'l lvalue_pack list
       ; loc: (Location_span.t[@sexp.opaque] [@compare.ignore]) }
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type ('e, 'm) lval_with = {lval: (('e, 'm) lval_with, 'e) lvalue; lmeta: 'm}
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type untyped_lval = (untyped_expression, located_meta) lval_with
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type untyped_lval_pack = untyped_lval lvalue_pack [@@deriving sexp, compare]
 
 type typed_lval = (typed_expression, typed_expr_meta) lval_with
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type typed_lval_pack = typed_lval lvalue_pack [@@deriving sexp, compare]
 
 type 'e variable = {identifier: identifier; initial_value: 'e option}
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 (** Statement shapes, where we substitute untyped_expression and
     untyped_statement for 'e and 's respectively to get untyped_statement and
@@ -181,7 +181,7 @@ type ('e, 's, 'l, 'f) statement =
           (Middle.UnsizedType.autodifftype * Middle.UnsizedType.t * identifier)
           list
       ; body: 's }
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 (** Statement return types which we will decorate statements with during type
     checking:
@@ -198,23 +198,23 @@ type statement_returntype =
   | Incomplete
   | NonlocalControlFlow (* is any break present *)
   | Complete
-[@@deriving sexp, hash, compare]
+[@@deriving sexp, compare]
 
 type ('e, 'm, 'l, 'f) statement_with =
   {stmt: ('e, ('e, 'm, 'l, 'f) statement_with, 'l, 'f) statement; smeta: 'm}
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 (** Untyped statements, which have location_spans as meta-data *)
 type untyped_statement =
   (untyped_expression, located_meta, untyped_lval, unit) statement_with
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 let mk_untyped_statement ~stmt ~loc : untyped_statement = {stmt; smeta= {loc}}
 
 type stmt_typed_located_meta =
   { loc: (Middle.Location_span.t[@sexp.opaque] [@compare.ignore])
   ; return_type: statement_returntype }
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 (** Typed statements also have meta-data after type checking: a location_span,
     as well as a statement returntype to check that function bodies have the
@@ -225,7 +225,7 @@ type typed_statement =
   , typed_lval
   , fun_kind )
   statement_with
-[@@deriving sexp, compare, hash]
+[@@deriving sexp, compare]
 
 let mk_typed_statement ~stmt ~loc ~return_type =
   {stmt; smeta= {loc; return_type}}
@@ -234,7 +234,7 @@ let mk_typed_statement ~stmt ~loc ~return_type =
     untyped statements for 's *)
 type 's block =
   {stmts: 's list; xloc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 type comment_type =
   | LineComment of string * Location_span.t
@@ -254,7 +254,7 @@ type 's program =
   ; modelblock: 's block option
   ; generatedquantitiesblock: 's block option
   ; comments: (comment_type list[@sexp.opaque] [@compare.ignore]) }
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 let get_stmts = Option.value_map ~default:[] ~f:(fun x -> x.stmts)
 

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -8,7 +8,6 @@
  (inline_tests)
  (preprocess
   (pps
-   ppx_hash
    ppx_compare
    ppx_sexp_conv
    ppx_pipebang

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -2,7 +2,7 @@ open Core
 open Common
 
 module Pattern = struct
-  type litType = Int | Real | Imaginary | Str [@@deriving sexp, hash, compare]
+  type litType = Int | Real | Imaginary | Str [@@deriving sexp, compare]
 
   type 'a t =
     | Var of string
@@ -14,7 +14,7 @@ module Pattern = struct
     | Indexed of 'a * 'a Index.t list
     | Promotion of 'a * UnsizedType.t * UnsizedType.autodifftype
     | TupleProjection of 'a * int
-  [@@deriving sexp, hash, map, compare, fold]
+  [@@deriving sexp, map, compare, fold]
 
   let pp pp_e ppf = function
     | Var varname -> Fmt.string ppf varname
@@ -45,8 +45,7 @@ end
     module name, since [ppx_deriving] does not support the [nonrec] keyword *)
 module Fixed = struct
   (** Fixed-point of MIR expressions *)
-  type 'a t = {pattern: 'a t Pattern.t; meta: 'a}
-  [@@deriving compare, hash, sexp]
+  type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, sexp]
 end
 
 include Fixed
@@ -64,14 +63,14 @@ module Typed = struct
       { type_: UnsizedType.t
       ; loc: (Location_span.t[@sexp.opaque] [@compare.ignore])
       ; adlevel: UnsizedType.autodifftype }
-    [@@deriving compare, create, sexp, hash]
+    [@@deriving compare, create, sexp]
 
     let empty =
       create ~type_:UnsizedType.UInt ~adlevel:UnsizedType.DataOnly
         ~loc:Location_span.empty ()
   end
 
-  type t = (Meta.t[@compare.ignore]) Fixed.t [@@deriving hash, sexp, compare]
+  type t = (Meta.t[@compare.ignore]) Fixed.t [@@deriving sexp, compare]
 
   let equal t1 t2 = compare t1 t2 = 0
   let type_of {meta= Meta.{type_; _}; _} = type_

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -1,7 +1,7 @@
 (** MIR types and modules corresponding to the expressions of the language *)
 
 module Pattern : sig
-  type litType = Int | Real | Imaginary | Str [@@deriving sexp, hash, compare]
+  type litType = Int | Real | Imaginary | Str [@@deriving sexp, compare]
 
   type 'a t =
     | Var of string
@@ -13,12 +13,12 @@ module Pattern : sig
     | Indexed of 'a * 'a Index.t list
     | Promotion of 'a * UnsizedType.t * UnsizedType.autodifftype
     | TupleProjection of 'a * int
-  [@@deriving sexp, hash, compare, map, fold]
+  [@@deriving sexp, compare, map, fold]
 end
 
 (** The "two-level" type for statements in the MIR. This corresponds to what the
     AST calls [Frontend.Ast.expr_with] *)
-type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, hash, sexp]
+type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, sexp]
 
 val pp : 'a t Fmt.t
 
@@ -34,12 +34,12 @@ module Typed : sig
       { type_: UnsizedType.t
       ; loc: Location_span.t [@sexp.opaque] [@compare.ignore]
       ; adlevel: UnsizedType.autodifftype }
-    [@@deriving compare, create, sexp, hash]
+    [@@deriving compare, create, sexp]
 
     val empty : t
   end
 
-  type nonrec t = (Meta.t[@compare.ignore]) t [@@deriving hash, sexp, compare]
+  type nonrec t = (Meta.t[@compare.ignore]) t [@@deriving sexp, compare]
 
   val equal : t -> t -> bool
   val type_of : t -> UnsizedType.t

--- a/src/middle/Fun_kind.ml
+++ b/src/middle/Fun_kind.ml
@@ -10,7 +10,7 @@ type 'propto suffix =
   | FnLpmf of 'propto
   | FnTarget
   | FnJacobian
-[@@deriving compare, hash, map, sexp, equal]
+[@@deriving compare, map, sexp, equal]
 
 let without_propto = map_suffix (Fn.const () : bool -> unit)
 
@@ -18,7 +18,7 @@ type 'e t =
   | StanLib of string * bool suffix * Mem_pattern.t
   | CompilerInternal of 'e Internal_fun.t
   | UserDefined of string * bool suffix
-[@@deriving compare, sexp, hash, map, fold]
+[@@deriving compare, sexp, map, fold]
 
 let suffix_from_name fname =
   let is_suffix suffix = Core.String.is_suffix ~suffix fname in

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -8,7 +8,7 @@ type 'a t =
   | Upfrom of 'a
   | Between of 'a * 'a
   | MultiIndex of 'a
-[@@deriving sexp, hash, map, compare, fold]
+[@@deriving sexp, map, compare, fold]
 
 let pp pp_e ppf = function
   | All -> Fmt.char ppf ':'

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -28,7 +28,7 @@ type 'expr t =
   | FnNaN
   | FnDeepCopy
   | FnReadWriteEventsOpenCL of string
-[@@deriving sexp, hash, compare, map, fold]
+[@@deriving sexp, compare, map, fold]
 
 let to_string
     ?(expr_to_string =

--- a/src/middle/Location.ml
+++ b/src/middle/Location.ml
@@ -1,7 +1,7 @@
 open Core
 
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
-[@@deriving sexp, hash]
+[@@deriving sexp]
 
 let pp_context_for ppf (({line_num; _} as loc), lines) =
   let faint pp = Fmt.(styled `Faint pp) in

--- a/src/middle/Location.mli
+++ b/src/middle/Location.mli
@@ -2,7 +2,7 @@
 
 (** Source code locations *)
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
-[@@deriving sexp, hash]
+[@@deriving sexp]
 
 val compare : t -> t -> int
 val empty : t

--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -1,7 +1,6 @@
 open Core
 
-type t = {begin_loc: Location.t; end_loc: Location.t}
-[@@deriving sexp, hash, compare]
+type t = {begin_loc: Location.t; end_loc: Location.t} [@@deriving sexp, compare]
 
 let empty = {begin_loc= Location.empty; end_loc= Location.empty}
 let merge left right = {begin_loc= left.begin_loc; end_loc= right.end_loc}

--- a/src/middle/Location_span.mli
+++ b/src/middle/Location_span.mli
@@ -1,7 +1,6 @@
 (** Delimited locations in source code *)
 
-type t = {begin_loc: Location.t; end_loc: Location.t}
-[@@deriving sexp, hash, compare]
+type t = {begin_loc: Location.t; end_loc: Location.t} [@@deriving sexp, compare]
 
 val empty : t
 val merge : t -> t -> t

--- a/src/middle/Mem_pattern.ml
+++ b/src/middle/Mem_pattern.ml
@@ -8,7 +8,7 @@ open Core.Poly
     In the C++ this allows us to swap out matrix types from an
     [Eigen::Matrix<stan::math::var_value<double>, Rows, Cols>] to an
     [stan::math::var_value<Eigen::Matrix<double, Rows, Cols>>]. *)
-type t = AoS | SoA [@@deriving sexp, compare, hash, equal]
+type t = AoS | SoA [@@deriving sexp, compare, equal]
 
 let pp ppf = function
   | AoS -> Fmt.string ppf "AoS"

--- a/src/middle/Operator.ml
+++ b/src/middle/Operator.ml
@@ -26,7 +26,7 @@ type t =
   | Geq
   | PNot
   | Transpose
-[@@deriving sexp, hash, compare]
+[@@deriving sexp, compare]
 
 let is_cmp = function
   | Equals | NEquals | Less | Leq | Greater | Geq -> true

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -3,7 +3,7 @@
 open Core
 
 type fun_arg_decl = (UnsizedType.autodifftype * string * UnsizedType.t) list
-[@@deriving sexp, hash, map]
+[@@deriving sexp, map]
 
 type 'a fun_def =
   { fdrt: UnsizedType.returntype
@@ -14,17 +14,17 @@ type 'a fun_def =
         (* If fdbody is None, this is an external function declaration (forward
            decls are removed during AST lowering) *)
   ; fdloc: (Location_span.t[@sexp.opaque] [@compare.ignore]) }
-[@@deriving compare, hash, sexp, map, fold]
+[@@deriving compare, sexp, map, fold]
 
 type io_block = Parameters | TransformedParameters | GeneratedQuantities
-[@@deriving sexp, hash]
+[@@deriving sexp]
 
 type 'e outvar =
   { out_unconstrained_st: 'e SizedType.t
   ; out_constrained_st: 'e SizedType.t
   ; out_block: io_block
   ; out_trans: 'e Transformation.t }
-[@@deriving sexp, map, hash, fold]
+[@@deriving sexp, map, fold]
 
 type ('a, 'b, 'm) t =
   { functions_block: 'b fun_def list

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -14,7 +14,7 @@ type 'a t =
   | SComplexMatrix of 'a * 'a
   | SArray of 'a t * 'a
   | STuple of 'a t list
-[@@deriving sexp, compare, map, hash, fold]
+[@@deriving sexp, compare, map, fold]
 
 let rec pp pp_e ppf = function
   | SInt -> Fmt.string ppf "int"

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -22,16 +22,16 @@ module Pattern = struct
         ; decl_id: string
         ; decl_type: 'a Type.t
         ; initialize: 'a decl_init }
-  [@@deriving sexp, hash, map, fold, compare]
+  [@@deriving sexp, map, fold, compare]
 
   and 'e lvalue = 'e lbase * 'e Index.t list
-  [@@deriving sexp, hash, map, compare, fold]
+  [@@deriving sexp, map, compare, fold]
 
   and 'e lbase = LVariable of string | LTupleProjection of 'e lvalue * int
-  [@@deriving sexp, hash, map, compare, fold]
+  [@@deriving sexp, map, compare, fold]
 
   and 'a decl_init = Uninit | Default | Assign of 'a
-  [@@deriving sexp, hash, map, fold, compare]
+  [@@deriving sexp, map, fold, compare]
 
   let rec pp_lvalue pp_e ppf (lbase, idcs) =
     match lbase with
@@ -82,7 +82,7 @@ end
 module Fixed = struct
   (** Fixed-point of statements *)
   type ('a, 'b) t = {pattern: ('a Expr.t, ('a, 'b) t) Pattern.t; meta: 'b}
-  [@@deriving compare, hash, sexp]
+  [@@deriving compare, sexp]
 end
 
 include Fixed
@@ -101,13 +101,13 @@ let rec rewrite_bottom_up ~f ~g t =
 module Located = struct
   module Meta = struct
     type t = (Location_span.t[@sexp.opaque] [@compare.ignore])
-    [@@deriving compare, sexp, hash]
+    [@@deriving compare, sexp]
 
     let empty = Location_span.empty
   end
 
   type t = (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) Fixed.t
-  [@@deriving compare, sexp, hash]
+  [@@deriving compare, sexp]
 
   let pp = pp
 
@@ -121,21 +121,20 @@ module Located = struct
     type t =
       { pattern: (Expr.Typed.t, int) Pattern.t
       ; meta: (Meta.t[@sexp.opaque] [@compare.ignore]) }
-    [@@deriving compare, sexp, hash]
+    [@@deriving compare, sexp]
   end
 end
 
 module Numbered = struct
   module Meta = struct
-    type t = (int[@sexp.opaque] [@compare.ignore])
-    [@@deriving compare, sexp, hash]
+    type t = (int[@sexp.opaque] [@compare.ignore]) [@@deriving compare, sexp]
 
     let empty = 0
     let from_int (i : int) : t = i
   end
 
   type t = (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) Fixed.t
-  [@@deriving compare, sexp, hash]
+  [@@deriving compare, sexp]
 
   let pp = pp
 end

--- a/src/middle/Stmt.mli
+++ b/src/middle/Stmt.mli
@@ -21,22 +21,22 @@ module Pattern : sig
         ; decl_id: string
         ; decl_type: 'a Type.t
         ; initialize: 'a decl_init }
-  [@@deriving sexp, hash, compare, map, fold]
+  [@@deriving sexp, compare, map, fold]
 
   and 'e lvalue = 'e lbase * 'e Index.t list
-  [@@deriving sexp, hash, map, compare, fold]
+  [@@deriving sexp, map, compare, fold]
 
   and 'e lbase = LVariable of string | LTupleProjection of 'e lvalue * int
-  [@@deriving sexp, hash, map, compare, fold]
+  [@@deriving sexp, map, compare, fold]
 
   and 'a decl_init = Uninit | Default | Assign of 'a
-  [@@deriving sexp, hash, map, fold, compare]
+  [@@deriving sexp, map, fold, compare]
 end
 
 (** The "two-level" type for statements in the MIR. This corresponds to what the
     AST calls [Frontend.Ast.statement_with] *)
 type ('a, 'b) t = {pattern: ('a Expr.t, ('a, 'b) t) Pattern.t; meta: 'b}
-[@@deriving compare, hash, sexp]
+[@@deriving compare, sexp]
 
 val pp : ('a, 'b) t Fmt.t
 
@@ -57,14 +57,14 @@ val rewrite_bottom_up :
 module Located : sig
   module Meta : sig
     type t = (Location_span.t[@sexp.opaque] [@compare.ignore])
-    [@@deriving compare, sexp, hash]
+    [@@deriving compare, sexp]
 
     val empty : t
   end
 
   type nonrec t =
     (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) t
-  [@@deriving compare, sexp, hash]
+  [@@deriving compare, sexp]
 
   val pp : t Fmt.t
 
@@ -72,14 +72,13 @@ module Located : sig
     type t =
       { pattern: (Expr.Typed.t, int) Pattern.t
       ; meta: (Meta.t[@sexp.opaque] [@compare.ignore]) }
-    [@@deriving compare, sexp, hash]
+    [@@deriving compare, sexp]
   end
 end
 
 module Numbered : sig
   module Meta : sig
-    type t = (int[@sexp.opaque] [@compare.ignore])
-    [@@deriving compare, sexp, hash]
+    type t = (int[@sexp.opaque] [@compare.ignore]) [@@deriving compare, sexp]
 
     val empty : t
     val from_int : int -> t
@@ -87,7 +86,7 @@ module Numbered : sig
 
   type nonrec t =
     (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) t
-  [@@deriving compare, sexp, hash]
+  [@@deriving compare, sexp]
 
   val pp : t Fmt.t
 end

--- a/src/middle/Transformation.ml
+++ b/src/middle/Transformation.ml
@@ -24,7 +24,7 @@ type 'e t =
   | StochasticRow
   | StochasticColumn
   | TupleTransformation of 'e t list
-[@@deriving sexp, compare, map, hash, fold, show]
+[@@deriving sexp, compare, map, fold, show]
 
 let rec has_check = function
   | Identity | Offset _ | Multiplier _ | OffsetMultiplier _ -> false

--- a/src/middle/Type.ml
+++ b/src/middle/Type.ml
@@ -1,7 +1,7 @@
 (** A type which unifies [SizedTypes] and [UnsizedTypes] for declarations *)
 
 type 'a t = Sized of 'a SizedType.t | Unsized of UnsizedType.t
-[@@deriving sexp, compare, map, hash, fold]
+[@@deriving sexp, compare, map, fold]
 
 let pp pp_e ppf = function
   | Sized st -> SizedType.pp pp_e ppf st

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -23,7 +23,7 @@ and argumentlist = (autodifftype * t) list
 and returntype = Void | ReturnType of t
 
 and signature = argumentlist * returntype * bool Fun_kind.suffix * Mem_pattern.t
-[@@deriving compare, hash, sexp, equal]
+[@@deriving compare, sexp, equal]
 
 type variadic_signature =
   { return_type: t

--- a/src/middle/dune
+++ b/src/middle/dune
@@ -9,7 +9,6 @@
   (pps
    ppx_compare
    ppx_sexp_conv
-   ppx_hash
    ppx_expect
    ppx_sexp_value
    ppx_deriving.map

--- a/src/stan_math_backend/Lower_expr.ml
+++ b/src/stan_math_backend/Lower_expr.ml
@@ -66,7 +66,7 @@ let reduce_sum_functor_suffix = "_rsfunctor__"
 let variadic_functor_suffix x = sprintf "_variadic%d_functor__" x
 
 type variadic = FixedArgs | ReduceSum | VariadicHOF of int
-[@@deriving compare, hash]
+[@@deriving compare]
 
 let functor_type hof =
   match Stan_math_signatures.lookup_stan_math_variadic_function hof with

--- a/src/stan_math_backend/Numbering.ml
+++ b/src/stan_math_backend/Numbering.ml
@@ -1,5 +1,5 @@
-open Core
-open Core.Poly
+open StdLabels
+open MoreLabels
 open Middle
 
 type state_t = Location_span.t list
@@ -11,18 +11,18 @@ let prepare_prog (mir : Program.Typed.t) :
     Program.Numbered.t * state_t * map_rect_registration_t * bool =
   let label_locations = Queue.create () in
   let map_rect_calls = Queue.create () in
-  let location_to_label = Hashtbl.create (module Location_span) in
+  let location_to_label = Hashtbl.create 64 in
   let needs_mix_header = ref false in
-  Queue.enqueue label_locations (no_span_num, Location_span.empty);
-  Hashtbl.set location_to_label ~key:Location_span.empty ~data:no_span_num;
+  Queue.push (no_span_num, Location_span.empty) label_locations;
+  Hashtbl.replace location_to_label ~key:Location_span.empty ~data:no_span_num;
   (* turn locations into numbers for array printing *)
   let number_meta meta =
-    match Hashtbl.find location_to_label meta with
+    match Hashtbl.find_opt location_to_label meta with
     | Some i -> i
     | None ->
         let new_label = Queue.length label_locations in
-        Queue.enqueue label_locations (new_label, meta);
-        Hashtbl.set location_to_label ~key:meta ~data:new_label;
+        Queue.push (new_label, meta) label_locations;
+        Hashtbl.replace location_to_label ~key:meta ~data:new_label;
         new_label in
   let rec number_locations_stmt ({pattern; meta} : Stmt.Located.t) :
       Stmt.Numbered.t =
@@ -40,8 +40,9 @@ let prepare_prog (mir : Program.Typed.t) :
         ( StanLib ("map_rect", suffix, mem_pattern)
         , ({pattern= Var f; _} :: _ as es) ) ->
         let next_map_rect_id = Queue.length map_rect_calls + 1 in
-        Queue.enqueue map_rect_calls
-          (next_map_rect_id, f ^ Lower_expr.functor_suffix);
+        Queue.push
+          (next_map_rect_id, f ^ Lower_expr.functor_suffix)
+          map_rect_calls;
         let pattern =
           Expr.Pattern.FunApp
             ( StanLib ("map_rect", suffix, mem_pattern)
@@ -60,9 +61,13 @@ let prepare_prog (mir : Program.Typed.t) :
   let location_list =
     List.map ~f:snd
       (List.sort
-         ~compare:(fun x y -> compare_int (fst x) (fst y))
-         (Queue.to_list label_locations)) in
-  let map_rect_calls_list = List.sort ~compare (Queue.to_list map_rect_calls) in
+         ~cmp:(fun x y -> Int.compare (fst x) (fst y))
+         (List.of_seq (Queue.to_seq label_locations))) in
+  let map_rect_calls_list =
+    List.sort
+      ~cmp:(fun (x1, x2) (y1, y2) ->
+        match Int.compare x1 y1 with 0 -> String.compare x2 y2 | x -> x)
+      (List.of_seq (Queue.to_seq map_rect_calls)) in
   (mir, location_list, map_rect_calls_list, !needs_mix_header)
 
 let gen_globals ?printed_filename location_list =

--- a/src/stan_math_backend/dune
+++ b/src/stan_math_backend/dune
@@ -17,7 +17,6 @@
   (pps
    ppx_compare
    ppx_sexp_conv
-   ppx_hash
    ppx_pipebang
    ppx_expect
    ppx_sexp_value

--- a/stanc.opam
+++ b/stanc.opam
@@ -14,7 +14,6 @@ depends: [
   "yojson" {= "3.0.0"}
   "cmdliner" {= "2.1.1"}
   "ppx_deriving" {= "6.1.1"}
-  "ppx_hash"
   "ppx_compare"
   "ppx_sexp_conv"
   "ppx_expect"


### PR DESCRIPTION
Believe it or not, we were only actually using the non-polymorphic hash function in a single spot (Numbering.ml), and as far as I can tell that location is perfectly happy to use stdlib.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

Removed dependency on `ppx_hash`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
