### PR TITLE
Expose new matrix reshaping functions

### DIFF
--- a/src/stan_math_signatures/Generate.ml
+++ b/src/stan_math_signatures/Generate.ml
@@ -2440,6 +2440,7 @@ let () =
   add_unqualified
     ("to_matrix", ReturnType UMatrix, [UMatrix; UInt; UInt; UInt], AoS);
   add_unqualified ("to_matrix", ReturnType UMatrix, [UVector], AoS);
+  add_unqualified ("to_matrix", ReturnType UMatrix, [UArray UVector], AoS);
   add_unqualified ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt], AoS);
   add_unqualified
     ("to_matrix", ReturnType UMatrix, [UVector; UInt; UInt; UInt], AoS);
@@ -2470,6 +2471,8 @@ let () =
     , [UComplexMatrix; UInt; UInt; UInt]
     , AoS );
   add_unqualified ("to_matrix", ReturnType UComplexMatrix, [UComplexVector], AoS);
+  add_unqualified
+    ("to_matrix", ReturnType UComplexMatrix, [UArray UComplexVector], AoS);
   add_unqualified
     ("to_matrix", ReturnType UComplexMatrix, [UComplexVector; UInt; UInt], AoS);
   add_unqualified
@@ -2516,6 +2519,13 @@ let () =
     ("to_row_vector", ReturnType UComplexRowVector, [UComplexRowVector], AoS);
   add_unqualified
     ("to_row_vector", ReturnType UComplexRowVector, [UArray UComplex], AoS);
+  add_unqualified
+    ("to_row_vector_array", ReturnType (UArray URowVector), [UMatrix], AoS);
+  add_unqualified
+    ( "to_row_vector_array"
+    , ReturnType (UArray UComplexRowVector)
+    , [UComplexMatrix]
+    , AoS );
   add_unqualified ("to_vector", ReturnType UVector, [UMatrix], SoA);
   add_unqualified ("to_vector", ReturnType UVector, [UVector], SoA);
   add_unqualified ("to_vector", ReturnType UVector, [URowVector], SoA);
@@ -2527,6 +2537,13 @@ let () =
     ("to_vector", ReturnType UComplexVector, [UComplexRowVector], AoS);
   add_unqualified
     ("to_vector", ReturnType UComplexVector, [UArray UComplex], AoS);
+  add_unqualified
+    ("to_vector_array", ReturnType (UArray UVector), [UMatrix], AoS);
+  add_unqualified
+    ( "to_vector_array"
+    , ReturnType (UArray UComplexVector)
+    , [UComplexMatrix]
+    , AoS );
   add_unqualified ("trace", ReturnType UReal, [UMatrix], SoA);
   add_unqualified ("trace", ReturnType UComplex, [UComplexMatrix], AoS);
   add_unqualified ("trace_dot", ReturnType UReal, [UMatrix; UMatrix], SoA);

--- a/test/integration/good/function-signatures/math/matrix/to_matrix.stan
+++ b/test/integration/good/function-signatures/math/matrix/to_matrix.stan
@@ -2,6 +2,7 @@ data {
   int d_int;
   matrix[d_int, d_int] d_matrix;
   vector[d_int] d_vector;
+  array[d_int] vector[d_int] array_d_vector;
   row_vector[d_int] d_row_vector;
   array[d_int] row_vector[d_int] array_d_row_vector;
   array[6] real d_array;
@@ -11,6 +12,7 @@ data {
 
   complex_matrix[d_int, d_int] d_cmatrix;
   complex_vector[d_int] d_cvector;
+  array[d_int] complex_vector[d_int] array_d_cvector;
   complex_row_vector[d_int] d_crow_vector;
   array[d_int] complex_row_vector[d_int] array_d_crow_vector;
   array[6] complex d_carray;
@@ -21,6 +23,7 @@ transformed data {
 
   transformed_data_matrix = to_matrix(d_matrix);
   transformed_data_matrix = to_matrix(d_vector);
+  transformed_data_matrix = to_matrix(array_d_vector);
   transformed_data_matrix = to_matrix(d_row_vector);
   transformed_data_matrix = to_matrix(array_d_row_vector);
 
@@ -40,13 +43,13 @@ transformed data {
   transformed_data_matrix = to_matrix(d_array2);
   transformed_data_matrix = to_matrix(d_iarray2);
 
-
   complex_matrix[d_int, d_int] transformed_data_cmatrix;
 
   transformed_data_cmatrix = to_matrix(d_cmatrix);
   transformed_data_cmatrix = to_matrix(d_cvector);
+  transformed_data_cmatrix = to_matrix(array_d_cvector);
   transformed_data_cmatrix = to_matrix(d_crow_vector);
-  transformed_data_cmatrix = to_matrix(array_d_row_vector);
+  transformed_data_cmatrix = to_matrix(array_d_crow_vector);
 
   transformed_data_cmatrix = to_matrix(d_cmatrix, 4, 2);
   transformed_data_cmatrix = to_matrix(d_cvector, 4, 3);
@@ -63,6 +66,7 @@ parameters {
   real y_p;
   matrix[d_int, d_int] p_matrix;
   vector[d_int] p_vector;
+  array[d_int] vector[d_int] array_p_vector;
   row_vector[d_int] p_row_vector;
   array[d_int] row_vector[d_int] array_p_row_vector;
   array[6] real p_array;
@@ -70,6 +74,7 @@ parameters {
 
   complex_matrix[d_int, d_int] p_cmatrix;
   complex_vector[d_int] p_cvector;
+  array[d_int] complex_vector[d_int] array_p_cvector;
   complex_row_vector[d_int] p_crow_vector;
   array[d_int] complex_row_vector[d_int] array_p_crow_vector;
   array[6] complex p_carray;
@@ -80,8 +85,9 @@ transformed parameters {
 
   transformed_param_matrix = to_matrix(d_matrix);
   transformed_param_matrix = to_matrix(d_vector);
+  transformed_param_matrix = to_matrix(array_d_vector);
   transformed_param_matrix = to_matrix(d_row_vector);
-  transformed_param_matrix = to_matrix(array_p_row_vector);
+  transformed_param_matrix = to_matrix(array_d_row_vector);
 
   transformed_param_matrix = to_matrix(d_matrix, 4, 2);
   transformed_param_matrix = to_matrix(d_vector, 3, 5);
@@ -101,7 +107,9 @@ transformed parameters {
 
   transformed_param_matrix = to_matrix(p_matrix);
   transformed_param_matrix = to_matrix(p_vector);
+  transformed_param_matrix = to_matrix(array_p_vector);
   transformed_param_matrix = to_matrix(p_row_vector);
+  transformed_param_matrix = to_matrix(array_p_row_vector);
 
   transformed_param_matrix = to_matrix(p_matrix, 4, 2);
   transformed_param_matrix = to_matrix(p_vector, 3, 5);
@@ -116,13 +124,13 @@ transformed parameters {
 
   transformed_param_matrix = to_matrix(p_array2);
 
-
   complex_matrix[d_int, d_int] transformed_param_cmatrix;
 
   transformed_param_cmatrix = to_matrix(d_cmatrix);
   transformed_param_cmatrix = to_matrix(d_cvector);
+  transformed_param_cmatrix = to_matrix(array_d_cvector);
   transformed_param_cmatrix = to_matrix(d_crow_vector);
-  transformed_param_cmatrix = to_matrix(array_p_row_vector);
+  transformed_param_cmatrix = to_matrix(array_d_crow_vector);
 
   transformed_param_cmatrix = to_matrix(d_cmatrix, 4, 2);
   transformed_param_cmatrix = to_matrix(d_cvector, 3, 5);
@@ -139,7 +147,9 @@ transformed parameters {
 
   transformed_param_cmatrix = to_matrix(p_cmatrix);
   transformed_param_cmatrix = to_matrix(p_cvector);
+  transformed_param_cmatrix = to_matrix(array_p_cvector);
   transformed_param_cmatrix = to_matrix(p_crow_vector);
+  transformed_param_cmatrix = to_matrix(array_p_crow_vector);
 
   transformed_param_cmatrix = to_matrix(p_cmatrix, 4, 2);
   transformed_param_cmatrix = to_matrix(p_cvector, 3, 5);
@@ -157,4 +167,3 @@ transformed parameters {
 model {
   y_p ~ normal(0, 1);
 }
-

--- a/test/integration/good/function-signatures/math/matrix/to_row_vector_array.stan
+++ b/test/integration/good/function-signatures/math/matrix/to_row_vector_array.stan
@@ -1,0 +1,40 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_complex_matrix;
+
+
+}
+
+transformed data {
+  int td_int;
+  matrix[d_int, d_int] td_matrix;
+  complex_matrix[d_int, d_int] td_complex_matrix;
+  array[d_int] row_vector[d_int] td_row_vector_array_1d;
+  array[d_int] complex_row_vector[d_int] td_complex_row_vector_array_1d;
+
+  td_complex_row_vector_array_1d = to_row_vector_array(d_complex_matrix);
+  td_row_vector_array_1d = to_row_vector_array(d_matrix);
+}
+
+parameters {
+  matrix[d_int, d_int] p_matrix;
+  complex_matrix[d_int, d_int] p_complex_matrix;
+  array[d_int] row_vector[d_int] p_row_vector_array_1d;
+  array[d_int] complex_row_vector[d_int] p_complex_row_vector_array_1d;
+
+
+}
+
+transformed parameters {
+  matrix[d_int, d_int] transformed_param_matrix;
+  complex_matrix[d_int, d_int] transformed_param_complex_matrix;
+  array[d_int] row_vector[d_int] transformed_param_row_vector_array_1d;
+  array[d_int] complex_row_vector[d_int] transformed_param_complex_row_vector_array_1d;
+
+  transformed_param_complex_row_vector_array_1d = to_row_vector_array(d_complex_matrix);
+  transformed_param_complex_row_vector_array_1d = to_row_vector_array(p_complex_matrix);
+  transformed_param_row_vector_array_1d = to_row_vector_array(d_matrix);
+  transformed_param_row_vector_array_1d = to_row_vector_array(p_matrix);
+}
+

--- a/test/integration/good/function-signatures/math/matrix/to_vector_array.stan
+++ b/test/integration/good/function-signatures/math/matrix/to_vector_array.stan
@@ -1,0 +1,40 @@
+data {
+  int d_int;
+  matrix[d_int, d_int] d_matrix;
+  complex_matrix[d_int, d_int] d_complex_matrix;
+
+
+}
+
+transformed data {
+  int td_int;
+  matrix[d_int, d_int] td_matrix;
+  array[d_int] vector[d_int] td_vector_array_1d;
+  complex_matrix[d_int, d_int] td_complex_matrix;
+  array[d_int] complex_vector[d_int] td_complex_vector_array_1d;
+
+  td_complex_vector_array_1d = to_vector_array(d_complex_matrix);
+  td_vector_array_1d = to_vector_array(d_matrix);
+}
+
+parameters {
+  matrix[d_int, d_int] p_matrix;
+  array[d_int] vector[d_int] p_vector_array_1d;
+  complex_matrix[d_int, d_int] p_complex_matrix;
+  array[d_int] complex_vector[d_int] p_complex_vector_array_1d;
+
+
+}
+
+transformed parameters {
+  matrix[d_int, d_int] transformed_param_matrix;
+  array[d_int] vector[d_int] transformed_param_vector_array_1d;
+  complex_matrix[d_int, d_int] transformed_param_complex_matrix;
+  array[d_int] complex_vector[d_int] transformed_param_complex_vector_array_1d;
+
+  transformed_param_complex_vector_array_1d = to_vector_array(d_complex_matrix);
+  transformed_param_complex_vector_array_1d = to_vector_array(p_complex_matrix);
+  transformed_param_vector_array_1d = to_vector_array(d_matrix);
+  transformed_param_vector_array_1d = to_vector_array(p_matrix);
+}
+

--- a/test/integration/signatures/stan_math_signatures.t
+++ b/test/integration/signatures/stan_math_signatures.t
@@ -21962,9 +21962,11 @@ Display all Stan math signatures exposed in the language
   to_matrix(array[] int, int, int, int) => matrix
   to_matrix(array[] real, int, int) => matrix
   to_matrix(array[] real, int, int, int) => matrix
+  to_matrix(array[] vector) => matrix
   to_matrix(array[] complex, int, int) => complex_matrix
   to_matrix(array[] complex, int, int, int) => complex_matrix
   to_matrix(array[] row_vector) => matrix
+  to_matrix(array[] complex_vector) => complex_matrix
   to_matrix(array[] complex_row_vector) => complex_matrix
   to_matrix(array[,] int) => matrix
   to_matrix(array[,] real) => matrix
@@ -21978,6 +21980,8 @@ Display all Stan math signatures exposed in the language
   to_row_vector(array[] int) => row_vector
   to_row_vector(array[] real) => row_vector
   to_row_vector(array[] complex) => complex_row_vector
+  to_row_vector_array(matrix) => array[] row_vector
+  to_row_vector_array(complex_matrix) => array[] complex_row_vector
   to_vector(vector) => vector
   to_vector(row_vector) => vector
   to_vector(matrix) => vector
@@ -21987,6 +21991,8 @@ Display all Stan math signatures exposed in the language
   to_vector(array[] int) => vector
   to_vector(array[] real) => vector
   to_vector(array[] complex) => complex_vector
+  to_vector_array(matrix) => array[] vector
+  to_vector_array(complex_matrix) => array[] complex_vector
   trace(matrix) => real
   trace(complex_matrix) => complex
   trace_dot(matrix, matrix) => real


### PR DESCRIPTION
See https://github.com/stan-dev/math/pull/3312

#### Submission Checklist

- [x] Run unit tests
- Documentation
    - [x] If a user-facing facing change was made, the documentation PR is here: TK
    - [ ] OR, no user-facing changes were made

## Release notes

Added `to_vector_array(matrix)`, `to_row_vector_array(matrix)`, and new overloads for `to_matrix`

## Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the BSD 3-clause license (https://opensource.org/licenses/BSD-3-Clause)
