### PR TITLE
Add flag to print compiler's over-approximation of factor graph

### DIFF
--- a/src/driver/Entry.ml
+++ b/src/driver/Entry.ml
@@ -91,8 +91,8 @@ let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
   if flags.warn_pedantic then
     output (Warnings (Pedantic_analysis.warn_pedantic mir));
   if flags.debug_settings.debug_print_factor_graph then
-    print_endline (Factor_graph.factor_graph_to_dot 
-      (Factor_graph.prog_factor_graph mir));
+    print_endline
+      (Factor_graph.factor_graph_to_dot (Factor_graph.prog_factor_graph mir));
   debug_output_mir output mir flags.debug_settings.print_mir;
   let* generation_context =
     match flags.debug_settings.debug_data_json with

--- a/src/driver/Entry.ml
+++ b/src/driver/Entry.ml
@@ -90,6 +90,9 @@ let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
     output (Warnings (Pedantic_analysis.warn_uninitialized mir));
   if flags.warn_pedantic then
     output (Warnings (Pedantic_analysis.warn_pedantic mir));
+  if flags.debug_settings.debug_print_factor_graph then
+    print_endline (Factor_graph.factor_graph_to_dot 
+      (Factor_graph.prog_factor_graph mir));
   debug_output_mir output mir flags.debug_settings.print_mir;
   let* generation_context =
     match flags.debug_settings.debug_data_json with

--- a/src/driver/Flags.ml
+++ b/src/driver/Flags.ml
@@ -28,7 +28,8 @@ and debug_settings =
   ; print_lir: bool
   ; debug_generate_data: bool
   ; debug_generate_inits: bool
-  ; debug_data_json: (string * string) option }
+  ; debug_data_json: (string * string) option
+  ; debug_print_factor_graph: bool }
 
 and debug_options = Off | Basic | Pretty
 
@@ -63,7 +64,8 @@ let default =
       ; print_lir= false
       ; debug_generate_data= false
       ; debug_generate_inits= false
-      ; debug_data_json= None }
+      ; debug_data_json= None
+      ; debug_print_factor_graph= false }
   ; line_length= 78
   ; canonicalizer_settings= Frontend.Canonicalize.none
   ; warn_pedantic= false

--- a/src/driver/Flags.mli
+++ b/src/driver/Flags.mli
@@ -39,7 +39,8 @@ and debug_settings =
   ; print_lir: bool
   ; debug_generate_data: bool
   ; debug_generate_inits: bool
-  ; debug_data_json: (string * string) option }
+  ; debug_data_json: (string * string) option
+  ; debug_print_factor_graph: bool }
 
 and debug_options = Off | Basic | Pretty
 

--- a/src/stanc/CLI.ml
+++ b/src/stanc/CLI.ml
@@ -322,8 +322,9 @@ module Debug_Options = struct
     debug_basic_or_pretty ~doc "debug-transformed-mir"
 
   let debug_print_factor_graph =
-    let doc = "For debugging purposes: print a conservative over-approximation \
-    of the factor graph for the model(s) implemented in the Stan program." in
+    let doc =
+      "For debugging purposes: print a conservative over-approximation of the \
+       factor graph for the model(s) implemented in the Stan program." in
     Arg.(value & flag & info ["debug-print-factor-graph"] ~doc ~docs)
 
   let force_soa =
@@ -376,7 +377,7 @@ module Conversion = struct
     and+ debug_generate_data
     and+ debug_generate_inits
     and+ debug_data_json = Term.ret debug_data_json
-    and+ debug_print_factor_graph = debug_print_factor_graph in
+    and+ debug_print_factor_graph in
     Driver.Flags.
       { print_ast
       ; print_typed_ast

--- a/src/stanc/CLI.ml
+++ b/src/stanc/CLI.ml
@@ -321,6 +321,11 @@ module Debug_Options = struct
        it." in
     debug_basic_or_pretty ~doc "debug-transformed-mir"
 
+  let debug_print_factor_graph =
+    let doc = "For debugging purposes: print a conservative over-approximation \
+    of the factor graph for the model(s) implemented in the Stan program." in
+    Arg.(value & flag & info ["debug-print-factor-graph"] ~doc ~docs)
+
   let force_soa =
     let doc =
       "Debugging features. Valid values: $(b,-fsoa) to force on the Struct of \
@@ -370,7 +375,8 @@ module Conversion = struct
     and+ print_lir = debug_lir
     and+ debug_generate_data
     and+ debug_generate_inits
-    and+ debug_data_json = Term.ret debug_data_json in
+    and+ debug_data_json = Term.ret debug_data_json
+    and+ debug_print_factor_graph = debug_print_factor_graph in
     Driver.Flags.
       { print_ast
       ; print_typed_ast
@@ -382,7 +388,8 @@ module Conversion = struct
       ; print_lir
       ; debug_generate_data
       ; debug_generate_inits
-      ; debug_data_json }
+      ; debug_data_json
+      ; debug_print_factor_graph }
 
   let flags : Driver.Flags.t Term.t =
     let open Options in

--- a/src/stancjs/conversion.ml
+++ b/src/stancjs/conversion.ml
@@ -131,6 +131,7 @@ let process_flags name code (flags : 'a Js.opt) includes :
               ; print_mem_patterns= is_flag_set "debug-mem-patterns"
               ; force_soa= None
               ; print_lir= is_flag_set "debug-lir"
+              ; debug_print_factor_graph= is_flag_set "debug-print-factor-graph"
               ; debug_generate_data= is_flag_set "debug-generate-data"
               ; debug_generate_inits= is_flag_set "debug-generate-inits"
               ; debug_data_json=

--- a/test/integration/cli-args/debug-flags.t/run.t
+++ b/test/integration/cli-args/debug-flags.t/run.t
@@ -577,6 +577,17 @@ Flags not used elsewhere in the tests
     parameters real theta; //real
   }
 
+  $ stanc basic.stan --debug-print-factor-graph
+  graph {
+  "bernoulli_lupmf(y, theta)" [shape=box]
+  "beta_lupdf(theta, promote(1, real, data), promote(1, real, data))" [shape=box]
+  theta
+  y
+  "bernoulli_lupmf(y, theta)" -- theta
+  "bernoulli_lupmf(y, theta)" -- y
+  "beta_lupdf(theta, promote(1, real, data), promote(1, real, data))" -- theta
+  }
+
   $ stanc parse_error.stan --debug-parse
   Syntax error in 'parse_error.stan', line 1, column 0 to column 5, parsing error:
      -------------------------------------------------

--- a/test/integration/cli-args/stanc.t
+++ b/test/integration/cli-args/stanc.t
@@ -178,6 +178,10 @@ Show help
          --debug-parse
              For debugging purposes: print the parser actions.
   
+         --debug-print-factor-graph
+             For debugging purposes: print a conservative over-approximation of
+             the factor graph for the model(s) implemented in the Stan program.
+  
          --debug-transformed-mir
              For debugging purposes: print the MIR after the backend has
              transformed it.


### PR DESCRIPTION


#### Submission Checklist

- [ ] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [ ] OR, no user-facing changes were made

## Summary

Adds a debug flag that causes the compiler to compute and print it's factor graph approximation in DOT format.

The compiler already has machinery for computing a conservative over-approximation of the factor graph for the model(s) that a Stan program implements in `Factor_graph.ml`. I believe this was implemented in response to [#177](https://github.com/stan-dev/stanc3/issues/177), and while the module contains a function to print this graph to DOT format, this function is never called anywhere in the compiler or exposed to users. While the approximation is coarse, the information can still be useful.

Tests: The test `integration/cli-args/stanc.t` currently fails. I was unsure whether I should edit that test file manually. I think I recall @WardBrian saying something about a tool for automatically updating expected test output, but I couldn't figure out how to run that. I'm happy to update the test in whatever way is standard practice.

Docs: While the change is user-facing, I noticed that not all debug flags are currently documented in the [stanc CLI doc](https://mc-stan.org/docs/stan-users-guide/using-stanc.html), so I defaulted to not adding documentation so as to not clutter the doc. Also happy to add that if desired.

## Release notes

Add debug flag `--debug-print-factor-graph` to print the compiler's conservative over-approximation of the factor graph for the model(s) implemented in the Stan program.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
