### PR TITLE
Update ocamlformat to 0.29.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.28.1
+version=0.29.0
 ocaml-version=5.5
 # loosely re-creates the now-removed "compact" profile
 break-separators=before
@@ -14,3 +14,4 @@ space-around-variants=false
 sequence-blank-line=compact
 parse-docstrings=true
 wrap-comments=true
+letop-punning=always

--- a/docs/dependencies.mld
+++ b/docs/dependencies.mld
@@ -35,7 +35,7 @@ build requirements) with [scripts/setup_dev_env.sh]. Versioning of these depende
 strict, though some (like ocamlformat) are used to ensure a standard format across developers
 and must use the same version.
 
-- ocamlformat 0.28.1
+- ocamlformat 0.29.0
 - merlin
 - ocaml-lsp-server
 - utop

--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
   (ocamlformat
    (and
     :with-dev-setup
-    (= 0.28.1)))
+    (= 0.29.0)))
    (menhirformat
     :with-dev-setup)
   (bisect_ppx :with-dev-setup)

--- a/scripts/install_ci_deps.sh
+++ b/scripts/install_ci_deps.sh
@@ -4,6 +4,6 @@
 set -e
 
 # ocamlformat, bisect_ppx, and odoc are needed for CI and useful for developers
-opam pin -y ocamlformat 0.28.1 --no-action
+opam pin -y ocamlformat 0.29.0 --no-action
 opam pin -y bisect_ppx https://github.com/aantron/bisect_ppx.git#7061d643ff492b0045796357ee6917ded21fb1f0 --no-action
 opam install -y ocamlformat bisect_ppx odoc sherlodoc menhirformat

--- a/src/analysis_and_optimization/Dependence_analysis.ml
+++ b/src/analysis_and_optimization/Dependence_analysis.ml
@@ -109,8 +109,8 @@ let mir_reaching_definitions (mir : Program.Typed.t) (stmt : Stmt.Located.t) :
       {entry= to_rd_set entry; exit= to_rd_set exit})
 
 let all_labels
-    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH with type labels = int)
-    : int Set.Poly.t =
+    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
+      with type labels = int) : int Set.Poly.t =
   let step set =
     Set.union set
       (union_map set ~f:(fun l -> Map.Poly.find_exn Flowgraph.successors l))

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -900,7 +900,8 @@ let rec declared_variables_stmt
         (List.map ~f:(fun x -> declared_variables_stmt x.pattern) l)
 
 let propagation_mfp (prog : Program.Typed.t)
-    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH with type labels = int)
+    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
+      with type labels = int)
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
     (propagation_transfer :
          (int, Stmt.Located.Non_recursive.t) Map.Poly.t
@@ -934,7 +935,8 @@ let propagation_mfp (prog : Program.Typed.t)
   Mf.mfp ()
 
 let reaching_definitions_mfp (mir : Program.Typed.t)
-    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH with type labels = int)
+    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
+      with type labels = int)
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
   let variables =
     (module struct
@@ -959,7 +961,8 @@ let reaching_definitions_mfp (mir : Program.Typed.t)
   Mf.mfp ()
 
 let initialized_vars_mfp (total : string Set.Poly.t)
-    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH with type labels = int)
+    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
+      with type labels = int)
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
   let (module Lattice) =
     dual_powerset_lattice_empty_initial
@@ -1015,7 +1018,8 @@ let live_variables_mfp (prog : Program.Typed.t)
 (** Instantiate all four instances of the monotone framework for lazy code
     motion, reusing code between them *)
 let lazy_expressions_mfp
-    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH with type labels = int)
+    (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
+      with type labels = int)
     (module Rev_Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
     (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =

--- a/stanc.opam
+++ b/stanc.opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_inline_test"
   "ppx_pipebang"
   "ppx_sexp_value"
-  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "ocamlformat" {with-dev-setup & = "0.29.0"}
   "menhirformat" {with-dev-setup}
   "bisect_ppx" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}


### PR DESCRIPTION
Main thing is better support for new 5.5 syntax

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
