### PR TITLE
Remove dead code/deriving annotations

### DIFF
--- a/docs/core_ideas.mld
+++ b/docs/core_ideas.mld
@@ -34,7 +34,7 @@ If you look at a type declaration of something like [Ast.typed_expression], you'
 
 {[
 type typed_expression = (typed_expr_meta, fun_kind) expr_with
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 ]}
 
 When using an editor that supports code completion, you may notice that the [Ast] module suggests functions
@@ -42,8 +42,9 @@ which are not defined in the actual source text. This is because these functions
 {{:https://github.com/ocaml-ppx/ppx_deriving}[ppx_deriving]}.The above syntax [[@@deriving ...]] indicates which
 functions we would like to be generated.
 
-These are very helpful - if a type derives [hash], it can automatically be used as keys in Jane Street's hash tables, and
-a type which derives [sexp] can be serialized to Lisp-style S-Expressions. Most of our major types derive at least one function.
+These are very helpful - if a type derives [compare], it provides a comparison function which allows for use in sorting functions or
+Map types, and a type which derives [sexp_of] can be serialized to Lisp-style S-Expressions.
+Most of our major types derive at least one function.
 
 {1 "Two Level Types"}
 

--- a/src/analysis_and_optimization/Dataflow_types.ml
+++ b/src/analysis_and_optimization/Dataflow_types.ml
@@ -6,15 +6,15 @@ open Core
 
 (** A label is a unique identifier for a node in the dataflow/dependency graph,
     and often corresponds to one node in the Mir. *)
-type label = int [@@deriving sexp]
+type label = int [@@deriving sexp_of]
 
 (** Representation of an expression that can be assigned to. This should also be
     able to represent indexed variables, but we don't support that yet. *)
-type vexpr = VVar of string [@@deriving sexp]
+type vexpr = VVar of string [@@deriving sexp_of]
 
 (** A 'reaching definition' (or reaching_defn or RD) statement (v, l) says that
     the variable v could have been affected at the label l. *)
-type reaching_defn = vexpr * label [@@deriving sexp]
+type reaching_defn = vexpr * label [@@deriving sexp_of]
 
 (** The most recently nested control flow (block start, if/then, or loop)
 

--- a/src/analysis_and_optimization/Factor_graph.ml
+++ b/src/analysis_and_optimization/Factor_graph.ml
@@ -9,7 +9,7 @@ type factor =
   | TargetTerm of Expr.Typed.t
   | Reject
   | LPFunction of (string * Expr.Typed.t list)
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 type factor_graph =
   { factor_map: (factor * label, vexpr Set.Poly.t) Map.Poly.t

--- a/src/common/Nonempty_list.ml
+++ b/src/common/Nonempty_list.ml
@@ -1,7 +1,5 @@
 type 'a t = ( :: ) of 'a * 'a list
 
-let to_list (hd :: tl) : _ list = hd :: tl
-
 let of_list : _ list -> _ t option = function
   | [] -> None
   | hd :: tl -> Some (hd :: tl)

--- a/src/common/Nonempty_list.mli
+++ b/src/common/Nonempty_list.mli
@@ -5,6 +5,5 @@
 
 type 'a t = ( :: ) of 'a * 'a list
 
-val to_list : 'a t -> 'a list
 val of_list : 'a list -> 'a t option
 val of_list_exn : 'a list -> 'a t

--- a/src/frontend/Ast.ml
+++ b/src/frontend/Ast.ml
@@ -14,7 +14,7 @@ open Middle
 (** Our type for identifiers, on which we record a location *)
 type identifier =
   {name: string; id_loc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 (** Indices for array access *)
 type 'e index =
@@ -23,13 +23,13 @@ type 'e index =
   | Upfrom of 'e
   | Downfrom of 'e
   | Between of 'e * 'e
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 (** Front-end function kinds *)
 type fun_kind =
   | StanLib of bool Fun_kind.suffix
   | UserDefined of bool Fun_kind.suffix
-[@@deriving compare, sexp]
+[@@deriving compare, sexp_of]
 
 (** Expression shapes (used for both typed and untyped expressions, where we
     substitute untyped_expression or typed_expression for 'e *)
@@ -52,34 +52,34 @@ type ('e, 'f, 'p) expression =
   | Indexed of 'e * 'e index list
   | TupleProjection of 'e * int
   | TupleExpr of 'e list
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 type ('m, 'f, 'p) expr_with =
   {expr: (('m, 'f, 'p) expr_with, 'f, 'p) expression; emeta: 'm}
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 (** Untyped expressions, which have location_spans as meta-data *)
 type located_meta = {loc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 type untyped_expression = (located_meta, unit, Core.Nothing.t) expr_with
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 (** Typed expressions also have meta-data after type checking: a location_span,
     as well as a type and an origin block (lub of the origin blocks of the
     identifiers in it) *)
 type typed_expr_meta =
-  { loc: (Location_span.t[@sexp.opaque] [@compare.ignore])
+  { loc: (Location_span.t[@sexp.opaque])
   ; ad_level: UnsizedType.autodifftype
   ; type_: UnsizedType.t }
-[@@deriving sexp, compare]
+[@@deriving sexp_of]
 
 type typed_expression =
   ( typed_expr_meta
   , fun_kind
   , UnsizedType.t * UnsizedType.autodifftype )
   expr_with
-[@@deriving sexp, compare]
+[@@deriving sexp_of]
 
 let expr_loc_lub exprs =
   match List.map ~f:(fun e -> e.emeta.loc) exprs with
@@ -93,7 +93,7 @@ let expr_ad_lub exprs =
 
 (** Assignment operators *)
 type assignmentoperator = Assign | OperatorAssign of Operator.t
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 (** Truncations *)
 type 'e truncation =
@@ -101,40 +101,40 @@ type 'e truncation =
   | TruncateUpFrom of 'e
   | TruncateDownFrom of 'e
   | TruncateBetween of 'e * 'e
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 (** Things that can be printed *)
 type 'e printable = PString of string | PExpr of 'e
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 type ('l, 'e) lvalue =
   | LVariable of identifier
   | LIndexed of 'l * 'e index list
   | LTupleProjection of 'l * int
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 type 'l lvalue_pack =
   | LValue of 'l
   | LTuplePack of
       { lvals: 'l lvalue_pack list
       ; loc: (Location_span.t[@sexp.opaque] [@compare.ignore]) }
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 type ('e, 'm) lval_with = {lval: (('e, 'm) lval_with, 'e) lvalue; lmeta: 'm}
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 type untyped_lval = (untyped_expression, located_meta) lval_with
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
-type untyped_lval_pack = untyped_lval lvalue_pack [@@deriving sexp, compare]
+type untyped_lval_pack = untyped_lval lvalue_pack [@@deriving sexp_of, compare]
 
 type typed_lval = (typed_expression, typed_expr_meta) lval_with
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, map, fold]
 
-type typed_lval_pack = typed_lval lvalue_pack [@@deriving sexp, compare]
+type typed_lval_pack = typed_lval lvalue_pack [@@deriving sexp_of]
 
 type 'e variable = {identifier: identifier; initial_value: 'e option}
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 (** Statement shapes, where we substitute untyped_expression and
     untyped_statement for 'e and 's respectively to get untyped_statement and
@@ -181,7 +181,7 @@ type ('e, 's, 'l, 'f) statement =
           (Middle.UnsizedType.autodifftype * Middle.UnsizedType.t * identifier)
           list
       ; body: 's }
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 (** Statement return types which we will decorate statements with during type
     checking:
@@ -198,23 +198,23 @@ type statement_returntype =
   | Incomplete
   | NonlocalControlFlow (* is any break present *)
   | Complete
-[@@deriving sexp, compare]
+[@@deriving sexp_of]
 
 type ('e, 'm, 'l, 'f) statement_with =
   {stmt: ('e, ('e, 'm, 'l, 'f) statement_with, 'l, 'f) statement; smeta: 'm}
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 (** Untyped statements, which have location_spans as meta-data *)
 type untyped_statement =
   (untyped_expression, located_meta, untyped_lval, unit) statement_with
-[@@deriving sexp, compare]
+[@@deriving sexp_of, compare]
 
 let mk_untyped_statement ~stmt ~loc : untyped_statement = {stmt; smeta= {loc}}
 
 type stmt_typed_located_meta =
-  { loc: (Middle.Location_span.t[@sexp.opaque] [@compare.ignore])
+  { loc: (Middle.Location_span.t[@sexp.opaque])
   ; return_type: statement_returntype }
-[@@deriving sexp, compare]
+[@@deriving sexp_of]
 
 (** Typed statements also have meta-data after type checking: a location_span,
     as well as a statement returntype to check that function bodies have the
@@ -225,7 +225,7 @@ type typed_statement =
   , typed_lval
   , fun_kind )
   statement_with
-[@@deriving sexp, compare]
+[@@deriving sexp_of]
 
 let mk_typed_statement ~stmt ~loc ~return_type =
   {stmt; smeta= {loc; return_type}}
@@ -234,7 +234,7 @@ let mk_typed_statement ~stmt ~loc ~return_type =
     untyped statements for 's *)
 type 's block =
   {stmts: 's list; xloc: (Location_span.t[@sexp.opaque] [@compare.ignore])}
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 type comment_type =
   | LineComment of string * Location_span.t
@@ -254,15 +254,15 @@ type 's program =
   ; modelblock: 's block option
   ; generatedquantitiesblock: 's block option
   ; comments: (comment_type list[@sexp.opaque] [@compare.ignore]) }
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 let get_stmts = Option.value_map ~default:[] ~f:(fun x -> x.stmts)
 
 (** Untyped programs (before type checking) *)
-type untyped_program = untyped_statement program [@@deriving sexp, compare]
+type untyped_program = untyped_statement program [@@deriving sexp_of, compare]
 
 (** Typed programs (after type checking) *)
-type typed_program = typed_statement program [@@deriving sexp, compare]
+type typed_program = typed_statement program [@@deriving sexp_of]
 
 (*========================== Helper functions ===============================*)
 

--- a/src/frontend/Ast_to_Mir.ml
+++ b/src/frontend/Ast_to_Mir.ml
@@ -243,7 +243,7 @@ let trans_printables mloc (ps : Ast.typed_expression Ast.printable list) =
 
 (** These types signal the context for a declaration during statement
     translation. They are only interpreted by trans_decl.*)
-type transform_action = Check | Constrain | IgnoreTransform [@@deriving sexp]
+type transform_action = Check | Constrain | IgnoreTransform
 
 type decl_context =
   {transform_action: transform_action; dadlevel: UnsizedType.autodifftype}

--- a/src/frontend/Promotion.ml
+++ b/src/frontend/Promotion.ml
@@ -12,7 +12,7 @@ type t =
   | IntToComplex
   | RealToComplex
   | TuplePromotion of t list
-[@@deriving sexp, show]
+[@@deriving sexp_of, show]
 
 (** Our promotion nodes only store the scalar type to promote, e.g to promote a
     [tuple(array int)] to a [tuple(array real)], we store [tuple(real)], not

--- a/src/frontend/SignatureMismatch.ml
+++ b/src/frontend/SignatureMismatch.ml
@@ -87,7 +87,7 @@ type ('unique, 'error) generic_match_result =
       * Location_span.t option)
       list
   | SignatureErrors of 'error
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 type match_result =
   ( UnsizedType.returntype

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -2,7 +2,7 @@ open Core
 open Common
 
 module Pattern = struct
-  type litType = Int | Real | Imaginary | Str [@@deriving sexp, compare]
+  type litType = Int | Real | Imaginary | Str [@@deriving sexp_of, compare]
 
   type 'a t =
     | Var of string
@@ -14,7 +14,7 @@ module Pattern = struct
     | Indexed of 'a * 'a Index.t list
     | Promotion of 'a * UnsizedType.t * UnsizedType.autodifftype
     | TupleProjection of 'a * int
-  [@@deriving sexp, map, compare, fold]
+  [@@deriving sexp_of, map, compare, fold]
 
   let pp pp_e ppf = function
     | Var varname -> Fmt.string ppf varname
@@ -45,7 +45,7 @@ end
     module name, since [ppx_deriving] does not support the [nonrec] keyword *)
 module Fixed = struct
   (** Fixed-point of MIR expressions *)
-  type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, sexp]
+  type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, sexp_of]
 end
 
 include Fixed
@@ -61,16 +61,16 @@ module Typed = struct
   module Meta = struct
     type t =
       { type_: UnsizedType.t
-      ; loc: (Location_span.t[@sexp.opaque] [@compare.ignore])
+      ; loc: (Location_span.t[@sexp.opaque])
       ; adlevel: UnsizedType.autodifftype }
-    [@@deriving compare, create, sexp]
+    [@@deriving create, sexp_of]
 
     let empty =
       create ~type_:UnsizedType.UInt ~adlevel:UnsizedType.DataOnly
         ~loc:Location_span.empty ()
   end
 
-  type t = (Meta.t[@compare.ignore]) Fixed.t [@@deriving sexp, compare]
+  type t = (Meta.t[@compare.ignore]) Fixed.t [@@deriving sexp_of, compare]
 
   let equal t1 t2 = compare t1 t2 = 0
   let type_of {meta= Meta.{type_; _}; _} = type_

--- a/src/middle/Expr.mli
+++ b/src/middle/Expr.mli
@@ -1,7 +1,7 @@
 (** MIR types and modules corresponding to the expressions of the language *)
 
 module Pattern : sig
-  type litType = Int | Real | Imaginary | Str [@@deriving sexp, compare]
+  type litType = Int | Real | Imaginary | Str [@@deriving sexp_of, compare]
 
   type 'a t =
     | Var of string
@@ -13,12 +13,12 @@ module Pattern : sig
     | Indexed of 'a * 'a Index.t list
     | Promotion of 'a * UnsizedType.t * UnsizedType.autodifftype
     | TupleProjection of 'a * int
-  [@@deriving sexp, compare, map, fold]
+  [@@deriving sexp_of, compare, map, fold]
 end
 
 (** The "two-level" type for statements in the MIR. This corresponds to what the
     AST calls [Frontend.Ast.expr_with] *)
-type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, sexp]
+type 'a t = {pattern: 'a t Pattern.t; meta: 'a} [@@deriving compare, sexp_of]
 
 val pp : 'a t Fmt.t
 
@@ -32,14 +32,14 @@ module Typed : sig
   module Meta : sig
     type t =
       { type_: UnsizedType.t
-      ; loc: Location_span.t [@sexp.opaque] [@compare.ignore]
+      ; loc: (Location_span.t[@sexp.opaque])
       ; adlevel: UnsizedType.autodifftype }
-    [@@deriving compare, create, sexp]
+    [@@deriving create, sexp_of]
 
     val empty : t
   end
 
-  type nonrec t = (Meta.t[@compare.ignore]) t [@@deriving sexp, compare]
+  type nonrec t = (Meta.t[@compare.ignore]) t [@@deriving sexp_of, compare]
 
   val equal : t -> t -> bool
   val type_of : t -> UnsizedType.t

--- a/src/middle/Fun_kind.ml
+++ b/src/middle/Fun_kind.ml
@@ -10,7 +10,7 @@ type 'propto suffix =
   | FnLpmf of 'propto
   | FnTarget
   | FnJacobian
-[@@deriving compare, map, sexp, equal]
+[@@deriving compare, map, sexp_of, equal]
 
 let without_propto = map_suffix (Fn.const () : bool -> unit)
 
@@ -18,7 +18,7 @@ type 'e t =
   | StanLib of string * bool suffix * Mem_pattern.t
   | CompilerInternal of 'e Internal_fun.t
   | UserDefined of string * bool suffix
-[@@deriving compare, sexp, map, fold]
+[@@deriving compare, sexp_of, map, fold]
 
 let suffix_from_name fname =
   let is_suffix suffix = Core.String.is_suffix ~suffix fname in

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -8,7 +8,7 @@ type 'a t =
   | Upfrom of 'a
   | Between of 'a * 'a
   | MultiIndex of 'a
-[@@deriving sexp, map, compare, fold]
+[@@deriving sexp_of, map, compare, fold]
 
 let pp pp_e ppf = function
   | All -> Fmt.char ppf ':'

--- a/src/middle/Internal_fun.ml
+++ b/src/middle/Internal_fun.ml
@@ -28,7 +28,7 @@ type 'expr t =
   | FnNaN
   | FnDeepCopy
   | FnReadWriteEventsOpenCL of string
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 let to_string
     ?(expr_to_string =

--- a/src/middle/Location.ml
+++ b/src/middle/Location.ml
@@ -1,7 +1,7 @@
 open Core
 
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 let pp_context_for ppf (({line_num; _} as loc), lines) =
   let faint pp = Fmt.(styled `Faint pp) in

--- a/src/middle/Location.mli
+++ b/src/middle/Location.mli
@@ -2,7 +2,7 @@
 
 (** Source code locations *)
 type t = {filename: string; line_num: int; col_num: int; included_from: t option}
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 val compare : t -> t -> int
 val empty : t

--- a/src/middle/Location_span.ml
+++ b/src/middle/Location_span.ml
@@ -1,6 +1,7 @@
 open Core
 
-type t = {begin_loc: Location.t; end_loc: Location.t} [@@deriving sexp, compare]
+type t = {begin_loc: Location.t; end_loc: Location.t}
+[@@deriving sexp_of, compare]
 
 let empty = {begin_loc= Location.empty; end_loc= Location.empty}
 let merge left right = {begin_loc= left.begin_loc; end_loc= right.end_loc}

--- a/src/middle/Location_span.mli
+++ b/src/middle/Location_span.mli
@@ -1,6 +1,7 @@
 (** Delimited locations in source code *)
 
-type t = {begin_loc: Location.t; end_loc: Location.t} [@@deriving sexp, compare]
+type t = {begin_loc: Location.t; end_loc: Location.t}
+[@@deriving sexp_of, compare]
 
 val empty : t
 val merge : t -> t -> t

--- a/src/middle/Mem_pattern.ml
+++ b/src/middle/Mem_pattern.ml
@@ -8,7 +8,7 @@ open Core.Poly
     In the C++ this allows us to swap out matrix types from an
     [Eigen::Matrix<stan::math::var_value<double>, Rows, Cols>] to an
     [stan::math::var_value<Eigen::Matrix<double, Rows, Cols>>]. *)
-type t = AoS | SoA [@@deriving sexp, compare, equal]
+type t = AoS | SoA [@@deriving sexp_of, compare, equal]
 
 let pp ppf = function
   | AoS -> Fmt.string ppf "AoS"

--- a/src/middle/Operator.ml
+++ b/src/middle/Operator.ml
@@ -30,7 +30,10 @@ type t =
 
 let is_cmp = function
   | Equals | NEquals | Less | Leq | Greater | Geq -> true
-  | _ -> false
+  | Plus | PPlus | Minus | PMinus | Times | Divide | IntDivide | Modulo
+   |LDivide | EltTimes | EltDivide | Pow | EltPow | Or | And | PNot | Transpose
+    ->
+      false
 
 let pp ppf = function
   | Plus | PPlus -> Fmt.pf ppf "+"

--- a/src/middle/Program.ml
+++ b/src/middle/Program.ml
@@ -3,7 +3,6 @@
 open Core
 
 type fun_arg_decl = (UnsizedType.autodifftype * string * UnsizedType.t) list
-[@@deriving sexp, map]
 
 type 'a fun_def =
   { fdrt: UnsizedType.returntype
@@ -13,18 +12,18 @@ type 'a fun_def =
   ; fdbody: 'a option
         (* If fdbody is None, this is an external function declaration (forward
            decls are removed during AST lowering) *)
-  ; fdloc: (Location_span.t[@sexp.opaque] [@compare.ignore]) }
-[@@deriving compare, sexp, map, fold]
+  ; fdloc: (Location_span.t[@sexp.opaque]) }
+[@@deriving sexp_of, map, fold]
 
 type io_block = Parameters | TransformedParameters | GeneratedQuantities
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 type 'e outvar =
   { out_unconstrained_st: 'e SizedType.t
   ; out_constrained_st: 'e SizedType.t
   ; out_block: io_block
   ; out_trans: 'e Transformation.t }
-[@@deriving sexp, map, fold]
+[@@deriving sexp_of, map, fold]
 
 type ('a, 'b, 'm) t =
   { functions_block: 'b fun_def list
@@ -49,7 +48,7 @@ type ('a, 'b, 'm) t =
   ; output_vars: (string * 'm * 'a outvar) list
   ; prog_name: string
   ; prog_path: string }
-[@@deriving sexp, map, fold]
+[@@deriving sexp_of, map, fold]
 
 (* -- Pretty printers -- *)
 let pp_fun_arg_decl ppf (autodifftype, name, unsizedtype) =

--- a/src/middle/SizedType.ml
+++ b/src/middle/SizedType.ml
@@ -14,7 +14,7 @@ type 'a t =
   | SComplexMatrix of 'a * 'a
   | SArray of 'a t * 'a
   | STuple of 'a t list
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, compare, map, fold]
 
 let rec pp pp_e ppf = function
   | SInt -> Fmt.string ppf "int"

--- a/src/middle/Stmt.ml
+++ b/src/middle/Stmt.ml
@@ -22,16 +22,15 @@ module Pattern = struct
         ; decl_id: string
         ; decl_type: 'a Type.t
         ; initialize: 'a decl_init }
-  [@@deriving sexp, map, fold, compare]
+  [@@deriving sexp_of, map, fold]
 
-  and 'e lvalue = 'e lbase * 'e Index.t list
-  [@@deriving sexp, map, compare, fold]
+  and 'e lvalue = 'e lbase * 'e Index.t list [@@deriving sexp_of, map, fold]
 
   and 'e lbase = LVariable of string | LTupleProjection of 'e lvalue * int
-  [@@deriving sexp, map, compare, fold]
+  [@@deriving sexp_of, map, fold]
 
   and 'a decl_init = Uninit | Default | Assign of 'a
-  [@@deriving sexp, map, fold, compare]
+  [@@deriving sexp_of, map, fold]
 
   let rec pp_lvalue pp_e ppf (lbase, idcs) =
     match lbase with
@@ -82,7 +81,7 @@ end
 module Fixed = struct
   (** Fixed-point of statements *)
   type ('a, 'b) t = {pattern: ('a Expr.t, ('a, 'b) t) Pattern.t; meta: 'b}
-  [@@deriving compare, sexp]
+  [@@deriving sexp_of]
 end
 
 include Fixed
@@ -100,14 +99,13 @@ let rec rewrite_bottom_up ~f ~g t =
 (** Statements with location information and types for contained expressions *)
 module Located = struct
   module Meta = struct
-    type t = (Location_span.t[@sexp.opaque] [@compare.ignore])
-    [@@deriving compare, sexp]
+    type t = Location_span.t
 
     let empty = Location_span.empty
   end
 
-  type t = (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) Fixed.t
-  [@@deriving compare, sexp]
+  type t = (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque])) Fixed.t
+  [@@deriving sexp_of]
 
   let pp = pp
 
@@ -118,23 +116,19 @@ module Located = struct
       subterms. My feeling is that ultimately we want to use the recursive type
       directly and rely on OCaml for sharing *)
   module Non_recursive = struct
-    type t =
-      { pattern: (Expr.Typed.t, int) Pattern.t
-      ; meta: (Meta.t[@sexp.opaque] [@compare.ignore]) }
-    [@@deriving compare, sexp]
+    type t = {pattern: (Expr.Typed.t, int) Pattern.t; meta: Meta.t}
   end
 end
 
 module Numbered = struct
   module Meta = struct
-    type t = (int[@sexp.opaque] [@compare.ignore]) [@@deriving compare, sexp]
+    type t = int
 
     let empty = 0
     let from_int (i : int) : t = i
   end
 
-  type t = (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) Fixed.t
-  [@@deriving compare, sexp]
+  type t = (Expr.Typed.Meta.t, Meta.t) Fixed.t
 
   let pp = pp
 end

--- a/src/middle/Stmt.mli
+++ b/src/middle/Stmt.mli
@@ -21,22 +21,21 @@ module Pattern : sig
         ; decl_id: string
         ; decl_type: 'a Type.t
         ; initialize: 'a decl_init }
-  [@@deriving sexp, compare, map, fold]
+  [@@deriving sexp_of, map, fold]
 
-  and 'e lvalue = 'e lbase * 'e Index.t list
-  [@@deriving sexp, map, compare, fold]
+  and 'e lvalue = 'e lbase * 'e Index.t list [@@deriving sexp_of, map, fold]
 
   and 'e lbase = LVariable of string | LTupleProjection of 'e lvalue * int
-  [@@deriving sexp, map, compare, fold]
+  [@@deriving sexp_of, map, fold]
 
   and 'a decl_init = Uninit | Default | Assign of 'a
-  [@@deriving sexp, map, fold, compare]
+  [@@deriving sexp_of, map, fold]
 end
 
 (** The "two-level" type for statements in the MIR. This corresponds to what the
     AST calls [Frontend.Ast.statement_with] *)
 type ('a, 'b) t = {pattern: ('a Expr.t, ('a, 'b) t) Pattern.t; meta: 'b}
-[@@deriving compare, sexp]
+[@@deriving sexp_of]
 
 val pp : ('a, 'b) t Fmt.t
 
@@ -56,37 +55,30 @@ val rewrite_bottom_up :
 
 module Located : sig
   module Meta : sig
-    type t = (Location_span.t[@sexp.opaque] [@compare.ignore])
-    [@@deriving compare, sexp]
+    type t = Location_span.t
 
     val empty : t
   end
 
-  type nonrec t =
-    (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) t
-  [@@deriving compare, sexp]
+  type nonrec t = (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque])) t
+  [@@deriving sexp_of]
 
   val pp : t Fmt.t
 
   module Non_recursive : sig
-    type t =
-      { pattern: (Expr.Typed.t, int) Pattern.t
-      ; meta: (Meta.t[@sexp.opaque] [@compare.ignore]) }
-    [@@deriving compare, sexp]
+    type t = {pattern: (Expr.Typed.t, int) Pattern.t; meta: Meta.t}
   end
 end
 
 module Numbered : sig
   module Meta : sig
-    type t = (int[@sexp.opaque] [@compare.ignore]) [@@deriving compare, sexp]
+    type t = int
 
     val empty : t
     val from_int : int -> t
   end
 
-  type nonrec t =
-    (Expr.Typed.Meta.t, (Meta.t[@sexp.opaque] [@compare.ignore])) t
-  [@@deriving compare, sexp]
+  type nonrec t = (Expr.Typed.Meta.t, Meta.t) t
 
   val pp : t Fmt.t
 end

--- a/src/middle/Transformation.ml
+++ b/src/middle/Transformation.ml
@@ -24,7 +24,7 @@ type 'e t =
   | StochasticRow
   | StochasticColumn
   | TupleTransformation of 'e t list
-[@@deriving sexp, compare, map, fold, show]
+[@@deriving sexp_of, compare, map, fold, show]
 
 let rec has_check = function
   | Identity | Offset _ | Multiplier _ | OffsetMultiplier _ -> false

--- a/src/middle/Type.ml
+++ b/src/middle/Type.ml
@@ -1,7 +1,7 @@
 (** A type which unifies [SizedTypes] and [UnsizedTypes] for declarations *)
 
 type 'a t = Sized of 'a SizedType.t | Unsized of UnsizedType.t
-[@@deriving sexp, compare, map, fold]
+[@@deriving sexp_of, map, fold]
 
 let pp pp_e ppf = function
   | Sized st -> SizedType.pp pp_e ppf st

--- a/src/middle/UnsizedType.ml
+++ b/src/middle/UnsizedType.ml
@@ -23,7 +23,7 @@ and argumentlist = (autodifftype * t) list
 and returntype = Void | ReturnType of t
 
 and signature = argumentlist * returntype * bool Fun_kind.suffix * Mem_pattern.t
-[@@deriving compare, sexp, equal]
+[@@deriving compare, sexp_of, equal]
 
 type variadic_signature =
   { return_type: t

--- a/src/stan_math_backend/Cpp.ml
+++ b/src/stan_math_backend/Cpp.ml
@@ -2,7 +2,7 @@
 
 open Core
 
-type identifier = string [@@deriving sexp, show]
+type identifier = string [@@deriving sexp_of]
 
 (** C++ types *)
 type type_ =
@@ -11,21 +11,22 @@ type type_ =
   | Int
   | Double
   | Complex of type_
-  | TemplateType of identifier
+  | TemplateType of identifier [@printer Fmt.string]
   | StdVector of type_
       (** A std::vector. For Eigen Vectors, use [Matrix] with a row or column
           size of 1 *)
   | Array of type_ * int
   | Tuple of type_ list
-  | TypeLiteral of identifier  (** Used for things like Eigen::Index *)
+  | TypeLiteral of identifier [@printer Fmt.string]
+      (** Used for things like Eigen::Index *)
   | NonTypeTemplateInt of int
   | Matrix of type_ * int * int * Middle.Mem_pattern.t
   | Ref of type_
   | Const of type_
   | Pointer of type_
-  | TypeTrait of identifier * type_ list
+  | TypeTrait of (identifier[@printer Fmt.string]) * type_ list
       (** e.g. stan::promote_scalar, stan:base_type *)
-[@@deriving sexp, show]
+[@@deriving sexp_of, show]
 
 module Types = struct
   (** Helpers for constructing types *)
@@ -86,7 +87,7 @@ type operator =
   | Gthn
   | And
   | Or
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 type expr =
   | Literal of string  (** printed as-is *)
@@ -115,7 +116,7 @@ type expr =
   | BinOp of expr * operator * expr
   | PMinus of expr
   | Increment of expr
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 module Exprs = struct
   (** Some helper values and functions *)
@@ -212,7 +213,7 @@ type init =
   | Construction of expr list
   | InitializerList of expr list
   | Uninitialized
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 type variable_defn =
   { static: bool [@default false]
@@ -220,7 +221,7 @@ type variable_defn =
   ; type_: type_
   ; name: identifier
   ; init: init [@default Uninitialized] }
-[@@deriving make, sexp]
+[@@deriving make, sexp_of]
 
 type stmt =
   | Expression of expr
@@ -238,7 +239,7 @@ type stmt =
   | Continue
   | Using of string * type_ option
   | Comment of string
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 module Stmts = struct
   (** Helpers for common statement constructs *)
@@ -337,9 +338,9 @@ type template_parameter =
       (** A C++ type trait (e.g. [is_arithmetic]) and the template types which
           need to satisfy that. These are collated into one
           [require_all_t<...>]. *)
-[@@deriving sexp]
+[@@deriving sexp_of]
 
-type cv_qualifiers = Const | Final | NoExcept [@@deriving sexp]
+type cv_qualifiers = Const | Final | NoExcept [@@deriving sexp_of]
 
 type fun_defn =
   { templates_init: template_parameter list list * bool [@default [[]], false]
@@ -351,7 +352,7 @@ type fun_defn =
   ; args: (type_ * string) list
   ; cv_qualifiers: cv_qualifiers list [@default []]
   ; body: stmt list option }
-[@@deriving make, sexp]
+[@@deriving make, sexp_of]
 
 let split_fun_decl_defn (fn : fun_defn) =
   ( {fn with body= None}
@@ -361,7 +362,7 @@ type constructor =
   { args: (type_ * string) list
   ; init_list: (identifier * expr list) list
   ; body: stmt list }
-[@@deriving make, sexp]
+[@@deriving make, sexp_of]
 
 (** Incomplete list of C++ preprocessor directives *)
 type directive =
@@ -391,7 +392,7 @@ and defn =
   | GlobalUsing of string * type_ option
   | Namespace of identifier * defn list
   | Preprocessor of directive
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 (* can't be derivided since it is simultaneously declared with non-records *)
 let make_class_defn ~name ~public_base ?(final = true) ~private_members
@@ -420,7 +421,7 @@ end
 let ( !// ) s = GlobalComment s
 
 (** Much like in C++, we define a translation unit as a list of definitions *)
-type program = defn list [@@deriving sexp]
+type program = defn list [@@deriving sexp_of]
 
 module Printing = struct
   (** Pretty-printing of the C++ type *)


### PR DESCRIPTION
Similar to #1651, this removes a bunch of `@@deriving` annotations that are dead code. This increases our test coverage percentage and decreases the binary sizes for free

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
