### PR TITLE
Lower_functions: Make struct order deterministic

### DIFF
--- a/src/stan_math_backend/Lower_functions.ml
+++ b/src/stan_math_backend/Lower_functions.ml
@@ -389,7 +389,12 @@ let collect_functors_functions (p : Program.Numbered.t) : defn list =
           let decl, defn = Cpp.split_fun_decl_defn fn in
           Some (FunDef decl, [signature_comment d; FunDef defn]))
     |> List.unzip in
-  let structs = Hashtbl.data structs |> List.map ~f:(fun s -> Struct s) in
+  let structs =
+    Hashtbl.data structs
+    |> List.stable_sort
+         ~compare:(fun {struct_name; _} {struct_name= struct_name2; _} ->
+           String.compare struct_name struct_name2)
+    |> List.map ~f:(fun s -> Struct s) in
   fun_decls @ structs @ List.concat fun_defns
 
 let lower_standalone_fun_def namespace_fun

--- a/test/integration/good/code-gen/cpp.expected
+++ b/test/integration/good/code-gen/cpp.expected
@@ -8022,22 +8022,6 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
 Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>, T2__, T3__>,-1,-1>
 K_function(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
            rho, std::ostream* pstream__);
-struct ll_function_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_col_vector<T0__>,
-                                stan::is_vt_not_complex<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T1__>,
-                                  stan::is_floating_point<T1__>>,
-                                stan::is_col_vector<T2__>,
-                                stan::is_vt_not_complex<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, T1__, stan::base_type_t<T2__>>
-  operator()(const T0__& theta, const T1__& eta, const T2__& log_ye,
-             const T3__& y, std::ostream* pstream__) const {
-    return ll_function(theta, eta, log_ye, y, pstream__);
-  }
-};
 struct K_function_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
@@ -8052,6 +8036,22 @@ struct K_function_functor__ {
   operator()(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
              rho, std::ostream* pstream__) const {
     return K_function(x, n_obs, alpha, rho, pstream__);
+  }
+};
+struct ll_function_functor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T1__>,
+                                  stan::is_floating_point<T1__>>,
+                                stan::is_col_vector<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, T1__, stan::base_type_t<T2__>>
+  operator()(const T0__& theta, const T1__& eta, const T2__& log_ye,
+             const T3__& y, std::ostream* pstream__) const {
+    return ll_function(theta, eta, log_ye, y, pstream__);
   }
 };
 // real ll_function(vector, real, vector, array[] int)
@@ -9787,6 +9787,35 @@ Eigen::Matrix<stan::return_type_t<stan::base_type_t<stan::tuple_element_t<0,
                 T3__>,-1,-1>
 arr_and_vec_tuple(const T0__& x, const T1__& n_obs, const T2__& alpha,
                   const T3__& rho, std::ostream* pstream__);
+struct arr_and_vec_tuple_functor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_tuple_of_size<T0__, 2>,
+                                stan::is_std_vector<stan::tuple_element_t<0,
+                                                      T0__>>,
+                                stan::is_col_vector<stan::value_type_t<
+                                                      stan::tuple_element_t<0,
+                                                        T0__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::tuple_element_t<0,
+                                                            T0__>>>,
+                                stan::is_col_vector<stan::tuple_element_t<1,
+                                                      T0__>>,
+                                stan::is_vt_not_complex<stan::tuple_element_t<1,
+                                                          T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T2__>,
+                                  stan::is_floating_point<T2__>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T3__>,
+                                  stan::is_floating_point<T3__>>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<stan::base_type_t<stan::tuple_element_t<0,
+                                                        T0__>>,
+                  stan::base_type_t<stan::tuple_element_t<1, T0__>>, T2__,
+                  T3__>,-1,-1>
+  operator()(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
+             rho, std::ostream* pstream__) const {
+    return arr_and_vec_tuple(x, n_obs, alpha, rho, pstream__);
+  }
+};
 struct arr_vec_tuple_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_tuple_of_size<T0__, 2>,
@@ -9818,35 +9847,6 @@ struct arr_vec_tuple_functor__ {
   operator()(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
              rho, std::ostream* pstream__) const {
     return arr_vec_tuple(x, n_obs, alpha, rho, pstream__);
-  }
-};
-struct arr_and_vec_tuple_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_tuple_of_size<T0__, 2>,
-                                stan::is_std_vector<stan::tuple_element_t<0,
-                                                      T0__>>,
-                                stan::is_col_vector<stan::value_type_t<
-                                                      stan::tuple_element_t<0,
-                                                        T0__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::tuple_element_t<0,
-                                                            T0__>>>,
-                                stan::is_col_vector<stan::tuple_element_t<1,
-                                                      T0__>>,
-                                stan::is_vt_not_complex<stan::tuple_element_t<1,
-                                                          T0__>>,
-                                stan::is_integral<T1__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T2__>,
-                                  stan::is_floating_point<T2__>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T3__>,
-                                  stan::is_floating_point<T3__>>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<stan::base_type_t<stan::tuple_element_t<0,
-                                                        T0__>>,
-                  stan::base_type_t<stan::tuple_element_t<1, T0__>>, T2__,
-                  T3__>,-1,-1>
-  operator()(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
-             rho, std::ostream* pstream__) const {
-    return arr_and_vec_tuple(x, n_obs, alpha, rho, pstream__);
   }
 };
 struct scalar_tuple_functor__ {
@@ -10795,6 +10795,22 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
 Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>, T2__, T3__>,-1,-1>
 K_function(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
            rho, std::ostream* pstream__);
+struct K_function_functor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_col_vector<stan::value_type_t<T0__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T2__>,
+                                  stan::is_floating_point<T2__>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T3__>,
+                                  stan::is_floating_point<T3__>>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>, T2__, T3__>,-1,-1>
+  operator()(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
+             rho, std::ostream* pstream__) const {
+    return K_function(x, n_obs, alpha, rho, pstream__);
+  }
+};
 struct arr_vec_tuple_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_col_vector<T0__>,
@@ -10816,33 +10832,6 @@ struct arr_vec_tuple_functor__ {
   operator()(const T0__& theta, const T1__& eta, const T2__& p, std::ostream*
              pstream__) const {
     return arr_vec_tuple(theta, eta, p, pstream__);
-  }
-};
-struct scalar_tuple_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_col_vector<T0__>,
-                                stan::is_vt_not_complex<T0__>,
-                                stan::is_tuple_of_size<T1__, 2>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::tuple_element_t<0,
-                                                            T1__>>,
-                                  stan::is_floating_point<stan::tuple_element_t<0,
-                                                            T1__>>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::tuple_element_t<1,
-                                                            T1__>>,
-                                  stan::is_floating_point<stan::tuple_element_t<1,
-                                                            T1__>>>,
-                                stan::is_col_vector<T2__>,
-                                stan::is_vt_not_complex<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>,
-    stan::tuple_element_t<0, T1__>, stan::tuple_element_t<1, T1__>,
-    stan::base_type_t<T2__>>
-  operator()(const T0__& theta, const T1__& eta, const T2__& log_ye,
-             const T3__& y, std::ostream* pstream__) const {
-    return scalar_tuple(theta, eta, log_ye, y, pstream__);
   }
 };
 struct nested_functor__ {
@@ -10883,20 +10872,31 @@ struct nested_functor__ {
     return nested(theta, p, unused, pstream__);
   }
 };
-struct K_function_functor__ {
+struct scalar_tuple_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_col_vector<stan::value_type_t<T0__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
-                                stan::is_integral<T1__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T2__>,
-                                  stan::is_floating_point<T2__>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T3__>,
-                                  stan::is_floating_point<T3__>>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>, T2__, T3__>,-1,-1>
-  operator()(const T0__& x, const T1__& n_obs, const T2__& alpha, const T3__&
-             rho, std::ostream* pstream__) const {
-    return K_function(x, n_obs, alpha, rho, pstream__);
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_tuple_of_size<T1__, 2>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::tuple_element_t<0,
+                                                            T1__>>,
+                                  stan::is_floating_point<stan::tuple_element_t<0,
+                                                            T1__>>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::tuple_element_t<1,
+                                                            T1__>>,
+                                  stan::is_floating_point<stan::tuple_element_t<1,
+                                                            T1__>>>,
+                                stan::is_col_vector<T2__>,
+                                stan::is_vt_not_complex<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>,
+    stan::tuple_element_t<0, T1__>, stan::tuple_element_t<1, T1__>,
+    stan::base_type_t<T2__>>
+  operator()(const T0__& theta, const T1__& eta, const T2__& log_ye,
+             const T3__& y, std::ostream* pstream__) const {
+    return scalar_tuple(theta, eta, log_ye, y, pstream__);
   }
 };
 // real scalar_tuple(vector, tuple(real, real), vector, array[] int)
@@ -11904,6 +11904,50 @@ Eigen::Matrix<stan::return_type_t<stan::base_type_t<stan::tuple_element_t<0,
                                       stan::base_type_t<T0__>>>>,
                 T1__>,-1,-1>
 K_function(const T0__& p, const T1__& rho, std::ostream* pstream__);
+struct K_function_functor__ {
+  template <typename T0__, typename T1__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_tuple_of_size<stan::value_type_t<T0__>,
+                                  2>,
+                                stan::is_std_vector<stan::tuple_element_t<0,
+                                                      stan::value_type_t<T0__>>>,
+                                stan::is_col_vector<stan::value_type_t<
+                                                      stan::tuple_element_t<0,
+                                                        stan::value_type_t<T0__>>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::tuple_element_t<0,
+                                                            stan::value_type_t<T0__>>>>,
+                                stan::is_std_vector<stan::tuple_element_t<1,
+                                                      stan::value_type_t<T0__>>>,
+                                stan::is_tuple_of_size<stan::value_type_t<
+                                                         stan::tuple_element_t<1,
+                                                           stan::value_type_t<T0__>>>,
+                                  2>,
+                                stan::is_integral<stan::tuple_element_t<0,
+                                                    stan::value_type_t<
+                                                      stan::tuple_element_t<1,
+                                                        stan::value_type_t<T0__>>>>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::tuple_element_t<1,
+                                                            stan::value_type_t<
+                                                              stan::tuple_element_t<1,
+                                                                stan::value_type_t<T0__>>>>>,
+                                  stan::is_floating_point<stan::tuple_element_t<1,
+                                                            stan::value_type_t<
+                                                              stan::tuple_element_t<1,
+                                                                stan::value_type_t<T0__>>>>>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T1__>,
+                                  stan::is_floating_point<T1__>>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<stan::base_type_t<stan::tuple_element_t<0,
+                                                        stan::base_type_t<T0__>>>,
+                  stan::tuple_element_t<1,
+                    stan::base_type_t<stan::tuple_element_t<1,
+                                        stan::base_type_t<T0__>>>>,
+                  T1__>,-1,-1>
+  operator()(const T0__& p, const T1__& rho, std::ostream* pstream__) const {
+    return K_function(p, rho, pstream__);
+  }
+};
 struct ll_nested_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_col_vector<T0__>,
@@ -11951,50 +11995,6 @@ struct ll_nested_functor__ {
   operator()(const T0__& theta, const T1__& p, const T2__& unused,
              std::ostream* pstream__) const {
     return ll_nested(theta, p, unused, pstream__);
-  }
-};
-struct K_function_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_tuple_of_size<stan::value_type_t<T0__>,
-                                  2>,
-                                stan::is_std_vector<stan::tuple_element_t<0,
-                                                      stan::value_type_t<T0__>>>,
-                                stan::is_col_vector<stan::value_type_t<
-                                                      stan::tuple_element_t<0,
-                                                        stan::value_type_t<T0__>>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::tuple_element_t<0,
-                                                            stan::value_type_t<T0__>>>>,
-                                stan::is_std_vector<stan::tuple_element_t<1,
-                                                      stan::value_type_t<T0__>>>,
-                                stan::is_tuple_of_size<stan::value_type_t<
-                                                         stan::tuple_element_t<1,
-                                                           stan::value_type_t<T0__>>>,
-                                  2>,
-                                stan::is_integral<stan::tuple_element_t<0,
-                                                    stan::value_type_t<
-                                                      stan::tuple_element_t<1,
-                                                        stan::value_type_t<T0__>>>>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::tuple_element_t<1,
-                                                            stan::value_type_t<
-                                                              stan::tuple_element_t<1,
-                                                                stan::value_type_t<T0__>>>>>,
-                                  stan::is_floating_point<stan::tuple_element_t<1,
-                                                            stan::value_type_t<
-                                                              stan::tuple_element_t<1,
-                                                                stan::value_type_t<T0__>>>>>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T1__>,
-                                  stan::is_floating_point<T1__>>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<stan::base_type_t<stan::tuple_element_t<0,
-                                                        stan::base_type_t<T0__>>>,
-                  stan::tuple_element_t<1,
-                    stan::base_type_t<stan::tuple_element_t<1,
-                                        stan::base_type_t<T0__>>>>,
-                  T1__>,-1,-1>
-  operator()(const T0__& p, const T1__& rho, std::ostream* pstream__) const {
-    return K_function(p, rho, pstream__);
   }
 };
 /* real
@@ -12925,6 +12925,16 @@ template <typename T0__,
                               stan::is_vt_not_complex<stan::value_type_t<T0__>>>* = nullptr>
 Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>>,-1,-1>
 K_function(const T0__& x, std::ostream* pstream__);
+struct K_function_functor__ {
+  template <typename T0__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_col_vector<stan::value_type_t<T0__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T0__>>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>>,-1,-1>
+  operator()(const T0__& x, std::ostream* pstream__) const {
+    return K_function(x, pstream__);
+  }
+};
 struct ll_function_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_col_vector<T0__>,
@@ -12939,16 +12949,6 @@ struct ll_function_functor__ {
   operator()(const T0__& theta, const T1__& eta, const T2__& log_ye,
              const T3__& y, std::ostream* pstream__) const {
     return ll_function(theta, eta, log_ye, y, pstream__);
-  }
-};
-struct K_function_functor__ {
-  template <typename T0__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_col_vector<stan::value_type_t<T0__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T0__>>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>>,-1,-1>
-  operator()(const T0__& x, std::ostream* pstream__) const {
-    return K_function(x, pstream__);
   }
 };
 // real ll_function(vector, real, vector, array[] int)
@@ -14486,6 +14486,15 @@ template <typename T0__,
                                 stan::is_floating_point<T0__>>>* = nullptr>
 Eigen::Matrix<stan::return_type_t<T0__>,-1,-1>
 cov_fun(const T0__& sigma, const int& N, std::ostream* pstream__);
+struct cov_fun_functor__ {
+  template <typename T0__,
+            stan::require_all_t<stan::math::disjunction<stan::is_autodiff_scalar<T0__>,
+                                  stan::is_floating_point<T0__>>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<T0__>,-1,-1>
+  operator()(const T0__& sigma, const int& N, std::ostream* pstream__) const {
+    return cov_fun(sigma, N, pstream__);
+  }
+};
 struct poisson_re_log_ll_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_col_vector<T0__>,
@@ -14498,15 +14507,6 @@ struct poisson_re_log_ll_functor__ {
   operator()(const T0__& theta, const T1__& y, const T2__& mu, std::ostream*
              pstream__) const {
     return poisson_re_log_ll(theta, y, mu, pstream__);
-  }
-};
-struct cov_fun_functor__ {
-  template <typename T0__,
-            stan::require_all_t<stan::math::disjunction<stan::is_autodiff_scalar<T0__>,
-                                  stan::is_floating_point<T0__>>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<T0__>,-1,-1>
-  operator()(const T0__& sigma, const int& N, std::ostream* pstream__) const {
-    return cov_fun(sigma, N, pstream__);
   }
 };
 // real poisson_re_log_ll(vector, array[] int, vector)
@@ -26982,7 +26982,7 @@ Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>,
                 stan::base_type_t<T1__>, stan::base_type_t<T2__>>,-1,1>
 algebra_system(const T0__& x_arg__, const T1__& y_arg__, const T2__& dat,
                const T3__& dat_int, std::ostream* pstream__);
-struct goo_functor__ {
+struct algebra_system_functor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_col_vector<T0__>,
                                 stan::is_vt_not_complex<T0__>,
@@ -26996,9 +26996,9 @@ struct goo_functor__ {
                                 stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
   Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>,
                   stan::base_type_t<T1__>, stan::base_type_t<T2__>>,-1,1>
-  operator()(const T0__& shared_params, const T1__& job_params, const T2__&
-             data_r, const T3__& data_i, std::ostream* pstream__) const {
-    return goo(shared_params, job_params, data_r, data_i, pstream__);
+  operator()(const T0__& x, const T1__& y, const T2__& dat, const T3__&
+             dat_int, std::ostream* pstream__) const {
+    return algebra_system(x, y, dat, dat_int, pstream__);
   }
 };
 struct foo_functor__ {
@@ -27018,6 +27018,25 @@ struct foo_functor__ {
   operator()(const T0__& shared_params, const T1__& job_params, const T2__&
              data_r, const T3__& data_i, std::ostream* pstream__) const {
     return foo(shared_params, job_params, data_r, data_i, pstream__);
+  }
+};
+struct goo_functor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_col_vector<T0__>,
+                                stan::is_vt_not_complex<T0__>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>,
+                                stan::is_std_vector<T2__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T2__>>,
+                                  stan::is_floating_point<stan::value_type_t<T2__>>>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>,
+                  stan::base_type_t<T1__>, stan::base_type_t<T2__>>,-1,1>
+  operator()(const T0__& shared_params, const T1__& job_params, const T2__&
+             data_r, const T3__& data_i, std::ostream* pstream__) const {
+    return goo(shared_params, job_params, data_r, data_i, pstream__);
   }
 };
 struct integrand_functor__ {
@@ -27042,25 +27061,6 @@ struct integrand_functor__ {
   operator()(const T0__& x, const T1__& xc, const T2__& theta, const T3__&
              x_r, const T4__& x_i, std::ostream* pstream__) const {
     return integrand(x, xc, theta, x_r, x_i, pstream__);
-  }
-};
-struct algebra_system_functor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_col_vector<T0__>,
-                                stan::is_vt_not_complex<T0__>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>,
-                                stan::is_std_vector<T2__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T2__>>,
-                                  stan::is_floating_point<stan::value_type_t<T2__>>>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_integral<stan::value_type_t<T3__>>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<stan::base_type_t<T0__>,
-                  stan::base_type_t<T1__>, stan::base_type_t<T2__>>,-1,1>
-  operator()(const T0__& x, const T1__& y, const T2__& dat, const T3__&
-             dat_int, std::ostream* pstream__) const {
-    return algebra_system(x, y, dat, dat_int, pstream__);
   }
 };
 struct sho_functor__ {
@@ -42262,22 +42262,19 @@ template <bool propto__, typename T0__, typename T1__, typename T2__,
 stan::return_type_t<stan::base_type_t<T0__>>
 foo_lpdf(const T0__& y_slice, const T1__& start, const T2__& end,
          std::ostream* pstream__);
-struct h_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
+template <bool propto__>
+struct foo_lpdf_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_std_vector<T0__>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<T0__>>,
                                   stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T3__>>,
-                                  stan::is_floating_point<stan::value_type_t<T3__>>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return h(y_slice, (start + 1), (end + 1), a, pstream__);
+             std::ostream* pstream__) const {
+    return foo_lpdf<propto__>(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
 struct g_rsfunctor__ {
@@ -42294,19 +42291,22 @@ struct g_rsfunctor__ {
     return g(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
-template <bool propto__>
-struct foo_lpdf_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct h_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<T0__>>,
                                   stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T3__>>,
+                                  stan::is_floating_point<stan::value_type_t<T3__>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return foo_lpdf<propto__>(y_slice, (start + 1), (end + 1), pstream__);
+             std::ostream* pstream__, const T3__& a) const {
+    return h(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
 // real g(array[] real, int, int)
@@ -43242,25 +43242,122 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
 stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
 h8(const T0__& y, const T1__& start, const T2__& end, const T3__& a,
    std::ostream* pstream__);
-struct h5_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
+struct g1_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_std_vector<T0__>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<T0__>>,
                                   stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_std_vector<stan::value_type_t<T3__>>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g1(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g2_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_col_vector<stan::value_type_t<T0__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g2(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g3_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_row_vector<stan::value_type_t<T0__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g3(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g4_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_eigen_matrix_dynamic<stan::value_type_t<T0__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g4(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g5_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<
-                                                            stan::value_type_t<T3__>>>,
+                                                            stan::value_type_t<T0__>>>,
                                   stan::is_floating_point<stan::value_type_t<
-                                                            stan::value_type_t<T3__>>>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
-             pstream__, const T3__& a) const {
-    return h5(y, (start + 1), (end + 1), a, pstream__);
+                                                            stan::value_type_t<T0__>>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g5(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g6_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_col_vector<stan::value_type_t<
+                                                      stan::value_type_t<T0__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g6(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g7_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_row_vector<stan::value_type_t<
+                                                      stan::value_type_t<T0__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g7(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct g8_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_eigen_matrix_dynamic<stan::value_type_t<
+                                                                stan::value_type_t<T0__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return g8(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
 struct h1_rsfunctor__ {
@@ -43281,20 +43378,7 @@ struct h1_rsfunctor__ {
     return h1(y, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct g3_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_row_vector<stan::value_type_t<T0__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g3(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct h7_rsfunctor__ {
+struct h2_rsfunctor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
@@ -43303,15 +43387,12 @@ struct h7_rsfunctor__ {
                                 stan::is_integral<T1__>,
                                 stan::is_integral<T2__>,
                                 stan::is_std_vector<T3__>,
-                                stan::is_std_vector<stan::value_type_t<T3__>>,
-                                stan::is_row_vector<stan::value_type_t<
-                                                      stan::value_type_t<T3__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T3__>>>>* = nullptr>
+                                stan::is_col_vector<stan::value_type_t<T3__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
   stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
   operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
              pstream__, const T3__& a) const {
-    return h7(y, (start + 1), (end + 1), a, pstream__);
+    return h2(y, (start + 1), (end + 1), a, pstream__);
   }
 };
 struct h3_rsfunctor__ {
@@ -43331,101 +43412,6 @@ struct h3_rsfunctor__ {
     return h3(y, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct g2_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_col_vector<stan::value_type_t<T0__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g2(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct g8_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::is_eigen_matrix_dynamic<stan::value_type_t<
-                                                                stan::value_type_t<T0__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g8(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct h2_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_col_vector<stan::value_type_t<T3__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
-             pstream__, const T3__& a) const {
-    return h2(y, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct h8_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_std_vector<stan::value_type_t<T3__>>,
-                                stan::is_eigen_matrix_dynamic<stan::value_type_t<
-                                                                stan::value_type_t<T3__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T3__>>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
-             pstream__, const T3__& a) const {
-    return h8(y, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g7_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::is_row_vector<stan::value_type_t<
-                                                      stan::value_type_t<T0__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g7(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct g4_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_eigen_matrix_dynamic<stan::value_type_t<T0__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g4(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
 struct h4_rsfunctor__ {
   template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
@@ -43443,37 +43429,25 @@ struct h4_rsfunctor__ {
     return h4(y, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct g6_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct h5_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::is_col_vector<stan::value_type_t<
-                                                      stan::value_type_t<T0__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T0__>>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g6(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct g5_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_std_vector<stan::value_type_t<T3__>>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<
-                                                            stan::value_type_t<T0__>>>,
+                                                            stan::value_type_t<T3__>>>,
                                   stan::is_floating_point<stan::value_type_t<
-                                                            stan::value_type_t<T0__>>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g5(y_slice, (start + 1), (end + 1), pstream__);
+                                                            stan::value_type_t<T3__>>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
+             pstream__, const T3__& a) const {
+    return h5(y, (start + 1), (end + 1), a, pstream__);
   }
 };
 struct h6_rsfunctor__ {
@@ -43496,18 +43470,44 @@ struct h6_rsfunctor__ {
     return h6(y, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct g1_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct h7_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<T0__>>,
                                   stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return g1(y_slice, (start + 1), (end + 1), pstream__);
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_std_vector<stan::value_type_t<T3__>>,
+                                stan::is_row_vector<stan::value_type_t<
+                                                      stan::value_type_t<T3__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T3__>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
+             pstream__, const T3__& a) const {
+    return h7(y, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct h8_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_std_vector<stan::value_type_t<T3__>>,
+                                stan::is_eigen_matrix_dynamic<stan::value_type_t<
+                                                                stan::value_type_t<T3__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T3__>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y, const T1__& start, const T2__& end, std::ostream*
+             pstream__, const T3__& a) const {
+    return h8(y, (start + 1), (end + 1), a, pstream__);
   }
 };
 // real g1(array[] real, int, int)
@@ -46656,6 +46656,20 @@ s(const T0__& y_slice, const T1__& start, const T2__& end, const T3__& a,
   const T16__& n, const T17__& o, const T18__& p, const T19__& q,
   std::ostream* pstream__);
 double r(std::ostream* pstream__);
+struct f10_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_integral<stan::value_type_t<
+                                                    stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  double
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return f10(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
 struct f11_rsfunctor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_std_vector<T0__>,
@@ -46671,193 +46685,6 @@ struct f11_rsfunctor__ {
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
              std::ostream* pstream__) const {
     return f11(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct f10_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::is_integral<stan::value_type_t<
-                                                    stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  double
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f10(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct g8_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_eigen_matrix_dynamic<stan::value_type_t<T3__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g8(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g7_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_row_vector<stan::value_type_t<T3__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g7(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g4_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_eigen_matrix_dynamic<T3__>,
-                                stan::is_vt_not_complex<T3__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g4(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g6_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_col_vector<stan::value_type_t<T3__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g6(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g11_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_std_vector<stan::value_type_t<T3__>>,
-                                stan::is_row_vector<stan::value_type_t<
-                                                      stan::value_type_t<T3__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T3__>>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g11(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct f5_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<
-                                                            stan::value_type_t<T0__>>>,
-                                  stan::is_floating_point<stan::value_type_t<
-                                                            stan::value_type_t<T0__>>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f5(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct f1_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f1(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct g5_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T3__>>,
-                                  stan::is_floating_point<stan::value_type_t<T3__>>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g5(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g9_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_std_vector<T3__>,
-                                stan::is_std_vector<stan::value_type_t<T3__>>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<
-                                                            stan::value_type_t<T3__>>>,
-                                  stan::is_floating_point<stan::value_type_t<
-                                                            stan::value_type_t<T3__>>>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g9(y_slice, (start + 1), (end + 1), a, pstream__);
-  }
-};
-struct g1_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<T3__>,
-                                  stan::is_floating_point<T3__>>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, T3__>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g1(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
 struct f12_rsfunctor__ {
@@ -46881,20 +46708,45 @@ struct f12_rsfunctor__ {
     return f12(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
-struct g3_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
+struct f1_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_std_vector<T0__>,
                                 stan::math::disjunction<stan::is_autodiff_scalar<
                                                           stan::value_type_t<T0__>>,
                                   stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_row_vector<T3__>,
-                                stan::is_vt_not_complex<T3__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g3(y_slice, (start + 1), (end + 1), a, pstream__);
+             std::ostream* pstream__) const {
+    return f1(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct f1a_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return f1a(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct f2_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_col_vector<stan::value_type_t<T0__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return f2(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
 struct f3_rsfunctor__ {
@@ -46910,17 +46762,34 @@ struct f3_rsfunctor__ {
     return f3(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
-struct f2_rsfunctor__ {
+struct f4_rsfunctor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_col_vector<stan::value_type_t<T0__>>,
+                                stan::is_eigen_matrix_dynamic<stan::value_type_t<T0__>>,
                                 stan::is_vt_not_complex<stan::value_type_t<T0__>>,
                                 stan::is_integral<T1__>,
                                 stan::is_integral<T2__>>* = nullptr>
   stan::return_type_t<stan::base_type_t<T0__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
              std::ostream* pstream__) const {
-    return f2(y_slice, (start + 1), (end + 1), pstream__);
+    return f4(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct f5_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<
+                                                            stan::value_type_t<T0__>>>,
+                                  stan::is_floating_point<stan::value_type_t<
+                                                            stan::value_type_t<T0__>>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return f5(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
 struct f6_rsfunctor__ {
@@ -46939,20 +46808,48 @@ struct f6_rsfunctor__ {
     return f6(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
-struct g2_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__, typename T3__,
+struct f7_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_row_vector<stan::value_type_t<
+                                                      stan::value_type_t<T0__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>,
-                                stan::is_col_vector<T3__>,
-                                stan::is_vt_not_complex<T3__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__, const T3__& a) const {
-    return g2(y_slice, (start + 1), (end + 1), a, pstream__);
+             std::ostream* pstream__) const {
+    return f7(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct f8_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_std_vector<stan::value_type_t<T0__>>,
+                                stan::is_eigen_matrix_dynamic<stan::value_type_t<
+                                                                stan::value_type_t<T0__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return f8(y_slice, (start + 1), (end + 1), pstream__);
+  }
+};
+struct f9_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::is_integral<stan::value_type_t<T0__>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>>* = nullptr>
+  double
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__) const {
+    return f9(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
 struct g10_rsfunctor__ {
@@ -46975,20 +46872,24 @@ struct g10_rsfunctor__ {
     return g10(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct f8_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct g11_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::is_eigen_matrix_dynamic<stan::value_type_t<
-                                                                stan::value_type_t<T0__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T0__>>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_std_vector<stan::value_type_t<T3__>>,
+                                stan::is_row_vector<stan::value_type_t<
+                                                      stan::value_type_t<T3__>>>,
+                                stan::is_vt_not_complex<stan::value_type_t<
+                                                          stan::value_type_t<T3__>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f8(y_slice, (start + 1), (end + 1), pstream__);
+             std::ostream* pstream__, const T3__& a) const {
+    return g11(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
 struct g12_rsfunctor__ {
@@ -47011,29 +46912,158 @@ struct g12_rsfunctor__ {
     return g12(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct f9_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct g1_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_integral<stan::value_type_t<T0__>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  double
+                                stan::is_integral<T2__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<T3__>,
+                                  stan::is_floating_point<T3__>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, T3__>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f9(y_slice, (start + 1), (end + 1), pstream__);
+             std::ostream* pstream__, const T3__& a) const {
+    return g1(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
-struct f4_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
+struct g2_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
             stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_eigen_matrix_dynamic<stan::value_type_t<T0__>>,
-                                stan::is_vt_not_complex<stan::value_type_t<T0__>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
                                 stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
+                                stan::is_integral<T2__>,
+                                stan::is_col_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
   operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f4(y_slice, (start + 1), (end + 1), pstream__);
+             std::ostream* pstream__, const T3__& a) const {
+    return g2(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g3_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_row_vector<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g3(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g4_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_eigen_matrix_dynamic<T3__>,
+                                stan::is_vt_not_complex<T3__>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g4(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g5_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T3__>>,
+                                  stan::is_floating_point<stan::value_type_t<T3__>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g5(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g6_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_col_vector<stan::value_type_t<T3__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g6(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g7_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_row_vector<stan::value_type_t<T3__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g7(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g8_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_eigen_matrix_dynamic<stan::value_type_t<T3__>>,
+                                stan::is_vt_not_complex<stan::value_type_t<T3__>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g8(y_slice, (start + 1), (end + 1), a, pstream__);
+  }
+};
+struct g9_rsfunctor__ {
+  template <typename T0__, typename T1__, typename T2__, typename T3__,
+            stan::require_all_t<stan::is_std_vector<T0__>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<T0__>>,
+                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
+                                stan::is_integral<T1__>,
+                                stan::is_integral<T2__>,
+                                stan::is_std_vector<T3__>,
+                                stan::is_std_vector<stan::value_type_t<T3__>>,
+                                stan::math::disjunction<stan::is_autodiff_scalar<
+                                                          stan::value_type_t<
+                                                            stan::value_type_t<T3__>>>,
+                                  stan::is_floating_point<stan::value_type_t<
+                                                            stan::value_type_t<T3__>>>>>* = nullptr>
+  stan::return_type_t<stan::base_type_t<T0__>, stan::base_type_t<T3__>>
+  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
+             std::ostream* pstream__, const T3__& a) const {
+    return g9(y_slice, (start + 1), (end + 1), a, pstream__);
   }
 };
 struct s_rsfunctor__ {
@@ -47134,36 +47164,6 @@ struct s_rsfunctor__ {
              const T17__& o, const T18__& p, const T19__& q) const {
     return s(y_slice, (start + 1), (end + 1), a, b, c, d, e, f, g, h, i, j,
              k, l, m, n, o, p, q, pstream__);
-  }
-};
-struct f7_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::is_std_vector<stan::value_type_t<T0__>>,
-                                stan::is_row_vector<stan::value_type_t<
-                                                      stan::value_type_t<T0__>>>,
-                                stan::is_vt_not_complex<stan::value_type_t<
-                                                          stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f7(y_slice, (start + 1), (end + 1), pstream__);
-  }
-};
-struct f1a_rsfunctor__ {
-  template <typename T0__, typename T1__, typename T2__,
-            stan::require_all_t<stan::is_std_vector<T0__>,
-                                stan::math::disjunction<stan::is_autodiff_scalar<
-                                                          stan::value_type_t<T0__>>,
-                                  stan::is_floating_point<stan::value_type_t<T0__>>>,
-                                stan::is_integral<T1__>,
-                                stan::is_integral<T2__>>* = nullptr>
-  stan::return_type_t<stan::base_type_t<T0__>>
-  operator()(const T0__& y_slice, const T1__& start, const T2__& end,
-             std::ostream* pstream__) const {
-    return f1a(y_slice, (start + 1), (end + 1), pstream__);
   }
 };
 // real f1(array[] real, int, int)

--- a/test/integration/good/code-gen/ode/cpp.expected
+++ b/test/integration/good/code-gen/ode/cpp.expected
@@ -70,6 +70,17 @@ template <typename T0__, typename T1__, typename T2__, typename T3__,
 Eigen::Matrix<stan::return_type_t<T0__, stan::base_type_t<T1__>, T3__>,-1,1>
 f_2_arg(const T0__& t, const T1__& z_arg__, const T2__& b, const T3__& a,
         std::ostream* pstream__);
+struct f_0_arg_variadic2_functor__ {
+  template <typename T0__, typename T1__,
+            stan::require_all_t<stan::math::disjunction<stan::is_autodiff_scalar<T0__>,
+                                  stan::is_floating_point<T0__>>,
+                                stan::is_col_vector<T1__>,
+                                stan::is_vt_not_complex<T1__>>* = nullptr>
+  Eigen::Matrix<stan::return_type_t<T0__, stan::base_type_t<T1__>>,-1,1>
+  operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const {
+    return f_0_arg(t, z, pstream__);
+  }
+};
 struct f_1_arg_variadic2_functor__ {
   template <typename T0__, typename T1__, typename T2__,
             stan::require_all_t<stan::math::disjunction<stan::is_autodiff_scalar<T0__>,
@@ -97,17 +108,6 @@ struct f_2_arg_variadic2_functor__ {
   operator()(const T0__& t, const T1__& z, std::ostream* pstream__,
              const T2__& b, const T3__& a) const {
     return f_2_arg(t, z, b, a, pstream__);
-  }
-};
-struct f_0_arg_variadic2_functor__ {
-  template <typename T0__, typename T1__,
-            stan::require_all_t<stan::math::disjunction<stan::is_autodiff_scalar<T0__>,
-                                  stan::is_floating_point<T0__>>,
-                                stan::is_col_vector<T1__>,
-                                stan::is_vt_not_complex<T1__>>* = nullptr>
-  Eigen::Matrix<stan::return_type_t<T0__, stan::base_type_t<T1__>>,-1,1>
-  operator()(const T0__& t, const T1__& z, std::ostream* pstream__) const {
-    return f_0_arg(t, z, pstream__);
   }
 };
 // vector f_0_arg(real, vector)


### PR DESCRIPTION
This may seem strange, but when preparing another change I ran afoul of this and a test diff that should be empty was massive. By changing it here in a very-obviously-benign change, it makes that diff less scary

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes



## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
