### PR TITLE
Stanc.Std: Move over Analysis module

### DIFF
--- a/src/analysis_and_optimization/Dataflow_types.ml
+++ b/src/analysis_and_optimization/Dataflow_types.ml
@@ -1,4 +1,5 @@
-open Core
+open Std
+open Std.Sexp_conv
 
 (***********************************)
 (* Basic datatypes                 *)
@@ -21,3 +22,12 @@ type reaching_defn = vexpr * label [@@deriving sexp_of]
     This isn't included in the traversal_state because it only flows downward
     through the tree, not across and up like everything else *)
 type cf_state = label
+
+module LabelMap = struct
+  include Int.Map
+
+  let sexp_of_t f t = sexp_of_list (sexp_of_pair sexp_of_int f) (to_list t)
+end
+
+module ExprSet = Set.Make (Middle.Expr.Typed)
+module ExprMap = Map.Make (Middle.Expr.Typed)

--- a/src/analysis_and_optimization/Dataflow_utils.ml
+++ b/src/analysis_and_optimization/Dataflow_utils.ml
@@ -1,27 +1,17 @@
-open Core
+open Std
 open Middle
 open Dataflow_types
 open Mir_utils
 
 (** Union maps, preserving the left element in a collision *)
-let union_maps_left (m1 : ('a, 'b) Map.Poly.t) (m2 : ('a, 'b) Map.Poly.t) :
-    ('a, 'b) Map.Poly.t =
-  let f ~key:_ opt =
-    match opt with
-    | `Left v -> Some v
-    | `Right v -> Some v
-    | `Both (v1, _) -> Some v1 in
-  Map.Poly.merge m1 m2 ~f
+let union_maps_left (module M : Map.S) (m1 : 'a M.t) (m2 : 'a M.t) : 'a M.t =
+  M.union ~f:(fun _ v1 _ -> Some v1) m1 m2
 
 (** Merge two maps whose values are sets, and union the sets when there's a
     collision. *)
-let merge_set_maps m1 m2 =
-  let merge_map_elems ~key:_ es =
-    match es with
-    | `Left e1 -> Some e1
-    | `Right e2 -> Some e2
-    | `Both (e1, e2) -> Some (Set.union e1 e2) in
-  Map.Poly.merge ~f:merge_map_elems m1 m2
+let merge_set_maps (module M : Map.S) m1 m2 =
+  let merge_map_elems _ e1 e2 = Some (Set.Poly.union e1 e2) in
+  M.union ~f:merge_map_elems m1 m2
 
 (** Like a forward traversal, but branches accumulate two different states that
     are recombined with join. *)
@@ -51,10 +41,12 @@ let build_statement_map extract metadata stmt =
     let (next_label'', map), built =
       fwd_traverse_statement (extract stmt) ~init:(next_label', map) ~f in
     ( ( next_label''
-      , union_maps_left map
-          (Map.Poly.singleton this_label (built, metadata stmt)) )
+      , union_maps_left
+          (module LabelMap)
+          map
+          (LabelMap.singleton this_label (built, metadata stmt)) )
     , this_label ) in
-  let (_, map), _ = build_statement_map_rec 1 Map.Poly.empty stmt in
+  let (_, map), _ = build_statement_map_rec 1 LabelMap.empty stmt in
   map
 
 (* TODO: this currently does not seem to be labelling inside function bodies.
@@ -62,9 +54,9 @@ let build_statement_map extract metadata stmt =
 
 (** See interface file *)
 let rec build_recursive_statement rebuild statement_map label =
-  let stmt_ints, meta = Map.Poly.find_exn statement_map label in
+  let stmt_ints, meta = LabelMap.find label statement_map in
   let build_stmt = build_recursive_statement rebuild statement_map in
-  let stmt = Stmt.Pattern.map Fn.id build_stmt stmt_ints in
+  let stmt = Stmt.Pattern.map Fun.id build_stmt stmt_ints in
   rebuild stmt meta
 
 (** Represents the state required to build control flow information during an
@@ -92,10 +84,10 @@ type cf_edges = {predecessors: label Set.Poly.t; parents: label Set.Poly.t}
 (** Join the state of a controlflow traversal across different branches of
     execution such as over if/else branch. *)
 let join_cf_states (state1 : cf_state) (state2 : cf_state) : cf_state =
-  { breaks= Set.union state1.breaks state2.breaks
-  ; continues= Set.union state1.continues state2.continues
-  ; returns= Set.union state1.returns state2.returns
-  ; exits= Set.union state1.exits state2.exits }
+  { breaks= Set.Poly.union state1.breaks state2.breaks
+  ; continues= Set.Poly.union state1.continues state2.continues
+  ; returns= Set.Poly.union state1.returns state2.returns
+  ; exits= Set.Poly.union state1.exits state2.exits }
 
 (** Check if the statement controls the execution of its substatements. *)
 let is_ctrl_flow pattern =
@@ -112,13 +104,14 @@ let is_ctrl_flow pattern =
 let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
     statement_map =
   let rec build_cf_graph_rec (cf_parent : label option)
-      ((in_state, in_map) : cf_state * (label, cf_edges) Map.Poly.t)
-      (label : label) : cf_state * (label, cf_edges) Map.Poly.t =
-    let stmt, _ = Map.Poly.find_exn statement_map label in
+      ((in_state, in_map) : cf_state * cf_edges LabelMap.t) (label : label) :
+      cf_state * cf_edges LabelMap.t =
+    let stmt, _ = LabelMap.find label statement_map in
     (* Only control flow nodes should pass themselves down as parents *)
     let child_cf = if is_ctrl_flow stmt then Some label else cf_parent in
     let join (state1, map1) (state2, map2) =
-      (join_cf_states state1 state2, union_maps_left map1 map2) in
+      (join_cf_states state1 state2, union_maps_left (module LabelMap) map1 map2)
+    in
     (* This node is the parent of substatements, unless this is a Block, which
        is visited after substatements *)
     let substmt_preds =
@@ -146,8 +139,8 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
           let loop_predecessors =
             Set.Poly.union_list
               [ (*1*) in_state.exits; (*2*) substmt_state_unlooped.exits; (*3*)
-                Set.diff substmt_state_unlooped.continues in_state.continues ]
-          in
+                Set.Poly.diff substmt_state_unlooped.continues
+                  in_state.continues ] in
           (* Loop exits are:
 
              1. The loop node itself, since the last action of a typical loop
@@ -160,7 +153,8 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
             else
               Set.Poly.union_list
                 [ (*1*) Set.Poly.singleton label; (*2*)
-                  Set.diff substmt_state_unlooped.breaks in_state.breaks ] in
+                  Set.Poly.diff substmt_state_unlooped.breaks in_state.breaks ]
+          in
           ({substmt_state_unlooped with exits= loop_exits}, loop_predecessors)
       | (Block _ | Profile _) when blocks_after_body ->
           (* Block statements are preceded by the natural exit points of the
@@ -176,25 +170,25 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
     let breaks_out, returns_out, continues_out, extra_cf_deps =
       match stmt with
       | Break ->
-          ( Set.add substmt_state.breaks label
+          ( Set.Poly.add label substmt_state.breaks
           , substmt_state.returns
           , substmt_state.continues
           , Set.Poly.empty )
       | Return _ ->
           ( substmt_state.breaks
-          , Set.add substmt_state.returns label
+          , Set.Poly.add label substmt_state.returns
           , substmt_state.continues
           , Set.Poly.empty )
       | Continue ->
           ( substmt_state.breaks
           , substmt_state.returns
-          , Set.add substmt_state.continues label
+          , Set.Poly.add label substmt_state.continues
           , Set.Poly.empty )
       | While _ | For _ ->
           ( in_state.breaks
           , substmt_state.returns
           , in_state.continues
-          , Set.union substmt_state.breaks substmt_state.returns )
+          , Set.Poly.union substmt_state.breaks substmt_state.returns )
       | _ ->
           ( substmt_state.breaks
           , substmt_state.returns
@@ -209,7 +203,7 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
       ; continues= continues_out
       ; returns= returns_out
       ; exits= substmt_state.exits }
-    , Map.add_exn substmt_map ~key:label
+    , LabelMap.add substmt_map ~key:label
         ~data:{parents= cf_parents; predecessors} ) in
   let state, edges =
     build_cf_graph_rec None
@@ -217,11 +211,11 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
         ; continues= Set.Poly.empty
         ; returns= Set.Poly.empty
         ; exits= Set.Poly.empty }
-      , Map.Poly.empty )
+      , LabelMap.empty )
       1 in
   ( state.exits
-  , Map.Poly.map edges ~f:(fun e -> e.predecessors)
-  , Map.Poly.map edges ~f:(fun e -> e.parents) )
+  , LabelMap.map edges ~f:(fun e -> e.predecessors)
+  , LabelMap.map edges ~f:(fun e -> e.parents) )
 
 (** See interface file *)
 let build_cf_graph statement_map =

--- a/src/analysis_and_optimization/Dataflow_utils.mli
+++ b/src/analysis_and_optimization/Dataflow_utils.mli
@@ -1,18 +1,14 @@
-open Core
+open Std
 open Middle
 open Dataflow_types
-
-val union_maps_left :
-  ('a, 'b) Map.Poly.t -> ('a, 'b) Map.Poly.t -> ('a, 'b) Map.Poly.t
-(** Union maps, preserving the left element in a collision *)
 
 val build_cf_graphs :
      ?flatten_loops:bool
   -> ?blocks_after_body:bool
-  -> (label, (Expr.Typed.t, label) Stmt.Pattern.t * 'm) Map.Poly.t
+  -> ((Expr.Typed.t, label) Stmt.Pattern.t * 'm) LabelMap.t
   -> label Set.Poly.t
-     * (label, label Set.Poly.t) Map.Poly.t
-     * (label, label Set.Poly.t) Map.Poly.t
+     * label Set.Poly.t LabelMap.t
+     * label Set.Poly.t LabelMap.t
 (** Simultaneously builds the controlflow parent graph, the predecessor graph
     and the exit set of a statement. It's advantageous to build them together
     because they both rely on some of the same Break, Continue and Return
@@ -25,8 +21,8 @@ val build_cf_graphs :
     - (controlflow parent graph) is the return value of build_cf_graph *)
 
 val build_cf_graph :
-     (label, (Expr.Typed.t, label) Stmt.Pattern.t * 'm) Map.Poly.t
-  -> (label, label Set.Poly.t) Map.Poly.t
+     ((Expr.Typed.t, label) Stmt.Pattern.t * 'm) LabelMap.t
+  -> label Set.Poly.t LabelMap.t
 (** Building the controlflow graph requires a traversal with state that includes
     continues, breaks, returns and the controlflow graph accumulator. The
     traversal should be a branching traversal with set unions rather than a
@@ -36,8 +32,8 @@ val build_cf_graph :
 val build_predecessor_graph :
      ?flatten_loops:bool
   -> ?blocks_after_body:bool
-  -> (label, (Expr.Typed.t, label) Stmt.Pattern.t * 'm) Map.Poly.t
-  -> label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t
+  -> ((Expr.Typed.t, label) Stmt.Pattern.t * 'm) LabelMap.t
+  -> label Set.Poly.t * label Set.Poly.t LabelMap.t
 (** Building the predecessor graph requires a traversal with state that includes
     the current previous nodes and the predecessor graph accumulator. Special
     cases are made for loops, because they should include the body exits as
@@ -47,7 +43,7 @@ val build_predecessor_graph :
 
 val build_recursive_statement :
      (('e, 's) Stmt.Pattern.t -> 'm -> 's)
-  -> (label, ('e, label) Stmt.Pattern.t * 'm) Map.Poly.t
+  -> (('e, label) Stmt.Pattern.t * 'm) LabelMap.t
   -> label
   -> 's
 (** Build a fixed-point data type representation of a statement given a
@@ -57,9 +53,8 @@ val is_ctrl_flow : ('a, 'b) Stmt.Pattern.t -> bool
 (** Check if the statement controls the execution of its substatements. *)
 
 val merge_set_maps :
-     ('a, 'b Set.Poly.t) Map.Poly.t
-  -> ('a, 'b Set.Poly.t) Map.Poly.t
-  -> ('a, 'b Set.Poly.t) Map.Poly.t
+  (module M : Map.S)
+  -> 'b Set.Poly.t M.t -> 'b Set.Poly.t M.t -> 'b Set.Poly.t M.t
 (** Merge two maps whose values are sets, and union the sets when there's a
     collision. *)
 
@@ -67,7 +62,7 @@ val build_statement_map :
      ('s -> ('e, 's) Stmt.Pattern.t)
   -> ('s -> 'm)
   -> 's
-  -> (label, ('e, label) Stmt.Pattern.t * 'm) Map.Poly.t
+  -> (('e, label) Stmt.Pattern.t * 'm) LabelMap.t
 (** The statement map is built by traversing substatements recursively to
     replace substatements with their labels while building up the substatements'
     statement maps. Then, the result is the union of the substatement maps with

--- a/src/analysis_and_optimization/Debug_data_generation.ml
+++ b/src/analysis_and_optimization/Debug_data_generation.ml
@@ -32,7 +32,7 @@ let rec vect_to_mat l m =
     hd :: vect_to_mat tl m
 
 let eval_expr m e =
-  let e = Mir_utils.subst_expr_std m e in
+  let e = Mir_utils.subst_expr m e in
   let e = Partial_evaluator.eval_expr e in
   let rec strip_promotions (e : Middle.Expr.Typed.t) =
     match e.pattern with Promotion (e, _, _) -> strip_promotions e | _ -> e

--- a/src/analysis_and_optimization/Dependence_analysis.ml
+++ b/src/analysis_and_optimization/Dependence_analysis.ml
@@ -1,5 +1,4 @@
-open Core
-open Core.Poly
+open Std
 open Middle
 open Dataflow_types
 open Mir_utils
@@ -21,51 +20,52 @@ type node_dep_info =
 (** Find all of the reaching definitions of a variable in an RD set *)
 let reaching_defn_lookup (rds : reaching_defn Set.Poly.t) (var : vexpr) :
     label Set.Poly.t =
-  Set.Poly.map (Set.filter rds ~f:(fun (var', _) -> var' = var)) ~f:snd
+  Set.Poly.map (Set.Poly.filter rds ~f:(fun (var', _) -> var' = var)) ~f:snd
 
 let node_immediate_dependencies
     (statement_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t)
     ?(blockers : vexpr Set.Poly.t = Set.Poly.empty) (label : label) :
     label Set.Poly.t =
-  let stmt, info = Map.Poly.find_exn statement_map label in
+  let stmt, info = LabelMap.find label statement_map in
   let rhs_set = Set.Poly.map (stmt_rhs_var_set stmt) ~f:fst in
   let rhs_deps =
-    union_map
-      (Set.diff rhs_set blockers)
+    Set.Poly.union_map
+      (Set.Poly.diff rhs_set blockers)
       ~f:(reaching_defn_lookup info.reaching_defn_entry) in
-  Set.union info.parents rhs_deps
+  Set.Poly.union info.parents rhs_deps
 
 (* This is doing an explicit graph traversal with edges defined by
    node_immediate_dependencies. *)
 let rec node_dependencies_rec
     (statement_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
-    ?(blockers : vexpr Set.Poly.t = Set.Poly.empty) (visited : label Set.Poly.t)
-    (label : label) : label Set.Poly.t =
-  if Set.mem visited label then visited
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t)
+    ?(blockers : vexpr Set.Poly.t = Set.Poly.empty) (label : label)
+    (visited : label Set.Poly.t) : label Set.Poly.t =
+  if Set.Poly.mem label visited then visited
   else
-    let visited' = Set.add visited label in
+    let visited' = Set.Poly.add label visited in
     let deps = node_immediate_dependencies statement_map ~blockers label in
-    Set.fold deps ~init:visited' ~f:(node_dependencies_rec statement_map)
+    Set.Poly.fold deps ~init:visited' ~f:(node_dependencies_rec statement_map)
 
 let node_dependencies
     (statement_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t)
     (label : label) : label Set.Poly.t =
-  node_dependencies_rec statement_map Set.Poly.empty label
+  node_dependencies_rec statement_map label Set.Poly.empty
 
 let node_vars_dependencies
     (statement_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t)
     ?(blockers : vexpr Set.Poly.t = Set.Poly.empty) (vars : vexpr Set.Poly.t)
     (label : label) : label Set.Poly.t =
-  let _, info = Map.Poly.find_exn statement_map label in
+  let _, info = LabelMap.find label statement_map in
   let var_deps =
-    union_map (Set.diff vars blockers)
+    Set.Poly.union_map
+      (Set.Poly.diff vars blockers)
       ~f:(reaching_defn_lookup info.reaching_defn_entry) in
-  Set.fold
-    (Set.union info.parents var_deps)
+  Set.Poly.fold
+    (Set.Poly.union info.parents var_deps)
     ~init:Set.Poly.empty
     ~f:(node_dependencies_rec statement_map ~blockers)
 
@@ -76,27 +76,27 @@ let node_vars_dependencies
    node. *)
 let all_node_dependencies
     (statement_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
-    : (label, label Set.Poly.t) Map.Poly.t =
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t) :
+    label Set.Poly.t LabelMap.t =
   let immediate_map =
-    Map.mapi statement_map ~f:(fun ~key:label ~data:_ ->
+    LabelMap.mapi statement_map ~f:(fun label _ ->
         node_immediate_dependencies statement_map label) in
   let step_node label m =
-    let immediate = Map.find_exn immediate_map label in
+    let immediate = LabelMap.find label immediate_map in
     let updated =
-      Set.union
-        (union_map immediate ~f:(fun label -> Map.find_exn m label))
+      Set.Poly.union
+        (Set.Poly.union_map immediate ~f:(fun label -> LabelMap.find label m))
         immediate in
-    Set.remove updated label in
-  let step_map m = Map.mapi m ~f:(fun ~key:label ~data:_ -> step_node label m) in
-  let map_equal = Map.Poly.equal Set.equal in
+    Set.Poly.remove label updated in
+  let step_map m = LabelMap.mapi m ~f:(fun label _ -> step_node label m) in
+  let map_equal = LabelMap.equal ~cmp:Set.Poly.equal in
   let rec step_until_fixed m =
     let m' = step_map m in
     if map_equal m m' then m else step_until_fixed m' in
   step_until_fixed immediate_map
 
 let mir_reaching_definitions (mir : Program.Typed.t) (stmt : Stmt.Located.t) :
-    (label, reaching_defn Set.Poly.t entry_exit) Map.Poly.t =
+    reaching_defn Set.Poly.t entry_exit LabelMap.t =
   let flowgraph, flowgraph_to_mir =
     Monotone_framework.forward_flowgraph_of_stmt stmt in
   let (module Flowgraph) = flowgraph in
@@ -105,30 +105,29 @@ let mir_reaching_definitions (mir : Program.Typed.t) (stmt : Stmt.Located.t) :
   let to_rd_set set =
     Set.Poly.map set ~f:(fun (s, label_opt) ->
         (VVar s, Option.value label_opt ~default:1)) in
-  Map.Poly.map rd_map ~f:(fun {entry; exit} ->
+  LabelMap.map rd_map ~f:(fun {entry; exit} ->
       {entry= to_rd_set entry; exit= to_rd_set exit})
 
 let all_labels
     (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int) : int Set.Poly.t =
   let step set =
-    Set.union set
-      (union_map set ~f:(fun l -> Map.Poly.find_exn Flowgraph.successors l))
+    Set.Poly.union set
+      (Set.Poly.union_map set ~f:(fun l -> LabelMap.find l Flowgraph.successors))
   in
   let rec step_fix set =
     let next = step set in
-    if Set.equal set next then set else step_fix next in
+    if Set.Poly.equal set next then set else step_fix next in
   step_fix Flowgraph.initials
 
 let prog_rhs_variables
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t)
     (labels : int Set.Poly.t) : string Set.Poly.t =
   let label_vars label =
     Set.Poly.map
       ~f:(fun (VVar s, _) -> s)
-      (stmt_rhs_var_set (Map.Poly.find_exn flowgraph_to_mir label).pattern)
-  in
-  union_map labels ~f:label_vars
+      (stmt_rhs_var_set (LabelMap.find label flowgraph_to_mir).pattern) in
+  Set.Poly.union_map labels ~f:label_vars
 
 let stmt_uninitialized_variables (exceptions : string Set.Poly.t)
     (stmt : Stmt.Located.t) : (Location_span.t * string) Set.Poly.t =
@@ -140,36 +139,38 @@ let stmt_uninitialized_variables (exceptions : string Set.Poly.t)
   let initialized_vars_map =
     initialized_vars_mfp all_variables (module Flowgraph) flowgraph_to_mir in
   let uninitialized =
-    Map.Poly.fold initialized_vars_map ~init:Set.Poly.empty
+    LabelMap.fold initialized_vars_map ~init:Set.Poly.empty
       ~f:(fun ~key:label ~data:inits acc ->
-        let stmt = Map.Poly.find_exn flowgraph_to_mir label in
+        let stmt = LabelMap.find label flowgraph_to_mir in
         let rhs =
           Set.Poly.map
-            ~f:(fun (VVar s, {loc; _}) -> (loc, s))
+            ~f:(fun (VVar s, Expr.Typed.Meta.{loc; _}) -> (loc, s))
             (stmt_rhs_var_set stmt.pattern) in
-        let uninitialized (_, var) = not (Set.mem inits.entry var) in
-        let uninitialized_set = Set.filter ~f:uninitialized rhs in
-        Set.union acc uninitialized_set) in
-  Set.filter uninitialized ~f:(fun (_, v) -> not (Set.mem exceptions v))
+        let uninitialized (_, var) = not (Set.Poly.mem var inits.entry) in
+        let uninitialized_set = Set.Poly.filter ~f:uninitialized rhs in
+        Set.Poly.union acc uninitialized_set) in
+  Set.Poly.filter uninitialized ~f:(fun (_, v) ->
+      not (Set.Poly.mem v exceptions))
 
 let mir_uninitialized_variables (mir : Program.Typed.t) :
     (Location_span.t * string) Set.Poly.t =
   let flag_variables = List.map ~f:Flag_vars.to_string Flag_vars.enumerate in
   let function_names = function_names mir in
   let data_vars = data_set ~exclude_transformed:true mir in
-  let globals = Set.union function_names (Set.Poly.of_list flag_variables) in
+  let globals =
+    Set.Poly.union function_names (Set.Poly.of_list flag_variables) in
   let parameters =
     Set.Poly.of_list
       (List.map ~f:fst3
          (List.filter
-            ~f:(fun (_, _, {out_block; _}) -> out_block = Parameters)
+            ~f:(fun (_, _, Program.{out_block; _}) -> out_block = Parameters)
             mir.output_vars)) in
-  let globals_data = Set.union globals data_vars in
+  let globals_data = Set.Poly.union globals data_vars in
   let check_against_data b =
     stmt_uninitialized_variables globals_data
       {pattern= SList b; meta= Location_span.empty} in
   let check_against_data_params b =
-    let globals_data_prep = Set.union globals_data parameters in
+    let globals_data_prep = Set.Poly.union globals_data parameters in
     stmt_uninitialized_variables globals_data_prep
       (* prepend prepare_data to detect bad transformed data usages *)
       {pattern= SList (mir.prepare_data @ b); meta= Location_span.empty} in
@@ -183,17 +184,17 @@ let mir_uninitialized_variables (mir : Program.Typed.t) :
     ; check_against_data_params mir.generate_quantities
       (* functions scope: arguments *)
     ; Set.Poly.union_list
-        (List.map mir.functions_block ~f:(fun {fdbody; fdargs; _} ->
+        (List.map mir.functions_block ~f:(fun Program.{fdbody; fdargs; _} ->
              let arg_vars =
                Set.Poly.of_list
                  (List.map fdargs ~f:(fun (_, arg_name, _) -> arg_name)) in
              Option.value_map fdbody ~default:Set.Poly.empty ~f:(fun fdbody ->
                  stmt_uninitialized_variables
-                   (Set.union arg_vars globals)
+                   (Set.Poly.union arg_vars globals)
                    fdbody))) ]
 
 let build_dep_info_map (mir : Program.Typed.t) (stmt : Stmt.Located.t) :
-    (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t =
+    ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t =
   let statement_map =
     build_statement_map
       (fun Stmt.{pattern; _} -> pattern)
@@ -201,22 +202,22 @@ let build_dep_info_map (mir : Program.Typed.t) (stmt : Stmt.Located.t) :
       stmt in
   let _, preds, parents = build_cf_graphs statement_map in
   let rd_map = mir_reaching_definitions mir stmt in
-  Map.Poly.mapi statement_map ~f:(fun ~key:label ~data:(stmt, meta) ->
-      let rds = Map.find_exn rd_map label in
+  LabelMap.mapi statement_map ~f:(fun label (stmt, meta) ->
+      let rds = LabelMap.find label rd_map in
       ( stmt
-      , { predecessors= Map.find_exn preds label
-        ; parents= Map.find_exn parents label
+      , { predecessors= LabelMap.find label preds
+        ; parents= LabelMap.find label parents
         ; reaching_defn_entry= rds.entry
         ; reaching_defn_exit= rds.exit
         ; meta } ))
 
 let log_prob_build_dep_info_map (mir : Program.Typed.t) :
-    (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t =
+    ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t =
   let log_prob_stmt =
     Stmt.{meta= Location_span.empty; pattern= SList mir.log_prob} in
   build_dep_info_map mir log_prob_stmt
 
 let log_prob_dependency_graph (mir : Program.Typed.t) :
-    (label, label Set.Poly.t) Map.Poly.t =
+    label Set.Poly.t LabelMap.t =
   let dep_info_map = log_prob_build_dep_info_map mir in
   all_node_dependencies dep_info_map

--- a/src/analysis_and_optimization/Dependence_analysis.mli
+++ b/src/analysis_and_optimization/Dependence_analysis.mli
@@ -1,4 +1,4 @@
-open Core
+open Std
 open Middle
 open Dataflow_types
 
@@ -28,7 +28,7 @@ type node_dep_info =
   ; meta: Location_span.t }
 
 val node_immediate_dependencies :
-     (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t
+     ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t
   -> ?blockers:vexpr Set.Poly.t
   -> label
   -> label Set.Poly.t
@@ -37,14 +37,14 @@ val node_immediate_dependencies :
     flow parents and the reachable definitions of RHS variables. *)
 
 val node_dependencies :
-     (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t
+     ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t
   -> label
   -> label Set.Poly.t
 (** Given dependency information for each node, find all of the dependencies of
     a single node. *)
 
 val node_vars_dependencies :
-     (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t
+     ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t
   -> ?blockers:vexpr Set.Poly.t
   -> vexpr Set.Poly.t
   -> label
@@ -57,27 +57,26 @@ val node_vars_dependencies :
 val build_dep_info_map :
      Program.Typed.t
   -> Stmt.Located.t
-  -> (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t
+  -> ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t
 (** Build the dependency information for each node in the log_prob section of a
     program *)
 
 val log_prob_build_dep_info_map :
      Program.Typed.t
-  -> (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t
+  -> ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t
 (** Build the dependency information for each node in the log_prob section of a
     program *)
 
 val all_node_dependencies :
-     (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t
-  -> (label, label Set.Poly.t) Map.Poly.t
+     ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t
+  -> label Set.Poly.t LabelMap.t
 (** Given dependency information for each node, find all of the dependencies of
     all nodes, effectively building the dependency graph.
 
     This is more efficient than calling node_dependencies on each node
     individually. *)
 
-val log_prob_dependency_graph :
-  Program.Typed.t -> (label, label Set.Poly.t) Map.Poly.t
+val log_prob_dependency_graph : Program.Typed.t -> label Set.Poly.t LabelMap.t
 (** Build the dependency graph for the log_prob section of a program, where
     labels correspond to the labels built by statement_map. *)
 

--- a/src/analysis_and_optimization/Factor_graph.ml
+++ b/src/analysis_and_optimization/Factor_graph.ml
@@ -1,4 +1,5 @@
-open Core
+open Std
+open Std.Sexp_conv
 open Middle
 open Dataflow_types
 open Dataflow_utils
@@ -11,9 +12,32 @@ type factor =
   | LPFunction of (string * Expr.Typed.t list)
 [@@deriving sexp_of]
 
+module FactorMap = struct
+  include Map.Make (struct
+    type t = factor * label
+
+    let compare = Stdlib.compare
+  end)
+
+  let sexp_of_t f t =
+    sexp_of_list
+      (sexp_of_pair (sexp_of_pair sexp_of_factor sexp_of_label) f)
+      (to_list t)
+end
+
+module VExprMap = struct
+  include Map.Make (struct
+    type t = vexpr
+
+    let compare (VVar s1) (VVar s2) = String.compare s1 s2
+  end)
+
+  let sexp_of_t f t = sexp_of_list (sexp_of_pair sexp_of_vexpr f) (to_list t)
+end
+
 type factor_graph =
-  { factor_map: (factor * label, vexpr Set.Poly.t) Map.Poly.t
-  ; var_map: (vexpr, (factor * label) Set.Poly.t) Map.Poly.t }
+  { factor_map: vexpr Set.Poly.t FactorMap.t
+  ; var_map: (factor * label) Set.Poly.t VExprMap.t }
 [@@deriving sexp_of]
 
 let extract_factors_statement stmt =
@@ -33,10 +57,10 @@ let extract_factors_statement stmt =
       []
 
 let rec extract_factors statement_map label =
-  let stmt, _ = Map.Poly.find_exn statement_map label in
+  let stmt, _ = LabelMap.find label statement_map in
   let this_stmt =
     List.map (extract_factors_statement stmt) ~f:(fun x -> (label, x)) in
-  Stmt.Pattern.fold Fn.const
+  Stmt.Pattern.fold Fun.const
     (fun state label -> List.append state (extract_factors statement_map label))
     this_stmt stmt
 
@@ -49,46 +73,48 @@ let factor_rhs (factor : factor) : vexpr Set.Poly.t =
 let factor_var_dependencies statement_map blockers (label, factor) =
   let rhs = factor_rhs factor in
   let dep_labels = node_vars_dependencies statement_map ~blockers rhs label in
-  let label_vars l =
-    Set.Poly.map
-      (stmt_rhs_var_set (fst (Map.Poly.find_exn statement_map l)))
-      ~f:fst in
-  let dep_vars = union_map dep_labels ~f:label_vars in
-  Set.union dep_vars rhs
+  let label_vars l = stmt_rhs_names_set (fst (LabelMap.find l statement_map)) in
+  let dep_vars = Set.Poly.union_map dep_labels ~f:label_vars in
+  Set.Poly.union dep_vars rhs
 
 (** Helper function to generate the factor graph adjacency map representation
     from a factor-adjacency list *)
-let build_adjacency_maps (factors : (label * factor * vexpr Set.Poly.t) List.t)
-    : factor_graph =
+let build_adjacency_maps (factors : (label * factor * vexpr Set.Poly.t) list) :
+    factor_graph =
   let factor_map =
-    List.fold ~f:merge_set_maps ~init:Map.Poly.empty
+    List.fold_left
+      ~f:(merge_set_maps (module FactorMap))
+      ~init:FactorMap.empty
       (List.map
-         ~f:(fun (l, fac, vars) -> Map.Poly.singleton (fac, l) vars)
+         ~f:(fun (l, fac, vars) -> FactorMap.singleton (fac, l) vars)
          factors) in
   let var_map =
-    List.fold ~f:merge_set_maps ~init:Map.Poly.empty
+    List.fold_left
+      ~f:(merge_set_maps (module VExprMap))
+      ~init:VExprMap.empty
       (List.concat_map factors ~f:(fun (l, fac, vars) ->
            List.map
-             ~f:(fun v -> Map.Poly.singleton v (Set.Poly.singleton (fac, l)))
-             (Set.to_list vars))) in
+             ~f:(fun v -> VExprMap.singleton v (Set.Poly.singleton (fac, l)))
+             (Set.Poly.to_list vars))) in
   {factor_map; var_map}
 
-let fg_remove_fac (fg : factor_graph) (fac : factor * cf_state) : factor_graph =
-  let factor_map = Map.Poly.remove fg.factor_map fac in
+let fg_remove_fac (fac : factor * cf_state) (fg : factor_graph) : factor_graph =
+  let factor_map = FactorMap.remove fac fg.factor_map in
   {fg with factor_map}
 
-let fg_remove_var (fg : factor_graph) (var : vexpr) : factor_graph =
+let fg_remove_var (var : vexpr) (fg : factor_graph) : factor_graph =
   let factor_map =
-    Map.Poly.map fg.factor_map ~f:(fun vars -> Set.remove vars var) in
-  let var_map = Map.Poly.remove fg.var_map var in
+    FactorMap.map fg.factor_map ~f:(fun vars -> Set.Poly.remove var vars) in
+  let var_map = VExprMap.remove var fg.var_map in
   {factor_map; var_map}
 
 let remove_touching vars fg =
   let facs =
-    union_map vars ~f:(fun v ->
-        Option.value ~default:Set.Poly.empty (Map.Poly.find fg.var_map v)) in
-  let without_vars = Set.fold ~f:fg_remove_var ~init:fg vars in
-  let without_facs = Set.fold ~f:fg_remove_fac ~init:without_vars facs in
+    Set.Poly.union_map vars ~f:(fun v ->
+        Option.value ~default:Set.Poly.empty (VExprMap.find_opt v fg.var_map))
+  in
+  let without_vars = Set.Poly.fold ~f:fg_remove_var ~init:fg vars in
+  let without_facs = Set.Poly.fold ~f:fg_remove_fac ~init:without_vars facs in
   without_facs
 
 (** Build a factor graph from prog.log_prob using dependency analysis *)
@@ -99,14 +125,14 @@ let prog_factor_graph ?(exclude_data_facs : bool = false) prog : factor_graph =
   let vars =
     Set.Poly.map
       ~f:(fun v -> VVar v)
-      (Set.union data_vars
+      (Set.Poly.union data_vars
          (parameter_names_set ~include_transformed:false prog)) in
   let factor_list =
     List.map factors ~f:(fun (l, fac) ->
         ( l
         , fac
-        , Set.inter vars (factor_var_dependencies statement_map vars (l, fac))
-        )) in
+        , Set.Poly.inter vars
+            (factor_var_dependencies statement_map vars (l, fac)) )) in
   let fg = build_adjacency_maps factor_list in
   if exclude_data_facs then
     remove_touching (Set.Poly.map ~f:(fun v -> VVar v) data_vars) fg
@@ -117,29 +143,31 @@ let prog_factor_graph ?(exclude_data_facs : bool = false) prog : factor_graph =
 let fg_reaches (starts : vexpr Set.Poly.t) (goals : vexpr Set.Poly.t)
     (fg : factor_graph) : bool =
   let vneighbors v =
-    let factors = Map.Poly.find_exn fg.var_map v in
-    union_map factors ~f:(Map.Poly.find_exn fg.factor_map) in
+    let factors = VExprMap.find v fg.var_map in
+    Set.Poly.union_map factors ~f:(fun f -> FactorMap.find f fg.factor_map)
+  in
   let rec step (frontier : vexpr List.t) (visited : vexpr Set.Poly.t) =
     match frontier with
     | next :: frontier' ->
-        if Set.mem visited next then step frontier' visited
+        if Set.Poly.mem next visited then step frontier' visited
         else
-          let visited' = Set.add visited next in
+          let visited' = Set.Poly.add next visited in
           let expansion = vneighbors next in
-          if not (Set.is_empty (Set.inter expansion goals)) then true
-          else step (List.append frontier' (Set.to_list expansion)) visited'
+          if not (Set.Poly.is_empty (Set.Poly.inter expansion goals)) then true
+          else
+            step (List.append frontier' (Set.Poly.to_list expansion)) visited'
     | [] -> false in
-  step (Set.to_list starts) Set.Poly.empty
+  step (Set.Poly.to_list starts) Set.Poly.empty
 
 let fg_factor_reaches (start : factor * label) (goals : vexpr Set.Poly.t)
     (fg : factor_graph) : bool =
-  let var_starts = Map.Poly.find_exn fg.factor_map start in
+  let var_starts = FactorMap.find start fg.factor_map in
   fg_reaches var_starts goals fg
 
 let fg_factor_is_prior (var : vexpr) (fac : factor * label)
     (data : vexpr Set.Poly.t) (fg : factor_graph) : bool =
   (* build G'=G\V *)
-  let fg' = fg_remove_var fg var in
+  let fg' = fg_remove_var var fg in
   (* Check if the data is now unreachable *)
   not (fg_factor_reaches fac data fg')
 
@@ -149,26 +177,27 @@ let fg_factor_is_prior (var : vexpr) (fac : factor * label)
     is a prior *)
 let fg_var_priors (var : vexpr) (data : vexpr Set.Poly.t) (fg : factor_graph) :
     (factor * label) Set.Poly.t option =
-  match Map.Poly.find fg.var_map var with
+  match VExprMap.find_opt var fg.var_map with
   | Some factors ->
       Some
-        (Set.filter factors ~f:(fun fac -> fg_factor_is_prior var fac data fg))
+        (Set.Poly.filter factors ~f:(fun fac ->
+             fg_factor_is_prior var fac data fg))
   | None -> None
 
 let list_priors ?factor_graph:(fg_opt = None) (mir : Program.Typed.t) :
-    (vexpr, (factor * label) Set.Poly.t option * Location_span.t) Map.Poly.t =
+    ((factor * label) Set.Poly.t option * Location_span.t) VExprMap.t =
   let fg = Option.value ~default:(prog_factor_graph mir) fg_opt in
   let params =
     Set.Poly.map ~f:(fun (v, _, loc) -> (VVar v, loc)) (parameter_set mir) in
   let data = Set.Poly.map ~f:(fun v -> VVar v) (data_set mir) in
   let likely_sizes =
-    Set.diff data
+    Set.Poly.diff data
       (Set.Poly.map ~f:(fun v -> VVar v) (data_set ~exclude_ints:true mir))
   in
-  let fg' = Set.fold ~init:fg ~f:fg_remove_var likely_sizes in
+  let fg' = Set.Poly.fold ~init:fg ~f:fg_remove_var likely_sizes in
   (* for each param, apply fg_var_priors and collect results in a map *)
-  Set.fold params ~init:Map.Poly.empty ~f:(fun m (p, loc) ->
-      Map.Poly.add_exn m ~key:p ~data:(fg_var_priors p data fg', loc))
+  Set.Poly.fold params ~init:VExprMap.empty ~f:(fun (p, loc) m ->
+      VExprMap.add m ~key:p ~data:(fg_var_priors p data fg', loc))
 
 let string_of_factor (factor : factor) : string =
   match factor with
@@ -181,21 +210,22 @@ let string_of_vexpr (vexpr : vexpr) : string = match vexpr with VVar s -> s
 (** Utility to print a factor graph to the Graphviz dot language for
     visualization *)
 let factor_graph_to_dot (fg : factor_graph) : string =
-  let factors = Map.Poly.to_alist ~key_order:`Decreasing fg.factor_map in
+  let factors = FactorMap.to_list fg.factor_map in
   let names =
     List.map
       ~f:(fun ((f, _), ps) ->
-        (string_of_factor f, List.map ~f:string_of_vexpr (Set.to_list ps)))
+        (string_of_factor f, List.map ~f:string_of_vexpr (Set.Poly.to_list ps)))
       factors in
-  let factor_names, param_name_lists = List.unzip names in
+  let factor_names, param_name_lists = List.split names in
   let factor_strings =
-    List.map factor_names ~f:(fun n -> String.concat [n; " [shape=box]"]) in
+    List.map factor_names ~f:(fun n ->
+        String.concat ~sep:"" [n; " [shape=box]"]) in
   let param_strings =
-    List.dedup_and_sort ~compare:String.compare (List.concat param_name_lists)
-  in
+    List.sort_uniq ~cmp:String.compare (List.concat param_name_lists) in
   let edge_strings =
     List.concat_map
-      ~f:(fun (f, ps) -> List.map ~f:(fun p -> String.concat [f; " -- "; p]) ps)
+      ~f:(fun (f, ps) ->
+        List.map ~f:(fun p -> String.concat ~sep:"" [f; " -- "; p]) ps)
       names in
   [["graph {"]; factor_strings; param_strings; edge_strings; ["}"]]
   |> List.concat |> String.concat ~sep:"\n"

--- a/src/analysis_and_optimization/Memory_patterns.ml
+++ b/src/analysis_and_optimization/Memory_patterns.ml
@@ -1,8 +1,7 @@
-open Core
-open Core.Poly
+open Std
 open Middle
 
-type demotion = int * Mem_pattern.t * string [@@deriving compare]
+type demotion = int * Mem_pattern.t * string
 
 let demotion_reasons = ref []
 
@@ -10,7 +9,7 @@ let get_warnings () =
   let mem_name pattern =
     match pattern with Mem_pattern.SoA -> "SoA" | AoS -> "AoS" in
   !demotion_reasons
-  |> List.dedup_and_sort ~compare:compare_demotion
+  |> List.sort_uniq ~cmp:Stdlib.compare
   |> List.map ~f:(fun (linenum, pattern, msg) ->
       Printf.sprintf "Optimization hazard warning (Line %i): %s warning: %s"
         linenum (mem_name pattern) msg)
@@ -22,8 +21,8 @@ let user_warning_op (mem_pattern : Mem_pattern.t) (linenum : int) (msg : string)
       (linenum, mem_pattern, msg ^ " " ^ names) :: !demotion_reasons
 
 let concat_set_str (set : string Set.Poly.t) =
-  Set.fold
-    ~f:(fun acc elem -> if acc = "" then acc ^ elem else acc ^ ", " ^ elem)
+  Set.Poly.fold
+    ~f:(fun elem acc -> if acc = "" then acc ^ elem else acc ^ ", " ^ elem)
     ~init:"" set
 
 (** Return a Var expression of the name for each type containing an eigen matrix
@@ -51,13 +50,15 @@ let query_var_eigen_names (expr : Expr.Typed.t) : string Set.Poly.t =
       && UnsizedType.is_autodifftype adlevel
     then Some s
     else None in
-  Set.Poly.filter_map ~f:get_expr_eigen_names (matrix_set expr)
+  Set.Poly.of_list
+    (List.filter_map ~f:get_expr_eigen_names
+       (Set.Poly.to_list (matrix_set expr)))
 
 (** Check whether one set is a nonzero subset of another set. *)
 let is_nonzero_subset ~set ~subset =
-  Set.is_subset subset ~of_:set
-  && (not (Set.is_empty set))
-  && not (Set.is_empty subset)
+  Set.Poly.subset subset set
+  && (not (Set.Poly.is_empty set))
+  && not (Set.Poly.is_empty subset)
 
 (** Check an Index to count how many times we see a single index.
     @param acc An accumulator from previous folds of multiple expressions.
@@ -135,37 +136,39 @@ let rec query_initial_demotable_expr (in_loop : bool) (stmt_linenum : int)
         Set.Poly.union_list
           (List.map
              ~f:
-               (Index.apply ~default:Set.Poly.empty ~merge:Set.union
+               (Index.apply ~default:Set.Poly.empty ~merge:Set.Poly.union
                   (query_expr acc))
              indexed) in
       let index_demotes =
         if is_uni_eigen_loop_indexing in_loop type_ indexed then (
           let single_index_set = query_var_eigen_names expr in
-          let failure_str = concat_set_str (Set.inter acc single_index_set) in
+          let failure_str =
+            concat_set_str (Set.Poly.inter acc single_index_set) in
           let msg = "Accessed by element in a for loop:" in
           user_warning_op SoA stmt_linenum msg failure_str;
-          Set.union single_index_set index_set)
-        else Set.union (query_expr acc expr) index_set in
-      Set.union acc index_demotes
+          Set.Poly.union single_index_set index_set)
+        else Set.Poly.union (query_expr acc expr) index_set in
+      Set.Poly.union acc index_demotes
   | Var (_ : string) | Lit ((_ : Expr.Pattern.litType), (_ : string)) -> acc
   | Promotion (expr, _, _) -> query_expr acc expr
   | TupleProjection (expr, _) -> query_expr acc expr
   | TernaryIf (predicate, texpr, fexpr) ->
       let predicate_demotes = query_expr acc predicate in
       let full_set =
-        Set.union
-          (Set.union predicate_demotes (query_var_eigen_names texpr))
+        Set.Poly.union
+          (Set.Poly.union predicate_demotes (query_var_eigen_names texpr))
           (query_var_eigen_names fexpr) in
-      if Set.is_empty full_set then full_set
+      if Set.Poly.is_empty full_set then full_set
       else
-        let failure_str = concat_set_str (Set.inter acc full_set) in
+        let failure_str = concat_set_str (Set.Poly.inter acc full_set) in
         let msg = "Used in a ternary operator which is not allowed:" in
         user_warning_op SoA stmt_linenum msg failure_str;
         full_set
   | EAnd (lhs, rhs) | EOr (lhs, rhs) ->
       (* We need to get the demotes from both sides *)
-      let full_lhs_rhs = Set.union (query_expr acc lhs) (query_expr acc rhs) in
-      Set.union (query_expr full_lhs_rhs lhs) (query_expr full_lhs_rhs rhs)
+      let full_lhs_rhs =
+        Set.Poly.union (query_expr acc lhs) (query_expr acc rhs) in
+      Set.Poly.union (query_expr full_lhs_rhs lhs) (query_expr full_lhs_rhs rhs)
 
 (** Query a function to detect if it or any of its used expression's objects or
     expressions should be demoted to AoS.
@@ -191,37 +194,37 @@ and query_initial_demotable_funs (in_loop : bool) (stmt_linenum : int)
     query_initial_demotable_expr in_loop stmt_linenum ~acc:accum in
   let top_level_eigen_names =
     Set.Poly.union_list (List.map ~f:query_var_eigen_names exprs) in
-  let demoted_eigen_names = List.fold ~init:acc ~f:query_expr exprs in
+  let demoted_eigen_names = List.fold_left ~init:acc ~f:query_expr exprs in
   let demoted_and_top_level_names =
-    Set.union demoted_eigen_names top_level_eigen_names in
+    Set.Poly.union demoted_eigen_names top_level_eigen_names in
   match kind with
   | Fun_kind.StanLib (name, (_ : bool Fun_kind.suffix), _) -> (
       match name with
       | "check_matching_dims" -> acc
       | name ->
           if is_fun_soa_supported name exprs then
-            Set.union acc demoted_eigen_names
+            Set.Poly.union acc demoted_eigen_names
           else
             let fail_names =
-              concat_set_str (Set.inter acc top_level_eigen_names) in
+              concat_set_str (Set.Poly.inter acc top_level_eigen_names) in
             user_warning_op SoA stmt_linenum
               ("Function " ^ name ^ " is not supported:")
               fail_names;
-            Set.union acc demoted_and_top_level_names)
+            Set.Poly.union acc demoted_and_top_level_names)
   | CompilerInternal (Internal_fun.FnMakeArray | FnMakeRowVec | FnMakeTuple) ->
       let fail_names =
-        concat_set_str (Set.inter acc demoted_and_top_level_names) in
+        concat_set_str (Set.Poly.inter acc demoted_and_top_level_names) in
       user_warning_op SoA stmt_linenum
         "Used in {} make array or make row vector compiler functions:"
         fail_names;
-      Set.union acc demoted_and_top_level_names
+      Set.Poly.union acc demoted_and_top_level_names
   | CompilerInternal (_ : 'a Internal_fun.t) -> acc
   | UserDefined ((_ : string), (_ : bool Fun_kind.suffix)) ->
       let fail_names =
-        concat_set_str (Set.inter acc demoted_and_top_level_names) in
+        concat_set_str (Set.Poly.inter acc demoted_and_top_level_names) in
       user_warning_op SoA stmt_linenum "Used in user defined function:"
         fail_names;
-      Set.union acc demoted_and_top_level_names
+      Set.Poly.union acc demoted_and_top_level_names
 
 (** Recurse through subexpressions and return a list of Unsized types. Recursion
     continues until
@@ -329,7 +332,7 @@ let rec query_initial_demotable_stmt (in_loop : bool) (acc : string Set.Poly.t)
       let idx_demotable =
         let idx = Stmt.Helpers.lhs_indices lval in
         let idx_list =
-          List.fold ~init:acc
+          List.fold_left ~init:acc
             ~f:(fun accum x ->
               Index.folder accum
                 (fun acc -> query_initial_demotable_expr in_loop linenum ~acc)
@@ -337,11 +340,12 @@ let rec query_initial_demotable_stmt (in_loop : bool) (acc : string Set.Poly.t)
             idx in
         if is_uni_eigen_loop_indexing in_loop ut idx then (
           user_warning_op SoA linenum "Accessed by element in a for loop:"
-            (if Set.mem acc name then "" else name);
-          Set.add idx_list name)
+            (if Set.Poly.mem name acc then "" else name);
+          Set.Poly.add name idx_list)
         else idx_list in
       let rhs_demotable_names = query_expr acc rhs in
-      let rhs_and_idx_demotions = Set.union idx_demotable rhs_demotable_names in
+      let rhs_and_idx_demotions =
+        Set.Poly.union idx_demotable rhs_demotable_names in
       (* RHS (1)*)
       let tuple_demotions =
         match lval with
@@ -349,7 +353,7 @@ let rec query_initial_demotable_stmt (in_loop : bool) (acc : string Set.Poly.t)
             let tuple_set = query_var_eigen_names rhs in
             let fail_set = concat_set_str tuple_set in
             user_warning_op SoA linenum "Used in tuple:" fail_set;
-            Set.add (Set.union rhs_and_idx_demotions tuple_set) name
+            Set.Poly.add name (Set.Poly.union rhs_and_idx_demotions tuple_set)
         | _ -> rhs_and_idx_demotions in
       let assign_demotions =
         let is_eigen_stmt = UnsizedType.contains_eigen_type rhs.meta.type_ in
@@ -397,21 +401,21 @@ let rec query_initial_demotable_stmt (in_loop : bool) (acc : string Set.Poly.t)
                   ^ "' on right hand side of assignment is not supported by \
                      SoA:"
               | None -> "" in
-            let rhs_name_set = Set.add rhs_set name in
+            let rhs_name_set = Set.Poly.add name rhs_set in
             let rhs_name_set_str = concat_set_str rhs_name_set in
             user_warning_op SoA linenum all_rhs_warn rhs_name_set_str;
             user_warning_op SoA linenum rhs_not_promotable_to_soa_warn
               rhs_name_set_str;
             user_warning_op SoA linenum not_supported_func_warn rhs_name_set_str;
-            Set.add (Set.union tuple_demotions rhs_set) name)
+            Set.Poly.add name (Set.Poly.union tuple_demotions rhs_set))
           else tuple_demotions
         else tuple_demotions in
-      Set.union acc assign_demotions
+      Set.Poly.union acc assign_demotions
   | NRFunApp (kind, exprs) ->
       query_initial_demotable_funs in_loop linenum acc kind exprs
   | IfElse (predicate, true_stmt, op_false_stmt) ->
       let predicate_acc = query_expr acc predicate in
-      Set.union acc
+      Set.Poly.union acc
         (Set.Poly.union_list
            [ predicate_acc
            ; query_initial_demotable_stmt in_loop predicate_acc true_stmt
@@ -434,8 +438,8 @@ let rec query_initial_demotable_stmt (in_loop : bool) (acc : string Set.Poly.t)
     when lb = "1" && ub = "1" ->
       query_initial_demotable_stmt in_loop acc body
   | For {lower; upper; body; _} ->
-      Set.union
-        (Set.union (query_expr acc lower) (query_expr acc upper))
+      Set.Poly.union
+        (Set.Poly.union (query_expr acc lower) (query_expr acc upper))
         (query_initial_demotable_stmt true acc body)
   | While (predicate, body) ->
       Set.Poly.union_list
@@ -452,7 +456,7 @@ let rec query_initial_demotable_stmt (in_loop : bool) (acc : string Set.Poly.t)
         match initialize with
         | Assign e -> query_expr acc e
         | _ -> Set.Poly.empty in
-      Set.union acc (Set.union complex_name init_names)
+      Set.Poly.union acc (Set.Poly.union complex_name init_names)
   | Skip | Break | Continue | Decl _ -> acc
 
 (** Look through a statement to see whether the objects used in it need to be
@@ -473,31 +477,33 @@ let query_demotable_stmt (aos_exits : string Set.Poly.t)
   | Stmt.Pattern.Assignment (lval, (_ : UnsizedType.t), (rhs : Expr.Typed.t)) ->
       let assign_name = Stmt.Helpers.lhs_variable lval in
       let all_rhs_eigen_names = query_var_eigen_names rhs in
-      if Set.mem aos_exits assign_name then (
+      if Set.Poly.mem assign_name aos_exits then (
         user_warning_op SoA linenum
           "Right hand side contains only AoS expressions:" assign_name;
-        Set.add all_rhs_eigen_names assign_name)
+        Set.Poly.add assign_name all_rhs_eigen_names)
       else if is_nonzero_subset ~set:aos_exits ~subset:all_rhs_eigen_names then (
         let warn =
           Fmt.(
             str "Right hand side contains AoS expressions (%s):"
-              (concat_set_str (Set.inter aos_exits all_rhs_eigen_names))) in
+              (concat_set_str (Set.Poly.inter aos_exits all_rhs_eigen_names)))
+        in
         user_warning_op SoA linenum warn assign_name;
-        Set.add all_rhs_eigen_names assign_name)
+        Set.Poly.add assign_name all_rhs_eigen_names)
       else Set.Poly.empty
   | Decl {decl_id; initialize= Assign e; _} ->
       let all_rhs_eigen_names = query_var_eigen_names e in
-      if Set.mem aos_exits decl_id then (
+      if Set.Poly.mem decl_id aos_exits then (
         user_warning_op SoA linenum
           "Right hand side contains only AoS expressions:" decl_id;
-        Set.add all_rhs_eigen_names decl_id)
+        Set.Poly.add decl_id all_rhs_eigen_names)
       else if is_nonzero_subset ~set:aos_exits ~subset:all_rhs_eigen_names then (
         let warn =
           Fmt.(
             str "Right hand side contains AoS expressions (%s):"
-              (concat_set_str (Set.inter aos_exits all_rhs_eigen_names))) in
+              (concat_set_str (Set.Poly.inter aos_exits all_rhs_eigen_names)))
+        in
         user_warning_op SoA linenum warn decl_id;
-        Set.add all_rhs_eigen_names decl_id)
+        Set.Poly.add decl_id all_rhs_eigen_names)
       else Set.Poly.empty
   (* All other statements do not need logic here *)
   | _ -> Set.Poly.empty
@@ -606,7 +612,7 @@ and modify_expr ?force_demotion:(force = false)
     @param modifiable_set The name of the variable we are searching for. *)
 let rec modify_stmt_pattern
     (pattern : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t)
-    (modifiable_set : string Core.Set.Poly.t) =
+    (modifiable_set : string Set.Poly.t) =
   let mod_expr force = modify_expr ~force_demotion:force modifiable_set in
   let mod_stmt stmt = modify_stmt stmt modifiable_set in
   match pattern with
@@ -619,7 +625,7 @@ let rec modify_stmt_pattern
             ({ pattern= FunApp (CompilerInternal (FnReadParam read_param), args)
              ; _ } as assigner) } ->
       let name = decl_id in
-      if Set.mem modifiable_set name then
+      if Set.Poly.mem name modifiable_set then
         Stmt.Pattern.Decl
           { decl_id
           ; decl_adtype
@@ -649,7 +655,7 @@ let rec modify_stmt_pattern
                       , List.map ~f:(mod_expr false) args ) } }
   | Stmt.Pattern.Decl
       ({decl_id; decl_type= Type.Sized sized_type; initialize; _} as decl) ->
-      if Set.mem modifiable_set decl_id then
+      if Set.Poly.mem decl_id modifiable_set then
         let init_expr =
           match initialize with
           | Stmt.Pattern.Assign e -> Stmt.Pattern.Assign (mod_expr false e)
@@ -674,7 +680,7 @@ let rec modify_stmt_pattern
       , ({pattern= FunApp (CompilerInternal (FnReadParam read_param), args); _}
          as assigner) ) ->
       let name = Stmt.Helpers.lhs_variable lval in
-      if Set.mem modifiable_set name then
+      if Set.Poly.mem name modifiable_set then
         Assignment
           ( lval
           , ut
@@ -696,7 +702,7 @@ let rec modify_stmt_pattern
                   , List.map ~f:(mod_expr false) args ) } )
   | Assignment (lval, (ut : UnsizedType.t), rhs) ->
       let name = Stmt.Helpers.lhs_variable lval in
-      if Set.mem modifiable_set name then
+      if Set.Poly.mem name modifiable_set then
         (* If assignee is in bad set, force demotion of rhs functions *)
         Assignment (lval, ut, mod_expr true rhs)
       else Assignment (lval, ut, (mod_expr false) rhs)
@@ -738,7 +744,8 @@ let collect_mem_pattern_variables stmts =
       when SizedType.has_mem_pattern stype ->
         (decl_id, stype) :: acc
     | _ -> acc in
-  Mir_utils.fold_stmts ~take_expr:Fn.const ~take_stmt ~init:[] stmts |> List.rev
+  Mir_utils.fold_stmts ~take_expr:Fun.const ~take_stmt ~init:[] stmts
+  |> List.rev
 
 let pp_mem_patterns ppf (Program.{reverse_mode_log_prob; _} : Program.Typed.t) =
   let pp_var ppf (name, stype) =

--- a/src/analysis_and_optimization/Mir_utils.ml
+++ b/src/analysis_and_optimization/Mir_utils.ml
@@ -1,5 +1,4 @@
-open Core
-open Core.Poly
+open Std
 open Middle
 open Middle.Program
 open Middle.Expr
@@ -17,7 +16,7 @@ let fold_stmts ~take_expr ~take_stmt ~(init : 'c)
       (fun a e -> fold_expr ~take_expr ~init:(take_expr a e) e)
       (fun a s -> fold_stmt (take_stmt a s) s)
       state stmt.pattern in
-  List.fold ~f:(fun a s -> fold_stmt (take_stmt a s) s) ~init stmts
+  List.fold_left ~f:(fun a s -> fold_stmt (take_stmt a s) s) ~init stmts
 
 let rec num_expr_value (v : Expr.Typed.t) : (float * string) option =
   match v with
@@ -57,7 +56,7 @@ let trans_bounds_values (trans : Expr.Typed.t Transformation.t) : bound_values =
 
 let chop_dist_name (fname : string) : string Option.t =
   (* Slightly inefficient, would be better to short-circuit *)
-  List.fold ~init:None ~f:Option.first_some
+  List.fold_left ~init:None ~f:Option.first_some
     (List.map
        ~f:(fun suffix -> String.chop_suffix ~suffix fname)
        Middle.Utils.distribution_suffices)
@@ -77,18 +76,19 @@ let data_set ?(exclude_transformed = false) ?(exclude_ints = false)
   let data = Set.Poly.of_list mir.input_vars in
   (* Possibly remove ints from the data set *)
   let filtered_data =
-    let remove_ints = Set.filter ~f:(fun (_, _, st) -> st <> SizedType.SInt) in
-    Set.Poly.map ~f:fst3 ((if exclude_ints then remove_ints else Fn.id) data)
+    let remove_ints =
+      Set.Poly.filter ~f:(fun (_, _, st) -> st <> SizedType.SInt) in
+    Set.Poly.map ~f:fst3 ((if exclude_ints then remove_ints else Fun.id) data)
   in
   (* Transformed data are declarations in prepare_data but excluding data *)
   if exclude_transformed then filtered_data
   else
     let trans_data =
-      Set.diff
+      Set.Poly.diff
         (Set.Poly.union_list
            (List.map ~f:top_var_declarations mir.prepare_data))
         (Set.Poly.map ~f:fst3 data) in
-    Set.union trans_data filtered_data
+    Set.Poly.union trans_data filtered_data
 
 let parameter_set ?(include_transformed = false) (mir : Program.Typed.t) =
   Set.Poly.of_list
@@ -109,7 +109,7 @@ let rec var_declarations Stmt.{pattern; _} : string Set.Poly.t =
   | Decl {decl_id; _} -> Set.Poly.singleton decl_id
   | IfElse (_, s, None) | While (_, s) | For {body= s; _} -> var_declarations s
   | IfElse (_, s1, Some s2) ->
-      Set.union (var_declarations s1) (var_declarations s2)
+      Set.Poly.union (var_declarations s1) (var_declarations s2)
   | Block slist | SList slist | Profile (_, slist) ->
       Set.Poly.union_list (List.map ~f:var_declarations slist)
   | _ -> Set.Poly.empty
@@ -130,11 +130,11 @@ let map_rec_expr_state f state e =
 
 let rec map_rec_stmt_loc f stmt =
   let recurse = map_rec_stmt_loc f in
-  Stmt.{stmt with pattern= f (Pattern.map Fn.id recurse stmt.pattern)}
+  Stmt.{stmt with pattern= f (Pattern.map Fun.id recurse stmt.pattern)}
 
 let rec top_down_map_rec_stmt_loc f stmt =
   let recurse = top_down_map_rec_stmt_loc f in
-  Stmt.{stmt with pattern= Pattern.map Fn.id recurse (f stmt.pattern)}
+  Stmt.{stmt with pattern= Pattern.map Fun.id recurse (f stmt.pattern)}
 
 let map_rec_state_stmt_loc f state stmt =
   let cur_state = ref state in
@@ -149,15 +149,14 @@ let map_rec_state_stmt_loc f state stmt =
 let map_rec_stmt_loc_num flowgraph_to_mir f s =
   let rec map_rec_stmt_loc_num' (cur_node : int)
       (stmt : Stmt.Located.Non_recursive.t) =
-    let find_node i = Map.find_exn flowgraph_to_mir i in
+    let find_node i = LabelMap.find i flowgraph_to_mir in
     let recurse i = map_rec_stmt_loc_num' i (find_node i) in
     Stmt.
-      { pattern= f cur_node (Pattern.map Fn.id recurse stmt.pattern)
+      { pattern= f cur_node (Pattern.map Fun.id recurse stmt.pattern)
       ; meta= stmt.meta } in
   map_rec_stmt_loc_num' 1 s
 
 let stmt_loc_of_stmt_loc_num flowgraph_to_mir s =
-  (* (flowgraph_to_mir : (int, stmt_loc_num) Map.Poly.t) (s : stmt_loc_num) = *)
   map_rec_stmt_loc_num flowgraph_to_mir (fun _ s' -> s') s
 
 let statement_stmt_loc_of_statement_stmt_loc_num flowgraph_to_mir pattern =
@@ -167,7 +166,7 @@ let statement_stmt_loc_of_statement_stmt_loc_num flowgraph_to_mir pattern =
 
 (** Forgetful function from numbered to unnumbered programs *)
 let unnumbered_prog_of_numbered_prog flowgraph_to_mir p =
-  Program.map (stmt_loc_of_stmt_loc_num flowgraph_to_mir) p Fn.id
+  Program.map (stmt_loc_of_stmt_loc_num flowgraph_to_mir) p Fun.id
 
 (** See interface file *)
 let fwd_traverse_statement stmt ~init ~f =
@@ -248,7 +247,7 @@ and index_var_set ix =
   | Single expr -> expr_var_set expr
   | Upfrom expr -> expr_var_set expr
   | Between (expr1, expr2) ->
-      Set.union (expr_var_set expr1) (expr_var_set expr2)
+      Set.Poly.union (expr_var_set expr1) (expr_var_set expr2)
   | MultiIndex expr -> expr_var_set expr
 
 let expr_var_names_set expr =
@@ -271,10 +270,8 @@ let stmt_rhs stmt =
    |Break | Continue | Skip | Decl _ | Profile _ | Block _ | SList _ ->
       Set.Poly.empty
 
-let union_map (set : ('a, 'c) Set.t) ~(f : 'a -> 'b Set.Poly.t) =
-  Set.fold set ~init:Set.Poly.empty ~f:(fun s a -> Set.union s (f a))
-
-let stmt_rhs_var_set stmt = union_map (stmt_rhs stmt) ~f:expr_var_set
+let stmt_rhs_var_set stmt = Set.Poly.union_map (stmt_rhs stmt) ~f:expr_var_set
+let stmt_rhs_names_set s = Set.Poly.map ~f:fst (stmt_rhs_var_set s)
 
 (** See interface file *)
 let expr_assigned_var Expr.{pattern; _} =
@@ -313,25 +310,21 @@ let fn_subst_stmt m = map_rec_stmt_loc (fn_subst_stmt_base m)
 let name_map m (e : Expr.Typed.t) =
   match e.pattern with
   | Var s -> (
-      match Map.Poly.find m s with
+      match String.Map.find_opt s m with
       | Some s' -> Some {e with pattern= Var s'}
       | None -> None)
   | _ -> None
 
 let name_subst_stmt m = fn_subst_stmt (name_map m)
 
-let var_map_std m (e : Expr.Typed.t) =
-  match e.pattern with Var s -> Std.String.Map.find_opt s m | _ -> None
-
 let var_map m (e : Expr.Typed.t) =
-  match e.pattern with Var s -> Map.find m s | _ -> None
+  match e.pattern with Var s -> String.Map.find_opt s m | _ -> None
 
 let subst_expr m e = fn_subst_expr (var_map m) e
-let subst_expr_std m e = fn_subst_expr (var_map_std m) e
 let subst_idx m = Index.map (subst_expr m)
 let subst_stmt_base m = fn_subst_stmt_base_helper (subst_expr m) (subst_idx m)
 let subst_stmt m = map_rec_stmt_loc (subst_stmt_base m)
-let expr_map m (e : Expr.Typed.t) = Map.find m e
+let expr_map m (e : Expr.Typed.t) = ExprMap.find_opt e m
 let expr_subst_expr m e = fn_subst_expr (expr_map m) e
 let expr_subst_idx m = Index.map (expr_subst_expr m)
 
@@ -345,22 +338,21 @@ let rec expr_depth Expr.{pattern; _} =
       let l = args @ Fun_kind.collect_exprs kind in
       1
       + Option.value ~default:0
-          (List.max_elt ~compare:compare_int (List.map ~f:expr_depth l))
+          (List.max_elt ~cmp:Int.compare (List.map ~f:expr_depth l))
   | TernaryIf (e1, e2, e3) ->
       1
       + Option.value ~default:0
-          (List.max_elt ~compare:compare_int
-             (List.map ~f:expr_depth [e1; e2; e3]))
+          (List.max_elt ~cmp:Int.compare (List.map ~f:expr_depth [e1; e2; e3]))
   | Indexed (e, l) ->
       1
       + max (expr_depth e)
           (Option.value ~default:0
-             (List.max_elt ~compare:compare_int (List.map ~f:idx_depth l)))
+             (List.max_elt ~cmp:Int.compare (List.map ~f:idx_depth l)))
   | Promotion (expr, _, _) -> 1 + expr_depth expr
   | EAnd (e1, e2) | EOr (e1, e2) ->
       1
       + Option.value ~default:0
-          (List.max_elt ~compare:compare_int (List.map ~f:expr_depth [e1; e2]))
+          (List.max_elt ~cmp:Int.compare (List.map ~f:expr_depth [e1; e2]))
   | TupleProjection (e, _) -> 1 + expr_depth e
 
 and idx_depth i =
@@ -380,7 +372,7 @@ let rec update_expr_ad_levels autodiffable_variables (Expr.{pattern; _} as e) =
     UnsizedType.fill_adtype_for_type base Expr.Typed.Meta.(e.meta.type_) in
   match pattern with
   | Var x ->
-      if Set.mem autodiffable_variables x then e
+      if Set.Poly.mem x autodiffable_variables then e
       else
         let adlevel =
           UnsizedType.fill_adtype_for_type DataOnly
@@ -446,10 +438,10 @@ let cleanup_empty_stmts stmts =
     match s.pattern with
     (* NB: Does not include Profile since we don't want to remove those
        blocks *)
-    | (SList ls | Block ls) when List.for_all ~f:(Fn.non is_decl) ls -> ls
+    | (SList ls | Block ls) when List.for_all ~f:(Fun.negate is_decl) ls -> ls
     | _ -> [s] in
   let ellide_skip s = match s.pattern with Skip -> [] | _ -> [s] in
-  List.map stmts ~f:(rewrite_bottom_up ~f:Fn.id ~g:cleanup_stmt)
+  List.map stmts ~f:(rewrite_bottom_up ~f:Fun.id ~g:cleanup_stmt)
   |> List.concat_map ~f:flatten_block
   |> List.concat_map ~f:ellide_skip
 

--- a/src/analysis_and_optimization/Mir_utils.mli
+++ b/src/analysis_and_optimization/Mir_utils.mli
@@ -1,4 +1,4 @@
-open Core
+open Std
 open Middle
 open Dataflow_types
 
@@ -70,7 +70,7 @@ val map_rec_state_stmt_loc :
   -> Stmt.Located.t * 's
 
 val map_rec_stmt_loc_num :
-     (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+     Stmt.Located.Non_recursive.t LabelMap.t
   -> (   int
       -> (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t
       -> (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t)
@@ -78,17 +78,17 @@ val map_rec_stmt_loc_num :
   -> Stmt.Located.t
 
 val stmt_loc_of_stmt_loc_num :
-     (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+     Stmt.Located.Non_recursive.t LabelMap.t
   -> Stmt.Located.Non_recursive.t
   -> Stmt.Located.t
 
 val statement_stmt_loc_of_statement_stmt_loc_num :
-     (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+     Stmt.Located.Non_recursive.t LabelMap.t
   -> (Expr.Typed.t, int) Stmt.Pattern.t
   -> (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t
 
 val unnumbered_prog_of_numbered_prog :
-     (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+     Stmt.Located.Non_recursive.t LabelMap.t
   -> ('a -> 'b)
   -> (Stmt.Located.Non_recursive.t, 'a, 'c) Program.t
   -> (Stmt.Located.t, 'b, 'c) Program.t
@@ -116,7 +116,7 @@ val index_var_set :
 (** The set of variables in an index. For use in RHS sets, not LHS assignment
     sets, except in a target term *)
 
-val expr_var_names_set : Expr.Typed.t -> string Core.Set.Poly.t
+val expr_var_names_set : Expr.Typed.t -> string Set.Poly.t
 (** Return the names of the variables in an expression. *)
 
 val stmt_rhs : (Expr.Typed.t, 's) Stmt.Pattern.t -> Expr.Typed.t Set.Poly.t
@@ -124,13 +124,14 @@ val stmt_rhs : (Expr.Typed.t, 's) Stmt.Pattern.t -> Expr.Typed.t Set.Poly.t
     expression, i.e. rhs. Using Set.Poly instead of ExprSet so that 'e can be
     polymorphic, it usually doesn't matter if there's duplication. *)
 
-val union_map : 'a Set.Poly.t -> f:('a -> 'b Set.Poly.t) -> 'b Set.Poly.t
-(** This is a helper function equivalent to List.concat_map but for Sets *)
-
 val stmt_rhs_var_set :
   (Expr.Typed.t, 's) Stmt.Pattern.t -> (vexpr * Expr.Typed.Meta.t) Set.Poly.t
 (** The set of variables in an expression, including inside an index. For use in
     RHS sets, not LHS assignment sets, except in a target term. *)
+
+val stmt_rhs_names_set : ('a Expr.t, 'b) Stmt.Pattern.t -> vexpr Set.Poly.t
+(** The set of variable names in an expression, including inside an index. For
+    use in RHS sets, not LHS assignment sets, except in a target term. *)
 
 val expr_assigned_var : Expr.Typed.t -> vexpr
 (** The variable being assigned to when the expression is the LHS *)
@@ -138,38 +139,30 @@ val expr_assigned_var : Expr.Typed.t -> vexpr
 val summation_terms : Expr.Typed.t -> Expr.Typed.t list
 (** The list of terms in expression separated by a + *)
 
-val subst_expr :
-  (string, Expr.Typed.t) Map.Poly.t -> Expr.Typed.t -> Expr.Typed.t
-(** Substitute variables in an expression according to the provided Map. *)
-
-val subst_expr_std :
-  Expr.Typed.t Std.String.Map.t -> Expr.Typed.t -> Expr.Typed.t
+val subst_expr : Expr.Typed.t String.Map.t -> Expr.Typed.t -> Expr.Typed.t
 (** Substitute variables in an expression according to the provided Map. *)
 
 val subst_stmt_base :
-     (string, Expr.Typed.t) Map.Poly.t
+     Expr.Typed.t String.Map.t
   -> (Expr.Typed.t, 'a) Stmt.Pattern.t
   -> (Expr.Typed.t, 'a) Stmt.Pattern.t
 (** Substitute variables occurring at the top level in statements according to
     the provided Map. *)
 
-val subst_stmt :
-  (string, Expr.Typed.t) Map.Poly.t -> Stmt.Located.t -> Stmt.Located.t
+val subst_stmt : Expr.Typed.t String.Map.t -> Stmt.Located.t -> Stmt.Located.t
 (** Substitute variables occurring anywhere in a statement according to the
     provided Map. *)
 
-val name_subst_stmt :
-  (string, string) Map.Poly.t -> Stmt.Located.t -> Stmt.Located.t
+val name_subst_stmt : string String.Map.t -> Stmt.Located.t -> Stmt.Located.t
 (** Substitute subexpressions occurring anywhere in a statement according to the
     provided Map. *)
 
-val expr_subst_expr :
-  Expr.Typed.t Map.M(Expr.Typed).t -> Expr.Typed.t -> Expr.Typed.t
+val expr_subst_expr : Expr.Typed.t ExprMap.t -> Expr.Typed.t -> Expr.Typed.t
 (** Substitute subexpressions in an expression according to the provided Map,
     trying to match on larger subexpressions before smaller ones. *)
 
 val expr_subst_stmt_base :
-     Expr.Typed.t Map.M(Expr.Typed).t
+     Expr.Typed.t ExprMap.t
   -> (Expr.Typed.t, 'a) Stmt.Pattern.t
   -> (Expr.Typed.t, 'a) Stmt.Pattern.t
 (** Substitute subexpressions occurring at the top level in statements according

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -1,18 +1,10 @@
 (** The common elements of a monotone framework *)
 
-open Core
-open Core.Poly
+open Std
 open Monotone_framework_sigs
 open Mir_utils
 open Middle
-
-module Expr_set = struct
-  type t = Set.M(Expr.Typed).t
-
-  let empty = Set.empty (module Expr.Typed)
-  let singleton = Set.singleton (module Expr.Typed)
-  let union_list = Set.union_list (module Expr.Typed)
-end
+open Dataflow_types
 
 (** Calculate the free (non-bound) variables in an expression *)
 let rec free_vars_expr (e : Expr.Typed.t) =
@@ -34,7 +26,7 @@ and free_vars_idx (i : Expr.Typed.t Index.t) =
   match i with
   | All -> Set.Poly.empty
   | Single e | Upfrom e | MultiIndex e -> free_vars_expr e
-  | Between (e1, e2) -> Set.union (free_vars_expr e1) (free_vars_expr e2)
+  | Between (e1, e2) -> Set.Poly.union (free_vars_expr e1) (free_vars_expr e2)
 
 and free_vars_fnapp kind l =
   let arg_vars = List.map ~f:free_vars_expr (l @ Fun_kind.collect_exprs kind) in
@@ -47,7 +39,7 @@ let rec free_vars_lval ((lval, idxs) : Expr.Typed.t Stmt.Pattern.lvalue) =
   let free_idx = Set.Poly.union_list (List.map ~f:free_vars_idx idxs) in
   match lval with
   | LVariable _ -> free_idx
-  | LTupleProjection (e, _) -> Set.union free_idx (free_vars_lval e)
+  | LTupleProjection (e, _) -> Set.Poly.union free_idx (free_vars_lval e)
 
 (** Calculate the free (non-bound) variables in a statement *)
 let rec free_vars_stmt (s : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t) =
@@ -60,19 +52,20 @@ let rec free_vars_stmt (s : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t) =
       Set.Poly.union_list
         [free_vars_expr e; free_vars_stmt b1.pattern; free_vars_stmt b2.pattern]
   | IfElse (e, b, None) | While (e, b) ->
-      Set.union (free_vars_expr e) (free_vars_stmt b.pattern)
+      Set.Poly.union (free_vars_expr e) (free_vars_stmt b.pattern)
   | For {lower= e1; upper= e2; body= b; _} ->
       Set.Poly.union_list
         [free_vars_expr e1; free_vars_expr e2; free_vars_stmt b.pattern]
   | Profile (_, l) | Block l | SList l ->
-      Set.Poly.union_list (List.map ~f:(fun s -> free_vars_stmt s.pattern) l)
+      Set.Poly.union_list
+        (List.map ~f:(fun s -> free_vars_stmt s.Stmt.pattern) l)
   | Decl {initialize= Assign e; _} -> free_vars_expr e
   | Decl _ | Break | Continue | Return None | Skip -> Set.Poly.empty
 
 (** A variation on free_vars_stmt, where we do not recursively count free
     variables in sub statements *)
 let top_free_vars_stmt
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t)
     (s : (Expr.Typed.t, int) Stmt.Pattern.t) =
   match s with
   | Decl {initialize= Assign e; _} -> free_vars_expr e
@@ -89,7 +82,7 @@ let top_free_vars_stmt
 let inverse_flowgraph_of_stmt ?(flatten_loops = false)
     ?(blocks_after_body = true) (stmt : Stmt.Located.t) :
     (module FLOWGRAPH with type labels = int)
-    * (int, Stmt.Located.Non_recursive.t) Map.Poly.t =
+    * Stmt.Located.Non_recursive.t LabelMap.t =
   let flowgraph_to_mir =
     Dataflow_utils.build_statement_map
       (fun Stmt.{pattern; _} -> pattern)
@@ -100,40 +93,35 @@ let inverse_flowgraph_of_stmt ?(flatten_loops = false)
       flowgraph_to_mir in
   ( (module struct
       type labels = int
-      type t = labels
 
-      let compare = Int.compare
-      let hash = Int.hash
-      let sexp_of_t = Int.sexp_of_t
       let initials = initials
       let successors = successors
     end : FLOWGRAPH
       with type labels = int)
-  , Map.Poly.map
+  , LabelMap.map
       ~f:(fun (pattern, meta) -> Stmt.Located.Non_recursive.{pattern; meta})
       flowgraph_to_mir )
 
 (** Reverse flowgraphs to be used for reverse analyses. Observe that this
     respects the invariants listed for a FLOWGRAPH *)
-let reverse (type l) (module F : FLOWGRAPH with type labels = l) =
+let reverse (module F : FLOWGRAPH with type labels = int) =
   (module struct
     type labels = F.labels
-    type t = labels
 
-    let compare = F.compare
-    let hash = F.hash
-    let sexp_of_t = F.sexp_of_t
-    let initials = Set.of_map_keys (Map.filter F.successors ~f:Set.is_empty)
+    let initials =
+      Set.Poly.of_list
+        (LabelMap.filter F.successors ~f:(fun _ s -> Set.Poly.is_empty s)
+        |> LabelMap.to_list |> List.map ~f:fst)
 
     let successors =
-      Map.fold F.successors
-        ~init:(Map.map F.successors ~f:(fun _ -> Set.Poly.empty))
+      LabelMap.fold F.successors
+        ~init:(LabelMap.map F.successors ~f:(fun _ -> Set.Poly.empty))
         ~f:(fun ~key:old_pred ~data:old_succs accum ->
-          Set.fold old_succs ~init:accum ~f:(fun accum old_succ ->
-              Map.set accum ~key:old_succ
-                ~data:(Set.add (Map.find_exn accum old_succ) old_pred)))
+          Set.Poly.fold old_succs ~init:accum ~f:(fun old_succ accum ->
+              LabelMap.add accum ~key:old_succ
+                ~data:(Set.Poly.add old_pred (LabelMap.find old_succ accum))))
   end : FLOWGRAPH
-    with type labels = l)
+    with type labels = int)
 
 (** Modify the end nodes of a flowgraph to depend on its inits To force the
     monotone framework to run until the program never changes this function
@@ -143,26 +131,22 @@ let reverse (type l) (module F : FLOWGRAPH with type labels = l) =
     @param l Type of the label for each flowgraph, most commonly an int
     @param Flowgraph The flowgraph to modify
     @param RevFlowgraph The same flowgraph as [Flowgraph] but reversed. *)
-let make_circular_flowgraph (type l)
-    (module Flowgraph : FLOWGRAPH with type labels = l)
-    (module RevFlowgraph : FLOWGRAPH with type labels = l) =
+let make_circular_flowgraph
+    (module Flowgraph : FLOWGRAPH with type labels = int)
+    (module RevFlowgraph : FLOWGRAPH with type labels = int) =
   (module struct
     type labels = Flowgraph.labels
-    type t = labels
 
-    let compare = Flowgraph.compare
-    let hash = Flowgraph.hash
-    let sexp_of_t = Flowgraph.sexp_of_t
     let initials = Flowgraph.initials
 
     let successors =
-      let set_exits_to_depend_on_inits ~key ~data =
-        if Set.mem RevFlowgraph.initials key then
-          Set.union data Flowgraph.initials
+      let set_exits_to_depend_on_inits key data =
+        if Set.Poly.mem key RevFlowgraph.initials then
+          Set.Poly.union data Flowgraph.initials
         else data in
-      Map.mapi Flowgraph.successors ~f:set_exits_to_depend_on_inits
+      LabelMap.mapi Flowgraph.successors ~f:set_exits_to_depend_on_inits
   end : FLOWGRAPH
-    with type labels = l)
+    with type labels = int)
 
 (** Compute the forward flowgraph of a Stan statement (for forward analyses) *)
 let forward_flowgraph_of_stmt ?(flatten_loops = false)
@@ -178,8 +162,8 @@ let powerset_lattice (type v) (module S : INITIALTYPE with type vals = v) =
     type properties = S.vals Set.Poly.t
 
     let bottom = Set.Poly.empty
-    let lub s1 s2 = Set.union s1 s2
-    let leq s1 s2 = Set.is_subset s1 ~of_:s2
+    let lub s1 s2 = Set.Poly.union s1 s2
+    let leq s1 s2 = Set.Poly.subset s1 s2
     let initial = S.initial
   end : LATTICE
     with type properties = v Set.Poly.t)
@@ -192,34 +176,34 @@ let dual_powerset_lattice (type v)
     type properties = S.vals Set.Poly.t
 
     let bottom = S.total
-    let lub s1 s2 = Set.inter s1 s2
-    let leq s1 s2 = Set.is_subset s2 ~of_:s1
+    let lub s1 s2 = Set.Poly.inter s1 s2
+    let leq s1 s2 = Set.Poly.subset s2 s1
     let initial = S.initial
   end : LATTICE
     with type properties = v Set.Poly.t)
 
-let powerset_lattice_expressions (initial : Expr_set.t) =
+let powerset_lattice_expressions (initial : ExprSet.t) =
   (module struct
-    type properties = Expr_set.t
+    type properties = ExprSet.t
 
-    let bottom = Expr_set.empty
-    let lub s1 s2 = Set.union s1 s2
-    let leq s1 s2 = Set.is_subset s1 ~of_:s2
+    let bottom = ExprSet.empty
+    let lub s1 s2 = ExprSet.union s1 s2
+    let leq s1 s2 = ExprSet.subset s1 s2
     let initial = initial
   end : LATTICE
-    with type properties = Expr_set.t)
+    with type properties = ExprSet.t)
 
-let dual_powerset_lattice_expressions (initial : Expr_set.t)
-    (total : Expr_set.t) =
+let dual_powerset_lattice_expressions (initial : ExprSet.t) (total : ExprSet.t)
+    =
   (module struct
-    type properties = Expr_set.t
+    type properties = ExprSet.t
 
     let bottom = total
-    let lub s1 s2 = Set.inter s1 s2
-    let leq s1 s2 = Set.is_subset s2 ~of_:s1
+    let lub s1 s2 = ExprSet.inter s1 s2
+    let leq s1 s2 = ExprSet.subset s2 s1
     let initial = initial
   end : LATTICE
-    with type properties = Expr_set.t)
+    with type properties = ExprSet.t)
 
 (** Add a fresh bottom element to a lattice (possibly without bottom) *)
 let new_bot (type p) (module L : LATTICE_NO_BOT with type properties = p) =
@@ -242,32 +226,32 @@ let new_bot (type p) (module L : LATTICE_NO_BOT with type properties = p) =
 
 (** The lattice (without bottom) of partial functions, ordered under inverse
     graph inclusion, with intersection *)
-let dual_partial_function_lattice (type dv cv)
-    (module Dom : TOTALTYPE with type vals = dv)
+let dual_partial_function_lattice (type cv)
+    (module Dom : TOTALTYPE with type vals = string)
     (module Codom : TYPE with type vals = cv) =
   (module struct
-    type properties = (Dom.vals, Codom.vals) Map.Poly.t
+    type properties = Codom.vals String.Map.t
 
     (* intersection *)
     let lub s1 s2 =
-      let f ~key ~data = Map.find s2 key = Some data in
-      Map.filteri ~f s1
+      let f key data = String.Map.find_opt key s2 = Some data in
+      String.Map.filter ~f s1
 
     let leq s1 s2 =
-      Set.for_all Dom.total ~f:(fun k ->
-          match (Map.find s1 k, Map.find s2 k) with
+      Set.Poly.for_all Dom.total ~f:(fun k ->
+          match (String.Map.find_opt k s1, String.Map.find_opt k s2) with
           | Some x, Some y -> x = y
           | Some _, None | None, None -> true
           | None, Some _ -> false)
 
-    let initial = Map.Poly.empty
+    let initial = String.Map.empty
   end : LATTICE_NO_BOT
-    with type properties = (dv, cv) Map.Poly.t)
+    with type properties = cv String.Map.t)
 
 (** The lattice of partial functions, where we add a fresh bottom element, to
     represent an inconsistent combination of functions *)
-let dual_partial_function_lattice_with_bot (type dv cv)
-    (module Dom : TOTALTYPE with type vals = dv)
+let dual_partial_function_lattice_with_bot (type cv)
+    (module Dom : TOTALTYPE with type vals = string)
     (module Codom : TYPE with type vals = cv) =
   new_bot (dual_partial_function_lattice (module Dom) (module Codom))
 
@@ -314,16 +298,16 @@ let minimal_variables_lattice initial_variables =
 
 (* The transfer function for a constant propagation analysis *)
 let constant_propagation_transfer ?(preserve_stability = false)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
-    type properties = (string, Expr.Typed.t) Map.Poly.t option
+    type properties = Expr.Typed.t String.Map.t option
 
     let transfer_function l p =
       match p with
       | None -> None
       | Some m ->
-          let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
+          let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
           Some
             (match mir_node with
             (* TODO: we are currently only propagating constants for scalars.
@@ -336,11 +320,11 @@ let constant_propagation_transfer ?(preserve_stability = false)
                   ; _ } as e'
                   when not (preserve_stability && UnsizedType.is_autodiffable t)
                   ->
-                    Map.set m ~key:s ~data:e'
-                | _ -> Map.remove m s)
-            | Decl {decl_id= s; _} -> Map.remove m s
+                    String.Map.add m ~key:s ~data:e'
+                | _ -> String.Map.remove s m)
+            | Decl {decl_id= s; _} -> String.Map.remove s m
             | Assignment (lhs, _, _) ->
-                Map.remove m (Middle.Stmt.Helpers.lhs_variable lhs)
+                String.Map.remove (Middle.Stmt.Helpers.lhs_variable lhs) m
             | TargetPE _ | JacobianPE _
              |NRFunApp (_, _)
              |Break | Continue | Return _ | Skip
@@ -350,12 +334,12 @@ let constant_propagation_transfer ?(preserve_stability = false)
                 m)
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = (string, Expr.Typed.t) Map.Poly.t option)
+     and type properties = Expr.Typed.t String.Map.t option)
 
 let rec label_top_decls
-    (flowgraph_to_mir : (int, Middle.Stmt.Located.Non_recursive.t) Map.Poly.t)
-    label : string Set.Poly.t =
-  let stmt = Map.Poly.find_exn flowgraph_to_mir label in
+    (flowgraph_to_mir : Middle.Stmt.Located.Non_recursive.t LabelMap.t) label :
+    string Set.Poly.t =
+  let stmt = LabelMap.find label flowgraph_to_mir in
   match stmt.pattern with
   | Decl {decl_id= s; _} -> Set.Poly.singleton s
   | SList ids ->
@@ -366,40 +350,40 @@ let rec label_top_decls
     substitution (see page 396 of Muchnick) *)
 let expression_propagation_transfer ?(preserve_stability = false)
     (can_side_effect_expr : Middle.Expr.Typed.t -> bool)
-    (flowgraph_to_mir : (int, Middle.Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Middle.Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
-    type properties = (string, Expr.Typed.t) Map.Poly.t option
+    type properties = Expr.Typed.t String.Map.t option
 
     let transfer_function l p =
       match p with
       | None -> None
       | Some m ->
-          let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
-          let kill_var m v =
-            Map.filteri m ~f:(fun ~key ~data ->
-                not (key = v || Set.mem (free_vars_expr data) v)) in
+          let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
+          let kill_var v m =
+            String.Map.filter m ~f:(fun key data ->
+                not (key = v || Set.Poly.mem v (free_vars_expr data))) in
           Some
             (match mir_node with
             (* TODO: we are currently only propagating constants for scalars. We
                could do the same for matrix and array expressions if we
                wanted. *)
             | Middle.Stmt.Pattern.Assignment ((LVariable s, []), t, e) ->
-                let m' = kill_var m s in
+                let m' = kill_var s m in
                 if
                   can_side_effect_expr e
-                  || Set.mem (free_vars_expr e) s
+                  || Set.Poly.mem s (free_vars_expr e)
                   || (preserve_stability && UnsizedType.is_autodiffable t)
                 then m'
-                else Map.set m ~key:s ~data:(subst_expr m e)
-            | Decl {decl_id= s; _} -> kill_var m s
+                else String.Map.add m ~key:s ~data:(subst_expr m e)
+            | Decl {decl_id= s; _} -> kill_var s m
             | Assignment (lhs, _, _) ->
-                kill_var m (Middle.Stmt.Helpers.lhs_variable lhs)
+                kill_var (Middle.Stmt.Helpers.lhs_variable lhs) m
             | Profile (_, b) | Block b ->
                 let kills =
                   Set.Poly.union_list
                     (List.map ~f:(label_top_decls flowgraph_to_mir) b) in
-                Set.fold kills ~init:m ~f:kill_var
+                Set.Poly.fold kills ~init:m ~f:kill_var
             | TargetPE _ | JacobianPE _
              |NRFunApp (_, _)
              |Break | Continue | Return _ | Skip
@@ -409,41 +393,41 @@ let expression_propagation_transfer ?(preserve_stability = false)
                 m)
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = (string, Expr.Typed.t) Map.Poly.t option)
+     and type properties = Expr.Typed.t String.Map.t option)
 
 (** The transfer function for a copy propagation analysis *)
 let copy_propagation_transfer (globals : string Set.Poly.t)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
-    type properties = (string, Expr.Typed.t) Map.Poly.t option
+    type properties = Expr.Typed.t String.Map.t option
 
     let transfer_function int_label optional_map =
       match optional_map with
       | None -> None
       | Some expr_map ->
-          let mir_node = (Map.find_exn flowgraph_to_mir int_label).pattern in
-          let kill_var m var_name =
-            Map.filteri m ~f:(fun ~key ~(data : Expr.Typed.t) ->
+          let mir_node = (LabelMap.find int_label flowgraph_to_mir).pattern in
+          let kill_var var_name m =
+            String.Map.filter m ~f:(fun key (data : Expr.Typed.t) ->
                 not (key = var_name || data.pattern = Var var_name)) in
           Some
             (match mir_node with
             | Assignment
                 ((LVariable assignee, []), _, {pattern= Var assigner; meta}) ->
-                let m' = kill_var expr_map assignee in
-                if Set.mem globals assignee then expr_map
+                let m' = kill_var assignee expr_map in
+                if Set.Poly.mem assignee globals then expr_map
                 else
-                  Map.set m' ~key:assignee
+                  String.Map.add m' ~key:assignee
                     ~data:Expr.{pattern= Var assigner; meta}
-            | Decl {decl_id= name; _} -> kill_var expr_map name
+            | Decl {decl_id= name; _} -> kill_var name expr_map
             | Assignment (lhs, _, _) ->
-                kill_var expr_map (Stmt.Helpers.lhs_variable lhs)
+                kill_var (Stmt.Helpers.lhs_variable lhs) expr_map
             | Profile (_, stmt_lst) | Block stmt_lst ->
                 let kills =
                   Set.Poly.union_list
                     (List.map ~f:(label_top_decls flowgraph_to_mir) stmt_lst)
                 in
-                Set.fold kills ~init:expr_map ~f:kill_var
+                Set.Poly.fold kills ~init:expr_map ~f:kill_var
             | TargetPE _ | JacobianPE _
              |NRFunApp (_, _)
              |Break | Continue | Return _ | Skip | SList _
@@ -453,10 +437,10 @@ let copy_propagation_transfer (globals : string Set.Poly.t)
                 expr_map)
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = (string, Expr.Typed.t) Map.Poly.t option)
+     and type properties = Expr.Typed.t String.Map.t option)
 
 (** A helper function for building transfer functions from gen and kill sets *)
-let transfer_gen_kill p gen kill = Set.union gen (Set.diff p kill)
+let transfer_gen_kill p gen kill = Set.Poly.union gen (Set.Poly.diff p kill)
 
 (* TODO: from here *)
 
@@ -489,17 +473,17 @@ let declared_vars_stmt (s : (Expr.Typed.t, 'a) Stmt.Pattern.t) =
 
 (** Calculate the set of variables that a statement can assign to or declare *)
 let assigned_or_declared_vars_stmt (s : (Expr.Typed.t, 'a) Stmt.Pattern.t) =
-  Set.union (assigned_vars_stmt s) (declared_vars_stmt s)
+  Set.Poly.union (assigned_vars_stmt s) (declared_vars_stmt s)
 
 (** The transfer function for a reaching definitions analysis *)
 let reaching_definitions_transfer
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
     type properties = (string * labels option) Set.Poly.t
 
     let transfer_function l p =
-      let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
+      let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
       let gen =
         Set.Poly.map
           ~f:(fun x -> (x, Some l))
@@ -509,14 +493,14 @@ let reaching_definitions_transfer
         | Decl {decl_id= x; _}
          |Assignment ((LVariable x, []), _, _)
          |For {loopvar= x; _} ->
-            Set.filter p ~f:(fun (y, _) -> y = x)
+            Set.Poly.filter p ~f:(fun (y, _) -> y = x)
         | TargetPE _ | JacobianPE _ ->
-            Set.filter p ~f:(fun (y, _) -> y = "target")
+            Set.Poly.filter p ~f:(fun (y, _) -> y = "target")
         | NRFunApp
             ( ( UserDefined (_, (FnTarget | FnJacobian))
               | StanLib (_, (FnTarget | FnJacobian), _) )
             , _ ) ->
-            Set.filter p ~f:(fun (y, _) -> y = "target")
+            Set.Poly.filter p ~f:(fun (y, _) -> y = "target")
         | NRFunApp (_, _)
          |Break | Continue | Return _ | Skip
          |IfElse (_, _, _)
@@ -530,13 +514,13 @@ let reaching_definitions_transfer
 
 (** The transfer function for an initialized variables analysis *)
 let initialized_vars_transfer
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
     type properties = string Set.Poly.t
 
     let transfer_function l p =
-      let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
+      let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
       let gen = assigned_vars_stmt mir_node in
       transfer_gen_kill p gen Set.Poly.empty
   end : TRANSFER_FUNCTION
@@ -545,13 +529,13 @@ let initialized_vars_transfer
 
 (** The transfer function for a live variables analysis *)
 let live_variables_transfer (never_kill : string Set.Poly.t)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
     type properties = string Set.Poly.t
 
     let transfer_function l p =
-      let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
+      let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
       let gen = top_free_vars_stmt flowgraph_to_mir mir_node in
       let kill =
         match mir_node with
@@ -565,50 +549,51 @@ let live_variables_transfer (never_kill : string Set.Poly.t)
          |For _ | Profile _ | Block _ | SList _
          |Assignment (_, _, _) ->
             Set.Poly.empty in
-      transfer_gen_kill p gen (Set.diff kill never_kill)
+      transfer_gen_kill p gen (Set.Poly.diff kill never_kill)
   end : TRANSFER_FUNCTION
     with type labels = int
      and type properties = string Set.Poly.t)
 
 (** Calculate the set of sub-expressions of an expression *)
 let rec used_subexpressions_expr (e : Expr.Typed.t) =
-  Set.union (Expr_set.singleton e)
+  ExprSet.union (ExprSet.singleton e)
     (match e.pattern with
-    | Var _ | Lit (_, _) -> Expr_set.empty
+    | Var _ | Lit (_, _) -> ExprSet.empty
     | Promotion (expr, _, _) -> used_subexpressions_expr expr
     | FunApp (k, l) ->
-        Expr_set.union_list
+        ExprSet.union_list
           (List.map ~f:used_subexpressions_expr (l @ Fun_kind.collect_exprs k))
     | TernaryIf (e1, e2, e3) ->
-        Expr_set.union_list
+        ExprSet.union_list
           [ used_subexpressions_expr e1; used_subexpressions_expr e2
           ; used_subexpressions_expr e3 ]
     | Indexed (e, l) ->
-        Expr_set.union_list
+        ExprSet.union_list
           (used_subexpressions_expr e
           :: List.map ~f:(used_expressions_idx_help used_subexpressions_expr) l
           )
     | TupleProjection (e, _) -> used_subexpressions_expr e
     | EAnd (e1, e2) | EOr (e1, e2) ->
-        Expr_set.union_list
+        ExprSet.union_list
           [used_subexpressions_expr e1; used_subexpressions_expr e2])
 
 and used_expressions_idx_help f (i : Expr.Typed.t Index.t) =
   match i with
-  | All -> Expr_set.empty
+  | All -> ExprSet.empty
   | Single e | Upfrom e | MultiIndex e -> f e
-  | Between (e1, e2) -> Set.union (f e1) (f e2)
+  | Between (e1, e2) -> ExprSet.union (f e1) (f e2)
 
 let rec used_expressions_lval f
     ((lval, idxs) : Expr.Typed.t Stmt.Pattern.lvalue) =
   let used_idx =
-    Expr_set.union_list (List.map ~f:(used_expressions_idx_help f) idxs) in
+    ExprSet.union_list (List.map ~f:(used_expressions_idx_help f) idxs) in
   match lval with
   | LVariable _ -> used_idx
-  | LTupleProjection (e, _) -> Set.union used_idx (used_expressions_lval f e)
+  | LTupleProjection (e, _) ->
+      ExprSet.union used_idx (used_expressions_lval f e)
 
 (** Calculate the set of expressions of an expression *)
-let used_expressions_expr e = Expr_set.singleton e
+let used_expressions_expr e = ExprSet.singleton e
 
 let rec used_expressions_stmt_help f
     (s : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t) =
@@ -616,28 +601,28 @@ let rec used_expressions_stmt_help f
   | TargetPE e | JacobianPE e | Return (Some e) | Decl {initialize= Assign e; _}
     ->
       f e
-  | Assignment (l, _, e) -> Set.union (f e) (used_expressions_lval f l)
+  | Assignment (l, _, e) -> ExprSet.union (f e) (used_expressions_lval f l)
   | IfElse (e, b1, Some b2) ->
-      Expr_set.union_list
+      ExprSet.union_list
         [ f e; used_expressions_stmt_help f b1.pattern
         ; used_expressions_stmt_help f b2.pattern ]
   | NRFunApp (k, l) ->
-      Expr_set.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
-  | Decl _ | Return None | Break | Continue | Skip -> Expr_set.empty
+      ExprSet.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
+  | Decl _ | Return None | Break | Continue | Skip -> ExprSet.empty
   | IfElse (e, b, None) | While (e, b) ->
-      Set.union (f e) (used_expressions_stmt_help f b.pattern)
+      ExprSet.union (f e) (used_expressions_stmt_help f b.pattern)
   | For {lower= e1; upper= e2; body= b; loopvar= s} ->
-      Expr_set.union_list
+      ExprSet.union_list
         [ f e1; f e2; used_expressions_stmt_help f b.pattern
-        ; Expr_set.singleton
+        ; ExprSet.singleton
             { pattern= Var s
             ; meta=
                 Expr.Typed.Meta.
                   {type_= UInt; adlevel= DataOnly; loc= Location_span.empty} }
         ]
   | Profile (_, l) | Block l | SList l ->
-      Expr_set.union_list
-        (List.map ~f:(fun s -> used_expressions_stmt_help f s.pattern) l)
+      ExprSet.union_list
+        (List.map ~f:(fun s -> used_expressions_stmt_help f s.Stmt.pattern) l)
 
 (** Calculate the set of sub-expressions in a statement *)
 let used_subexpressions_stmt =
@@ -651,15 +636,15 @@ let top_used_expressions_stmt_help f (s : (Expr.Typed.t, int) Stmt.Pattern.t) =
   | TargetPE e | JacobianPE e | Return (Some e) | Decl {initialize= Assign e; _}
     ->
       f e
-  | Assignment (l, _, e) -> Set.union (f e) (used_expressions_lval f l)
+  | Assignment (l, _, e) -> ExprSet.union (f e) (used_expressions_lval f l)
   | While (e, _) | IfElse (e, _, _) -> f e
   | NRFunApp (k, l) ->
-      Expr_set.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
+      ExprSet.union_list (List.map ~f (l @ Fun_kind.collect_exprs k))
   | Profile _ | Block _ | SList _ | Decl _
    |Return None
    |Break | Continue | Skip ->
-      Expr_set.empty
-  | For {lower= e1; upper= e2; _} -> Expr_set.union_list [f e1; f e2]
+      ExprSet.empty
+  | For {lower= e1; upper= e2; _} -> ExprSet.union_list [f e1; f e2]
 
 (** Calculate the set of sub-expressions at the top level in a statement *)
 let top_used_subexpressions_stmt =
@@ -672,21 +657,23 @@ let top_used_expressions_stmt =
 (** Calculate the subset (of p) of expressions that will need to be recomputed
     as a consequence of evaluating the statement s (because of writes to
     variables performed by s) *)
-let killed_expressions_stmt (p : Expr_set.t)
+let killed_expressions_stmt (p : ExprSet.t)
     (s : (Expr.Typed.t, int) Stmt.Pattern.t) =
-  Set.filter p ~f:(fun e ->
+  ExprSet.filter p ~f:(fun e ->
       let free_vars = free_vars_expr e in
       (* Note: a simple test for membership would be more efficient here, but it
          would require us to duplicate some code. *)
       let assigned_vars = assigned_or_declared_vars_stmt s in
-      not (Set.is_empty (Set.inter free_vars assigned_vars)))
+      not (Set.Poly.is_empty (Set.Poly.inter free_vars assigned_vars)))
 
 (** Calculate the set of subexpressions that needs to be computed at each node
     in the flowgraph *)
-let used (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
-  Map.Poly.fold flowgraph_to_mir ~init:Map.Poly.empty
+let used (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
+  LabelMap.fold flowgraph_to_mir ~init:LabelMap.empty
     ~f:(fun ~key ~data accum ->
-      Map.Poly.set accum ~key ~data:(top_used_subexpressions_stmt data.pattern))
+      LabelMap.add accum ~key
+        ~data:
+          (top_used_subexpressions_stmt data.Stmt.Located.Non_recursive.pattern))
 
 (* TODO: figure out whether we will also want to reuse the computation of
    killed *)
@@ -694,25 +681,25 @@ let used (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
 (** The transfer function for an anticipated expressions analysis (as a part of
     lazy code motion) *)
 let anticipated_expressions_transfer
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
-    (used : (int, Expr_set.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t)
+    (used : ExprSet.t LabelMap.t) =
   (module struct
     type labels = int
-    type properties = Expr_set.t
+    type properties = ExprSet.t
 
     let transfer_function l p =
-      let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
-      let gen = Map.Poly.find_exn used l in
+      let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
+      let gen = LabelMap.find l used in
       let kill = killed_expressions_stmt p mir_node in
-      transfer_gen_kill p gen kill
+      ExprSet.union gen (ExprSet.diff p kill)
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr_set.t)
+     and type properties = ExprSet.t)
 
 (** A helper function for defining transfer functions in terms of gen and kill
     sets in an alternative way, that is used in some of the subanalyses of lazy
     code motion *)
-let transfer_gen_kill_alt p gen kill = Set.diff (Set.union p gen) kill
+let transfer_gen_kill_alt p gen kill = ExprSet.diff (ExprSet.union p gen) kill
 
 (* NOTE: we want to implement lazy code motion. Aho describes a slightly more
    general available expression pass for that that uses the anticipated
@@ -721,96 +708,97 @@ let transfer_gen_kill_alt p gen kill = Set.diff (Set.union p gen) kill
 
 (** An available expressions analysis, to be used in lazy code motion *)
 let available_expressions_transfer
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
-    (anticipated_expressions : (int, Expr_set.t entry_exit) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t)
+    (anticipated_expressions : ExprSet.t entry_exit LabelMap.t) =
   (module struct
     type labels = int
-    type properties = Expr_set.t
+    type properties = ExprSet.t
 
     let transfer_function l p =
-      let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
-      let gen = (Map.find_exn anticipated_expressions l).exit in
-      let kill = killed_expressions_stmt (Set.union p gen) mir_node in
+      let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
+      let gen = (LabelMap.find l anticipated_expressions).exit in
+      let kill = killed_expressions_stmt (ExprSet.union p gen) mir_node in
       transfer_gen_kill_alt p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr_set.t)
+     and type properties = ExprSet.t)
 
 (** Calculates the set of expressions that can be calculated for the first time
     at each node in the flow graph *)
-let earliest (anticipated_expressions : (int, Expr_set.t entry_exit) Map.Poly.t)
-    (available_expressions : (int, Expr_set.t entry_exit) Map.Poly.t) =
-  Map.fold anticipated_expressions ~init:Map.Poly.empty
+let earliest (anticipated_expressions : ExprSet.t entry_exit LabelMap.t)
+    (available_expressions : ExprSet.t entry_exit LabelMap.t) =
+  LabelMap.fold anticipated_expressions ~init:LabelMap.empty
     ~f:(fun ~key ~data accum ->
-      Map.set accum ~key
+      LabelMap.add accum ~key
         ~data:
-          (Set.diff data.exit (Map.find_exn available_expressions key).entry))
+          (ExprSet.diff data.exit
+             (LabelMap.find key available_expressions).entry))
 
 (** The transfer function for a postponable expressions analysis (as a part of
     lazy code motion) *)
-let postponable_expressions_transfer (earliest : (int, Expr_set.t) Map.Poly.t)
-    (used : (int, Expr_set.t) Map.Poly.t) =
+let postponable_expressions_transfer (earliest : ExprSet.t LabelMap.t)
+    (used : ExprSet.t LabelMap.t) =
   (module struct
     type labels = int
-    type properties = Expr_set.t
+    type properties = ExprSet.t
 
     let transfer_function l p =
-      let gen = Map.find_exn earliest l in
-      let kill = Map.find_exn used l in
+      let gen = LabelMap.find l earliest in
+      let kill = LabelMap.find l used in
       transfer_gen_kill_alt p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr_set.t)
+     and type properties = ExprSet.t)
 
 (** Calculates the set of expressions that can be computed at the latest at each
     node *)
-let latest (successors : (int, int Set.Poly.t) Map.Poly.t)
-    (earliest : (int, Expr_set.t) Map.Poly.t)
-    (postponable_expressions : (int, Expr_set.t entry_exit) Map.Poly.t)
-    (used : (int, Expr_set.t) Map.Poly.t) =
+let latest (successors : int Set.Poly.t LabelMap.t)
+    (earliest : ExprSet.t LabelMap.t)
+    (postponable_expressions : ExprSet.t entry_exit LabelMap.t)
+    (used : ExprSet.t LabelMap.t) =
   let earliest_or_postponable key =
-    Set.union
-      (Map.Poly.find_exn earliest key)
-      (Map.Poly.find_exn postponable_expressions key).entry in
+    ExprSet.union
+      (LabelMap.find key earliest)
+      (LabelMap.find key postponable_expressions).entry in
   let latest key =
-    Set.filter (earliest_or_postponable key) ~f:(fun e ->
-        Set.mem (Map.Poly.find_exn used key) e
-        || Set.exists (Map.Poly.find_exn successors key) ~f:(fun s ->
-            not (Set.mem (earliest_or_postponable s) e))) in
-  Map.fold successors ~init:Map.Poly.empty ~f:(fun ~key ~data:_ accum ->
-      Map.set accum ~key ~data:(latest key))
+    ExprSet.filter (earliest_or_postponable key) ~f:(fun e ->
+        ExprSet.mem e (LabelMap.find key used)
+        || Set.Poly.exists (LabelMap.find key successors) ~f:(fun s ->
+            not (ExprSet.mem e (earliest_or_postponable s)))) in
+  LabelMap.fold successors ~init:LabelMap.empty ~f:(fun ~key ~data:_ accum ->
+      LabelMap.add accum ~key ~data:(latest key))
 
 (** The transfer function for a used-not-latest expressions analysis, as a part
     of lazy code motion *)
-let used_not_latest_expressions_transfer (used : (int, Expr_set.t) Map.Poly.t)
-    (latest : (int, Expr_set.t) Map.Poly.t) =
+let used_not_latest_expressions_transfer (used : ExprSet.t LabelMap.t)
+    (latest : ExprSet.t LabelMap.t) =
   (module struct
     type labels = int
-    type properties = Expr_set.t
+    type properties = ExprSet.t
 
     let transfer_function l p =
-      let gen = Map.find_exn used l in
-      let kill = Map.find_exn latest l in
+      let gen = LabelMap.find l used in
+      let kill = LabelMap.find l latest in
       transfer_gen_kill_alt p gen kill
   end : TRANSFER_FUNCTION
     with type labels = int
-     and type properties = Expr_set.t)
+     and type properties = ExprSet.t)
 
 (** The transfer function for the first forward analysis part of determining
     optimal ad-levels for variables *)
 let minimal_variables_fwd_transfer
     (gen_variable :
-         (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+         Stmt.Located.Non_recursive.t LabelMap.t
       -> int
       -> string Set.Poly.t
       -> string Set.Poly.t)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   (module struct
     type labels = int
     type properties = string Set.Poly.t
 
     let transfer_function l p =
-      let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
+      let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
       let gen = gen_variable flowgraph_to_mir l p in
       let kill =
         match mir_node with
@@ -831,53 +819,52 @@ let minimal_variables_fwd_transfer
     a safe approximation to the MOP (meet over all paths) solution that we would
     really be interested in, but which is often incomputable. In case of a
     distributive lattice of properties, the MFP and MOP solutions coincide. *)
-let monotone_framework (type l p) (module F : FLOWGRAPH with type labels = l)
+let monotone_framework (type p) (module F : FLOWGRAPH with type labels = int)
     (module L : LATTICE with type properties = p)
-    (module T : TRANSFER_FUNCTION with type labels = l and type properties = p)
-    =
+    (module T : TRANSFER_FUNCTION
+      with type labels = int
+       and type properties = p) =
   (module struct
-    type labels = l
     type properties = p
 
     let mfp () =
       (* STEP 1: initialize data structures *)
       let workstack = Stack.create () in
       (* TODO: does the order matter a lot for efficiency here? *)
-      Map.iteri F.successors ~f:(fun ~key ~data ->
-          Set.iter data ~f:(fun succ -> Stack.push workstack (key, succ)));
-      let analysis_in = Hashtbl.create (module F) in
-      Map.iter_keys
-        ~f:(fun l ->
-          Hashtbl.add_exn analysis_in ~key:l
-            ~data:(if Set.mem F.initials l then L.initial else L.bottom))
+      LabelMap.iter F.successors ~f:(fun ~key ~data ->
+          Set.Poly.iter data ~f:(fun succ -> Stack.push (key, succ) workstack));
+      let analysis_in = Hashtbl.create 32 in
+      LabelMap.iter
+        ~f:(fun ~key:l ~data:_ ->
+          Hashtbl.add analysis_in ~key:l
+            ~data:(if Set.Poly.mem l F.initials then L.initial else L.bottom))
         F.successors;
       (* STEP 2: iterate *)
       while Stack.length workstack <> 0 do
-        let l, l' = Stack.pop_exn workstack in
-        let old_analysis_in_l' = Hashtbl.find_exn analysis_in l' in
+        let l, l' = Stack.pop workstack in
+        let old_analysis_in_l' = Hashtbl.find analysis_in l' in
         let new_analysis_in_l' =
-          T.transfer_function l (Hashtbl.find_exn analysis_in l) in
+          T.transfer_function l (Hashtbl.find analysis_in l) in
         if not (L.leq new_analysis_in_l' old_analysis_in_l') then
           let () =
-            Hashtbl.set analysis_in ~key:l'
+            Hashtbl.add analysis_in ~key:l'
               ~data:(L.lub old_analysis_in_l' new_analysis_in_l') in
-          Set.iter (Map.find_exn F.successors l') ~f:(fun l'' ->
-              Stack.push workstack (l', l''))
+          Set.Poly.iter (LabelMap.find l' F.successors) ~f:(fun l'' ->
+              Stack.push (l', l'') workstack)
       done;
       (* STEP 3: present final results *)
       let analysis_in_out =
-        Map.fold ~init:Map.Poly.empty
+        LabelMap.fold ~init:LabelMap.empty
           ~f:(fun ~key ~data:_ accum ->
-            let analysis_in_data = Hashtbl.find_exn analysis_in key in
-            Map.add_exn accum ~key
+            let analysis_in_data = Hashtbl.find analysis_in key in
+            LabelMap.add accum ~key
               ~data:
                 { entry= analysis_in_data
                 ; exit= T.transfer_function key analysis_in_data })
           F.successors in
       analysis_in_out
   end : MONOTONE_FRAMEWORK
-    with type labels = l
-     and type properties = p)
+    with type properties = p)
 
 let rec declared_variables_stmt
     (s : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t) =
@@ -889,26 +876,26 @@ let rec declared_variables_stmt
    |Break | Continue | Return _ | Skip ->
       Set.Poly.empty
   | IfElse (_, b1, Some b2) ->
-      Set.union
+      Set.Poly.union
         (declared_variables_stmt b1.pattern)
         (declared_variables_stmt b2.pattern)
   | While (_, b) | IfElse (_, b, None) -> declared_variables_stmt b.pattern
   | For {loopvar= s; body= b; _} ->
-      Set.add (declared_variables_stmt b.pattern) s
+      Set.Poly.add s (declared_variables_stmt b.pattern)
   | Profile (_, l) | Block l | SList l ->
       Set.Poly.union_list
-        (List.map ~f:(fun x -> declared_variables_stmt x.pattern) l)
+        (List.map ~f:(fun x -> declared_variables_stmt x.Stmt.pattern) l)
 
 let propagation_mfp (prog : Program.Typed.t)
     (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t)
     (propagation_transfer :
-         (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+         Stmt.Located.Non_recursive.t LabelMap.t
       -> (module TRANSFER_FUNCTION
             with type labels = int
-             and type properties = (string, Expr.Typed.t) Map.Poly.t option)) =
-  let mir = Map.find_exn flowgraph_to_mir 1 in
+             and type properties = Expr.Typed.t String.Map.t option)) =
+  let mir = LabelMap.find 1 flowgraph_to_mir in
   let domain =
     (module struct
       type vals = string
@@ -937,7 +924,7 @@ let propagation_mfp (prog : Program.Typed.t)
 let reaching_definitions_mfp (mir : Program.Typed.t)
     (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   let variables =
     (module struct
       type vals = string
@@ -963,7 +950,7 @@ let reaching_definitions_mfp (mir : Program.Typed.t)
 let initialized_vars_mfp (total : string Set.Poly.t)
     (module Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   let (module Lattice) =
     dual_powerset_lattice_empty_initial
       (module struct
@@ -997,7 +984,7 @@ let globals (prog : Program.Typed.t) =
 let live_variables_mfp (prog : Program.Typed.t)
     (module Rev_Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   let never_kill = globals prog in
   let variables =
     (module struct
@@ -1022,17 +1009,17 @@ let lazy_expressions_mfp
       with type labels = int)
     (module Rev_Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t) =
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) =
   let all_expressions =
     used_subexpressions_stmt
       (stmt_loc_of_stmt_loc_num flowgraph_to_mir
-         (Map.Poly.find_exn flowgraph_to_mir 1))
+         (LabelMap.find 1 flowgraph_to_mir))
         .pattern in
   (* TODO: this could probably be done in a nicer way *)
   let used_expr = used flowgraph_to_mir in
   let (module Lattice1) =
-    dual_powerset_lattice_expressions Expr_set.empty all_expressions in
-  let (module Lattice2) = powerset_lattice_expressions Expr_set.empty in
+    dual_powerset_lattice_expressions ExprSet.empty all_expressions in
+  let (module Lattice2) = powerset_lattice_expressions ExprSet.empty in
   let (module Transfer1) =
     anticipated_expressions_transfer flowgraph_to_mir used_expr in
   let (module Mf1) =
@@ -1080,10 +1067,10 @@ let lazy_expressions_mfp
 let minimal_variables_mfp
     (module Circular_Fwd_Flowgraph : Monotone_framework_sigs.FLOWGRAPH
       with type labels = int)
-    (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
+    (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t)
     (initial_variables : string Set.Poly.t)
     (gen_variable :
-         (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+         Stmt.Located.Non_recursive.t LabelMap.t
       -> int
       -> string Set.Poly.t
       -> string Set.Poly.t) =

--- a/src/analysis_and_optimization/Monotone_framework_sigs.mli
+++ b/src/analysis_and_optimization/Monotone_framework_sigs.mli
@@ -1,7 +1,9 @@
 (** The API for a monotone framework, as described in 2.3-2.4 of Nielson,
     Nielson, and Hankin or 9.3 of Aho et al.. This gives a modular way of
     implementing many static analyses. *)
-open Core
+
+open Std
+open Dataflow_types
 
 (** The API for a flowgraph, needed for the mfp algorithm in the monotone
     framework. Assumed invariants: successors contains all graph nodes as keys
@@ -9,10 +11,8 @@ open Core
 module type FLOWGRAPH = sig
   type labels
 
-  include Base__.Hashtbl_intf.Key.S with type t = labels
-
   val initials : labels Set.Poly.t
-  val successors : (labels, labels Set.Poly.t) Map.Poly.t
+  val successors : labels Set.Poly.t LabelMap.t
 end
 
 (** The minimal data we need to use a type in forming a lattice of various kinds
@@ -82,8 +82,7 @@ type 'a entry_exit = {entry: 'a; exit: 'a}
     graph. The analysis performed is always a forward analysis. For a reverse
     analysis, supply the reverse flow graph.*)
 module type MONOTONE_FRAMEWORK = sig
-  type labels
   type properties
 
-  val mfp : unit -> (labels, properties entry_exit) Map.Poly.t
+  val mfp : unit -> properties entry_exit LabelMap.t
 end

--- a/src/analysis_and_optimization/Optimize.ml
+++ b/src/analysis_and_optimization/Optimize.ml
@@ -1,10 +1,10 @@
 (** Code for optimization passes on the MIR *)
 
-open Core
-open Core.Poly
+open Std
 open Common
 open Middle
 open Mir_utils
+open Dataflow_types
 
 (** Apply the transformation to each function body and to the rest of the
     program as one block. *)
@@ -22,7 +22,7 @@ let transform_program (mir : Program.Typed.t)
   let transformed_prog_body = transform packed_prog_body in
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
-        {fs with fdbody= Option.map ~f:transform fs.fdbody}) in
+        Program.{fs with fdbody= Option.map ~f:transform fs.fdbody}) in
   match transformed_prog_body with
   | { pattern=
         SList
@@ -58,7 +58,8 @@ let transform_program_blockwise (mir : Program.Typed.t)
         [@coverage off] in
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
-        {fs with fdbody= Option.map ~f:(transform (Some fs)) fs.fdbody}) in
+        Program.{fs with fdbody= Option.map ~f:(transform (Some fs)) fs.fdbody})
+  in
   { mir with
     functions_block= transformed_functions
   ; prepare_data= transform' None mir.prepare_data
@@ -80,40 +81,40 @@ let gen_inline_var (name : string) (id_var : string) =
   Gensym.generate ~prefix:("inline_" ^ name ^ "_" ^ id_var ^ "_") ()
 
 let replace_fresh_local_vars (fname : string) stmt =
-  let f (m : (string, string) Core.Map.Poly.t) = function
+  let f (m : string String.Map.t) = function
     | Stmt.Pattern.Decl {decl_adtype; decl_type; decl_id; initialize} ->
         let new_name =
-          match Map.Poly.find m decl_id with
+          match String.Map.find_opt decl_id m with
           | Some existing -> existing
           | None -> gen_inline_var fname decl_id in
         ( Stmt.Pattern.Decl
             {decl_adtype; decl_id= new_name; decl_type; initialize}
-        , Map.Poly.set m ~key:decl_id ~data:new_name )
+        , String.Map.add m ~key:decl_id ~data:new_name )
     | Stmt.Pattern.For {loopvar; lower; upper; body} ->
         let new_name =
-          match Map.Poly.find m loopvar with
+          match String.Map.find_opt loopvar m with
           | Some existing -> existing
           | None -> gen_inline_var fname loopvar in
         ( Stmt.Pattern.For {loopvar= new_name; lower; upper; body}
-        , Map.Poly.set m ~key:loopvar ~data:new_name )
+        , String.Map.add m ~key:loopvar ~data:new_name )
     | Assignment (lhs, type_, e) ->
         let update_name var_name =
-          match Map.Poly.find m var_name with
+          match String.Map.find_opt var_name m with
           | None -> var_name
           | Some var_name' -> var_name' in
         let lhs' = Middle.Stmt.Helpers.map_lhs_variable ~f:update_name lhs in
         (Stmt.Pattern.Assignment (lhs', type_, e), m)
     | x -> (x, m) in
-  let s, m = map_rec_state_stmt_loc f Map.Poly.empty stmt in
+  let s, m = map_rec_state_stmt_loc f String.Map.empty stmt in
   name_subst_stmt m s
 
 let subst_args_stmt args es =
-  let m = Map.Poly.of_alist_exn (List.zip_exn args es) in
+  let m = String.Map.of_list (List.combine args es) in
   subst_stmt m
 
 (** Count the number of returns that happen in a statement *)
 let rec count_returns Stmt.{pattern; _} : int =
-  Stmt.Pattern.fold Fn.const
+  Stmt.Pattern.fold Fun.const
     (fun acc -> function
       | Stmt.{pattern= Return _; _} -> acc + 1
       | stmt -> acc + count_returns stmt)
@@ -275,7 +276,7 @@ let rec inline_function_expression propto adt fim (Expr.{pattern; _} as e) =
           )
       | UserDefined (fname, suffix) -> (
           let suffix, fname' = compute_suffix_and_name propto suffix fname in
-          match Map.find fim fname' with
+          match String.Map.find_opt fname' fim with
           | None ->
               ( d_list
               , s_list
@@ -289,7 +290,7 @@ let rec inline_function_expression propto adt fim (Expr.{pattern; _} as e) =
               let d_list2, s_list2, (e : Expr.Typed.t) =
                 let decl_type =
                   Option.map ~f:Mir_utils.unsafe_unsized_to_sized_type rt
-                  |> Option.value_exn in
+                  |> Option.get in
                 ( [ Stmt.Pattern.Decl
                       { decl_adtype=
                           UnsizedType.fill_adtype_for_type adt
@@ -383,11 +384,12 @@ let rec inline_function_statement propto adt fim Stmt.{pattern; meta} =
             let dl1, sl1, e1 = inline_function_expression propto adt fim e1 in
             let dl2, sl2, e2 = inline_function_expression propto adt fim e2 in
             let lhs' =
-              Option.value_exn
-                (Middle.Stmt.Helpers.lvalue_of_expr_opt e1)
-                ~message:
-                  "Internal error in inline optimization: lhs could not be \
-                   converted round-trip to expression" in
+              match Middle.Stmt.Helpers.lvalue_of_expr_opt e1 with
+              | Some x -> x
+              | None ->
+                  ICE.internal_error
+                    "Internal error in inline optimization: lhs could not be \
+                     converted round-trip to expression" [@coverage off] in
             slist_concat_no_loc
               (dl2 @ dl1 @ sl2 @ sl1)
               (Assignment (lhs', ut, e2))
@@ -405,7 +407,7 @@ let rec inline_function_statement propto adt fim Stmt.{pattern; meta} =
               (match kind with
               | CompilerInternal _ | StanLib _ -> NRFunApp (kind, es)
               | UserDefined (s, _) -> (
-                  match Map.find fim s with
+                  match String.Map.find_opt s fim with
                   | None -> NRFunApp (kind, es)
                   | Some (_, args, b) ->
                       let b = replace_fresh_local_vars s b in
@@ -489,29 +491,28 @@ let create_function_inline_map adt l =
           , List.map ~f:(fun (_, name, _) -> name) fdargs
           , inline_function_statement propto adt accum fdbody ) in
         match Middle.Fun_kind.with_unnormalized_suffix fdname with
-        | None -> (
+        | None ->
             let data = create_data true in
-            match Map.add accum ~key:fdname ~data with
-            | `Ok m -> m
-            | `Duplicate -> accum)
+            if String.Map.mem fdname accum then accum
+            else String.Map.add accum ~key:fdname ~data
         | Some fdname' ->
             let data = create_data false in
             let data' = create_data true in
-            let m = Map.Poly.of_alist_exn [(fdname, data); (fdname', data')] in
-            Map.merge_skewed accum m ~combine:(fun ~key:_ f _ -> f)) in
-  List.fold l ~init:Map.Poly.empty ~f
+            let m = String.Map.of_list [(fdname, data); (fdname', data')] in
+            String.Map.union accum m ~f:(fun _ v1 _ -> Some v1)) in
+  List.fold_left l ~init:String.Map.empty ~f
 
 let function_inlining (mir : Program.Typed.t) =
   (* We add only the functions with a single definition to the inline map.
      Overloaded functions cannot be inlined. *)
   let can_inline =
-    List.fold mir.functions_block ~init:String.Map.empty
+    List.fold_left mir.functions_block ~init:String.Map.empty
       ~f:(fun accum Program.{fdname; _} ->
-        Map.update accum fdname
-          ~f:(Option.value_map ~default:true ~f:(fun _ -> false))) in
+        String.Map.update accum ~key:fdname ~f:(fun o ->
+            Some (Option.value_map o ~default:true ~f:(fun _ -> false)))) in
   let inlineable_functions =
     List.filter mir.functions_block ~f:(fun Program.{fdname; _} ->
-        Map.find_exn can_inline fdname) in
+        String.Map.find fdname can_inline) in
   let dataonly_inline_map =
     create_function_inline_map UnsizedType.DataOnly inlineable_functions in
   let autodiff_inline_map =
@@ -582,7 +583,7 @@ let unroll_static_loops_statement _ =
                             { type_= UInt
                             ; loc= Location_span.empty
                             ; adlevel= DataOnly } })
-                  (List.range ~start:`inclusive ~stop:`inclusive low up) in
+                  (List.range low (up + 1)) in
               let stmts =
                 List.map
                   ~f:(fun i ->
@@ -658,11 +659,10 @@ let list_collapsing (mir : Program.Typed.t) =
 
 let propagation
     (propagation_transfer :
-         (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+         Stmt.Located.Non_recursive.t LabelMap.t
       -> (module Monotone_framework_sigs.TRANSFER_FUNCTION
             with type labels = int
-             and type properties =
-               (string, Middle.Expr.Typed.t) Map.Poly.t option))
+             and type properties = Middle.Expr.Typed.t String.Map.t option))
     (mir : Program.Typed.t) =
   let transform stmt =
     let flowgraph, flowgraph_to_mir =
@@ -675,9 +675,9 @@ let propagation
     let propagate_stmt =
       map_rec_stmt_loc_num flowgraph_to_mir (fun i ->
           subst_stmt_base
-            (Option.value ~default:Map.Poly.empty (Map.find_exn values i).entry))
-    in
-    propagate_stmt (Map.find_exn flowgraph_to_mir 1) in
+            (Option.value ~default:String.Map.empty
+               (LabelMap.find i values).entry)) in
+    propagate_stmt (LabelMap.find 1 flowgraph_to_mir) in
   transform_program mir transform
 
 let constant_propagation ?(preserve_stability = false) =
@@ -744,11 +744,11 @@ let dead_code_elimination (mir : Program.Typed.t) =
       (* NOTE: entry in the reverse flowgraph, so exit in the forward
          flowgraph *)
       let live_variables_s =
-        (Map.find_exn live_variables i).Monotone_framework_sigs.entry in
+        (LabelMap.find i live_variables).Monotone_framework_sigs.entry in
       match stmt with
       | Stmt.Pattern.Assignment (lhs, _, rhs) ->
           if
-            Set.mem live_variables_s (Middle.Stmt.Helpers.lhs_variable lhs)
+            Set.Poly.mem (Middle.Stmt.Helpers.lhs_variable lhs) live_variables_s
             || cannot_remove_expr rhs
             || List.exists
                  ~f:(idx_any cannot_remove_expr)
@@ -760,7 +760,8 @@ let dead_code_elimination (mir : Program.Typed.t) =
             due to side effects. *)
       (* TODO: maybe we should revisit that. *)
       | Decl ({decl_id; initialize= Assign e; _} as decl) ->
-          if Set.mem live_variables_s decl_id || cannot_remove_expr e then stmt
+          if Set.Poly.mem decl_id live_variables_s || cannot_remove_expr e then
+            stmt
           else Decl {decl with initialize= Uninit}
       | Decl _ | TargetPE _ | JacobianPE _
        |NRFunApp (_, _)
@@ -795,17 +796,17 @@ let dead_code_elimination (mir : Program.Typed.t) =
           then Skip
           else For {loopvar; lower; upper; body}
       | Profile (name, l) ->
-          let l' = List.filter ~f:(fun x -> x.pattern <> Skip) l in
+          let l' = List.filter ~f:(fun x -> x.Stmt.pattern <> Skip) l in
           if List.is_empty l' then Skip else Profile (name, l')
       | Block l ->
-          let l' = List.filter ~f:(fun x -> x.pattern <> Skip) l in
+          let l' = List.filter ~f:(fun x -> x.Stmt.pattern <> Skip) l in
           if List.is_empty l' then Skip else Block l'
       | SList l ->
-          let l' = List.filter ~f:(fun x -> x.pattern <> Skip) l in
+          let l' = List.filter ~f:(fun x -> x.Stmt.pattern <> Skip) l in
           SList l' in
     let dead_code_elim_stmt =
       map_rec_stmt_loc_num flowgraph_to_mir dead_code_elim_stmt_base in
-    dead_code_elim_stmt (Map.find_exn flowgraph_to_mir 1) in
+    dead_code_elim_stmt (LabelMap.find 1 flowgraph_to_mir) in
   transform_program mir transform
 
 let partial_evaluation = Partial_evaluator.eval_prog
@@ -819,7 +820,7 @@ let rec find_assignment_idx (name : string) Stmt.{pattern; _} =
       let idx_lst = Stmt.Helpers.lhs_indices lval in
       if
         name = assign_name
-        && (not (Set.mem (expr_var_names_set rhs) assign_name))
+        && (not (Set.Poly.mem assign_name (expr_var_names_set rhs)))
         && not
              (rhs.meta.adlevel = UnsizedType.DataOnly
              && UnsizedType.is_array lhs_ut)
@@ -882,7 +883,7 @@ let transform_mir_blocks (mir : Program.Typed.t)
   let transformed_functions =
     List.map mir.functions_block ~f:(fun fs ->
         let new_body =
-          match fs.fdbody with
+          match fs.Program.fdbody with
           | Some (Stmt.{pattern= SList lst; _} as stmt) ->
               Some {stmt with pattern= SList (transformer lst)}
           | Some (Stmt.{pattern= Block lst; _} as stmt) ->
@@ -959,16 +960,17 @@ let lazy_code_motion ?(preserve_stability = false) (mir : Program.Typed.t) =
         | _ when cannot_duplicate_expr ~preserve_stability e ->
             (* Immovable expressions might have movable subexpressions *)
             Expr.Pattern.fold collect_expressions accum e.pattern
-        | _ -> Map.set accum ~key:e ~data:(Gensym.generate ~prefix:"lcm_" ())
+        | _ ->
+            ExprMap.add accum ~key:e ~data:(Gensym.generate ~prefix:"lcm_" ())
       in
-      Set.fold
+      ExprSet.fold
         (Monotone_framework.used_expressions_stmt s.pattern)
-        ~init:(Map.empty (module Expr.Typed))
-        ~f:collect_expressions in
+        ~init:ExprMap.empty
+        ~f:(Fun.flip collect_expressions) in
     (* TODO: it'd be more efficient to just not accumulate constants in the
        static analysis *)
     let declarations_list =
-      Map.fold expression_map ~init:[] ~f:(fun ~key ~data accum ->
+      ExprMap.fold expression_map ~init:[] ~f:(fun ~key ~data accum ->
           Stmt.
             { pattern=
                 Pattern.Decl
@@ -980,15 +982,15 @@ let lazy_code_motion ?(preserve_stability = false) (mir : Program.Typed.t) =
           :: accum) in
     let lazy_code_motion_base i stmt =
       let latest_and_used_after_i =
-        Set.inter
-          (Map.find_exn latest_expr i)
-          (Map.find_exn used_not_latest_expressions_mfp i).entry in
+        ExprSet.inter
+          (LabelMap.find i latest_expr)
+          (LabelMap.find i used_not_latest_expressions_mfp).entry in
       let to_assign_in_s =
         latest_and_used_after_i
-        |> Set.filter ~f:(fun x -> Map.mem expression_map x)
-        |> Set.to_list
-        |> List.sort ~compare:(fun e e' ->
-            compare_int (expr_depth e) (expr_depth e')) in
+        |> ExprSet.filter ~f:(fun x -> ExprMap.mem x expression_map)
+        |> ExprSet.to_list
+        |> List.sort ~cmp:(fun e e' ->
+            Int.compare (expr_depth e) (expr_depth e')) in
       (* TODO: is this sort doing anything or are they already stored in the
          right order by chance? It appears to not do anything. *)
       let assignments_to_add_to_s =
@@ -997,7 +999,7 @@ let lazy_code_motion ?(preserve_stability = false) (mir : Program.Typed.t) =
             Stmt.
               { pattern=
                   Assignment
-                    ( Stmt.Helpers.lvariable (Map.find_exn expression_map e)
+                    ( Stmt.Helpers.lvariable (ExprMap.find e expression_map)
                     , e.meta.type_
                     , e )
               ; meta= Location_span.empty })
@@ -1007,18 +1009,19 @@ let lazy_code_motion ?(preserve_stability = false) (mir : Program.Typed.t) =
           match stmt with
           | Stmt.Pattern.Assignment ((LVariable x, []), _, e')
            |Decl {decl_id= x; initialize= Assign e'; _}
-            when Map.mem m e'
+            when ExprMap.mem e' m
                  && Expr.Typed.equal {e' with pattern= Var x}
-                      (Map.find_exn m e') ->
-              expr_subst_stmt_base (Map.remove m e') stmt
+                      (ExprMap.find e' m) ->
+              expr_subst_stmt_base (ExprMap.remove e' m) stmt
           | _ -> expr_subst_stmt_base m stmt in
         map_rec_stmt_loc f in
       let expr_map =
-        Map.filter_keys
-          ~f:(fun key ->
-            Set.mem latest_and_used_after_i key
-            || Set.mem (Map.find_exn used_not_latest_expressions_mfp i).exit key)
-          (Map.mapi expression_map ~f:(fun ~key ~data ->
+        ExprMap.filter
+          ~f:(fun key _ ->
+            ExprSet.mem key latest_and_used_after_i
+            || ExprSet.mem key
+                 (LabelMap.find i used_not_latest_expressions_mfp).exit)
+          (ExprMap.mapi expression_map ~f:(fun key data ->
                {key with pattern= Var data})) in
       let f = expr_subst_stmt_except_initial_assign expr_map in
       if List.is_empty assignments_to_add_to_s then
@@ -1034,7 +1037,7 @@ let lazy_code_motion ?(preserve_stability = false) (mir : Program.Typed.t) =
       { pattern=
           SList
             (declarations_list
-            @ [lazy_code_motion_stmt (Map.find_exn flowgraph_to_mir 1)])
+            @ [lazy_code_motion_stmt (LabelMap.find 1 flowgraph_to_mir)])
       ; meta= Location_span.empty } in
   let cleanup =
     let cleanup_base (stmt : (Expr.Typed.t, Stmt.Located.t) Stmt.Pattern.t) :
@@ -1107,14 +1110,14 @@ let block_fixing mir =
     @param stmt the MIR statement to optimize. *)
 let optimize_minimal_variables
     ~(gen_variables :
-          (int, Stmt.Located.Non_recursive.t) Map.Poly.t
+          Stmt.Located.Non_recursive.t LabelMap.t
        -> int
        -> string Set.Poly.t
        -> string Set.Poly.t)
     ~(update_expr : string Set.Poly.t -> Expr.Typed.t -> Expr.Typed.t)
     ~(update_stmt :
           (Expr.Typed.t, (Expr.Typed.Meta.t, 'a) Stmt.t) Stmt.Pattern.t
-       -> string Core.Set.Poly.t
+       -> string Set.Poly.t
        -> (Expr.Typed.t, (Expr.Typed.Meta.t, 'a) Stmt.t) Stmt.Pattern.t)
     ~(extra_variables : string -> string Set.Poly.t)
     ~(initial_variables : string Set.Poly.t) (stmt : Stmt.Located.t) =
@@ -1129,22 +1132,22 @@ let optimize_minimal_variables
       flowgraph_to_mir initial_variables gen_variables in
   let optimize_min_vars_stmt_base i stmt_pattern =
     let variable_set =
-      let exits = (Map.find_exn mfp_variables i).exit in
-      Set.union exits (union_map exits ~f:extra_variables) in
+      let exits = (LabelMap.find i mfp_variables).exit in
+      Set.Poly.union exits (Set.Poly.union_map exits ~f:extra_variables) in
     let stmt_val =
       Stmt.Pattern.map (update_expr variable_set) (fun x -> x) stmt_pattern
     in
     update_stmt stmt_val variable_set in
   map_rec_stmt_loc_num flowgraph_to_mir optimize_min_vars_stmt_base
-    (Map.find_exn flowgraph_to_mir 1)
+    (LabelMap.find 1 flowgraph_to_mir)
 
 (* XXX: This optimization current promotes/demotes entire tuples at once. This
    could be significantly better *)
 let optimize_ad_levels (mir : Program.Typed.t) =
   let gen_ad_variables
-      (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
-      (l : int) (ad_variables : string Set.Poly.t) =
-    let mir_node = (Map.find_exn flowgraph_to_mir l).pattern in
+      (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) (l : int)
+      (ad_variables : string Set.Poly.t) =
+    let mir_node = (LabelMap.find l flowgraph_to_mir).pattern in
     match mir_node with
     | Assignment (lval, _, e)
       when UnsizedType.is_autodifftype
@@ -1161,7 +1164,7 @@ let optimize_ad_levels (mir : Program.Typed.t) =
     match (fundef_opt : Stmt.Located.t Program.fun_def option) with
     | None -> global_initial_ad_variables
     | Some {fdargs; _} ->
-        Set.union global_initial_ad_variables
+        Set.Poly.union global_initial_ad_variables
           (Set.Poly.of_list
              (List.filter_map fdargs ~f:(fun (_, name, ut) ->
                   if UnsizedType.is_autodiffable ut then Some name else None)))
@@ -1170,14 +1173,14 @@ let optimize_ad_levels (mir : Program.Typed.t) =
   let update_stmt stmt_pattern variable_set =
     match stmt_pattern with
     | Stmt.Pattern.Decl ({decl_id; decl_type; _} as decl)
-      when Set.mem variable_set decl_id ->
+      when Set.Poly.mem decl_id variable_set ->
         Stmt.Pattern.Decl
           { decl with
             decl_adtype=
               UnsizedType.fill_adtype_for_type UnsizedType.AutoDiffable
                 (Type.to_unsized decl_type) }
     | Decl ({decl_id; decl_type; _} as decl)
-      when not (Set.mem variable_set decl_id) ->
+      when not (Set.Poly.mem decl_id variable_set) ->
         Decl
           { decl with
             decl_adtype=
@@ -1209,12 +1212,12 @@ let optimize_ad_levels (mir : Program.Typed.t) =
     @param mir: The program's whole MIR. *)
 let optimize_soa (mir : Program.Typed.t) =
   let gen_aos_variables
-      (flowgraph_to_mir : (int, Stmt.Located.Non_recursive.t) Map.Poly.t)
-      (l : int) (aos_variables : string Set.Poly.t) =
-    let mir_node mir_idx = Map.find_exn flowgraph_to_mir mir_idx in
+      (flowgraph_to_mir : Stmt.Located.Non_recursive.t LabelMap.t) (l : int)
+      (aos_variables : string Set.Poly.t) =
+    let mir_node mir_idx = LabelMap.find mir_idx flowgraph_to_mir in
     Memory_patterns.query_demotable_stmt aos_variables (mir_node l) in
   let initial_variables =
-    List.fold ~init:Set.Poly.empty
+    List.fold_left ~init:Set.Poly.empty
       ~f:(Memory_patterns.query_initial_demotable_stmt false)
       mir.reverse_mode_log_prob in
   let mod_exprs aos_exits mod_expr =
@@ -1347,4 +1350,4 @@ let optimization_suite ?(settings = all_optimizations) mir =
   let optimizations =
     List.filter_map maybe_optimizations ~f:(fun (fn, flag) ->
         if flag then Some fn else None) in
-  List.fold optimizations ~init:mir ~f:Fn.( |> )
+  List.fold_left optimizations ~init:mir ~f:( |> )

--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -1,7 +1,6 @@
 (* A partial evaluator for use in static analysis and optimization *)
 
-open Core
-open Core.Poly
+open Std
 open Middle
 
 exception Rejected of Location_span.t * string
@@ -44,7 +43,7 @@ let apply_operator_int (op : string) i1 i2 =
         | "Minus__" -> i1 - i2
         | "Times__" -> i1 * i2
         | "Divide__" | "IntDivide__" -> i1 / i2
-        | "Modulo__" -> i1 % i2
+        | "Modulo__" -> Int.rem i1 i2
         | "Equals__" -> Bool.to_int (i1 = i2)
         | "NEquals__" -> Bool.to_int (i1 <> i2)
         | "Less__" -> Bool.to_int (i1 < i2)
@@ -1052,7 +1051,7 @@ let rec eval_expr ?(preserve_stability = false) (e : Expr.Typed.t) =
           | e1', e2' -> EOr (e1', e2'))
       | TupleProjection
           ({pattern= FunApp (CompilerInternal FnMakeTuple, ts); _}, ix) ->
-          (List.nth_exn ts (ix - 1)).pattern
+          (List.nth ts (ix - 1)).pattern
       | TupleProjection (e, ix) -> TupleProjection (eval_expr e, ix)
       | Indexed (e, l) ->
           (* TODO: do something clever with array and matrix expressions here?
@@ -1069,7 +1068,10 @@ let rec simplify_index_expr pattern =
            single)
           :: outer_tl )
       when List.exists ~f:is_multi_index inner_indices -> (
-        match List.split_while ~f:(Fn.non is_multi_index) inner_indices with
+        let idx =
+          List.find_index ~f:is_multi_index inner_indices
+          |> Option.value ~default:(List.length inner_indices) in
+        match List.split_n inner_indices idx with
         | inner_singles, MultiIndex first_multi :: inner_tl ->
             (* foo [arr1, ..., arrN] [i1, ..., iN] ->
              * foo [arr1[i1]] [arr[i2]] ... [arrN[iN]]
@@ -1145,10 +1147,10 @@ let rec eval_stmt s =
       { s with
         pattern=
           Pattern.map
-            (Fn.compose eval_expr simplify_indices_expr)
+            (Fun.compose eval_expr simplify_indices_expr)
             eval_stmt s.pattern }
   with Rejected (loc, m) ->
     { Stmt.pattern= NRFunApp (CompilerInternal FnReject, [Expr.Helpers.str m])
     ; meta= loc }
 
-let eval_prog p : Program.Typed.t = Program.map try_eval_expr eval_stmt Fn.id p
+let eval_prog p : Program.Typed.t = Program.map try_eval_expr eval_stmt Fun.id p

--- a/src/analysis_and_optimization/Pedantic_analysis.ml
+++ b/src/analysis_and_optimization/Pedantic_analysis.ml
@@ -1,5 +1,4 @@
-open Core
-open Core.Poly
+open Std
 open Optimize
 open Middle
 open Middle.Program
@@ -10,7 +9,7 @@ open Factor_graph
 open Mir_utils
 open Pedantic_dist_warnings
 
-type warning_span = Location_span.t * string [@@deriving compare]
+type warning_span = Location_span.t * string
 
 (********************* Pattern collection functions ********************)
 
@@ -22,11 +21,12 @@ let list_unused_params (factor_graph : factor_graph) (mir : Program.Typed.t) :
   let used_params =
     Set.Poly.map
       ~f:(fun (VVar v) -> v)
-      (Set.Poly.of_list (Map.Poly.keys factor_graph.var_map)) in
-  let unused = Set.diff params used_params in
+      (Set.Poly.of_list
+         (VExprMap.to_list factor_graph.var_map |> List.map ~f:fst)) in
+  let unused = Set.Poly.diff params used_params in
   Set.Poly.filter_map
     ~f:(fun (pname, _, loc) ->
-      if Set.mem unused pname then Some (pname, loc) else None)
+      if Set.Poly.mem pname unused then Some (pname, loc) else None)
     param_info
 
 let list_hard_constrained (mir : Program.Typed.t) :
@@ -51,20 +51,22 @@ let list_multi_tildes (mir : Program.Typed.t) :
     (string * Location_span.t Set.Poly.t) Set.Poly.t =
   (* Collect statements of the form "target += Dist(param, ...)" *)
   let collect_tilde_stmt (stmt : Stmt.Located.t) :
-      (string, Location_span.t Set.Poly.t) Map.Poly.t =
+      Location_span.t Set.Poly.t String.Map.t =
     match stmt.pattern with
     | Stmt.Pattern.TargetPE
         {pattern= Expr.Pattern.FunApp (_, {pattern= Var vname; _} :: _); _} ->
-        Map.Poly.singleton vname (Set.Poly.singleton stmt.meta)
-    | _ -> Map.Poly.empty in
+        String.Map.singleton vname (Set.Poly.singleton stmt.meta)
+    | _ -> String.Map.empty in
   let tildes =
     fold_stmts
-      ~take_stmt:(fun m s -> merge_set_maps m (collect_tilde_stmt s))
-      ~take_expr:Fn.const ~init:Map.Poly.empty mir.log_prob in
+      ~take_stmt:(fun m s ->
+        merge_set_maps (module String.Map) m (collect_tilde_stmt s))
+      ~take_expr:Fun.const ~init:String.Map.empty mir.log_prob in
   (* Filter for parameters assigned more than one distribution *)
-  let multi_tildes = Map.Poly.filter ~f:(fun s -> Set.length s <> 1) tildes in
-  Map.fold ~init:Set.Poly.empty
-    ~f:(fun ~key ~data s -> Set.add s (key, data))
+  let multi_tildes =
+    String.Map.filter ~f:(fun _ s -> Set.Poly.cardinal s <> 1) tildes in
+  String.Map.fold ~init:Set.Poly.empty
+    ~f:(fun ~key ~data s -> Set.Poly.add (key, data) s)
     multi_tildes
 
 (** Collect statements of the form "target += Dist(param, ...)" where param has
@@ -99,7 +101,7 @@ let list_possible_nonlinear (mir : Program.Typed.t) : Location_span.t Set.Poly.t
     | _ -> false
   and is_linear_function allow_var name (args : 'a Expr.t list) =
     match (name, args) with
-    | _, _ when Set.mem linear_fnames name ->
+    | _, _ when String.Set.mem name linear_fnames ->
         List.for_all ~f:(is_linear allow_var) args
     | _, _ when List.for_all ~f:(is_linear false) args ->
         (* A function of all constants is fine *) true
@@ -129,8 +131,8 @@ let list_possible_nonlinear (mir : Program.Typed.t) : Location_span.t Set.Poly.t
     | _ -> Set.Poly.empty in
   let bad_tildes =
     fold_stmts
-      ~take_stmt:(fun m s -> Set.union m (maybe_nonlinear_tilde s))
-      ~take_expr:Fn.const ~init:Set.Poly.empty mir.log_prob in
+      ~take_stmt:(fun m s -> Set.Poly.union m (maybe_nonlinear_tilde s))
+      ~take_expr:Fun.const ~init:Set.Poly.empty mir.log_prob in
   bad_tildes
 
 (* Find all of the targets which are dependencies for a given label *)
@@ -146,31 +148,32 @@ let var_deps info_map label ?expr:(expr_opt : Expr.Typed.t option = None)
         , Set.Poly.map ~f:string_of_vexpr vvars ) in
   (* expressions of dependencies *)
   let dep_exprs =
-    union_map dep_labels ~f:(fun label ->
-        let stmt, _ = Map.Poly.find_exn info_map label in
-        stmt_rhs_var_set stmt) in
+    Set.Poly.union_map dep_labels ~f:(fun label ->
+        let stmt, _ = LabelMap.find label info_map in
+        stmt_rhs_names_set stmt) in
   (* variable dependencies *)
-  let dep_vars = Set.Poly.map ~f:(fun (VVar v, _) -> v) dep_exprs in
+  let dep_vars = Set.Poly.map ~f:(fun (VVar v) -> v) dep_exprs in
   (* target dependencies *)
-  Set.inter targets (Set.union dep_vars expr_vars)
+  Set.Poly.inter targets (Set.Poly.union dep_vars expr_vars)
 
 let list_target_dependant_cf
     (info_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t)
     (targets : string Set.Poly.t) :
     (Location_span.t * string Set.Poly.t) Set.Poly.t =
   (* Find all the control flow nodes *)
   let cf_labels =
     Set.Poly.of_list
-      (Map.Poly.keys
-         (Map.Poly.filter info_map ~f:(fun (stmt, _) -> is_ctrl_flow stmt)))
+      (List.map ~f:fst
+         (LabelMap.to_list
+            (LabelMap.filter info_map ~f:(fun _ (stmt, _) -> is_ctrl_flow stmt))))
   in
   Set.Poly.filter_map
     ~f:(fun label ->
       let deps = var_deps info_map label targets in
-      if Set.is_empty deps then None
+      if Set.Poly.is_empty deps then None
       else
-        let _, info = Map.Poly.find_exn info_map label in
+        let _, info = LabelMap.find label info_map in
         Some (info.meta, deps))
     cf_labels
 
@@ -190,30 +193,31 @@ let list_arg_dependant_fundef_cf (mir : Program.Typed.t)
       (* build dataflow data structure *)
       let info_map = build_dep_info_map mir body in
       let cf_deps = list_target_dependant_cf info_map (Set.Poly.of_list args) in
-      union_map cf_deps ~f:(fun (loc, names) ->
+      Set.Poly.union_map cf_deps ~f:(fun (loc, names) ->
           Set.Poly.map names ~f:(fun name ->
-              let ix, _ =
-                Option.value_exn
-                  ~message:
-                    "INTERNAL ERROR: Pedantic mode found CF dependent on an \
-                     arg, but the arg is mismatched. Please report a bug.\n"
-                  (List.findi args ~f:(fun _ arg -> arg = name)) in
+              let ix =
+                match List.find_index args ~f:(String.equal name) with
+                | Some v -> v
+                | None ->
+                    Common.ICE.internal_error
+                      "Pedantic mode found CF dependent on an arg, but the arg \
+                       is mismatched." [@coverage off] in
               (loc, ix, name))))
 
 let expr_collect_exprs (expr : Expr.Typed.t) ~f : 'a Set.Poly.t =
   let collect_expr s (expr : Expr.Typed.t) =
-    match f expr with Some a -> Set.add s a | _ -> s in
+    match f expr with Some a -> Set.Poly.add a s | _ -> s in
   fold_expr ~init:Set.Poly.empty ~take_expr:collect_expr expr
 
 let stmts_collect_exprs (stmts : Stmt.Located.t List.t) ~f : 'a Set.Poly.t =
   let collect_expr s (expr : Expr.Typed.t) =
-    match f expr with Some a -> Set.add s a | _ -> s in
-  fold_stmts ~init:Set.Poly.empty ~take_stmt:Fn.const ~take_expr:collect_expr
+    match f expr with Some a -> Set.Poly.add a s | _ -> s in
+  fold_stmts ~init:Set.Poly.empty ~take_stmt:Fun.const ~take_expr:collect_expr
     stmts
 
 let list_param_dependant_fundef_cf (mir : Program.Typed.t)
     (info_map :
-      (label, (Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) Map.Poly.t)
+      ((Expr.Typed.t, label) Stmt.Pattern.t * node_dep_info) LabelMap.t)
     (fun_def : 'a Program.fun_def) :
     (Location_span.t * string Set.Poly.t * string * Location_span.t) Set.Poly.t
     =
@@ -221,23 +225,25 @@ let list_param_dependant_fundef_cf (mir : Program.Typed.t)
   let fun_calls : (Expr.Typed.t * label) Set.Poly.t =
     Set.Poly.union_list
       (List.map ~f:snd
-         (Map.Poly.to_alist
-            (Map.Poly.filter_mapi info_map ~f:(fun ~key:label ~data:(stmt, _) ->
+         (LabelMap.to_list
+            (LabelMap.filter_map info_map ~f:(fun label (stmt, _) ->
                  let funapps =
-                   union_map (stmt_rhs stmt) ~f:(fun rhs_expr ->
+                   Set.Poly.union_map (stmt_rhs stmt) ~f:(fun rhs_expr ->
                        expr_collect_exprs rhs_expr ~f:(fun rhs_subexpr ->
                            match rhs_subexpr.pattern with
                            | Expr.Pattern.FunApp (UserDefined (fname, _), _)
                              when fname = fun_def.fdname ->
                                Some (rhs_subexpr, label)
                            | _ -> None)) in
-                 if Set.is_empty funapps then None else Some funapps)))) in
+                 if Set.Poly.is_empty funapps then None else Some funapps))))
+  in
   let arg_exprs (fcall_expr : Expr.Typed.t) =
     match fcall_expr with
     | {pattern= Expr.Pattern.FunApp (UserDefined (fname, _), arg_exprs); _}
       when fname = fun_def.fdname ->
-        Set.Poly.map dep_args ~f:(fun (loc, ix, arg_name) ->
-            (loc, List.nth_exn arg_exprs ix, arg_name))
+        Set.Poly.map
+          ~f:(fun (loc, ix, arg_name) -> (loc, List.nth arg_exprs ix, arg_name))
+          dep_args
     | _ ->
         Common.ICE.internal_error
           "In finding searching for parameter dependent function arguments, \
@@ -245,18 +251,19 @@ let list_param_dependant_fundef_cf (mir : Program.Typed.t)
   let arg_param_deps label arg_expr =
     var_deps info_map ~expr:(Some arg_expr) label (parameter_names_set mir)
   in
-  union_map fun_calls ~f:(fun (fcall_expr, label) ->
-      Set.Poly.filter_map (arg_exprs fcall_expr)
+  Set.Poly.union_map fun_calls ~f:(fun (fcall_expr, label) ->
+      Set.Poly.filter_map
         ~f:(fun (cf_loc, arg_expr, arg_name) ->
           let deps = arg_param_deps label arg_expr in
-          if Set.is_empty deps then None
-          else Some (cf_loc, deps, arg_name, arg_expr.meta.loc)))
+          if Set.Poly.is_empty deps then None
+          else Some (cf_loc, deps, arg_name, arg_expr.meta.loc))
+        (arg_exprs fcall_expr))
 
 let list_param_dependant_fundefs_cf (mir : Program.Typed.t) :
     (string * Location_span.t * string Set.Poly.t * string * Location_span.t)
     Set.Poly.t =
   let info_map = log_prob_build_dep_info_map mir in
-  union_map (Set.Poly.of_list mir.functions_block) ~f:(fun fun_def ->
+  Set.Poly.union_map (Set.Poly.of_list mir.functions_block) ~f:(fun fun_def ->
       let dependant_args = list_param_dependant_fundef_cf mir info_map fun_def in
       Set.Poly.map dependant_args ~f:(fun (cf_loc, deps, arg_name, arg_loc) ->
           (fun_def.fdname, cf_loc, deps, arg_name, arg_loc)))
@@ -268,12 +275,12 @@ let list_non_one_priors (fg : factor_graph) (mir : Program.Typed.t) :
      except through P *)
   let priors = list_priors ~factor_graph:(Some fg) mir in
   let prior_set =
-    Map.Poly.fold priors ~init:Set.Poly.empty
+    VExprMap.fold priors ~init:Set.Poly.empty
       ~f:(fun ~key:(VVar v) ~data:(factors_opt, loc) s ->
         Option.value_map factors_opt ~default:s ~f:(fun factors ->
-            Set.add s (v, Set.length factors, loc))) in
+            Set.Poly.add (v, Set.Poly.cardinal factors, loc) s)) in
   (* Return only multi-prior parameters *)
-  Set.filter prior_set ~f:(fun (_, n, _) -> n <> 1)
+  Set.Poly.filter prior_set ~f:(fun (_, n, _) -> n <> 1)
 
 (* Collect useful information about an expression that's available at
    compile-time into a convenient form. *)
@@ -285,10 +292,14 @@ let compiletime_value_of_expr
   let v =
     match expr with
     | {pattern= Var pname; _} -> (
-        match Set.find params ~f:(fun (name, _, _) -> name = pname) with
+        match
+          Set.Poly.to_seq params |> Seq.find (fun (name, _, _) -> name = pname)
+        with
         | Some (name, trans, _) -> Param (name, trans)
         | None -> (
-            match Set.find data ~f:(fun name -> name = pname) with
+            match
+              Set.Poly.to_seq data |> Seq.find (fun name -> name = pname)
+            with
             | Some name -> Data name
             | None -> Opaque))
     | _ ->
@@ -304,7 +315,7 @@ let list_distributions (mir : Program.Typed.t) : dist_info Set.Poly.t =
     match expr.pattern with
     | Expr.Pattern.FunApp
         (StanLib (fname, (FnLpdf true | FnLpmf true), _), arg_exprs) ->
-        let fname = chop_dist_name fname |> Option.value_exn in
+        let fname = chop_dist_name fname |> Option.get in
         let params = parameter_set mir in
         let data = data_set mir in
         let args =
@@ -329,7 +340,7 @@ let list_unscaled_constants (distributions_list : dist_info Set.Poly.t) :
     | Number (num, num_str), meta when is_unscaled_value num ->
         Set.Poly.singleton (meta.loc, num_str)
     | _ -> Set.Poly.empty in
-  union_map
+  Set.Poly.union_map
     ~f:(fun {args; _} ->
       Set.Poly.union_list (List.map ~f:collect_unscaled_expr args))
     distributions_list
@@ -398,11 +409,12 @@ let multi_tildes_message (vname : string) : string =
 let multi_tildes_warnings (mir : Program.Typed.t) =
   let twds = list_multi_tildes mir in
   Set.Poly.map
-    ~f:(fun (vname, locs) -> (Set.min_elt_exn locs, multi_tildes_message vname))
+    ~f:(fun (vname, locs) ->
+      (Set.Poly.min_elt locs, multi_tildes_message vname))
     twds
 
 let param_dependant_cf_message (plist : string Set.Poly.t) : string =
-  let plistStr = String.concat ~sep:", " (Set.to_list plist) in
+  let plistStr = String.concat ~sep:", " (Set.Poly.to_list plist) in
   Printf.sprintf "A control flow statement depends on parameter(s): %s."
     plistStr
 
@@ -415,7 +427,7 @@ let param_dependant_cf_warnings (mir : Program.Typed.t) =
 let param_dependant_fundef_cf_message (fname : string)
     (plist : string Set.Poly.t) (arg_name : string) (callsite : Location_span.t)
     : string =
-  let plistStr = String.concat ~sep:", " (Set.to_list plist) in
+  let plistStr = String.concat ~sep:", " (Set.Poly.to_list plist) in
   Printf.sprintf
     "A control flow statement inside function %s depends on argument %s. At \
      %s, the value of %s depends on parameter(s): %s."
@@ -462,10 +474,10 @@ let uninitialized_message (vname : string) : string =
 
 let uninitialized_warnings (mir : Program.Typed.t) =
   let uninit_vars =
-    Set.filter
+    Set.Poly.filter
       ~f:(fun (span, _) -> span <> Location_span.empty)
       (Dependence_analysis.mir_uninitialized_variables mir) in
-  let vars = String.Hash_set.create () in
+  let vars = Hash_set.create 32 in
   let deduplicated =
     Set.Poly.filter_map uninit_vars ~f:(fun (loc, var) ->
         if Hash_set.mem vars var then None
@@ -477,7 +489,7 @@ let uninitialized_warnings (mir : Program.Typed.t) =
     deduplicated
 
 let to_list warning_set =
-  Set.to_list warning_set |> List.sort ~compare:compare_warning_span
+  Set.Poly.to_list warning_set |> List.sort ~cmp:Stdlib.compare
 
 (* String-print uninitialized warnings. In case a user wants only this
    warning *)

--- a/src/analysis_and_optimization/Pedantic_dist_warnings.ml
+++ b/src/analysis_and_optimization/Pedantic_dist_warnings.ml
@@ -1,5 +1,4 @@
-open Core
-open Core.Poly
+open Std
 open Middle
 open Mir_utils
 
@@ -154,7 +153,7 @@ let constr_literal_mismatch_message (dist_name : string) (num_str : string)
 let constr_mismatch_warning (constr : var_constraint_named) (arg : arg_info)
     ({args; name; loc} : dist_info) : (Location_span.t * string) option =
   let v =
-    match List.nth args (arg_number arg) with
+    match List.nth_opt args (arg_number arg) with
     | Some v -> v
     | None ->
         Common.ICE.(
@@ -465,6 +464,6 @@ let distribution_warning (dist_info : dist_info) :
 (** Generate the distribution warnings for a program *)
 let distribution_warnings (distributions_list : dist_info Set.Poly.t) :
     (Location_span.t * string) Set.Poly.t =
-  union_map
+  Set.Poly.union_map
     ~f:(fun dist_info -> Set.Poly.of_list (distribution_warning dist_info))
     distributions_list

--- a/src/analysis_and_optimization/dune
+++ b/src/analysis_and_optimization/dune
@@ -1,7 +1,7 @@
 (library
  (name analysis_and_optimization)
  (public_name stanc.analysis)
- (libraries core middle yojson frontend stan_math_signatures)
+ (libraries std middle yojson frontend stan_math_signatures)
  (instrumentation
   (backend bisect_ppx))
  (inline_tests)

--- a/src/middle/Index.ml
+++ b/src/middle/Index.ml
@@ -1,6 +1,6 @@
 (** Types of indexing operations *)
 
-open Core
+open Std
 
 type 'a t =
   | All

--- a/src/stan_math_backend/Transform_Mir.ml
+++ b/src/stan_math_backend/Transform_Mir.ml
@@ -765,7 +765,8 @@ let%expect_test "Flatten slists" =
            (While ((pattern (Var hi)) (meta ()))
             ((pattern (Block (((pattern Break) (meta ()))))) (meta ()))))
           (meta ())))))
-      (meta ()))) |}]
+      (meta ())))
+    |}]
 
 let add_reads vars mkread stmts =
   let vars = List.map ~f:(fun (id, l, outvar) -> (id, (l, outvar))) vars in

--- a/src/std/PolySet.ml
+++ b/src/std/PolySet.ml
@@ -1,0 +1,491 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+
+(**************************************************************************)
+
+[@@@warning "-9"]
+[@@@coverage off]
+
+type 'a t = Empty | Node of {l: 'a t; v: 'a; r: 'a t; h: int}
+
+(* Sets are represented by balanced binary trees (the heights of the children
+   differ by at most 2 *)
+
+let height = function Empty -> 0 | Node {h} -> h
+
+(* Creates a new node with left son l, value v and right son r. We must have all
+   elements of l < v < all elements of r. l and r must be balanced and | height
+   l - height r | <= 2. Inline expansion of height for better speed. *)
+
+let create l v r =
+  let hl = match l with Empty -> 0 | Node {h} -> h in
+  let hr = match r with Empty -> 0 | Node {h} -> h in
+  Node {l; v; r; h= (if hl >= hr then hl + 1 else hr + 1)}
+
+(* Same as create, but performs one step of rebalancing if necessary. Assumes l
+   and r balanced and | height l - height r | <= 3. Inline expansion of create
+   for better speed in the most frequent case where no rebalancing is
+   required. *)
+
+let bal l v r =
+  let hl = match l with Empty -> 0 | Node {h} -> h in
+  let hr = match r with Empty -> 0 | Node {h} -> h in
+  if hl > hr + 2 then
+    begin match l with
+    | Empty -> invalid_arg "Set.bal"
+    | Node {l= ll; v= lv; r= lr} ->
+        if height ll >= height lr then create ll lv (create lr v r)
+        else
+          begin match lr with
+          | Empty -> invalid_arg "Set.bal"
+          | Node {l= lrl; v= lrv; r= lrr} ->
+              create (create ll lv lrl) lrv (create lrr v r)
+          end
+    end
+  else if hr > hl + 2 then
+    begin match r with
+    | Empty -> invalid_arg "Set.bal"
+    | Node {l= rl; v= rv; r= rr} ->
+        if height rr >= height rl then create (create l v rl) rv rr
+        else
+          begin match rl with
+          | Empty -> invalid_arg "Set.bal"
+          | Node {l= rll; v= rlv; r= rlr} ->
+              create (create l v rll) rlv (create rlr rv rr)
+          end
+    end
+  else Node {l; v; r; h= (if hl >= hr then hl + 1 else hr + 1)}
+
+(* Insertion of one element *)
+
+let rec add x = function
+  | Empty -> Node {l= Empty; v= x; r= Empty; h= 1}
+  | Node {l; v; r} as t ->
+      let c = Stdlib.compare x v in
+      if c = 0 then t
+      else if c < 0 then
+        let ll = add x l in
+        if l == ll then t else bal ll v r
+      else
+        let rr = add x r in
+        if r == rr then t else bal l v rr
+
+let singleton x = Node {l= Empty; v= x; r= Empty; h= 1}
+
+(* Beware: those two functions assume that the added v is *strictly* smaller (or
+   bigger) than all the present elements in the tree; it does not test for
+   equality with the current min (or max) element. Indeed, they are only used
+   during the "join" operation which respects this precondition. *)
+
+let rec add_min_element x = function
+  | Empty -> singleton x
+  | Node {l; v; r} -> bal (add_min_element x l) v r
+
+let rec add_max_element x = function
+  | Empty -> singleton x
+  | Node {l; v; r} -> bal l v (add_max_element x r)
+
+(* Same as create and bal, but no assumptions are made on the relative heights
+   of l and r. *)
+
+let rec join l v r =
+  match (l, r) with
+  | Empty, _ -> add_min_element v r
+  | _, Empty -> add_max_element v l
+  | Node {l= ll; v= lv; r= lr; h= lh}, Node {l= rl; v= rv; r= rr; h= rh} ->
+      if lh > rh + 2 then bal ll lv (join lr v r)
+      else if rh > lh + 2 then bal (join l v rl) rv rr
+      else create l v r
+
+(* Smallest and greatest element of a set *)
+
+let rec min_elt = function
+  | Empty -> raise Not_found
+  | Node {l= Empty; v} -> v
+  | Node {l} -> min_elt l
+
+let rec min_elt_opt = function
+  | Empty -> None
+  | Node {l= Empty; v} -> Some v
+  | Node {l} -> min_elt_opt l
+
+let rec max_elt = function
+  | Empty -> raise Not_found
+  | Node {v; r= Empty} -> v
+  | Node {r} -> max_elt r
+
+let rec max_elt_opt = function
+  | Empty -> None
+  | Node {v; r= Empty} -> Some v
+  | Node {r} -> max_elt_opt r
+
+(* Remove the smallest element of the given set *)
+
+let rec remove_min_elt = function
+  | Empty -> invalid_arg "Set.remove_min_elt"
+  | Node {l= Empty; r} -> r
+  | Node {l; v; r} -> bal (remove_min_elt l) v r
+
+(* Merge two trees l and r into one. All elements of l must precede the elements
+   of r. Assume | height l - height r | <= 2. *)
+
+let merge t1 t2 =
+  match (t1, t2) with
+  | Empty, t -> t
+  | t, Empty -> t
+  | _, _ -> bal t1 (min_elt t2) (remove_min_elt t2)
+
+(* Merge two trees l and r into one. All elements of l must precede the elements
+   of r. No assumption on the heights of l and r. *)
+
+let concat t1 t2 =
+  match (t1, t2) with
+  | Empty, t -> t
+  | t, Empty -> t
+  | _, _ -> join t1 (min_elt t2) (remove_min_elt t2)
+
+(* Splitting. split x s returns a triple (l, present, r) where - l is the set of
+   elements of s that are < x - r is the set of elements of s that are > x -
+   present is false if s contains no element equal to x, or true if s contains
+   an element equal to x. *)
+
+let rec split x = function
+  | Empty -> (Empty, false, Empty)
+  | Node {l; v; r} ->
+      let c = Stdlib.compare x v in
+      if c = 0 then (l, true, r)
+      else if c < 0 then
+        let ll, pres, rl = split x l in
+        (ll, pres, join rl v r)
+      else
+        let lr, pres, rr = split x r in
+        (join l v lr, pres, rr)
+
+(* Implementation of the set operations *)
+
+let empty = Empty
+let is_empty = function Empty -> true | _ -> false
+
+let is_singleton = function
+  | Node {l= Empty; r= Empty} -> true
+  | Empty | Node _ -> false
+
+let rec mem x = function
+  | Empty -> false
+  | Node {l; v; r} ->
+      let c = Stdlib.compare x v in
+      c = 0 || mem x (if c < 0 then l else r)
+
+let rec remove x = function
+  | Empty -> Empty
+  | Node {l; v; r} as t ->
+      let c = Stdlib.compare x v in
+      if c = 0 then merge l r
+      else if c < 0 then
+        let ll = remove x l in
+        if l == ll then t else bal ll v r
+      else
+        let rr = remove x r in
+        if r == rr then t else bal l v rr
+
+let rec union s1 s2 =
+  match (s1, s2) with
+  | Empty, t2 -> t2
+  | t1, Empty -> t1
+  | Node {l= l1; v= v1; r= r1; h= h1}, Node {l= l2; v= v2; r= r2; h= h2} ->
+      if h1 >= h2 then
+        if h2 = 1 then add v2 s1
+        else begin
+          let l2, _, r2 = split v1 s2 in
+          join (union l1 l2) v1 (union r1 r2)
+        end
+      else if h1 = 1 then add v1 s2
+      else begin
+        let l1, _, r1 = split v2 s1 in
+        join (union l1 l2) v2 (union r1 r2)
+      end
+
+let rec inter s1 s2 =
+  match (s1, s2) with
+  | Empty, _ -> Empty
+  | _, Empty -> Empty
+  | Node {l= l1; v= v1; r= r1}, t2 -> (
+      match split v1 t2 with
+      | l2, false, r2 -> concat (inter l1 l2) (inter r1 r2)
+      | l2, true, r2 -> join (inter l1 l2) v1 (inter r1 r2))
+
+(* Same as split, but compute the left and right subtrees only if the pivot
+   element is not in the set. The right subtree is computed on demand. *)
+
+type 'a split_bis = Found | NotFound of 'a t * (unit -> 'a t)
+
+let rec split_bis x = function
+  | Empty -> NotFound (Empty, fun () -> Empty)
+  | Node {l; v; r; _} -> (
+      let c = Stdlib.compare x v in
+      if c = 0 then Found
+      else if c < 0 then
+        match split_bis x l with
+        | Found -> Found
+        | NotFound (ll, rl) -> NotFound (ll, fun () -> join (rl ()) v r)
+      else
+        match split_bis x r with
+        | Found -> Found
+        | NotFound (lr, rr) -> NotFound (join l v lr, rr))
+
+let rec disjoint s1 s2 =
+  match (s1, s2) with
+  | Empty, _ | _, Empty -> true
+  | Node {l= l1; v= v1; r= r1}, t2 -> (
+      if s1 == s2 then false
+      else
+        match split_bis v1 t2 with
+        | NotFound (l2, r2) -> disjoint l1 l2 && disjoint r1 (r2 ())
+        | Found -> false)
+
+let rec diff s1 s2 =
+  match (s1, s2) with
+  | Empty, _ -> Empty
+  | t1, Empty -> t1
+  | Node {l= l1; v= v1; r= r1}, t2 -> (
+      match split v1 t2 with
+      | l2, false, r2 -> join (diff l1 l2) v1 (diff r1 r2)
+      | l2, true, r2 -> concat (diff l1 l2) (diff r1 r2))
+
+type 'a enumeration = End | More of 'a * 'a t * 'a enumeration
+
+let rec cons_enum s e =
+  match s with Empty -> e | Node {l; v; r} -> cons_enum l (More (v, r, e))
+
+let rec compare_aux e1 e2 =
+  match (e1, e2) with
+  | End, End -> 0
+  | End, _ -> -1
+  | _, End -> 1
+  | More (v1, r1, e1), More (v2, r2, e2) ->
+      let c = Stdlib.compare v1 v2 in
+      if c <> 0 then c else compare_aux (cons_enum r1 e1) (cons_enum r2 e2)
+
+let compare s1 s2 = compare_aux (cons_enum s1 End) (cons_enum s2 End)
+let equal s1 s2 = compare s1 s2 = 0
+
+let rec subset s1 s2 =
+  match (s1, s2) with
+  | Empty, _ -> true
+  | _, Empty -> false
+  | Node {l= l1; v= v1; r= r1}, (Node {l= l2; v= v2; r= r2} as t2) ->
+      let c = Stdlib.compare v1 v2 in
+      if c = 0 then subset l1 l2 && subset r1 r2
+      else if c < 0 then
+        subset (Node {l= l1; v= v1; r= Empty; h= 0}) l2 && subset r1 t2
+      else subset (Node {l= Empty; v= v1; r= r1; h= 0}) r2 && subset l1 t2
+
+let rec iter ~f = function
+  | Empty -> ()
+  | Node {l; v; r} ->
+      iter ~f l;
+      f v;
+      iter ~f r
+
+let rec fold ~f ~init:accu s =
+  match s with
+  | Empty -> accu
+  | Node {l; v; r} -> fold ~f r ~init:(f v (fold ~f l ~init:accu))
+
+let rec for_all ~f = function
+  | Empty -> true
+  | Node {l; v; r} -> f v && for_all ~f l && for_all ~f r
+
+let rec exists ~f = function
+  | Empty -> false
+  | Node {l; v; r} -> f v || exists ~f l || exists ~f r
+
+let rec filter ~f = function
+  | Empty -> Empty
+  | Node {l; v; r} as t ->
+      (* call [p] in the expected left-to-right order *)
+      let l' = filter ~f l in
+      let pv = f v in
+      let r' = filter ~f r in
+      if pv then if l == l' && r == r' then t else join l' v r'
+      else concat l' r'
+
+let rec partition p = function
+  | Empty -> (Empty, Empty)
+  | Node {l; v; r} ->
+      (* call [p] in the expected left-to-right order *)
+      let lt, lf = partition p l in
+      let pv = p v in
+      let rt, rf = partition p r in
+      if pv then (join lt v rt, concat lf rf) else (concat lt rt, join lf v rf)
+
+let rec cardinal = function
+  | Empty -> 0
+  | Node {l; r} -> cardinal l + 1 + cardinal r
+
+let rec elements_aux accu = function
+  | Empty -> accu
+  | Node {l; v; r} -> elements_aux (v :: elements_aux accu r) l
+
+let elements s = elements_aux [] s
+let choose = min_elt
+let choose_opt = min_elt_opt
+
+let rec find_first_aux v0 f = function
+  | Empty -> v0
+  | Node {l; v; r} ->
+      if f v then find_first_aux v f l else find_first_aux v0 f r
+
+let rec find_first f = function
+  | Empty -> raise Not_found
+  | Node {l; v; r} -> if f v then find_first_aux v f l else find_first f r
+
+let rec find_first_opt_aux v0 f = function
+  | Empty -> Some v0
+  | Node {l; v; r} ->
+      if f v then find_first_opt_aux v f l else find_first_opt_aux v0 f r
+
+let rec find_first_opt f = function
+  | Empty -> None
+  | Node {l; v; r} ->
+      if f v then find_first_opt_aux v f l else find_first_opt f r
+
+let rec find_last_aux v0 f = function
+  | Empty -> v0
+  | Node {l; v; r} -> if f v then find_last_aux v f r else find_last_aux v0 f l
+
+let rec find_last f = function
+  | Empty -> raise Not_found
+  | Node {l; v; r} -> if f v then find_last_aux v f r else find_last f l
+
+let rec find_last_opt_aux v0 f = function
+  | Empty -> Some v0
+  | Node {l; v; r} ->
+      if f v then find_last_opt_aux v f r else find_last_opt_aux v0 f l
+
+let rec find_last_opt f = function
+  | Empty -> None
+  | Node {l; v; r} -> if f v then find_last_opt_aux v f r else find_last_opt f l
+
+let try_join l v r =
+  (* [join l v r] can only be called when (elements of l < v < elements of r);
+     use [try_join l v r] when this property may not hold, but you hope it does
+     hold in the common case *)
+  if
+    (l = Empty || Stdlib.compare (max_elt l) v < 0)
+    && (r = Empty || Stdlib.compare v (min_elt r) < 0)
+  then join l v r
+  else union l (add v r)
+
+let rec map ~f = function
+  | Empty -> Empty
+  | Node {l; v; r} ->
+      (* enforce left-to-right evaluation order *)
+      let l' = map ~f l in
+      let v' = f v in
+      let r' = map ~f r in
+      try_join l' v' r'
+
+let try_concat t1 t2 =
+  match (t1, t2) with
+  | Empty, t -> t
+  | t, Empty -> t
+  | _, _ -> try_join t1 (min_elt t2) (remove_min_elt t2)
+
+let rec filter_map ~f = function
+  | Empty -> Empty
+  | Node {l; v; r} ->
+      (* enforce left-to-right evaluation order *)
+      let l' = filter_map ~f l in
+      let v' = f v in
+      let r' = filter_map ~f r in
+      begin match v' with
+      | Some v' -> try_join l' v' r'
+      | None -> try_concat l' r'
+      end
+
+let of_sorted_list l =
+  let rec sub n l =
+    match (n, l) with
+    | 0, l -> (Empty, l)
+    | 1, x0 :: l -> (Node {l= Empty; v= x0; r= Empty; h= 1}, l)
+    | 2, x0 :: x1 :: l ->
+        ( Node {l= Node {l= Empty; v= x0; r= Empty; h= 1}; v= x1; r= Empty; h= 2}
+        , l )
+    | 3, x0 :: x1 :: x2 :: l ->
+        ( Node
+            { l= Node {l= Empty; v= x0; r= Empty; h= 1}
+            ; v= x1
+            ; r= Node {l= Empty; v= x2; r= Empty; h= 1}
+            ; h= 2 }
+        , l )
+    | n, l -> (
+        let nl = n / 2 in
+        let left, l = sub nl l in
+        match l with
+        | [] -> assert false
+        | mid :: l ->
+            let right, l = sub (n - nl - 1) l in
+            (create left mid right, l)) in
+  fst (sub (List.length l) l)
+
+let to_list = elements
+
+let of_list l =
+  match l with
+  | [] -> empty
+  | [x0] -> singleton x0
+  | [x0; x1] -> add x1 (singleton x0)
+  | [x0; x1; x2] -> add x2 (add x1 (singleton x0))
+  | [x0; x1; x2; x3] -> add x3 (add x2 (add x1 (singleton x0)))
+  | [x0; x1; x2; x3; x4] -> add x4 (add x3 (add x2 (add x1 (singleton x0))))
+  | _ -> of_sorted_list (List.sort_uniq Stdlib.compare l)
+
+let add_seq i m = Seq.fold_left (fun s x -> add x s) m i
+let of_seq i = add_seq i empty
+
+let rec seq_of_enum_ c () =
+  match c with
+  | End -> Seq.Nil
+  | More (x, t, rest) -> Seq.Cons (x, seq_of_enum_ (cons_enum t rest))
+
+let to_seq c = seq_of_enum_ (cons_enum c End)
+
+let rec snoc_enum s e =
+  match s with Empty -> e | Node {l; v; r} -> snoc_enum r (More (v, l, e))
+
+let rec rev_seq_of_enum_ c () =
+  match c with
+  | End -> Seq.Nil
+  | More (x, t, rest) -> Seq.Cons (x, rev_seq_of_enum_ (snoc_enum t rest))
+
+let to_rev_seq c = rev_seq_of_enum_ (snoc_enum c End)
+
+let to_seq_from low s =
+  let rec aux low s c =
+    match s with
+    | Empty -> c
+    | Node {l; r; v; _} ->
+        begin match Stdlib.compare v low with
+        | 0 -> More (v, r, c)
+        | n when n < 0 -> aux low r c
+        | _ -> aux low l (More (v, r, c))
+        end in
+  seq_of_enum_ (aux low s End)
+
+(** Added *)
+
+let union_map ~f o = fold ~f:(fun elt acc -> union (f elt) acc) o ~init:empty
+let union_list os = List.fold_left (fun sup s -> union sup s) empty os
+let sexp_of_t f t = Sexplib0.Sexp_conv.(sexp_of_list f (to_list t))

--- a/src/std/PolySet.mli
+++ b/src/std/PolySet.mli
@@ -1,0 +1,53 @@
+(** Polymorphic sets. This is a copy of Stdlib.Set.Make with [type elt] replaced
+    by a ['a], and [Ord.compare] replaced with [Stdlib.compare ]*)
+
+type 'a t
+
+val empty : 'a t
+val add : 'a -> 'a t -> 'a t
+val singleton : 'a -> 'a t
+val remove : 'a -> 'a t -> 'a t
+val union : 'a t -> 'a t -> 'a t
+val inter : 'a t -> 'a t -> 'a t
+val disjoint : 'a t -> 'a t -> bool
+val diff : 'a t -> 'a t -> 'a t
+val cardinal : 'a t -> int
+val elements : 'a t -> 'a list
+val min_elt : 'a t -> 'a
+val min_elt_opt : 'a t -> 'a option
+val max_elt : 'a t -> 'a
+val max_elt_opt : 'a t -> 'a option
+val choose : 'a t -> 'a
+val choose_opt : 'a t -> 'a option
+val find_first : ('a -> bool) -> 'a t -> 'a
+val find_first_opt : ('a -> bool) -> 'a t -> 'a option
+val find_last : ('a -> bool) -> 'a t -> 'a
+val find_last_opt : ('a -> bool) -> 'a t -> 'a option
+val iter : f:('a -> unit) -> 'a t -> unit
+val fold : f:('a -> 'b -> 'b) -> init:'b -> 'a t -> 'b
+val map : f:('a -> 'b) -> 'a t -> 'b t
+val filter : f:('a -> bool) -> 'a t -> 'a t
+val filter_map : f:('a -> 'b option) -> 'a t -> 'b t
+val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+val split : 'a -> 'a t -> 'a t * bool * 'a t
+val is_empty : 'a t -> bool
+val is_singleton : 'a t -> bool
+val mem : 'a -> 'a t -> bool
+val equal : 'a t -> 'a t -> bool
+val compare : 'a t -> 'a t -> int
+val subset : 'a t -> 'a t -> bool
+val for_all : f:('a -> bool) -> 'a t -> bool
+val exists : f:('a -> bool) -> 'a t -> bool
+val to_list : 'a t -> 'a list
+val of_list : 'a list -> 'a t
+val to_seq_from : 'a -> 'a t -> 'a Seq.t
+val to_seq : 'a t -> 'a Seq.t
+val to_rev_seq : 'a t -> 'a Seq.t
+val add_seq : 'a Seq.t -> 'a t -> 'a t
+val of_seq : 'a Seq.t -> 'a t
+
+(** Added *)
+
+val union_map : f:('a -> 'b t) -> 'a t -> 'b t
+val union_list : 'a t list -> 'a t
+val sexp_of_t : ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t

--- a/src/std/std.ml
+++ b/src/std/std.ml
@@ -51,6 +51,12 @@ module List = struct
       | e :: l -> if cmp e m < 0 then loop e l else loop m l in
     match l with [] -> None | e :: l -> Some (loop e l)
 
+  let max_elt ~cmp l =
+    let rec loop m = function
+      | [] -> m
+      | e :: l -> if cmp e m > 0 then loop e l else loop m l in
+    match l with [] -> None | e :: l -> Some (loop e l)
+
   let split_n l n =
     let tl = ref [] in
     let[@tail_mod_cons] rec aux l n =
@@ -140,6 +146,8 @@ module Set = struct
 
     let union_list = List.fold_left ~f:union ~init:empty
   end
+
+  module Poly = PolySet
 end
 
 module Map = struct
@@ -221,6 +229,8 @@ module Int = struct
 
   let of_string = int_of_string
   let of_string_opt = int_of_string_opt
+
+  module Map = Map.Make (Int)
 end
 
 module Hashtbl = struct
@@ -283,7 +293,11 @@ module Sexp_conv = struct
   let sexp_of_string = sexp_of_string
   let sexp_of_bool = sexp_of_bool
   let sexp_of_unit = sexp_of_unit
-  let print_s = Format.kasprintf print_endline "%a" Sexplib0.Sexp.pp_hum
+
+  let print_s s =
+    output_string stdout (Sexplib0.Sexp.to_string_hum s);
+    output_char stdout '\n';
+    flush stdout
 end
 
 module Compare = struct

--- a/test/integration/good/compiler-optimizations/cpp.expected
+++ b/test/integration/good/compiler-optimizations/cpp.expected
@@ -34886,7 +34886,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             "assigning variable lcm_sym9__");
           double qT = std::numeric_limits<double>::quiet_NaN();
           lcm_sym16__ = stan::math::prod(lcm_sym9__);
-          lcm_sym19__ = static_cast<double>(1);
           stan::model::assign(psi_con, ((lcm_sym14__ * lcm_sym16__) /
             stan::math::fma(lcm_sym14__, lcm_sym16__, (1 - lcm_sym14__))),
             "assigning variable psi_con", stan::model::index_uni(1));
@@ -34897,7 +34896,6 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
                 stan::model::index_uni(1)), base_rng__),
             "assigning variable z", stan::model::index_uni(1));
         } else {
-          lcm_sym19__ = static_cast<double>(1);
           stan::model::assign(psi_con, 1, "assigning variable psi_con",
             stan::model::index_uni(1));
           current_statement__ = 10;
@@ -34929,9 +34927,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
             lcm_sym15__ = stan::math::prod(lcm_sym8__);
             current_statement__ = 20;
             stan::model::assign(psi_con, ((lcm_sym13__ * lcm_sym15__) /
-              stan::math::fma(lcm_sym13__, lcm_sym15__, (lcm_sym19__ -
-                lcm_sym13__))), "assigning variable psi_con",
-              stan::model::index_uni(i));
+              stan::math::fma(lcm_sym13__, lcm_sym15__, (1 - lcm_sym13__))),
+              "assigning variable psi_con", stan::model::index_uni(i));
             current_statement__ = 16;
             stan::model::assign(z,
               stan::math::bernoulli_rng(
@@ -34940,8 +34937,8 @@ class off_dce_model final : public model_base_crtp<off_dce_model> {
               "assigning variable z", stan::model::index_uni(i));
           } else {
             current_statement__ = 19;
-            stan::model::assign(psi_con, lcm_sym19__,
-              "assigning variable psi_con", stan::model::index_uni(i));
+            stan::model::assign(psi_con, 1, "assigning variable psi_con",
+              stan::model::index_uni(i));
             current_statement__ = 10;
             stan::model::assign(z, 1, "assigning variable z",
               stan::model::index_uni(i));

--- a/test/unit/Ast_to_Mir_tests.ml
+++ b/test/unit/Ast_to_Mir_tests.ml
@@ -1,5 +1,5 @@
 open Middle
-open Core
+open Std.Sexp_conv
 
 let%expect_test "Operator-assign example" =
   Test_utils.mir_of_string

--- a/test/unit/Dataflow_utils.ml
+++ b/test/unit/Dataflow_utils.ml
@@ -1,7 +1,7 @@
 open Middle
 open Analysis_and_optimization.Dataflow_utils
-open Core
-open Core.Poly
+open Std
+open Std.Sexp_conv
 open Analysis_and_optimization.Dataflow_types
 
 (***********************************)
@@ -29,11 +29,9 @@ let%expect_test "Loop test" =
   print_s
     [%sexp
       (statement_map
-        : ( label
-          , (Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t )
-          Map.Poly.t)];
+        : ((Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t) LabelMap.t)];
   print_s [%sexp (exits : label Set.Poly.t)];
-  print_s [%sexp (preds : (label, label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (preds : label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((1
@@ -173,8 +171,8 @@ let example1_statement_map =
 let%expect_test "Statement label map example" =
   print_s
     [%sexp
-      (Map.Poly.map example1_statement_map ~f:fst
-        : (label, (Expr.Typed.t, label) Stmt.Pattern.t) Map.Poly.t)];
+      (LabelMap.map example1_statement_map ~f:fst
+        : (Expr.Typed.t, label) Stmt.Pattern.t LabelMap.t)];
   [%expect
     {|
       ((1 (Block (2))) (2 (Block (3 4 5)))
@@ -277,8 +275,7 @@ let%expect_test "Statement label map example" =
 let%expect_test "Predecessor graph example" =
   let exits, preds = build_predecessor_graph example1_statement_map in
   print_s
-    [%sexp
-      ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
+    [%sexp ((exits, preds) : label Set.Poly.t * label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((1)
@@ -290,7 +287,7 @@ let%expect_test "Predecessor graph example" =
 
 let%expect_test "Controlflow graph example" =
   let cf = build_cf_graph example1_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (cf : label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 ()) (6 (5)) (7 (5)) (8 (5)) (9 (5 13))
@@ -333,9 +330,7 @@ let%expect_test "Statement label map example 3" =
   print_s
     [%sexp
       (example3_statement_map
-        : ( label
-          , (Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t )
-          Map.Poly.t)];
+        : ((Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t) LabelMap.t)];
   [%expect
     {|
       ((1
@@ -379,7 +374,7 @@ let%expect_test "Statement label map example 3" =
 
 let%expect_test "Controlflow graph example 3" =
   let cf = build_cf_graph example3_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (cf : label Set.Poly.t LabelMap.t)];
   [%expect {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 (4)) (6 ()))
     |}]
@@ -391,8 +386,7 @@ let%expect_test "Predecessor graph example 3" =
    *)
   let exits, preds = build_predecessor_graph example3_statement_map in
   print_s
-    [%sexp
-      ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
+    [%sexp ((exits, preds) : label Set.Poly.t * label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((2) ((1 ()) (2 (3)) (3 (6)) (4 (1 5)) (5 (4)) (6 (4))))
@@ -427,9 +421,7 @@ let%expect_test "Statement label map example 4" =
   print_s
     [%sexp
       (example4_statement_map
-        : ( label
-          , (Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t )
-          Map.Poly.t)];
+        : ((Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t) LabelMap.t)];
   [%expect
     {|
       ((1
@@ -478,7 +470,7 @@ let%expect_test "Statement label map example 4" =
 
 let%expect_test "Controlflow graph example 4" =
   let cf = build_cf_graph example4_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (cf : label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 (4)) (6 (4)) (7 (4 6)))
@@ -492,8 +484,7 @@ let%expect_test "Predecessor graph example 4" =
    * ( (7) ( (1 ()) (2 (1)) (3 (2)) (4 (3 6 7)) (5 (4)) (6 (5)) (7 (6)) ) )
    *)
   print_s
-    [%sexp
-      ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
+    [%sexp ((exits, preds) : label Set.Poly.t * label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((2) ((1 ()) (2 (3)) (3 (4)) (4 (1 5 6)) (5 (7)) (6 (4)) (7 (6))))
@@ -529,9 +520,7 @@ let%expect_test "Statement label map example 5" =
   print_s
     [%sexp
       (example5_statement_map
-        : ( label
-          , (Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t )
-          Map.Poly.t)];
+        : ((Expr.Typed.t, label) Stmt.Pattern.t * Location_span.t) LabelMap.t)];
   [%expect
     {|
       ((1
@@ -585,7 +574,7 @@ let%expect_test "Statement label map example 5" =
 
 let%expect_test "Controlflow graph example 5" =
   let cf = build_cf_graph example5_statement_map in
-  print_s [%sexp (cf : (label, label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (cf : label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 (6)) (5 (4)) (6 (4)) (7 (4)) (8 ()))
@@ -597,8 +586,7 @@ let%expect_test "Predecessor graph example 5" =
      (2 (1)) (3 (2)) (4 (3)) (5 (4)) (6 (5)) (7 ()) (8 (6)) but maybe that's too
      much to ask for ) *)
   print_s
-    [%sexp
-      ((exits, preds) : label Set.Poly.t * (label, label Set.Poly.t) Map.Poly.t)];
+    [%sexp ((exits, preds) : label Set.Poly.t * label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((2) ((1 ()) (2 (3)) (3 (8)) (4 (1 5)) (5 (7)) (6 (4)) (7 (6)) (8 (4 6))))

--- a/test/unit/Debug_data_generation_tests.ml
+++ b/test/unit/Debug_data_generation_tests.ml
@@ -1,12 +1,12 @@
 open Analysis_and_optimization
-open Core
+open Std
 open Frontend
 open Debug_data_generation
 
 let print_data_prog ast =
-  Stdlib.Random.set_state (Stdlib.Random.State.make [| 111; 222; 333 |]);
+  Random.set_state (Random.State.make [| 111; 222; 333 |]);
   gen_values_json (Ast_to_Mir.gather_declarations ast.Ast.datablock)
-  |> Result.ok |> Option.value_exn
+  |> Result.get_ok
 
 let%expect_test "whole program data generation check" =
   let ast =

--- a/test/unit/Dependence_analysis.ml
+++ b/test/unit/Dependence_analysis.ml
@@ -1,4 +1,5 @@
-open Core
+open Std
+open Std.Sexp_conv
 open Analysis_and_optimization.Dependence_analysis
 open Middle
 open Analysis_and_optimization.Dataflow_types
@@ -40,7 +41,7 @@ let example1_program =
 
 let%expect_test "Dependency graph example" =
   let deps = log_prob_dependency_graph example1_program in
-  print_s [%sexp (deps : (label, label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (deps : label Set.Poly.t LabelMap.t)];
   [%expect
     {|
       ((1 ()) (2 ()) (3 ()) (4 ()) (5 (4)) (6 (4 5)) (7 (4 5)) (8 (4 5))
@@ -53,12 +54,11 @@ let%expect_test "Dependency graph example" =
 
 let%expect_test "Reaching defns example" =
   let deps =
-    Map.Poly.map (log_prob_build_dep_info_map example1_program)
+    LabelMap.map (log_prob_build_dep_info_map example1_program)
       ~f:(fun (_, x) ->
         ( reaching_defn_lookup x.reaching_defn_entry (VVar "j")
         , reaching_defn_lookup x.reaching_defn_exit (VVar "j") )) in
-  print_s
-    [%sexp (deps : (label, label Set.Poly.t * label Set.Poly.t) Map.Poly.t)];
+  print_s [%sexp (deps : (label Set.Poly.t * label Set.Poly.t) LabelMap.t)];
   [%expect
     {|
       ((1 (() ())) (2 ((9) (9))) (3 (() ())) (4 (() ())) (5 (() ())) (6 (() ()))
@@ -70,14 +70,11 @@ let%expect_test "Reaching defns example" =
 
 let%expect_test "Reaching defns example" =
   let deps =
-    Map.Poly.map (log_prob_build_dep_info_map example1_program)
+    LabelMap.map (log_prob_build_dep_info_map example1_program)
       ~f:(fun (_, x) -> (x.reaching_defn_entry, x.reaching_defn_exit)) in
   print_s
     [%sexp
-      (deps
-        : ( label
-          , reaching_defn Set.Poly.t * reaching_defn Set.Poly.t )
-          Map.Poly.t)];
+      (deps : (reaching_defn Set.Poly.t * reaching_defn Set.Poly.t) LabelMap.t)];
   [%expect
     {|
       ((1 (() ())) (2 ((((VVar i) 4) ((VVar j) 9)) (((VVar i) 4) ((VVar j) 9))))

--- a/test/unit/Desugar_test.ml
+++ b/test/unit/Desugar_test.ml
@@ -1,4 +1,3 @@
-open Core
 open Analysis_and_optimization
 
 let print_tdata Middle.Program.{prepare_data; _} =

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -1,10 +1,10 @@
-open Core
+open Std
 open Common
 
 let%expect_test "with_exn_message" =
   Printexc.record_backtrace false;
   ICE.with_exn_message (fun () -> ICE.internal_error "oops!")
-  |> Result.error |> Option.value_exn |> print_endline;
+  |> Result.get_error |> print_endline;
   Printexc.record_backtrace true;
   [%expect
     {|
@@ -19,10 +19,8 @@ let%expect_test "with_exn_message" =
 (* expect_tests warn against directly including a backtrace for fragility
    reasons *)
 let%expect_test "backtrace indirect test" =
-  ( ICE.with_exn_message (fun () -> assert false)
-  |> Result.error |> Option.value_exn
-  |> fun s ->
-    if String.is_substring ~substring:"Called from Common" s then
+  ( ICE.with_exn_message (fun () -> assert false) |> Result.get_error |> fun s ->
+    if String.includes ~affix:"Called from Common" s then
       print_endline "Backtrace found in message"
     else print_endline "FAILED TO FIND BACKTRACE" );
   [%expect {| Backtrace found in message |}]
@@ -33,7 +31,7 @@ let%expect_test "ICE triggered" =
       Middle.(
         Expr.Helpers.infer_type_of_indexed UnsizedType.UReal
           [Index.Single Expr.Helpers.loop_bottom]))
-  |> Result.error |> Option.value_exn |> print_endline;
+  |> Result.get_error |> print_endline;
   Printexc.record_backtrace true;
   [%expect
     {|

--- a/test/unit/Factor_graph.ml
+++ b/test/unit/Factor_graph.ml
@@ -1,5 +1,6 @@
 open Analysis_and_optimization.Factor_graph
-open Core
+open Std
+open Std.Sexp_conv
 open Analysis_and_optimization.Dataflow_types
 
 let reject_example =
@@ -386,9 +387,8 @@ let%expect_test "Priors complex example" =
   print_s
     [%sexp
       (priors
-        : ( vexpr
-          , (factor * label) Set.Poly.t option * Middle.Location_span.t )
-          Map.Poly.t)];
+        : ((factor * label) Set.Poly.t option * Middle.Location_span.t)
+          VExprMap.t)];
   [%expect
     {|
 (((VVar a)

--- a/test/unit/In_memory_include_tests.ml
+++ b/test/unit/In_memory_include_tests.ml
@@ -1,4 +1,5 @@
-open Core
+open Std
+open Std.Sexp_conv
 open Frontend
 
 let print_ast_or_error code =
@@ -17,7 +18,7 @@ data {
 
 (* TESTS *)
 let%expect_test "no includes" =
-  Include_files.include_provider := InMemory Std.String.Map.empty;
+  Include_files.include_provider := InMemory String.Map.empty;
   print_ast_or_error include_model;
   [%expect
     {|
@@ -36,7 +37,7 @@ let%expect_test "no includes" =
 
 let%expect_test "wrong include" =
   Include_files.include_provider :=
-    InMemory (Std.String.Map.of_list [("bar.stan", "functions { }")]);
+    InMemory (String.Map.of_list [("bar.stan", "functions { }")]);
   print_ast_or_error include_model;
   [%expect
     {|
@@ -65,8 +66,7 @@ let b = {|
 
 let%expect_test "recursive include" =
   Include_files.include_provider :=
-    InMemory
-      (Std.String.Map.of_list [("include/a.stan", a); ("include/b.stan", b)]);
+    InMemory (String.Map.of_list [("include/a.stan", a); ("include/b.stan", b)]);
   print_ast_or_error a;
   [%expect
     {|
@@ -93,7 +93,7 @@ functions {
 
 let%expect_test "good include" =
   Include_files.include_provider :=
-    InMemory (Std.String.Map.of_list [("foo.stan", foo)]);
+    InMemory (String.Map.of_list [("foo.stan", foo)]);
   print_ast_or_error include_model;
   [%expect
     {|

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -1,8 +1,10 @@
-open Core
+open Std
+open Std.Sexp_conv
 open Analysis_and_optimization.Optimize
 open Middle
 open Common
 open Analysis_and_optimization.Mir_utils
+open Analysis_and_optimization.Dataflow_types
 
 let reset_and_mir_of_string s =
   Gensym.reset_danger_use_cautiously ();
@@ -27,7 +29,7 @@ let%expect_test "map_rec_stmt_loc" =
     | Stmt.Pattern.NRFunApp (CompilerInternal FnPrint, [s]) ->
         Stmt.Pattern.NRFunApp (CompilerInternal FnPrint, [s; s])
     | x -> x in
-  let mir = Program.map Fn.id (map_rec_stmt_loc f) Fn.id mir in
+  let mir = Program.map Fun.id (map_rec_stmt_loc f) Fun.id mir in
   Fmt.str "@[<v>%a@]" Program.Typed.pp mir |> print_endline;
   [%expect
     {|
@@ -3560,7 +3562,7 @@ let%expect_test "Mapping acts recursively" =
     Stmt.Pattern.NRFunApp
       ( CompilerInternal (FnWriteParam {var= from; unconstrain_opt= None})
       , [from] ) in
-  let m = Map.of_alist_exn (module Expr.Typed) [(from, into)] in
+  let m = ExprMap.of_list [(from, into)] in
   let s' = expr_subst_stmt_base m s in
   Fmt.str "@[<v>%a@]" Stmt.Located.pp (unpattern s') |> print_endline;
   [%expect {| (FnWriteParam(unconstrain_opt())(var y))__(y); |}]

--- a/test/unit/Semantic_check_tests.ml
+++ b/test/unit/Semantic_check_tests.ml
@@ -1,4 +1,3 @@
-open Core
 open Frontend
 open Test_utils
 

--- a/test/unit/Test_utils.ml
+++ b/test/unit/Test_utils.ml
@@ -1,5 +1,6 @@
 open Frontend
-open Core
+open Std
+open Result.Syntax
 
 let untyped_ast_of_string s =
   let res, warnings = Parse.parse_program (`Code s) in
@@ -10,11 +11,10 @@ let error_to_string ~code =
   Fmt.str "%a" (Errors.pp ?printed_filename:None ?code:(Some code))
 
 let typed_ast_of_string_exn code =
-  Result.(
-    untyped_ast_of_string code >>= fun ast ->
+  let ast =
+    let* ast = untyped_ast_of_string code in
     Typechecker.check_program ~allow_undefined_functions:true ast
-    |> map_error ~f:(fun e -> Errors.Semantic_error e))
-  |> Result.map_error ~f:(error_to_string ~code)
-  |> Result.ok_or_failwith |> fst
+    |> Result.map_error ~f:(fun e -> Errors.Semantic_error e) in
+  ast |> Result.map_error ~f:(error_to_string ~code) |> Result.get_ok' |> fst
 
 let mir_of_string s = typed_ast_of_string_exn s |> Ast_to_Mir.trans_prog ""

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,7 +1,7 @@
 (library
  (name unit_tests)
  (libraries
-  core
+  std
   fmt
   frontend
   stan_math_backend


### PR DESCRIPTION
The most notable change here is the addition of our own vendored polymorphic set. This is based on OCaml's set implementation, but with polymorphic comparison swapped in. Remarkably, I've found that it is dramatically faster than Base.Set.Poly in our uses, presumably because `Base.Set.Poly` is storing the comparison function in the runtime representation still, even though it never changes

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>