### PR TITLE
Fix mistaken peephole optimization for categorical distribution

### DIFF
--- a/src/analysis_and_optimization/Partial_evaluator.ml
+++ b/src/analysis_and_optimization/Partial_evaluator.ml
@@ -256,7 +256,7 @@ let rec eval_expr ?(preserve_stability = false) (e : Expr.Typed.t) =
                 | ( "categorical_lpmf"
                   , [ y
                     ; { pattern=
-                          FunApp (StanLib ("inv_logit", FnPlain, mem), [alpha])
+                          FunApp (StanLib ("softmax", FnPlain, mem), [alpha])
                       ; _ } ] ) ->
                     FunApp
                       ( StanLib
@@ -264,7 +264,7 @@ let rec eval_expr ?(preserve_stability = false) (e : Expr.Typed.t) =
                       , [y; alpha] )
                 | ( "categorical_rng"
                   , [ { pattern=
-                          FunApp (StanLib ("inv_logit", FnPlain, mem), [alpha])
+                          FunApp (StanLib ("softmax", FnPlain, mem), [alpha])
                       ; _ } ] ) ->
                     FunApp
                       ( StanLib

--- a/test/unit/Optimize.ml
+++ b/test/unit/Optimize.ml
@@ -2195,8 +2195,8 @@ model {
     target += bernoulli_lupmf(y_arr| inv_logit(x_vector));
     target += binomial_lpmf(y_arr| j, inv_logit(x_vector));
     target += binomial_lupmf(y_arr| j, inv_logit(x_vector));
-    target += categorical_lpmf(y_arr| inv_logit(x_vector));
-    target += categorical_lupmf(y_arr| inv_logit(x_vector));
+    target += categorical_lpmf(y_arr| softmax(x_vector));
+    target += categorical_lupmf(y_arr| softmax(x_vector));
     target += columns_dot_product(x_matrix, x_matrix);
     target += dot_product(x_vector, x_vector);
     target += inv(sqrt(x_vector));


### PR DESCRIPTION
Closes #1684 

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [ ] If a user-facing facing change was made, the documentation PR is here: <LINK>
    - [x] OR, no user-facing changes were made

## Release notes
Fixed an incorrect optimization which could rewrite the categorical distribution in incorrect situations. 

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
