### PR TITLE
Fix infer_type_of_indexed handling of MultiIndex

### DIFF
--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -207,26 +207,34 @@ module Helpers = struct
     match (ut, indices) with
     | _, [] -> ut
     | _, [Index.All] | _, [Upfrom _] | _, [Between _] | _, [MultiIndex _] -> ut
-    | UnsizedType.UMatrix, [All; Single _]
-     |UMatrix, [Upfrom _; Single _]
-     |UMatrix, [Between _; Single _]
-     |UMatrix, [MultiIndex _; Single _]
-     |UMatrix, [Single _] ->
+    | ( (UnsizedType.UMatrix | UComplexMatrix)
+      , [ (All | Upfrom _ | Between _ | MultiIndex _)
+        ; (All | Upfrom _ | Between _ | MultiIndex _) ] ) ->
+        ut
+    | UMatrix, [Single _; (All | Upfrom _ | Between _ | MultiIndex _)] ->
+        URowVector
+    | UComplexMatrix, [Single _; (All | Upfrom _ | Between _ | MultiIndex _)] ->
+        UComplexRowVector
+    | ( UMatrix
+      , ([(All | Upfrom _ | Between _ | MultiIndex _); Single _] | [Single _]) )
+      ->
         UVector
-    | UComplexMatrix, [All; Single _]
-     |UComplexMatrix, [Upfrom _; Single _]
-     |UComplexMatrix, [Between _; Single _]
-     |UComplexMatrix, [MultiIndex _; Single _]
-     |UComplexMatrix, [Single _] ->
+    | ( UComplexMatrix
+      , ([(All | Upfrom _ | Between _ | MultiIndex _); Single _] | [Single _]) )
+      ->
         UComplexVector
     | UArray t, Single _ :: tl -> infer_type_of_indexed t tl
-    | UArray t, _ :: tl -> UArray (infer_type_of_indexed t tl)
-    | UMatrix, [Single _; Single _] | UVector, [_] | URowVector, [_] -> UReal
+    | UArray t, (All | Upfrom _ | Between _ | MultiIndex _) :: tl ->
+        UArray (infer_type_of_indexed t tl)
+    | UMatrix, [Single _; Single _] | (UVector | URowVector), [Single _] ->
+        UReal
     | UComplexMatrix, [Single _; Single _]
-     |UComplexVector, [_]
-     |UComplexRowVector, [_] ->
+     |(UComplexVector | UComplexRowVector), [Single _] ->
         UComplex
-    | _ ->
+    | ( (UInt | UReal | UComplex | UTuple _ | UFun _ | UMathLibraryFunction)
+      , _ :: _ )
+     |(UVector | URowVector | UComplexVector | UComplexRowVector), _ :: _ :: _
+     |(UMatrix | UComplexMatrix), _ :: _ :: _ :: _ ->
         ICE.(internal_errorf "Can't index %t" [UnsizedType.pp $ ut])
         [@coverage off]
 
@@ -283,13 +291,16 @@ module Helpers = struct
     ; (UMatrix, [MultiIndex (variable "idx")])
     ; (UMatrix, [MultiIndex (variable "idx"); Single loop_bottom])
     ; (UArray UVector, [MultiIndex (variable "idx")])
-    ; (UArray UVector, [Single loop_bottom; MultiIndex (variable "idx")]) ]
+    ; (UArray UVector, [Single loop_bottom; MultiIndex (variable "idx")])
+    ; (UMatrix, [Single loop_bottom; Between (loop_bottom, loop_bottom)])
+    ; ( UMatrix
+      , [Between (loop_bottom, loop_bottom); MultiIndex (variable "idx")] ) ]
     |> List.map ~f:(fun (ut, idx) -> infer_type_of_indexed ut idx)
     |> Fmt.(str "@[<hov>%a@]" (list ~sep:comma UnsizedType.pp))
     |> print_endline;
     [%expect
       {|
       vector, array[] matrix, matrix, array[] vector, real, array[] real, vector,
-      row_vector, matrix, vector, array[] vector, vector
+      row_vector, matrix, vector, array[] vector, vector, row_vector, matrix
       |}]
 end

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -206,17 +206,17 @@ module Helpers = struct
   let rec infer_type_of_indexed ut indices =
     match (ut, indices) with
     | _, [] -> ut
-    | _, [Index.All] | _, [Upfrom _] | _, [Between _] -> ut
+    | _, [Index.All] | _, [Upfrom _] | _, [Between _] | _, [MultiIndex _] -> ut
     | UnsizedType.UMatrix, [All; Single _]
      |UMatrix, [Upfrom _; Single _]
      |UMatrix, [Between _; Single _]
-     |UMatrix, [MultiIndex _]
+     |UMatrix, [MultiIndex _; Single _]
      |UMatrix, [Single _] ->
         UVector
     | UComplexMatrix, [All; Single _]
      |UComplexMatrix, [Upfrom _; Single _]
      |UComplexMatrix, [Between _; Single _]
-     |UComplexMatrix, [MultiIndex _]
+     |UComplexMatrix, [MultiIndex _; Single _]
      |UComplexMatrix, [Single _] ->
         UComplexVector
     | UArray t, Single _ :: tl -> infer_type_of_indexed t tl
@@ -277,11 +277,19 @@ module Helpers = struct
     ; ( UArray UMatrix
       , [Single loop_bottom; Single loop_bottom; Single loop_bottom] )
     ; ( UArray UMatrix
-      , [Upfrom loop_bottom; Single loop_bottom; Single loop_bottom] ) ]
+      , [Upfrom loop_bottom; Single loop_bottom; Single loop_bottom] )
+    ; (UVector, [MultiIndex (variable "idx")])
+    ; (URowVector, [MultiIndex (variable "idx")])
+    ; (UMatrix, [MultiIndex (variable "idx")])
+    ; (UMatrix, [MultiIndex (variable "idx"); Single loop_bottom])
+    ; (UArray UVector, [MultiIndex (variable "idx")])
+    ; (UArray UVector, [Single loop_bottom; MultiIndex (variable "idx")]) ]
     |> List.map ~f:(fun (ut, idx) -> infer_type_of_indexed ut idx)
     |> Fmt.(str "@[<hov>%a@]" (list ~sep:comma UnsizedType.pp))
     |> print_endline;
     [%expect
       {|
-      vector, array[] matrix, matrix, array[] vector, real, array[] real |}]
+      vector, array[] matrix, matrix, array[] vector, real, array[] real, vector,
+      row_vector, matrix, vector, array[] vector, vector
+      |}]
 end

--- a/src/middle/Expr.ml
+++ b/src/middle/Expr.ml
@@ -215,14 +215,13 @@ module Helpers = struct
         URowVector
     | UComplexMatrix, [Single _; (All | Upfrom _ | Between _ | MultiIndex _)] ->
         UComplexRowVector
-    | ( UMatrix
-      , ([(All | Upfrom _ | Between _ | MultiIndex _); Single _] | [Single _]) )
-      ->
+    | UMatrix, [(All | Upfrom _ | Between _ | MultiIndex _); Single _] ->
         UVector
-    | ( UComplexMatrix
-      , ([(All | Upfrom _ | Between _ | MultiIndex _); Single _] | [Single _]) )
-      ->
+    | UComplexMatrix, [(All | Upfrom _ | Between _ | MultiIndex _); Single _] ->
         UComplexVector
+    (* A single index selects a row: [x[1]] is [x[1, : ]]. *)
+    | UMatrix, [Single _] -> URowVector
+    | UComplexMatrix, [Single _] -> UComplexRowVector
     | UArray t, Single _ :: tl -> infer_type_of_indexed t tl
     | UArray t, (All | Upfrom _ | Between _ | MultiIndex _) :: tl ->
         UArray (infer_type_of_indexed t tl)
@@ -300,7 +299,8 @@ module Helpers = struct
     |> print_endline;
     [%expect
       {|
-      vector, array[] matrix, matrix, array[] vector, real, array[] real, vector,
-      row_vector, matrix, vector, array[] vector, vector, row_vector, matrix
+      row_vector, array[] matrix, matrix, array[] row_vector, real, array[] real,
+      vector, row_vector, matrix, vector, array[] vector, vector, row_vector,
+      matrix
       |}]
 end

--- a/test/integration/good/code-gen/mir.expected
+++ b/test/integration/good/code-gen/mir.expected
@@ -665,7 +665,7 @@
                                        (meta
                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                                   (meta
-                                   ((type_ UVector) (loc <opaque>)
+                                   ((type_ URowVector) (loc <opaque>)
                                     (adlevel AutoDiffable)))))))
                               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
                             (body
@@ -752,7 +752,7 @@
                                        (meta
                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                                   (meta
-                                   ((type_ UVector) (loc <opaque>)
+                                   ((type_ URowVector) (loc <opaque>)
                                     (adlevel AutoDiffable)))))))
                               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
                             (body

--- a/test/integration/good/code-gen/transformed_mir.expected
+++ b/test/integration/good/code-gen/transformed_mir.expected
@@ -678,7 +678,7 @@
                                        (meta
                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                                   (meta
-                                   ((type_ UVector) (loc <opaque>)
+                                   ((type_ URowVector) (loc <opaque>)
                                     (adlevel AutoDiffable)))))))
                               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
                             (body
@@ -765,7 +765,7 @@
                                        (meta
                                         ((type_ UInt) (loc <opaque>) (adlevel DataOnly))))))))
                                   (meta
-                                   ((type_ UVector) (loc <opaque>)
+                                   ((type_ URowVector) (loc <opaque>)
                                     (adlevel AutoDiffable)))))))
                               (meta ((type_ UInt) (loc <opaque>) (adlevel AutoDiffable)))))
                             (body


### PR DESCRIPTION
`Expr.Helpers.infer_type_of_indexed` mis-types multi-indexing. `vector[MultiIndex]` returns `real` (it falls through to the scalar arm), `matrix[MultiIndex]` returns `vector` (it is grouped with the `Single` arms), and `matrix[MultiIndex, Single]` matches no arm and raises an internal error. The rule is that `Single` reduces a dimension while `All`, `Upfrom`, `Between`, and `MultiIndex` preserve it.

The bug is latent today because codegen ignores the type metadata. It matters for anything that trusts it: `Memory_patterns.matrix_set` stops recursing at non-Eigen types, so an expression wrongly typed `real` can leave a variable out of the SoA demotion set. I hit this while working on #1666, where a compiler-built gather typed `real` produced C++ that assigned an SoA value into an AoS slice and did not compile. `Ast_to_Mir.copy_indices` also feeds arbitrary index lists into this function and could hit the internal error.

The fix moves `MultiIndex` into the dimension-preserving arm and adds `[MultiIndex, Single]` to the matrix arms next to `[All, Single]`. New cases in the inline expect test cover vector, row vector, matrix, matrix-then-column, and arrays. No other test output changes.

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] OR, no user-facing changes were made

## Release notes

Fixed the inferred type of multi-indexed expressions in the compiler's middle intermediate representation.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)

I used AI but understand the code and think it makes sense.
