### PR TITLE
Record backtraces by default in ICE.with_exn_message

### DIFF
--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -1,8 +1,16 @@
+open Std
+
 let internal_error s = failwith s
 let internal_errorf s a = failwith (Format.lasprintf s a)
 let ( $ ) pp x ppf = pp ppf x
 
-let with_exn_message ?(backtraces = true) f =
+(** Unless specifically disabled by the user, default to using backtraces *)
+let backtrace_default () =
+  match Sys.getenv_opt "OCAMLRUNPARAM" with
+  | None -> true
+  | Some v -> not (List.mem "b=0" ~set:(String.split_on_char ~sep:',' v))
+
+let with_exn_message ?(backtraces = backtrace_default ()) f =
   Printexc.record_backtrace backtraces;
   try Ok (f ())
   with e ->

--- a/src/common/ICE.ml
+++ b/src/common/ICE.ml
@@ -2,7 +2,8 @@ let internal_error s = failwith s
 let internal_errorf s a = failwith (Format.lasprintf s a)
 let ( $ ) pp x ppf = pp ppf x
 
-let with_exn_message f =
+let with_exn_message ?(backtraces = true) f =
+  Printexc.record_backtrace backtraces;
   try Ok (f ())
   with e ->
     let bt =

--- a/src/common/ICE.mli
+++ b/src/common/ICE.mli
@@ -19,7 +19,7 @@ val ( $ ) : 'a Fmt.t -> 'a -> Format.formatter -> unit
     {{:https://github.com/ocaml/ocaml/pull/13372#issuecomment-2325194034}PR}
     which introduced the [Format.Args.t] type *)
 
-val with_exn_message : (unit -> 'a) -> ('a, string) result
+val with_exn_message : ?backtraces:bool -> (unit -> 'a) -> ('a, string) result
 (** Catch all exceptions at the top-level and convert them into a
     ['a, string result] where the string contains the exception and a backtrace
     if present, followed by a link to our bugtracker. *)

--- a/test/unit/Error_tests.ml
+++ b/test/unit/Error_tests.ml
@@ -2,10 +2,8 @@ open Std
 open Common
 
 let%expect_test "with_exn_message" =
-  Printexc.record_backtrace false;
-  ICE.with_exn_message (fun () -> ICE.internal_error "oops!")
+  ICE.with_exn_message ~backtraces:false (fun () -> ICE.internal_error "oops!")
   |> Result.get_error |> print_endline;
-  Printexc.record_backtrace true;
   [%expect
     {|
     Internal compiler error:
@@ -19,20 +17,18 @@ let%expect_test "with_exn_message" =
 (* expect_tests warn against directly including a backtrace for fragility
    reasons *)
 let%expect_test "backtrace indirect test" =
-  ( ICE.with_exn_message (fun () -> assert false) |> Result.get_error |> fun s ->
-    if String.includes ~affix:"Called from Common" s then
-      print_endline "Backtrace found in message"
-    else print_endline "FAILED TO FIND BACKTRACE" );
+  ICE.with_exn_message (fun () -> assert false) |> Result.get_error |> fun s ->
+  if String.includes ~affix:"Called from Common" s then
+    print_endline "Backtrace found in message"
+  else print_endline "FAILED TO FIND BACKTRACE";
   [%expect {| Backtrace found in message |}]
 
 let%expect_test "ICE triggered" =
-  Printexc.record_backtrace false;
-  ICE.with_exn_message (fun () ->
+  ICE.with_exn_message ~backtraces:false (fun () ->
       Middle.(
         Expr.Helpers.infer_type_of_indexed UnsizedType.UReal
           [Index.Single Expr.Helpers.loop_bottom]))
   |> Result.get_error |> print_endline;
-  Printexc.record_backtrace true;
   [%expect
     {|
     Internal compiler error:


### PR DESCRIPTION
Cleans up some tests and makes this behavior explicit. Previously, Base was changing the default for us.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes


## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
