### PR TITLE
Optimize map operations in dataflow analyses

### DIFF
--- a/src/analysis_and_optimization/Dataflow_utils.ml
+++ b/src/analysis_and_optimization/Dataflow_utils.ml
@@ -3,34 +3,11 @@ open Middle
 open Dataflow_types
 open Mir_utils
 
-(** Union maps, preserving the left element in a collision *)
-let union_maps_left (module M : Map.S) (m1 : 'a M.t) (m2 : 'a M.t) : 'a M.t =
-  M.union ~f:(fun _ v1 _ -> Some v1) m1 m2
-
 (** Merge two maps whose values are sets, and union the sets when there's a
     collision. *)
 let merge_set_maps (module M : Map.S) m1 m2 =
   let merge_map_elems _ e1 e2 = Some (Set.Poly.union e1 e2) in
   M.union ~f:merge_map_elems m1 m2
-
-(** Like a forward traversal, but branches accumulate two different states that
-    are recombined with join. *)
-let branching_traverse_statement stmt ~join ~init ~f =
-  Stmt.Pattern.(
-    match stmt with
-    | IfElse (pred, then_s, else_s_opt) ->
-        let s', c = f init then_s in
-        Option.value_map else_s_opt
-          ~default:(join s' init, IfElse (pred, c, None))
-          ~f:(fun else_s ->
-            let s'', c' = f init else_s in
-            (join s' s'', IfElse (pred, c, Some c')))
-    | _ as s -> fwd_traverse_statement s ~init ~f)
-
-(** Like a branching traversal, but doesn't return an updated statement. *)
-let branching_fold_statement stmt ~join ~init ~f =
-  fst
-    (branching_traverse_statement stmt ~join ~init ~f:(fun s a -> (f s a, ())))
 
 (** See interface file *)
 let build_statement_map extract metadata stmt =
@@ -41,10 +18,7 @@ let build_statement_map extract metadata stmt =
     let (next_label'', map), built =
       fwd_traverse_statement (extract stmt) ~init:(next_label', map) ~f in
     ( ( next_label''
-      , union_maps_left
-          (module LabelMap)
-          map
-          (LabelMap.singleton this_label (built, metadata stmt)) )
+      , LabelMap.add map ~key:this_label ~data:(built, metadata stmt) )
     , this_label ) in
   let (_, map), _ = build_statement_map_rec 1 LabelMap.empty stmt in
   map
@@ -109,9 +83,6 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
     let stmt, _ = LabelMap.find label statement_map in
     (* Only control flow nodes should pass themselves down as parents *)
     let child_cf = if is_ctrl_flow stmt then Some label else cf_parent in
-    let join (state1, map1) (state2, map2) =
-      (join_cf_states state1 state2, union_maps_left (module LabelMap) map1 map2)
-    in
     (* This node is the parent of substatements, unless this is a Block, which
        is visited after substatements *)
     let substmt_preds =
@@ -119,10 +90,28 @@ let build_cf_graphs ?(flatten_loops = false) ?(blocks_after_body = true)
       | (Block _ | Profile _) when blocks_after_body -> in_state.exits
       | _ -> Set.Poly.singleton label in
     (* The accumulated state after traversing substatements *)
+    let child_init = {in_state with exits= substmt_preds} in
     let substmt_state_unlooped, substmt_map =
-      branching_fold_statement stmt ~join
-        ~init:({in_state with exits= substmt_preds}, in_map)
-        ~f:(build_cf_graph_rec child_cf) in
+      match stmt with
+      | IfElse (_, then_s, else_s_opt) ->
+          let then_state, after_then_map =
+            build_cf_graph_rec child_cf (child_init, in_map) then_s in
+          Option.value_map else_s_opt
+            ~default:(join_cf_states then_state child_init, after_then_map)
+            ~f:(fun else_s ->
+              (* The control-flow state starts from the same point on both
+                 branches. The graph map is only an accumulator of uniquely
+                 labelled nodes, so carry it through the branches instead of
+                 persistently unioning two maps that share the whole prefix. *)
+              let else_state, after_both_map =
+                build_cf_graph_rec child_cf (child_init, after_then_map) else_s
+              in
+              (join_cf_states then_state else_state, after_both_map))
+      | _ ->
+          fst
+            (fwd_traverse_statement stmt ~init:(child_init, in_map)
+               ~f:(fun state child ->
+                 (build_cf_graph_rec child_cf state child, ()))) in
     (* If the statement is a loop, we need to include the loop body exits as
        predecessors of the loop *)
     let substmt_state, predecessors =

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -238,11 +238,8 @@ let dual_partial_function_lattice (type cv)
       String.Map.filter ~f s1
 
     let leq s1 s2 =
-      Set.Poly.for_all Dom.total ~f:(fun k ->
-          match (String.Map.find_opt k s1, String.Map.find_opt k s2) with
-          | Some x, Some y -> x = y
-          | Some _, None | None, None -> true
-          | None, Some _ -> false)
+      String.Map.fold s2 ~init:true ~f:(fun ~key ~data leq ->
+          leq && String.Map.find_opt key s1 = Some data)
 
     let initial = String.Map.empty
   end : LATTICE_NO_BOT

--- a/src/analysis_and_optimization/Monotone_framework.ml
+++ b/src/analysis_and_optimization/Monotone_framework.ml
@@ -238,8 +238,9 @@ let dual_partial_function_lattice (type cv)
       String.Map.filter ~f s1
 
     let leq s1 s2 =
-      String.Map.fold s2 ~init:true ~f:(fun ~key ~data leq ->
-          leq && String.Map.find_opt key s1 = Some data)
+      String.Map.for_all
+        ~f:(fun key data -> String.Map.find_opt key s1 = Some data)
+        s2
 
     let initial = String.Map.empty
   end : LATTICE_NO_BOT


### PR DESCRIPTION
## Summary

The ctsem model current takes something like 75s to pass through -O1 in stanc3. This is a small PR that gets that down to 17s. I'm hoping to find more ways to get that lower soon.

- avoid persistent `LabelMap.union` calls when building predecessor graphs by carrying the unique-label graph accumulator through `if` branches
- compare dual partial-function lattice elements with a short-circuiting universal predicate over bindings present in the right-hand map instead of scanning every name in the procedure-wide domain

These are independent local changes, but they interact because O1 repeatedly rebuilds control-flow graphs and runs the monotone-framework fixpoint.

## Correctness

Statement labels are unique. Both branches still begin with the same control-flow state; only the graph-map accumulator is threaded from the completed `then` branch into the `else` traversal. This preserves every labelled node without repeatedly unioning two persistent maps that share their full prefix.

For the dual partial-function lattice, `s1 <= s2` still means that every binding in `s2` is present with the same value in `s1`. `String.Map.for_all` over `s2` is equivalent to scanning the full domain, avoids two string-map lookups for every procedure-wide name, and stops at the first mismatch.

The optimized MIR from the baseline, each isolated change, and the combined patch is byte-identical: 32,030,940 bytes, SHA-256 `9095704f4dead18ec68330b1d5763b28884c16831772cd1b0329b7e613adec1d`.

## Reproducer

Model-only source: [`ctsem/inst/stan/ctsm.stan` at `a0f1e69b`](https://github.com/cdriveraus/ctsem/blob/a0f1e69b7282c1dcaed820919ae0d8b280d076c4/inst/stan/ctsm.stan)

stanc3 revision: `5b824ee48c590fa229dcebf6b57457b2fd212aa8`

```sh
/usr/bin/time -l stanc \
  --O1 --debug-optimized-mir ctsm.stan \
  >optimized.mir
```

Apple M3 Ultra, 96 GiB, Darwin arm64:

| build | real | max RSS (bytes) | retired instructions | speedup |
| --- | ---: | ---: | ---: | ---: |
| baseline | 75.89 s | 731,889,664 | 1,096,932,192,045 | 1.00x |
| predecessor-map change only | 48.34 s | 695,943,168 | 668,814,667,792 | 1.57x |
| partial-function `leq` only | 50.45 s | 734,789,632 | 694,418,168,062 | 1.50x |
| combined patch (three-run median) | 17.98 s | 695,025,664 | 266,581,289,704 | 4.22x |

For context, `--debug-transformed-mir` takes 0.11 s and 53,133,312 bytes maximum RSS on this source. O1 grows the MIR from 4,525,185 bytes / 11 `While` nodes to 32,030,940 bytes / 95 `While` nodes, so this patch improves the hot path substantially but does not make this model ordinary-cost.

## Validation

```sh
dune runtest -j 8 --profile release \
  test/unit test/integration/good/compiler-optimizations
```

The targeted unit and compiler-optimization integration suites pass. 

I used AI.