### PR TITLE
Expose typed MIR from Driver.Entry

### DIFF
--- a/src/driver/Entry.ml
+++ b/src/driver/Entry.ml
@@ -45,6 +45,7 @@ type other_output =
   | Warnings of Warnings.t list
 
 type compilation_result = (string, Errors.t) result
+type mir_compilation_result = (Program.Typed.t, Errors.t) result
 
 let debug_output_mir output mir = function
   | Flags.Off -> ()
@@ -52,8 +53,8 @@ let debug_output_mir output mir = function
       output (DebugOutput (fmt_sexp (Middle.Program.Typed.sexp_of_t mir)))
   | Pretty -> output (DebugOutput (Fmt.str "%a" Program.Typed.pp mir))
 
-let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
-    : compilation_result =
+let stan2mir model_name model (flags : Flags.t) (output : other_output -> unit)
+    : mir_compilation_result =
   let open Result.Syntax in
   reset_mutable_states model_name flags;
   if flags.version then output (Version (Fmt.str "%s" version));
@@ -138,6 +139,12 @@ let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
             Fmt.(list string)
             (Memory_patterns.get_warnings ())));
   debug_output_mir output opt_mir flags.debug_settings.print_optimized_mir;
+  opt_mir
+
+let stan2cpp model_name model (flags : Flags.t) (output : other_output -> unit)
+    : compilation_result =
+  let open Result.Syntax in
+  let+ opt_mir = stan2mir model_name model flags output in
   let cpp =
     Lower_program.lower_program
       ~standalone_functions:(flags.functions_only || flags.standalone_functions)

--- a/src/driver/Entry.mli
+++ b/src/driver/Entry.mli
@@ -1,11 +1,15 @@
-(** The main entrypoint for Stan -> C++ compilation *)
+(** Stan compiler entrypoints *)
 
 open Frontend
 
 (** Either the C++ a model compiled to, or an error *)
 type compilation_result = (string, Errors.t) result
 
-(** The type of all non-C++-code outputs from the compiler *)
+(** Either a model compiled to Stan Math backend-transformed and optimized MIR,
+    or an error *)
+type mir_compilation_result = (Middle.Program.Typed.t, Errors.t) result
+
+(** The type of all auxiliary outputs from the compiler *)
 type other_output =
   | Formatted of string
   | DebugOutput of string
@@ -14,6 +18,16 @@ type other_output =
   | Version of string
   | Generated of string
   | Warnings of Warnings.t list
+
+val stan2mir :
+     string
+  -> [`Code of string | `File of string]
+  -> Flags.t
+  -> (other_output -> unit)
+  -> mir_compilation_result
+(** Compile a model through Stan Math backend transformation and MIR
+    optimization, without lowering it to C++. Takes the model's name, model
+    code, compiler settings, and a callback for auxiliary output. *)
 
 val stan2cpp :
      string

--- a/test/unit/Entry_tests.ml
+++ b/test/unit/Entry_tests.ml
@@ -1,0 +1,39 @@
+open Middle
+
+let compile_mir code flags =
+  match
+    Driver.Entry.stan2mir "entry_test_model" (`Code code) flags (fun _ -> ())
+  with
+  | Ok mir -> mir
+  | Error error -> failwith (Test_utils.error_to_string ~code error)
+
+let%expect_test "stan2mir returns transformed and optimized MIR" =
+  let flags =
+    { Driver.Flags.default with
+      optimization_level= Analysis_and_optimization.Optimize.O1 } in
+  let mir = compile_mir "model { target += 1 + 2; }" flags in
+  Fmt.pr "%a@." Fmt.(list ~sep:cut Stmt.Located.pp) mir.log_prob;
+  [%expect {|
+    { target += 3;
+    }
+    |}]
+
+let%expect_test "stan2mir reports frontend errors" =
+  let code = "model { target += missing; }" in
+  match
+    Driver.Entry.stan2mir "entry_test_model" (`Code code) Driver.Flags.default
+      (fun _ -> ())
+  with
+  | Ok _ -> print_endline "unexpected success"
+  | Error error ->
+      print_endline (Test_utils.error_to_string ~code error);
+      [%expect
+        {|
+        Semantic error in 'string', line 1, column 18 to column 25:
+           -------------------------------------------------
+             1:  model { target += missing; }
+                                   ^
+           -------------------------------------------------
+
+        Identifier "missing" not in scope. Did you mean "is_inf"?
+        |}]

--- a/test/unit/Entry_tests.ml
+++ b/test/unit/Entry_tests.ml
@@ -20,13 +20,10 @@ let%expect_test "stan2mir returns transformed and optimized MIR" =
 
 let%expect_test "stan2mir reports frontend errors" =
   let code = "model { target += missing; }" in
-  match
-    Driver.Entry.stan2mir "entry_test_model" (`Code code) Driver.Flags.default
-      (fun _ -> ())
-  with
-  | Ok _ -> print_endline "unexpected success"
-  | Error error ->
-      print_endline (Test_utils.error_to_string ~code error);
+  match compile_mir code Driver.Flags.default with
+  | _ -> print_endline "unexpected success"
+  | exception Failure error ->
+      print_endline error;
       [%expect
         {|
         Semantic error in 'string', line 1, column 18 to column 25:

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -4,6 +4,7 @@
   std
   fmt
   frontend
+  driver
   stan_math_backend
   middle
   analysis_and_optimization)


### PR DESCRIPTION
## Summary

Expose `Driver.Entry.stan2mir`, which runs the existing frontend, Stan Math backend transformation, and configured MIR optimization suite, then returns the typed `Middle.Program.Typed.t` before C++ lowering.

This gives alternate in-process consumers a typed boundary without duplicating the driver phase sequence or parsing debug MIR output. `stan2cpp` now composes over `stan2mir`; CLI and stanc.js behavior remain unchanged.

The returned value is deliberately the exact backend-transformed and optimized MIR currently consumed by `Lower_program.lower_program`, rather than raw frontend MIR.

## Testing

- focused `Entry_tests` partition (optimized MIR and frontend error propagation)
- `dune build @fmt @check src/stanc/stanc.exe`
- `dune runtest test/integration/cli-args/debug-flags.t test/integration/good/code-gen`
- `dune runtest test/stancjs`

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] No user-facing changes were made

## Release notes

Expose a typed, optimized MIR entry point in `Driver.Entry` for alternate compiler consumers.

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause).

I used AI to prepare this PR but I vouch for the code.